### PR TITLE
Use recorded SHA-1 when updating git submodule

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ dependencies:
     - yarn global add greenkeeper-lockfile@1
     - yarn --pure-lockfile --cache-folder ~/.yarn-cache #truffle-contract replies on ethjs-abi which requires node>v6.5
     - yarn global add gulp@3.9.1
-    - git submodule update --init --recursive --remote
+    - git submodule update --init
 
     # Set up parity
     - wget http://d1h4xl4cr1h0mo.cloudfront.net/v1.5.12/x86_64-unknown-linux-gnu/parity_1.5.12_amd64.deb


### PR DESCRIPTION
The latest change in the git submodule mapping to `dappsys-monolithic` repo broke our build. This was due to the DappHub submodule being updated to the latest version of the remote tracking branch via the `--remote` switch in `git submodule update` during CI. For details see
https://git-scm.com/docs/git-submodule#git-submodule---remote

While this is desirable behaviour for the `truffle` submodule in `colonyDapp` repo, here we should preferably stay on the recorded SHA-1 to avoid this in the future. While this is safer, it does involve us explicitly updating the repo when a submodule update occurs.