### PR TITLE
Introduce staking and submission of Reputation Root Hashes, with skeleton of dispute mechanism

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ dependencies:
     - yarn global add greenkeeper-lockfile@1
     - yarn --pure-lockfile --cache-folder ~/.yarn-cache #truffle-contract replies on ethjs-abi which requires node>v6.5
     - patch -N ./node_modules/ethereumjs-testrpc-sc/build/cli.node.js temp-testrpc.patch || true
-    - patch -N ./node_modules/ethereumjs-testrpc/build/cli.node.js temp-testrpc.patch || true
+    - patch -N ./node_modules/ganache-cli/build/cli.node.js temp-testrpc.patch || true
     - patch -N ./node_modules/truffle/build/cli.bundled.js temp-truffle.patch || true
     - git submodule update --init
 

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -67,6 +67,13 @@ contract Colony is ColonyStorage {
     return token.mint(_wad);
   }
 
+  function mintTokensForColonyNetwork(uint _wad) public {
+    require(msg.sender == colonyNetworkAddress); // Only the colony Network can call this function
+    require(this == IColonyNetwork(colonyNetworkAddress).getColony("Common Colony")); // Function only valid on the Common Colony
+    token.mint(_wad);
+    token.transfer(colonyNetworkAddress, _wad);
+  }
+
   //TODO: Secure this function
   function addGlobalSkill(uint _parentSkillId) public
   returns (uint256)

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -98,6 +98,7 @@ contract ColonyFunding is ColonyStorage, DSMath {
   {
     // Prevent people moving funds from the pot for paying out token holders
     require(_fromPot > 0);
+    // TODO Only allow sending from created pots - perhaps not necessary explicitly, but if not, note as such here.
     require(_toPot <= potCount); // Only allow sending to created pots
     if (pots[_fromPot].taskId > 0) {
       Task storage task = tasks[pots[_fromPot].taskId];

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -96,6 +96,14 @@ contract ColonyNetwork is ColonyNetworkStorage {
     return (x.user, x.amount, x.skillId, x.colony, x.nUpdates, x.nPreviousUpdates);
   }
 
+  function getReputationRootHash() public view returns (bytes32) {
+    return reputationRootHash;
+  }
+
+  function getReputationRootHashNNodes() public view returns (uint256) {
+    return reputationRootHashNNodes;
+  }
+
   function createColony(
     bytes32 _name,
     bytes32 _tokenName,

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -91,8 +91,12 @@ contract ColonyNetwork is ColonyNetworkStorage {
     return skills[_skillId].globalSkill;
   }
 
-  function getReputationUpdateLogEntry(uint256 _id) public view returns (address, int, uint, address, uint, uint) {
-    ReputationLogEntry storage x = ReputationUpdateLog[_id];
+  function getReputationUpdateLogEntry(uint256 _id, bool active) public view returns (address, int256, uint256, address, uint256, uint256) {
+    uint logIdx = activeReputationUpdateLog;
+    if (!active) {
+      logIdx = (logIdx + 1) % 2;
+    }
+    ReputationLogEntry storage x = ReputationUpdateLog[logIdx][_id];
     return (x.user, x.amount, x.skillId, x.colony, x.nUpdates, x.nPreviousUpdates);
   }
 
@@ -248,17 +252,17 @@ contract ColonyNetwork is ColonyNetworkStorage {
   calledByColony
   skillExists(_skillId)
   {
-    uint reputationUpdateLogLength = ReputationUpdateLog.length;
+    uint reputationUpdateLogLength = ReputationUpdateLog[activeReputationUpdateLog].length;
     uint nPreviousUpdates = 0;
     if (reputationUpdateLogLength > 0) {
-      nPreviousUpdates = ReputationUpdateLog[reputationUpdateLogLength-1].nPreviousUpdates + ReputationUpdateLog[reputationUpdateLogLength-1].nUpdates;
+      nPreviousUpdates = ReputationUpdateLog[activeReputationUpdateLog][reputationUpdateLogLength-1].nPreviousUpdates + ReputationUpdateLog[activeReputationUpdateLog][reputationUpdateLogLength-1].nUpdates;
     }
     uint nUpdates = (skills[_skillId].nParents + 1) * 2;
     if (_amount < 0) {
       //TODO: Never true currently. _amount needs to be an int.
       nUpdates += 2 * skills[_skillId].nChildren;
     }
-    ReputationUpdateLog.push(ReputationLogEntry(
+    ReputationUpdateLog[activeReputationUpdateLog].push(ReputationLogEntry(
       _user,
       _amount,
       _skillId,
@@ -267,7 +271,11 @@ contract ColonyNetwork is ColonyNetworkStorage {
       nPreviousUpdates));
   }
 
-  function getReputationUpdateLogLength() public view returns (uint) {
-    return ReputationUpdateLog.length;
+  function getReputationUpdateLogLength(bool active) public view returns (uint) {
+    uint logIdx = activeReputationUpdateLog;
+    if (!active) {
+      logIdx = (logIdx + 1 ) % 2;
+    }
+    return ReputationUpdateLog[logIdx].length;
   }
 }

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -96,7 +96,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
     if (!active) {
       logIdx = (logIdx + 1) % 2;
     }
-    ReputationLogEntry storage x = ReputationUpdateLog[logIdx][_id];
+    ReputationLogEntry storage x = ReputationUpdateLogs[logIdx][_id];
     return (x.user, x.amount, x.skillId, x.colony, x.nUpdates, x.nPreviousUpdates);
   }
 
@@ -252,17 +252,17 @@ contract ColonyNetwork is ColonyNetworkStorage {
   calledByColony
   skillExists(_skillId)
   {
-    uint reputationUpdateLogLength = ReputationUpdateLog[activeReputationUpdateLog].length;
+    uint reputationUpdateLogLength = ReputationUpdateLogs[activeReputationUpdateLog].length;
     uint nPreviousUpdates = 0;
     if (reputationUpdateLogLength > 0) {
-      nPreviousUpdates = ReputationUpdateLog[activeReputationUpdateLog][reputationUpdateLogLength-1].nPreviousUpdates + ReputationUpdateLog[activeReputationUpdateLog][reputationUpdateLogLength-1].nUpdates;
+      nPreviousUpdates = ReputationUpdateLogs[activeReputationUpdateLog][reputationUpdateLogLength-1].nPreviousUpdates + ReputationUpdateLogs[activeReputationUpdateLog][reputationUpdateLogLength-1].nUpdates;
     }
     uint nUpdates = (skills[_skillId].nParents + 1) * 2;
     if (_amount < 0) {
       //TODO: Never true currently. _amount needs to be an int.
       nUpdates += 2 * skills[_skillId].nChildren;
     }
-    ReputationUpdateLog[activeReputationUpdateLog].push(ReputationLogEntry(
+    ReputationUpdateLogs[activeReputationUpdateLog].push(ReputationLogEntry(
       _user,
       _amount,
       _skillId,
@@ -276,6 +276,6 @@ contract ColonyNetwork is ColonyNetworkStorage {
     if (!active) {
       logIdx = (logIdx + 1 ) % 2;
     }
-    return ReputationUpdateLog[logIdx].length;
+    return ReputationUpdateLogs[logIdx].length;
   }
 }

--- a/contracts/ColonyNetworkStaking.sol
+++ b/contracts/ColonyNetworkStaking.sol
@@ -1,0 +1,181 @@
+pragma solidity ^0.4.17;
+pragma experimental "v0.5.0";
+pragma experimental "ABIEncoderV2";
+
+import "../lib/dappsys/auth.sol";
+import "./Authority.sol";
+import "./IColony.sol";
+import "./EtherRouter.sol";
+import "./Token.sol";
+import "./ColonyNetworkStorage.sol";
+import "./IColonyNetwork.sol";
+
+
+contract ColonyNetworkStaking is ColonyNetworkStorage {
+
+  event Address(address _a);
+  event Bool(bool _b);
+  function deposit(uint _amount) public {
+    // Get CLNY address
+    Token clny = Token(IColony(_colonies["Common Colony"]).getToken());
+    uint256 networkBalance = clny.balanceOf(this);
+    // Move some over.
+    clny.transferFrom(msg.sender, this, _amount);
+    // Check it actually transferred
+    assert(clny.balanceOf(this)-networkBalance==_amount);
+    // Note who it belongs to.
+    stakedBalances[msg.sender] += _amount;
+  }
+
+  function withdraw(uint _amount) public {
+    uint256 balance = stakedBalances[msg.sender];
+    require(balance >= _amount);
+    bool hasRequesterSubmitted = ReputationMiningCycle(reputationMiningCycle).hasSubmitted(msg.sender);
+    Bool(hasRequesterSubmitted);
+    require(hasRequesterSubmitted==false);
+    stakedBalances[msg.sender] -= _amount;
+    Token clny = Token(IColony(_colonies["Common Colony"]).getToken());
+    clny.transfer(msg.sender, _amount);
+  }
+
+  function getStakedBalance(address _user) public view returns (uint) {
+    return stakedBalances[_user];
+  }
+
+  function setReputationRootHash(bytes32 newHash, uint256 newNNodes, address[] stakers) public {
+    require(msg.sender == reputationMiningCycle);
+    reputationRootHash = newHash;
+    reputationRootHashNNodes = newNNodes;
+    rewardStakers(stakers);
+    reputationMiningCycle = 0x0;
+    startNextCycle();
+  }
+
+  function startNextCycle() public {
+    require(reputationMiningCycle == 0x0);
+    reputationMiningCycle = new ReputationMiningCycle();
+  }
+
+  function getReputationMiningCycle() public view returns(address) {
+    return reputationMiningCycle;
+  }
+
+  function punishStakers(address[] stakers) public {
+    // TODO: Actually think about this function
+    // Passing an array so that we don't incur the EtherRouter overhead for each staker if we looped over
+    // it in ReputationMiningCycle.invalidateHash;
+    require(msg.sender == reputationMiningCycle);
+    for (uint256 i = 0; i < stakers.length; i++) {
+      // This is pretty harsh! Are we happy with this?
+      stakedBalances[stakers[i]] = 0;
+    }
+    // TODO: Where do these staked tokens go?
+  }
+
+  function rewardStakers(address[] stakers) internal {
+    // Internal unlike punish, because it's only ever called from setReputationRootHash
+
+    // TODO: Actually think about this function
+    // Passing an array so that we don't incur the EtherRouter overhead for each staker if we looped over
+    // it in ReputationMiningCycle.invalidateHash;
+    // for (uint256 i = 0; i < stakers.length; i++) {
+    //   //We need to... do something. They get newly minted tokens, right?
+    // }
+  }
+}
+
+
+contract ReputationMiningCycle {
+  address colonyNetworkAddress;
+  mapping (bytes32 => mapping( uint256 => address[])) public submittedHashes;
+  uint reputationMiningWindowOpenTimestamp;
+  mapping (uint256 => Submission[]) disputeRounds;
+  uint256 public nSubmittedHashes = 0;
+  uint256 public nInvalidatedHashes = 0;
+  mapping (address => bool) public hasSubmitted;
+
+  struct Submission {
+    bytes32 hash;
+    uint256 nNodes;
+  }
+
+  // Prevent addresses from submitting more than one hash?
+
+
+  // Records for which hashes, for which addresses, for which entries have been accepted
+  // Otherwise, people could keep submitting the same entry.
+  mapping (bytes32 => mapping(address => mapping(uint => bool))) submittedEntries;
+
+  event Hash(bytes32 hash);
+
+  function ReputationMiningCycle() public {
+    colonyNetworkAddress = msg.sender;
+    reputationMiningWindowOpenTimestamp = now;
+  }
+
+  function submitNewHash(bytes32 newHash, uint256 nNodes, uint256 entry) public {
+    //Check the ticket is an eligible one for them to claim
+    require(entry <= IColonyNetwork(colonyNetworkAddress).getStakedBalance(msg.sender) / 10**15);
+    require(entry > 0);
+    //Check the ticket is a winning one.
+    // require((now-reputationMiningWindowOpenTimestamp) < 3600);
+    // x = floor(uint((2**256 - 1) / 3600)
+    if (now-reputationMiningWindowOpenTimestamp < 3600) {
+      uint x = 32164469232587832062103051391302196625908329073789045566515995557753647122;
+      uint target = (now - reputationMiningWindowOpenTimestamp ) * x;
+      require(uint256(keccak256(msg.sender, entry, newHash)) < target);
+    }
+
+    //Insert in to list of submissions if there's still room.
+    require (submittedHashes[newHash][nNodes].length <= 12);
+
+    // Require they've not submitted this before
+    // require (submittedEntries[newHash][msg.sender][entry] == false);
+
+    // If this is a new hash, increment nSubmittedHashes as such.
+    if (submittedHashes[newHash][nNodes].length == 0) {
+      nSubmittedHashes += 1;
+      // And add it to the first disputeRound
+      disputeRounds[0].push(Submission({hash: newHash, nNodes: nNodes}));
+    }
+
+
+    hasSubmitted[msg.sender] = true;
+    //And add the miner to the array list of submissions here
+    submittedHashes[newHash][nNodes].push(msg.sender);
+    //Note that they submitted it.
+    submittedEntries[newHash][msg.sender][entry] = true;
+
+  }
+
+  function confirmNewHash(uint256 roundNumber) public {
+    require (nSubmittedHashes - nInvalidatedHashes == 1);
+    require (disputeRounds[roundNumber].length == 1); //i.e. this is the hash that 'survived' all the challenges
+    // TODO: Require some amount of time to have passed (i.e. people have had a chance to submit other hashes)
+    Submission storage reputationRootHash = disputeRounds[roundNumber][0];
+    IColonyNetwork(colonyNetworkAddress).setReputationRootHash(reputationRootHash.hash, reputationRootHash.nNodes, submittedHashes[disputeRounds[roundNumber][0].hash][disputeRounds[roundNumber][0].nNodes]);
+    selfdestruct(colonyNetworkAddress);
+  }
+
+  function invalidateHash(uint256 round, uint256 idx) public {
+    // TODO: Require that it has failed a challenge, or failed to respond in time.
+    // Move its opponent on to the next stage.
+    uint256 opponentIdx = (idx % 2 == 1 ? idx-1 : idx+1);
+    // TODO: Check opponent is good to move on - we're assuming both haven't timed out here.
+
+    // We require that we actually had an opponent - can't invalidate the last hash.
+    // If we try, then the next require should catch it.
+    require(disputeRounds[round][opponentIdx].hash!="");
+    disputeRounds[round+1].push(disputeRounds[round][opponentIdx]);
+    delete disputeRounds[round][opponentIdx];
+    nInvalidatedHashes += 1;
+
+    // Punish the people who proposed this
+    IColonyNetwork(colonyNetworkAddress).punishStakers(submittedHashes[disputeRounds[round][0].hash][disputeRounds[round][0].nNodes]);
+
+    //TODO: Can we do some deleting to make calling this as cheap as possible for people?
+  }
+
+
+
+}

--- a/contracts/ColonyNetworkStaking.sol
+++ b/contracts/ColonyNetworkStaking.sol
@@ -216,7 +216,11 @@ contract ReputationMiningCycle {
 
   function confirmNewHash(uint256 roundNumber) public {
     require (nSubmittedHashes - nInvalidatedHashes == 1);
-    require (disputeRounds[roundNumber].length == 1); //i.e. this is the hash that 'survived' all the challenges
+    require (disputeRounds[roundNumber].length == 1); //i.e. this is the final round
+    // Note that even if we are passed the penultimate round, which had a length of two, and had one eliminated,
+    // and therefore 'delete' called in `invalidateHash`, the array still has a length of '2' - it's just that one
+    // element is zeroed. If this functionality of 'delete' is ever changed, this will have to change too.
+
     // TODO: Require some amount of time to have passed (i.e. people have had a chance to submit other hashes)
     Submission storage reputationRootHash = disputeRounds[roundNumber][0];
     IColonyNetwork(colonyNetworkAddress).setReputationRootHash(reputationRootHash.hash, reputationRootHash.nNodes, submittedHashes[disputeRounds[roundNumber][0].hash][disputeRounds[roundNumber][0].nNodes]);
@@ -266,6 +270,7 @@ contract ReputationMiningCycle {
         // don't know if they're valid or not yet. Move them on to the next round.
         disputeRounds[round+1].push(disputeRounds[round][opponentIdx]);
         delete disputeRounds[round][opponentIdx];
+        // TODO Delete the hash(es) being invalidated?
         nInvalidatedHashes += 1;
         // Check if the hash we just moved to the next round is the second of a pairing that should now face off.
         nInNextRound = disputeRounds[round+1].length;

--- a/contracts/ColonyNetworkStaking.sol
+++ b/contracts/ColonyNetworkStaking.sol
@@ -30,8 +30,9 @@ contract ColonyNetworkStaking is ColonyNetworkStorage {
   function withdraw(uint _amount) public {
     uint256 balance = stakedBalances[msg.sender];
     require(balance >= _amount);
-    bool hasRequesterSubmitted = ReputationMiningCycle(reputationMiningCycle).hasSubmitted(msg.sender) == 0x0 ? false : true;
-    Bool(hasRequesterSubmitted);
+    bytes32 submittedHash;
+    (submittedHash, ) = ReputationMiningCycle(reputationMiningCycle).hasSubmitted(msg.sender);
+    bool hasRequesterSubmitted = submittedHash == 0x0 ? false : true;
     require(hasRequesterSubmitted==false);
     stakedBalances[msg.sender] -= _amount;
     Token clny = Token(IColony(_colonies["Common Colony"]).getToken());
@@ -116,7 +117,7 @@ contract ReputationMiningCycle {
   address colonyNetworkAddress;
   // TODO: Do we need both these mappings?
   mapping (bytes32 => mapping( uint256 => address[])) public submittedHashes;
-  mapping (address => bytes32) public hasSubmitted;
+  mapping (address => Submission) public hasSubmitted;
   uint reputationMiningWindowOpenTimestamp;
   mapping (uint256 => Submission[]) disputeRounds;
   uint256 public nSubmittedHashes = 0;
@@ -145,12 +146,13 @@ contract ReputationMiningCycle {
     //Check the ticket is an eligible one for them to claim
     require(entry <= IColonyNetwork(colonyNetworkAddress).getStakedBalance(msg.sender) / 10**15);
     require(entry > 0);
-    if (hasSubmitted[msg.sender]!=0x0) {             // If this user has submitted before during this round...
-      require(newHash == hasSubmitted[msg.sender]); // ...require that they are submitting the same hash ...
+    if (hasSubmitted[msg.sender].hash != 0x0) {           // If this user has submitted before during this round...
+      require(newHash == hasSubmitted[msg.sender].hash);  // ...require that they are submitting the same hash ...
+      require(nNodes == hasSubmitted[msg.sender].nNodes); // ...require that they are submitting the same number of nodes for that hash ...
       require (submittedEntries[newHash][msg.sender][entry] == false); // ... but not this exact entry
     }
     // TODO: Require minimum stake, that is (much) more than the cost required to defend the valid submission.
-    //Check the ticket is a winning one.
+    // Check the ticket is a winning one.
     // require((now-reputationMiningWindowOpenTimestamp) < 3600);
     // x = floor(uint((2**256 - 1) / 3600)
     if (now-reputationMiningWindowOpenTimestamp < 3600) {
@@ -160,7 +162,7 @@ contract ReputationMiningCycle {
     }
 
     //Insert in to list of submissions if there's still room.
-    require (submittedHashes[newHash][nNodes].length <= 12);
+    require (submittedHashes[newHash][nNodes].length < 12);
 
     // If this is a new hash, increment nSubmittedHashes as such.
     if (submittedHashes[newHash][nNodes].length == 0) {
@@ -170,7 +172,7 @@ contract ReputationMiningCycle {
     }
 
 
-    hasSubmitted[msg.sender] = newHash;
+    hasSubmitted[msg.sender] = Submission({hash: newHash, nNodes: nNodes});
     //And add the miner to the array list of submissions here
     submittedHashes[newHash][nNodes].push(msg.sender);
     //Note that they submitted it.

--- a/contracts/ColonyNetworkStorage.sol
+++ b/contracts/ColonyNetworkStorage.sol
@@ -64,4 +64,9 @@ contract ColonyNetworkStorage is DSAuth {
   }
 
   ReputationLogEntry[] ReputationUpdateLog;
+
+  bytes32 reputationRootHash;
+  mapping (address => uint) stakedBalances;
+  address reputationMiningCycle;
+  uint256 reputationRootHashNNodes;
 }

--- a/contracts/ColonyNetworkStorage.sol
+++ b/contracts/ColonyNetworkStorage.sol
@@ -63,7 +63,8 @@ contract ColonyNetworkStorage is DSAuth {
     uint256 nPreviousUpdates;
   }
 
-  ReputationLogEntry[] ReputationUpdateLog;
+  mapping (uint => ReputationLogEntry[]) ReputationUpdateLog;
+  uint256 activeReputationUpdateLog;
 
   bytes32 reputationRootHash;
   mapping (address => uint) stakedBalances;

--- a/contracts/ColonyNetworkStorage.sol
+++ b/contracts/ColonyNetworkStorage.sol
@@ -63,7 +63,7 @@ contract ColonyNetworkStorage is DSAuth {
     uint256 nPreviousUpdates;
   }
 
-  mapping (uint => ReputationLogEntry[]) ReputationUpdateLog;
+  mapping (uint => ReputationLogEntry[]) ReputationUpdateLogs;
   uint256 activeReputationUpdateLog;
 
   bytes32 reputationRootHash;

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -31,6 +31,7 @@ contract IColony {
   function getToken() public view returns (address);
   function initialiseColony(address _network) public;
   function mintTokens(uint256 _wad) public;
+  function mintTokensForColonyNetwork(uint256 _wad) public;
   function addGlobalSkill(uint256 _parentSkillId) public returns (uint256);
   function addDomain(uint256 _parentSkillId) public;
   function getDomain(uint256 _id) public view returns (uint256, uint256);

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -49,4 +49,6 @@ contract IColonyNetwork {
   function startNextCycle() public;
   function punishStakers(address[] stakers) public;
   function getReputationMiningCycle() public view returns (address);
+  function getReputationRootHash() public view returns (bytes32);
+  function getReputationRootHashNNodes() public view returns (uint256);
 }

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -39,9 +39,9 @@ contract IColonyNetwork {
   function upgradeColony(bytes32 _name, uint256 _newVersion) public;
   function getParentSkillId(uint256 _skillId, uint256 _parentSkillIndex) public view returns (uint256);
   function getChildSkillId(uint256 _skillId, uint256 _childSkillIndex) public view returns (uint256);
-  function getReputationUpdateLogLength() public view returns (uint256);
+  function getReputationUpdateLogLength(bool activeLog) public view returns (uint256);
   function getColonyVersionResolver(uint256 _version) public view returns (address);
-  function getReputationUpdateLogEntry(uint256 _id) public view returns (address, int, uint256, address, uint256, uint256);
+  function getReputationUpdateLogEntry(uint256 _id, bool activeLog) public view returns (address, int, uint256, address, uint256, uint256);
   function deposit(uint256 _amount) public;
   function withdraw(uint256 amount) public;
   function getStakedBalance(address _user) public view returns (uint256);

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -42,4 +42,11 @@ contract IColonyNetwork {
   function getReputationUpdateLogLength() public view returns (uint256);
   function getColonyVersionResolver(uint256 _version) public view returns (address);
   function getReputationUpdateLogEntry(uint256 _id) public view returns (address, int, uint256, address, uint256, uint256);
+  function deposit(uint256 _amount) public;
+  function withdraw(uint256 amount) public;
+  function getStakedBalance(address _user) public view returns (uint256);
+  function setReputationRootHash(bytes32, uint256, address[]) public;
+  function startNextCycle() public;
+  function punishStakers(address[] stakers) public;
+  function getReputationMiningCycle() public view returns (address);
 }

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -165,7 +165,8 @@ contract("all", () => {
       approveTaskChangeCost = tx.receipt.gasUsed;
       console.log("approveTaskChange actual cost :", approveTaskChangeCost);
 
-      const dueDate = testHelper.currentBlockTime() + SECONDS_PER_DAY * 5;
+      let dueDate = await testHelper.currentBlockTime();
+      dueDate += SECONDS_PER_DAY * 5;
       txData = await colony.contract.setTaskDueDate.getData(1, dueDate);
       await colony.proposeTaskChange(txData, 0, MANAGER_ROLE);
       transactionId = await colony.getTransactionCount.call();

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -66,7 +66,6 @@ module.exports = {
     } else {
       tokenAddress = token === 0x0 ? 0x0 : token.address;
     }
-
     const taskId = await this.setupAssignedTask(colonyNetwork, colony, dueDate, domain, skill, evaluator, worker);
     const task = await colony.getTask.call(taskId);
     const potId = task[6].toNumber();

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -19,15 +19,7 @@ import {
 import testHelper from "../helpers/test-helper";
 
 module.exports = {
-  async setupAssignedTask(
-    colonyNetwork,
-    colony,
-    dueDate,
-    domain = 1,
-    skill = 0,
-    evaluator = EVALUATOR,
-    worker = WORKER
-  ) {
+  async setupAssignedTask(colonyNetwork, colony, dueDate, domain = 1, skill = 0, evaluator = EVALUATOR, worker = WORKER) {
     let dueDateTimestamp = dueDate;
     if (!dueDateTimestamp) {
       dueDateTimestamp = await testHelper.currentBlockTime();

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -22,12 +22,16 @@ module.exports = {
   async setupAssignedTask(
     colonyNetwork,
     colony,
-    dueDate = testHelper.currentBlockTime(),
+    dueDate,
     domain = 1,
     skill = 0,
     evaluator = EVALUATOR,
     worker = WORKER
   ) {
+    let dueDateTimestamp = dueDate;
+    if (!dueDateTimestamp) {
+      dueDateTimestamp = await testHelper.currentBlockTime();
+    }
     await colony.makeTask(SPECIFICATION_HASH, domain);
     let taskId = await colony.getTaskCount.call();
     taskId = taskId.toNumber();
@@ -41,7 +45,7 @@ module.exports = {
     }
     await colony.setTaskRoleUser(taskId, EVALUATOR_ROLE, evaluator);
     await colony.setTaskRoleUser(taskId, WORKER_ROLE, worker);
-    const txData = await colony.contract.setTaskDueDate.getData(taskId, dueDate);
+    const txData = await colony.contract.setTaskDueDate.getData(taskId, dueDateTimestamp);
     await colony.proposeTaskChange(txData, 0, MANAGER_ROLE);
     const transactionId = await colony.getTransactionCount.call();
     await colony.approveTaskChange(transactionId, WORKER_ROLE, { from: worker });

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -116,7 +116,15 @@ module.exports = {
     return web3.toAscii(text).replace(/\u0000/g, "");
   },
   currentBlockTime() {
-    return web3.eth.getBlock("latest").timestamp;
+    const p = new Promise((resolve, reject) => {
+      web3.eth.getBlock("latest", (err, res) => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve(res.timestamp);
+      });
+    });
+    return p;
   },
   async expectEvent(tx, eventName) {
     const { logs } = await tx;

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -137,13 +137,13 @@ module.exports = {
       test.skip();
     } else {
       // console.log('Forwarding time with ' + seconds + 's ...');
-      web3.currentProvider.send({
+      await web3.currentProvider.send({
         jsonrpc: "2.0",
         method: "evm_increaseTime",
         params: [seconds],
         id: 0
       });
-      web3.currentProvider.send({
+      await web3.currentProvider.send({
         jsonrpc: "2.0",
         method: "evm_mine",
         params: [],

--- a/helpers/upgradable-contracts.js
+++ b/helpers/upgradable-contracts.js
@@ -26,9 +26,10 @@ module.exports = {
     const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
     assert.equal(version, currentColonyVersion.toNumber());
   },
-  async setupUpgradableColonyNetwork(etherRouter, resolver, colonyNetwork) {
+  async setupUpgradableColonyNetwork(etherRouter, resolver, colonyNetwork, colonyNetworkStaking) {
     const deployedImplementations = {};
     deployedImplementations.ColonyNetwork = colonyNetwork.address;
+    deployedImplementations.ColonyNetworkStaking = colonyNetworkStaking.address;
 
     await this.setupEtherRouter("IColonyNetwork", deployedImplementations, resolver);
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -4,6 +4,7 @@
 const SafeMath = artifacts.require("./SafeMath");
 const ColonyTask = artifacts.require("./ColonyTask");
 const ColonyNetwork = artifacts.require("./ColonyNetwork");
+const ColonyNetworkStaking = artifacts.require("./ColonyNetworkStaking");
 const EtherRouter = artifacts.require("./EtherRouter");
 const Resolver = artifacts.require("./Resolver");
 
@@ -12,6 +13,7 @@ module.exports = (deployer, network) => {
   deployer.deploy([SafeMath]);
   deployer.link(SafeMath, ColonyTask);
   deployer.deploy([ColonyNetwork]);
+  deployer.deploy([ColonyNetworkStaking]);
   deployer.deploy([EtherRouter]);
   deployer.deploy([Resolver]);
 };

--- a/migrations/3_setup_colony_network.js
+++ b/migrations/3_setup_colony_network.js
@@ -18,7 +18,7 @@ module.exports = deployer => {
       colonyNetwork = instance;
       return ColonyNetworkStaking.deployed();
     })
-    .then((instance) => {
+    .then(instance => {
       colonyNetworkStaking = instance;
       return EtherRouter.deployed();
     })

--- a/migrations/3_setup_colony_network.js
+++ b/migrations/3_setup_colony_network.js
@@ -3,6 +3,7 @@
 const upgradableContracts = require("../helpers/upgradable-contracts");
 
 const ColonyNetwork = artifacts.require("./ColonyNetwork");
+const ColonyNetworkStaking = artifacts.require("./ColonyNetworkStaking");
 const EtherRouter = artifacts.require("./EtherRouter");
 const Resolver = artifacts.require("./Resolver");
 
@@ -10,10 +11,15 @@ module.exports = deployer => {
   let etherRouter;
   let resolver;
   let colonyNetwork;
+  let colonyNetworkStaking;
   deployer
     .then(() => ColonyNetwork.deployed())
     .then(instance => {
       colonyNetwork = instance;
+      return ColonyNetworkStaking.deployed();
+    })
+    .then((instance) => {
+      colonyNetworkStaking = instance;
       return EtherRouter.deployed();
     })
     .then(instance => {
@@ -22,7 +28,7 @@ module.exports = deployer => {
     })
     .then(instance => {
       resolver = instance;
-      return upgradableContracts.setupUpgradableColonyNetwork(etherRouter, resolver, colonyNetwork);
+      return upgradableContracts.setupUpgradableColonyNetwork(etherRouter, resolver, colonyNetwork, colonyNetworkStaking);
     })
     .then(() => {
       console.log("### Colony Network setup with Resolver", resolver.address, "and EtherRouter", etherRouter.address);

--- a/package.json
+++ b/package.json
@@ -67,8 +67,5 @@
     "truffle": "^4.0.6",
     "web3-utils": "^1.0.0-beta.29"
   },
-  "dependencies": {
-    "solidity-sha3": "^0.4.1",
-    "truffle-contract": "^3.0.2"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-flowtype": "^2.42.0",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-prettier": "^2.6.0",
-    "ganache-cli": "^6.1.0-beta.0",
+    "ganache-cli": "6.0.3",
     "istanbul": "^0.4.5",
     "mocha": "^5.0.0",
     "mocha-circleci-reporter": "^0.0.2",
@@ -66,5 +66,9 @@
     "solium": "^1.1.3",
     "truffle": "^4.0.6",
     "web3-utils": "^1.0.0-beta.29"
+  },
+  "dependencies": {
+    "solidity-sha3": "^0.4.1",
+    "truffle-contract": "^3.0.2"
   }
 }

--- a/test/colony-network-staking.js
+++ b/test/colony-network-staking.js
@@ -10,7 +10,7 @@ const ReputationMiningCycle = artifacts.require("ReputationMiningCycle");
 
 const BN = require("bn.js");
 
-contract("ColonyNetwork", accounts => {
+contract("ColonyNetworkStaking", accounts => {
   const MAIN_ACCOUNT = accounts[0];
   const OTHER_ACCOUNT = accounts[1];
 
@@ -21,13 +21,10 @@ contract("ColonyNetwork", accounts => {
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
-    // await upgradableContracts.setupColonyVersionResolver(colony, colonyFunding, colonyTask, colonyTransactionReviewer, resolver, colonyNetwork);
 
     const commonColonyAddress = await colonyNetwork.getColony("Common Colony");
     commonColony = IColony.at(commonColonyAddress);
-    // console.log('CC address ', commonColonyAddress);
     const clnyAddress = await commonColony.getToken.call();
-    // console.log('CLNY address ', clnyAddress);
     clny = Token.at(clnyAddress);
     await colonyNetwork.startNextCycle();
   });
@@ -129,9 +126,8 @@ contract("ColonyNetwork", accounts => {
       await giveUserCLNYTokens(OTHER_ACCOUNT, 9000);
       await clny.approve(colonyNetwork.address, 5000, { from: OTHER_ACCOUNT });
       await colonyNetwork.deposit(5000, { from: OTHER_ACCOUNT });
-      let stakedBalance = await colonyNetwork.getStakedBalance.call(OTHER_ACCOUNT);
-      await colonyNetwork.withdraw(stakedBalance.toNumber(), { from: OTHER_ACCOUNT });
-      stakedBalance = await colonyNetwork.getStakedBalance.call(OTHER_ACCOUNT);
+      await colonyNetwork.withdraw(5000, { from: OTHER_ACCOUNT });
+      const stakedBalance = await colonyNetwork.getStakedBalance.call(OTHER_ACCOUNT);
       assert.equal(stakedBalance.toNumber(), 0);
     });
 
@@ -158,14 +154,6 @@ contract("ColonyNetwork", accounts => {
       const userBalance = await clny.balanceOf.call(OTHER_ACCOUNT);
       assert.equal(userBalance.toNumber(), 0);
     });
-
-    // it('should allow a new cycle to start if there is none currently', async function(){
-    //   let addr = await colonyNetwork.getReputationMiningCycle.call();
-    //   assert(addr==0x0);
-    //   await colonyNetwork.startNextCycle();
-    //   addr = await colonyNetwork.getReputationMiningCycle.call();
-    //   assert(addr!=0x0);
-    // })
 
     it("should allow a new reputation hash to be submitted", async () => {
       await giveUserCLNYTokens(MAIN_ACCOUNT, new BN("1000000000000000000"));

--- a/test/colony-network-staking.js
+++ b/test/colony-network-staking.js
@@ -1,0 +1,203 @@
+/* globals artifacts */
+import testHelper from "../helpers/test-helper";
+import testDataGenerator from "../helpers/test-data-generator";
+
+const EtherRouter = artifacts.require("EtherRouter");
+const IColony = artifacts.require("IColony");
+const IColonyNetwork = artifacts.require("IColonyNetwork");
+const Token = artifacts.require("Token");
+const ReputationMiningCycle = artifacts.require("ReputationMiningCycle");
+
+const BN = require("bn.js");
+
+contract("ColonyNetwork", accounts => {
+  const MAIN_ACCOUNT = accounts[0];
+  const OTHER_ACCOUNT = accounts[1];
+
+  let commonColony;
+  let colonyNetwork;
+  let clny;
+
+  before(async () => {
+    const etherRouter = await EtherRouter.deployed();
+    colonyNetwork = await IColonyNetwork.at(etherRouter.address);
+    // await upgradableContracts.setupColonyVersionResolver(colony, colonyFunding, colonyTask, colonyTransactionReviewer, resolver, colonyNetwork);
+
+    const commonColonyAddress = await colonyNetwork.getColony("Common Colony");
+    commonColony = IColony.at(commonColonyAddress);
+    // console.log('CC address ', commonColonyAddress);
+    const clnyAddress = await commonColony.getToken.call();
+    // console.log('CLNY address ', clnyAddress);
+    clny = Token.at(clnyAddress);
+  });
+
+  before(async () => {
+    await colonyNetwork.startNextCycle();
+  });
+
+  async function giveUserCLNYTokens(address, _amount) {
+    const amount = new BN(_amount);
+    const mainStartingBalance = await clny.balanceOf.call(MAIN_ACCOUNT);
+    const targetStartingBalance = await clny.balanceOf.call(address);
+    await commonColony.mintTokens(amount * 3);
+    await commonColony.claimColonyFunds(clny.address);
+    const taskId = await testDataGenerator.setupRatedTask(
+      colonyNetwork,
+      commonColony,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      amount.mul(new BN("2")),
+      new BN("0"),
+      new BN("0")
+    );
+    await commonColony.finalizeTask(taskId);
+    await commonColony.claimPayout(taskId, 0, clny.address);
+
+    let mainBalance = await clny.balanceOf.call(MAIN_ACCOUNT);
+    await clny.transfer(
+      0x0,
+      mainBalance
+        .sub(amount)
+        .sub(mainStartingBalance)
+        .toString()
+    );
+    await clny.transfer(address, amount.toString());
+    mainBalance = await clny.balanceOf.call(MAIN_ACCOUNT);
+    if (address !== MAIN_ACCOUNT) {
+      await clny.transfer(0x0, mainBalance.sub(mainStartingBalance).toString());
+    }
+    const userBalance = await clny.balanceOf.call(address);
+    assert.equal(targetStartingBalance.add(amount).toString(), userBalance.toString());
+  }
+
+  afterEach(async () => {
+    // Withdraw all stakes. Can only do this at the start of a new cycle, if anyone has submitted a hash in this current cycle.
+    const addr = await colonyNetwork.getReputationMiningCycle.call();
+    const repCycle = ReputationMiningCycle.at(addr);
+    const nSubmittedHashes = await repCycle.nSubmittedHashes.call();
+    if (nSubmittedHashes > 0) {
+      const nInvalidatedHashes = await repCycle.nInvalidatedHashes.call();
+      if (nSubmittedHashes - nInvalidatedHashes === 1) {
+        repCycle.confirmNewHash(0);
+      } else {
+        console.log("We're mid dispute process, and can't untangle from here"); // eslint-disable-line no-console
+        process.exit(1);
+      }
+    }
+    let stakedBalance = await colonyNetwork.getStakedBalance.call(OTHER_ACCOUNT);
+    if (stakedBalance.toNumber() > 0) {
+      await colonyNetwork.withdraw(stakedBalance.toNumber(), { from: OTHER_ACCOUNT });
+    }
+    stakedBalance = await colonyNetwork.getStakedBalance.call(MAIN_ACCOUNT);
+    if (stakedBalance.toNumber() > 0) {
+      await colonyNetwork.withdraw(stakedBalance.toNumber(), { from: MAIN_ACCOUNT });
+    }
+    let userBalance = await clny.balanceOf.call(OTHER_ACCOUNT);
+    await clny.transfer(0x0, userBalance, { from: OTHER_ACCOUNT });
+    userBalance = await clny.balanceOf.call(MAIN_ACCOUNT);
+    await clny.transfer(0x0, userBalance, { from: MAIN_ACCOUNT });
+  });
+
+  describe("when initialised", () => {
+    it("should allow miners to stake CLNY", async () => {
+      await giveUserCLNYTokens(OTHER_ACCOUNT, 9000);
+      await clny.approve(colonyNetwork.address, 5000, { from: OTHER_ACCOUNT });
+      await colonyNetwork.deposit(5000, { from: OTHER_ACCOUNT });
+      const userBalance = await clny.balanceOf.call(OTHER_ACCOUNT);
+      assert.equal(userBalance.toNumber(), 4000);
+      const stakedBalance = await colonyNetwork.getStakedBalance.call(OTHER_ACCOUNT);
+      assert.equal(stakedBalance.toNumber(), 5000);
+    });
+
+    it("should allow miners to withdraw staked CLNY", async () => {
+      await giveUserCLNYTokens(OTHER_ACCOUNT, 9000);
+      await clny.approve(colonyNetwork.address, 5000, { from: OTHER_ACCOUNT });
+      await colonyNetwork.deposit(5000, { from: OTHER_ACCOUNT });
+      let stakedBalance = await colonyNetwork.getStakedBalance.call(OTHER_ACCOUNT);
+      await colonyNetwork.withdraw(stakedBalance.toNumber(), { from: OTHER_ACCOUNT });
+      stakedBalance = await colonyNetwork.getStakedBalance.call(OTHER_ACCOUNT);
+      assert.equal(stakedBalance.toNumber(), 0);
+    });
+
+    it("should not allow miners to deposit more CLNY than they have", async () => {
+      await giveUserCLNYTokens(OTHER_ACCOUNT, 9000);
+      await clny.approve(colonyNetwork.address, 10000, { from: OTHER_ACCOUNT });
+      await testHelper.checkErrorRevert(colonyNetwork.deposit(10000, { from: OTHER_ACCOUNT }));
+      const userBalance = await clny.balanceOf.call(OTHER_ACCOUNT);
+      assert.equal(userBalance.toNumber(), 9000);
+      const stakedBalance = await colonyNetwork.getStakedBalance.call(OTHER_ACCOUNT);
+      assert.equal(stakedBalance.toNumber(), 0);
+    });
+
+    it("should not allow miners to withdraw more CLNY than they staked, even if enough has been staked total", async () => {
+      await giveUserCLNYTokens(MAIN_ACCOUNT, 9000);
+      await giveUserCLNYTokens(OTHER_ACCOUNT, 9000);
+      await clny.approve(colonyNetwork.address, 9000, { from: OTHER_ACCOUNT });
+      await clny.approve(colonyNetwork.address, 9000, { from: MAIN_ACCOUNT });
+      await colonyNetwork.deposit(9000, { from: OTHER_ACCOUNT });
+      await colonyNetwork.deposit(9000, { from: MAIN_ACCOUNT });
+      await testHelper.checkErrorRevert(colonyNetwork.withdraw(10000, { from: OTHER_ACCOUNT }));
+      const stakedBalance = await colonyNetwork.getStakedBalance.call(OTHER_ACCOUNT);
+      assert.equal(stakedBalance.toNumber(), 9000);
+      const userBalance = await clny.balanceOf.call(OTHER_ACCOUNT);
+      assert.equal(userBalance.toNumber(), 0);
+    });
+
+    // it('should allow a new cycle to start if there is none currently', async function(){
+    //   let addr = await colonyNetwork.getReputationMiningCycle.call();
+    //   assert(addr==0x0);
+    //   await colonyNetwork.startNextCycle();
+    //   addr = await colonyNetwork.getReputationMiningCycle.call();
+    //   assert(addr!=0x0);
+    // })
+
+    it("should allow a new reputation hash to be submitted", async () => {
+      await giveUserCLNYTokens(MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await clny.approve(colonyNetwork.address, "1000000000000000000");
+      await colonyNetwork.deposit("1000000000000000000");
+
+      const addr = await colonyNetwork.getReputationMiningCycle.call();
+      await testHelper.forwardTime(3600, this);
+      const repCycle = ReputationMiningCycle.at(addr);
+      await repCycle.submitNewHash("0x12345678", 10, 10);
+      const submitterAddress = await repCycle.submittedHashes.call("0x12345678", 10, 0);
+      assert.equal(submitterAddress, MAIN_ACCOUNT);
+    });
+
+    it("should not allow someone to submit a new reputation hash if they are not staking", async () => {
+      const addr = await colonyNetwork.getReputationMiningCycle.call();
+      await testHelper.forwardTime(3600);
+      const repCycle = ReputationMiningCycle.at(addr);
+      await testHelper.checkErrorRevert(repCycle.submitNewHash("0x12345678", 10, 0));
+      const nSubmittedHashes = await repCycle.nSubmittedHashes.call();
+      assert(nSubmittedHashes.equals(0));
+    });
+
+    it("should not allow someone to withdraw their stake if they have submitted a hash this round", async () => {
+      await giveUserCLNYTokens(MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await clny.approve(colonyNetwork.address, "1000000000000000000");
+      await colonyNetwork.deposit("1000000000000000000");
+
+      const addr = await colonyNetwork.getReputationMiningCycle.call();
+      await testHelper.forwardTime(3600);
+      const repCycle = ReputationMiningCycle.at(addr);
+      await repCycle.submitNewHash("0x12345678", 10, 10);
+      let stakedBalance = await colonyNetwork.getStakedBalance.call(MAIN_ACCOUNT);
+      await testHelper.checkErrorRevert(colonyNetwork.withdraw(stakedBalance.toNumber(), { from: MAIN_ACCOUNT }));
+      stakedBalance = await colonyNetwork.getStakedBalance.call(MAIN_ACCOUNT);
+      assert(stakedBalance.equals("1000000000000000000"));
+    });
+    it("should allow a new reputation hash to be set if only one was submitted");
+    it("should not allow a new reputation hash to be set if more than one was submitted and they have not been elimintated");
+    it("should allow a new reputation hash to be set if more than one was submitted and all but one have been elimintated");
+    it("should not allow the last reputation hash to be eliminated");
+    it("should not allow someone to submit a new reputation hash if they are ineligible");
+    it("should not allow a new reputation hash to be set if two or more were submitted");
+    it("should punish stakers if they misbehave");
+    it("should reward stakers if they submitted the agreed new hash");
+  });
+});

--- a/test/colony-network-staking.js
+++ b/test/colony-network-staking.js
@@ -264,11 +264,69 @@ contract("ColonyNetwork", accounts => {
       await repCycle.invalidateHash(0, 0);
     });
 
-    it("should allow a new reputation hash to be set if more than one was submitted and all but one have been elimintated");
-    it("should not allow the last reputation hash to be eliminated");
-    it("should not allow someone to submit a new reputation hash if they are ineligible");
-    it("should not allow a new reputation hash to be set if two or more were submitted");
-    it("should punish stakers if they misbehave");
-    it("should reward stakers if they submitted the agreed new hash");
+    it("should not allow the last reputation hash to be eliminated", async () => {
+      await giveUserCLNYTokens(MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await giveUserCLNYTokens(OTHER_ACCOUNT, new BN("1000000000000000000"));
+
+      await clny.approve(colonyNetwork.address, "1000000000000000000");
+      await colonyNetwork.deposit("1000000000000000000");
+      await clny.approve(colonyNetwork.address, "1000000000000000000", { from: OTHER_ACCOUNT });
+      await colonyNetwork.deposit("1000000000000000000", { from: OTHER_ACCOUNT });
+
+      const addr = await colonyNetwork.getReputationMiningCycle.call();
+      await testHelper.forwardTime(3600, this);
+      const repCycle = ReputationMiningCycle.at(addr);
+      await repCycle.submitNewHash("0x12345678", 10, 10);
+      await repCycle.submitNewHash("0x87654321", 10, 10, { from: OTHER_ACCOUNT });
+      await repCycle.invalidateHash(0, 1);
+      await testHelper.checkErrorRevert(repCycle.invalidateHash(1, 0));
+    });
+
+    it("should not allow someone to submit a new reputation hash if they are ineligible", async () => {
+      await giveUserCLNYTokens(MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await clny.approve(colonyNetwork.address, "1000000000000000000");
+      await colonyNetwork.deposit("1000000000000000000");
+
+      const addr = await colonyNetwork.getReputationMiningCycle.call();
+      const repCycle = ReputationMiningCycle.at(addr);
+      await testHelper.checkErrorRevert(repCycle.submitNewHash("0x12345678", 10, 10));
+      const nSubmittedHashes = await repCycle.nSubmittedHashes.call();
+      assert(nSubmittedHashes.equals(0));
+    });
+
+    it("should punish all stakers if they misbehave (and report a bad hash)", async () => {
+      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(OTHER_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(accounts[2], "1000000000000000000");
+
+      await clny.approve(colonyNetwork.address, "1000000000000000000");
+      await colonyNetwork.deposit("1000000000000000000");
+      await clny.approve(colonyNetwork.address, "1000000000000000000", { from: OTHER_ACCOUNT });
+      await colonyNetwork.deposit("1000000000000000000", { from: OTHER_ACCOUNT });
+      let balance = await colonyNetwork.getStakedBalance(OTHER_ACCOUNT);
+      assert(balance.equals("1000000000000000000"));
+      await clny.approve(colonyNetwork.address, "1000000000000000000", { from: accounts[2] });
+      await colonyNetwork.deposit("1000000000000000000", { from: accounts[2] });
+      let balance2 = await colonyNetwork.getStakedBalance(accounts[2]);
+      assert(balance.equals("1000000000000000000"));
+
+      const addr = await colonyNetwork.getReputationMiningCycle.call();
+      await testHelper.forwardTime(3600, this);
+      const repCycle = ReputationMiningCycle.at(addr);
+      await repCycle.submitNewHash("0x12345678", 10, 10);
+      await repCycle.submitNewHash("0x87654321", 10, 10, { from: OTHER_ACCOUNT });
+      await repCycle.submitNewHash("0x87654321", 10, 10, { from: accounts[2] });
+      await repCycle.invalidateHash(0, 1);
+      balance = await colonyNetwork.getStakedBalance(OTHER_ACCOUNT);
+      assert.equal(balance.toString(), "0", "Account was not punished properly");
+      balance2 = await colonyNetwork.getStakedBalance(accounts[2]);
+      assert.equal(balance2.toString(), "0", "Account was not punished properly");
+    });
+
+    it("should reward all stakers if they submitted the agreed new hash");
+    it("should not allow a user to back more than one hash in a single cycle");
+    it("should allow a user to back the same hash more than once in a same cycle with different valid entries");
+    it("should only allow 12 entries to back a single hash in each cycle");
+    it("should cope with many hashes being submitted and eliminated before a winner is assigned");
   });
 });

--- a/test/colony-network-staking.js
+++ b/test/colony-network-staking.js
@@ -41,45 +41,6 @@ contract("ColonyNetworkStaking", accounts => {
     return repCycle.invalidateHash(round, idx);
   }
 
-  async function giveUserCLNYTokens(address, _amount) {
-    const amount = new BN(_amount);
-    const mainStartingBalance = await clny.balanceOf.call(MAIN_ACCOUNT);
-    const targetStartingBalance = await clny.balanceOf.call(address);
-    await commonColony.mintTokens(amount * 3);
-    await commonColony.claimColonyFunds(clny.address);
-    const taskId = await testDataGenerator.setupRatedTask(
-      colonyNetwork,
-      commonColony,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      amount.mul(new BN("2")),
-      new BN("0"),
-      new BN("0")
-    );
-    await commonColony.finalizeTask(taskId);
-    await commonColony.claimPayout(taskId, 0, clny.address);
-
-    let mainBalance = await clny.balanceOf.call(MAIN_ACCOUNT);
-    await clny.transfer(
-      0x0,
-      mainBalance
-        .sub(amount)
-        .sub(mainStartingBalance)
-        .toString()
-    );
-    await clny.transfer(address, amount.toString());
-    mainBalance = await clny.balanceOf.call(MAIN_ACCOUNT);
-    if (address !== MAIN_ACCOUNT) {
-      await clny.transfer(0x0, mainBalance.sub(mainStartingBalance).toString());
-    }
-    const userBalance = await clny.balanceOf.call(address);
-    assert.equal(targetStartingBalance.add(amount).toString(), userBalance.toString());
-  }
-
   afterEach(async () => {
     // Withdraw all stakes. Can only do this at the start of a new cycle, if anyone has submitted a hash in this current cycle.
     const addr = await colonyNetwork.getReputationMiningCycle.call();
@@ -113,7 +74,7 @@ contract("ColonyNetworkStaking", accounts => {
 
   describe("when initialised", () => {
     it("should allow miners to stake CLNY", async () => {
-      await giveUserCLNYTokens(OTHER_ACCOUNT, 9000);
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, 9000);
       await clny.approve(colonyNetwork.address, 5000, { from: OTHER_ACCOUNT });
       await colonyNetwork.deposit(5000, { from: OTHER_ACCOUNT });
       const userBalance = await clny.balanceOf.call(OTHER_ACCOUNT);
@@ -123,7 +84,7 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should allow miners to withdraw staked CLNY", async () => {
-      await giveUserCLNYTokens(OTHER_ACCOUNT, 9000);
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, 9000);
       await clny.approve(colonyNetwork.address, 5000, { from: OTHER_ACCOUNT });
       await colonyNetwork.deposit(5000, { from: OTHER_ACCOUNT });
       await colonyNetwork.withdraw(5000, { from: OTHER_ACCOUNT });
@@ -132,7 +93,7 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow miners to deposit more CLNY than they have", async () => {
-      await giveUserCLNYTokens(OTHER_ACCOUNT, 9000);
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, 9000);
       await clny.approve(colonyNetwork.address, 10000, { from: OTHER_ACCOUNT });
       await testHelper.checkErrorRevert(colonyNetwork.deposit(10000, { from: OTHER_ACCOUNT }));
       const userBalance = await clny.balanceOf.call(OTHER_ACCOUNT);
@@ -142,8 +103,8 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow miners to withdraw more CLNY than they staked, even if enough has been staked total", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, 9000);
-      await giveUserCLNYTokens(OTHER_ACCOUNT, 9000);
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, 9000);
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, 9000);
       await clny.approve(colonyNetwork.address, 9000, { from: OTHER_ACCOUNT });
       await clny.approve(colonyNetwork.address, 9000, { from: MAIN_ACCOUNT });
       await colonyNetwork.deposit(9000, { from: OTHER_ACCOUNT });
@@ -156,7 +117,7 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should allow a new reputation hash to be submitted", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
@@ -178,7 +139,7 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow someone to withdraw their stake if they have submitted a hash this round", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
@@ -193,7 +154,7 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should allow a new reputation hash to be set if only one was submitted", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
@@ -213,8 +174,8 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should allow a new reputation hash to be set if all but one submitted have been elimintated", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, new BN("1000000000000000000"));
-      await giveUserCLNYTokens(OTHER_ACCOUNT, new BN("1000000000000000000"));
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, new BN("1000000000000000000"));
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -239,9 +200,9 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should allow a new reputation hash to be moved to the next stage of competition even if it does not have a partner", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(OTHER_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(accounts[2], "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, accounts[2], "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -272,8 +233,8 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow a new reputation hash to be set if more than one was submitted and they have not been elimintated", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(OTHER_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000", { from: OTHER_ACCOUNT });
@@ -293,8 +254,8 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow the last reputation hash to be eliminated", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, new BN("1000000000000000000"));
-      await giveUserCLNYTokens(OTHER_ACCOUNT, new BN("1000000000000000000"));
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, new BN("1000000000000000000"));
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -311,7 +272,7 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow someone to submit a new reputation hash if they are ineligible", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
@@ -323,9 +284,9 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should punish all stakers if they misbehave (and report a bad hash)", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(OTHER_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(accounts[2], "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, accounts[2], "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -352,9 +313,9 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should reward all stakers if they submitted the agreed new hash", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(OTHER_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(accounts[2], "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, accounts[2], "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -396,7 +357,7 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow a user to back more than one hash in a single cycle", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
@@ -410,7 +371,7 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow a user to back the same hash with different number of nodes in a single cycle", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
@@ -425,7 +386,7 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow a user to submit the same entry for the same hash twice in a single cycle", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
@@ -439,7 +400,7 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should allow a user to back the same hash more than once in a same cycle with different entries, and be rewarded", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
@@ -478,7 +439,7 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should only allow 12 entries to back a single hash in each cycle", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
@@ -503,7 +464,7 @@ contract("ColonyNetworkStaking", accounts => {
     it("should cope with many hashes being submitted and eliminated before a winner is assigned", async () => {
       // TODO: This test probably needs to be written more carefully to make sure all possible edge cases are dealt with
       for (let i = 0; i < accounts.length; i += 1) {
-        await giveUserCLNYTokens(accounts[i], "1000000000000000000"); // eslint-disable-line no-await-in-loop
+        await testDataGenerator.giveUserCLNYTokens(colonyNetwork, accounts[i], "1000000000000000000"); // eslint-disable-line no-await-in-loop
         // These have to be done sequentially because this function uses the total number of tasks as a proxy for getting the
         // right taskId, so if they're all created at once it messes up.
       }
@@ -542,7 +503,7 @@ contract("ColonyNetworkStaking", accounts => {
       assert(accounts.length >= 8, "Not enough accounts for test to run");
       const accountsForTest = accounts.slice(0, 8);
       for (let i = 0; i < 8; i += 1) {
-        await giveUserCLNYTokens(accountsForTest[i], "1000000000000000000"); // eslint-disable-line no-await-in-loop
+        await testDataGenerator.giveUserCLNYTokens(colonyNetwork, accountsForTest[i], "1000000000000000000"); // eslint-disable-line no-await-in-loop
         // These have to be done sequentially because this function uses the total number of tasks as a proxy for getting the
         // right taskId, so if they're all created at once it messes up.
       }
@@ -566,8 +527,8 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow a hash to be invalidated multiple times, which would move extra copies of its opponent to the next stage", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(OTHER_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -584,9 +545,9 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should invalidate a hash and its partner if both have timed out", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(OTHER_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(accounts[2], "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, accounts[2], "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -608,8 +569,8 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should prevent invalidation of hashes before they have timed out on a challenge", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(OTHER_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -628,8 +589,8 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should prevent submission of hashes with an invalid entry for the balance of a user", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(OTHER_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -644,7 +605,7 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should prevent submission of hashes with a valid entry, but invalid hash for the current time", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -670,8 +631,8 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should allow submitted hashes to go through multiple responses to a challenge", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(OTHER_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -692,8 +653,8 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should only allow the last hash standing to be confirmed", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(OTHER_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000", { from: OTHER_ACCOUNT });
@@ -709,9 +670,9 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should fail if one tries to invalidate a hash that does not exist", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(OTHER_ACCOUNT, "1000000000000000000");
-      await giveUserCLNYTokens(accounts[2], "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, accounts[2], "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -736,7 +697,7 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should keep reputation updates that occur during one update window for the next window", async () => {
-      await giveUserCLNYTokens(MAIN_ACCOUNT, "1000000000000000000");
+      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
       const addr = await colonyNetwork.getReputationMiningCycle.call();

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -49,12 +49,13 @@ contract("Colony Task Work Rating", () => {
 
   describe("when rating task work", () => {
     it("should allow rating, before the due date but after the work has been submitted", async () => {
-      const dueDate = testHelper.currentBlockTime() + SECONDS_PER_DAY * 7;
+      let dueDate = await testHelper.currentBlockTime();
+      dueDate += SECONDS_PER_DAY * 7;
       const taskId = await testDataGenerator.setupAssignedTask(colonyNetwork, colony, dueDate);
       await colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH, { from: WORKER });
 
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
-      const currentTime1 = testHelper.currentBlockTime();
+      const currentTime1 = await testHelper.currentBlockTime();
       const rating1 = await colony.getTaskWorkRatings.call(taskId);
       assert.equal(rating1[0], 1);
       assert.closeTo(rating1[1].toNumber(), currentTime1, 2);
@@ -62,7 +63,7 @@ contract("Colony Task Work Rating", () => {
       assert.equal(ratingSecret1, RATING_2_SECRET);
 
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
-      const currentTime2 = testHelper.currentBlockTime();
+      const currentTime2 = await testHelper.currentBlockTime();
       const rating2 = await colony.getTaskWorkRatings.call(taskId);
       assert.equal(rating2[0].toNumber(), 2);
       assert.closeTo(rating2[1].toNumber(), currentTime2, 2);
@@ -82,7 +83,8 @@ contract("Colony Task Work Rating", () => {
     });
 
     it("should fail if I try to rate before task's due date has passed and work has not been submitted", async () => {
-      const dueDate = testHelper.currentBlockTime() + SECONDS_PER_DAY * 7;
+      let dueDate = await testHelper.currentBlockTime();
+      dueDate += SECONDS_PER_DAY * 7;
       const taskId = await testDataGenerator.setupAssignedTask(colonyNetwork, colony, dueDate);
       await testHelper.checkErrorRevert(colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR }));
       const ratingSecrets = await colony.getTaskWorkRatings.call(taskId);
@@ -144,7 +146,8 @@ contract("Colony Task Work Rating", () => {
     });
 
     it("should allow revealing a rating from the evaluator after the 5 days wait for rating commits expires", async () => {
-      const dueDate = testHelper.currentBlockTime() + SECONDS_PER_DAY * 8;
+      let dueDate = await testHelper.currentBlockTime();
+      dueDate += SECONDS_PER_DAY * 8;
       const taskId = await testDataGenerator.setupAssignedTask(colonyNetwork, colony, dueDate);
       await colony.submitTaskDeliverable(1, DELIVERABLE_HASH, { from: WORKER });
       await colony.submitTaskWorkRating(1, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -116,7 +116,6 @@ contract("Colony Task Work Rating", () => {
 
     it("should fail if I try to rate a task too late", async () => {
       const taskId = await testDataGenerator.setupAssignedTask(colonyNetwork, colony);
-
       await testHelper.forwardTime(SECONDS_PER_DAY * 5 + 1, this);
       await testHelper.checkErrorRevert(colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR }));
       const ratingSecrets = await colony.getTaskWorkRatings.call(taskId);
@@ -125,7 +124,6 @@ contract("Colony Task Work Rating", () => {
 
     it("should fail if I try to submit work for a task using an invalid id", async () => {
       const taskId = await testDataGenerator.setupAssignedTask(colonyNetwork, colony);
-
       await testHelper.checkErrorRevert(colony.submitTaskWorkRating(10, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR }));
       const ratingSecrets = await colony.getTaskWorkRatings.call(taskId);
       assert.equal(ratingSecrets[0], 0);

--- a/test/colony.js
+++ b/test/colony.js
@@ -190,7 +190,7 @@ contract("Colony", () => {
     });
 
     it("should allow manager to submit an update of task due date and worker to approve it", async () => {
-      const dueDate = testHelper.currentBlockTime();
+      const dueDate = await testHelper.currentBlockTime();
 
       await colony.makeTask(SPECIFICATION_HASH, 1);
       await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
@@ -291,13 +291,14 @@ contract("Colony", () => {
 
   describe("when submitting task deliverable", () => {
     it("should update task", async () => {
-      const dueDate = testHelper.currentBlockTime() + SECONDS_PER_DAY * 4;
+      let dueDate = await testHelper.currentBlockTime();
+      dueDate += SECONDS_PER_DAY * 4;
       await testDataGenerator.setupAssignedTask(colonyNetwork, colony, dueDate);
 
       let task = await colony.getTask.call(1);
       assert.equal(testHelper.hexToUtf8(task[1]), "");
 
-      const currentTime = testHelper.currentBlockTime();
+      const currentTime = await testHelper.currentBlockTime();
       await colony.submitTaskDeliverable(1, DELIVERABLE_HASH, { from: WORKER });
       task = await colony.getTask.call(1);
       assert.equal(testHelper.hexToUtf8(task[1]), DELIVERABLE_HASH);
@@ -322,7 +323,8 @@ contract("Colony", () => {
     });
 
     it("should fail if I try to submit work twice", async () => {
-      const dueDate = testHelper.currentBlockTime() + SECONDS_PER_DAY * 4;
+      let dueDate = await testHelper.currentBlockTime();
+      dueDate += SECONDS_PER_DAY * 4;
       await testDataGenerator.setupAssignedTask(colonyNetwork, colony, dueDate);
       await colony.submitTaskDeliverable(1, DELIVERABLE_HASH, { from: WORKER });
 
@@ -332,7 +334,8 @@ contract("Colony", () => {
     });
 
     it("should fail if I try to submit work if I'm not the assigned worker", async () => {
-      const dueDate = testHelper.currentBlockTime() + SECONDS_PER_DAY * 4;
+      let dueDate = await testHelper.currentBlockTime();
+      dueDate += SECONDS_PER_DAY * 4;
       await testDataGenerator.setupAssignedTask(colonyNetwork, colony, dueDate);
 
       await testHelper.checkErrorRevert(colony.submitTaskDeliverable(1, SPECIFICATION_HASH, { from: OTHER }));

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -55,7 +55,7 @@ contract("Colony Reputation Updates", () => {
     it("should be readable", async () => {
       const taskId = await testDataGenerator.setupRatedTask(colonyNetwork, commonColony);
       await commonColony.finalizeTask(taskId);
-      const repLogEntryManager = await colonyNetwork.getReputationUpdateLogEntry.call(0);
+      const repLogEntryManager = await colonyNetwork.getReputationUpdateLogEntry.call(0, true);
       assert.equal(repLogEntryManager[0], MANAGER);
       assert.equal(repLogEntryManager[1].toNumber(), 1000 * 1e18 / 50);
       assert.equal(repLogEntryManager[2].toNumber(), 1);
@@ -63,7 +63,7 @@ contract("Colony Reputation Updates", () => {
       assert.equal(repLogEntryManager[4].toNumber(), 2);
       assert.equal(repLogEntryManager[5].toNumber(), 0);
 
-      const repLogEntryEvaluator = await colonyNetwork.getReputationUpdateLogEntry.call(1);
+      const repLogEntryEvaluator = await colonyNetwork.getReputationUpdateLogEntry.call(1, true);
       assert.equal(repLogEntryEvaluator[0], EVALUATOR);
       assert.equal(repLogEntryEvaluator[1].toNumber(), 50 * 1e18);
       assert.equal(repLogEntryEvaluator[2].toNumber(), 1);
@@ -71,7 +71,7 @@ contract("Colony Reputation Updates", () => {
       assert.equal(repLogEntryEvaluator[4].toNumber(), 2);
       assert.equal(repLogEntryEvaluator[5].toNumber(), 2);
 
-      const repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(2);
+      const repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(2, true);
       assert.equal(repLogEntryWorker[0], WORKER);
       assert.equal(repLogEntryWorker[1].toNumber(), 200 * 1e18);
       assert.equal(repLogEntryWorker[2].toNumber(), 1);
@@ -158,7 +158,7 @@ contract("Colony Reputation Updates", () => {
         );
         await commonColony.finalizeTask(taskId);
 
-        const repLogEntryManager = await colonyNetwork.getReputationUpdateLogEntry.call(0);
+        const repLogEntryManager = await colonyNetwork.getReputationUpdateLogEntry.call(0, true);
         assert.equal(repLogEntryManager[0], MANAGER);
         assert.equal(repLogEntryManager[1].toString(), rating.reputationChangeManager.toString());
         assert.equal(repLogEntryManager[2].toNumber(), 1);
@@ -166,7 +166,7 @@ contract("Colony Reputation Updates", () => {
         assert.equal(repLogEntryManager[4].toNumber(), 2);
         assert.equal(repLogEntryManager[5].toNumber(), 0);
 
-        const repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(2);
+        const repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(2, true);
         assert.equal(repLogEntryWorker[0], WORKER);
         assert.equal(repLogEntryWorker[1].toString(), rating.reputationChangeWorker.toString());
         assert.equal(repLogEntryWorker[2].toNumber(), 1);
@@ -177,25 +177,25 @@ contract("Colony Reputation Updates", () => {
     });
 
     it("should not be able to be appended by an account that is not a colony", async () => {
-      const lengthBefore = await colonyNetwork.getReputationUpdateLogLength.call();
+      const lengthBefore = await colonyNetwork.getReputationUpdateLogLength.call(true);
       await testHelper.checkErrorRevert(colonyNetwork.appendReputationUpdateLog(OTHER, 1, 2));
-      const lengthAfter = await colonyNetwork.getReputationUpdateLogLength.call();
+      const lengthAfter = await colonyNetwork.getReputationUpdateLogLength.call(true);
       assert.equal(lengthBefore.toNumber(), lengthAfter.toNumber());
     });
 
     it("should populate nPreviousUpdates correctly", async () => {
-      let initialRepLogLength = await colonyNetwork.getReputationUpdateLogLength.call();
+      let initialRepLogLength = await colonyNetwork.getReputationUpdateLogLength.call(true);
       initialRepLogLength = initialRepLogLength.toNumber();
       const taskId1 = await testDataGenerator.setupRatedTask(colonyNetwork, commonColony);
       await commonColony.finalizeTask(taskId1);
-      let repLogEntry = await colonyNetwork.getReputationUpdateLogEntry.call(initialRepLogLength);
+      let repLogEntry = await colonyNetwork.getReputationUpdateLogEntry.call(initialRepLogLength, true);
       const nPrevious = repLogEntry[5].toNumber();
-      repLogEntry = await colonyNetwork.getReputationUpdateLogEntry.call(initialRepLogLength + 1);
+      repLogEntry = await colonyNetwork.getReputationUpdateLogEntry.call(initialRepLogLength + 1, true);
       assert.equal(repLogEntry[5].toNumber(), 2 + nPrevious);
 
       const taskId2 = await testDataGenerator.setupRatedTask(colonyNetwork, commonColony);
       await commonColony.finalizeTask(taskId2);
-      repLogEntry = await colonyNetwork.getReputationUpdateLogEntry.call(initialRepLogLength + 2);
+      repLogEntry = await colonyNetwork.getReputationUpdateLogEntry.call(initialRepLogLength + 2, true);
       assert.equal(repLogEntry[5].toNumber(), 4 + nPrevious);
     });
 
@@ -207,14 +207,14 @@ contract("Colony Reputation Updates", () => {
       const taskId1 = await testDataGenerator.setupRatedTask(colonyNetwork, commonColony, undefined, undefined, undefined, 4);
       await commonColony.finalizeTask(taskId1);
 
-      let repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(2);
+      let repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(2, true);
       const result = web3Utils.toBN("1").mul(WORKER_PAYOUT);
       assert.equal(repLogEntryWorker[1].toString(), result.toString());
       assert.equal(repLogEntryWorker[4].toNumber(), 6);
 
       const taskId2 = await testDataGenerator.setupRatedTask(colonyNetwork, commonColony, undefined, undefined, undefined, 5);
       await commonColony.finalizeTask(taskId2);
-      repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(6);
+      repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(6, true);
       assert.equal(repLogEntryWorker[1].toString(), result.toString());
       assert.equal(repLogEntryWorker[4].toNumber(), 8); // Negative reputation change means children change as well.
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,7 +104,7 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0, ajv@^5.1.1, ajv@^5.1.5, ajv@^5.2.2, ajv@^5.2.3, ajv@^5.3.0:
+ajv@^5.1.0, ajv@^5.1.5, ajv@^5.2.2, ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -267,7 +267,7 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-cli@*, babel-cli@^6.26.0:
+babel-cli@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.26.0.tgz#502ab54874d7db88ad00b887a06383ce03d002f1"
   dependencies:
@@ -751,7 +751,7 @@ babel-polyfill@^6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-preset-es2015@*, babel-preset-es2015@^6.24.1:
+babel-preset-es2015@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
   dependencies:
@@ -799,7 +799,7 @@ babel-preset-stage-3@^6.24.1:
     babel-plugin-transform-exponentiation-operator "^6.24.1"
     babel-plugin-transform-object-rest-spread "^6.22.0"
 
-babel-register@*, babel-register@^6.26.0:
+babel-register@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
   dependencies:
@@ -880,14 +880,6 @@ big.js@^3.1.3:
 "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2":
   version "2.0.7"
   resolved "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-
-"bignumber.js@git+https://github.com/debris/bignumber.js.git#master":
-  version "2.0.7"
-  resolved "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-
-"bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git":
-  version "2.0.7"
-  resolved "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
 
 binary-extensions@^1.0.0:
   version "1.11.0"
@@ -1369,10 +1361,6 @@ crypto-js@^3.1.4:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.8.tgz#715f070bf6014f2ae992a98b3929258b713f08d5"
 
-crypto-js@^3.1.9-1:
-  version "3.1.9-1"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
-
 d@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
@@ -1399,13 +1387,13 @@ debug@2.2.0:
   dependencies:
     ms "0.7.1"
 
-debug@2.6.8, debug@^2.2.0, debug@^2.6.8:
+debug@2.6.8, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
     ms "2.0.0"
 
-debug@2.6.9, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -1850,14 +1838,6 @@ ethereumjs-testrpc-sc@6.0.7:
   resolved "https://registry.yarnpkg.com/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz#580a5b4dfb00d27fa6f4f9126aca56e0c722b2bf"
   dependencies:
     webpack "^3.0.0"
-
-ethjs-abi@0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/ethjs-abi/-/ethjs-abi-0.1.8.tgz#cd288583ed628cdfadaf8adefa3ba1dbcbca6c18"
-  dependencies:
-    bn.js "4.11.6"
-    js-sha3 "0.5.5"
-    number-to-bn "1.7.0"
 
 ethjs-unit@0.1.6:
   version "0.1.6"
@@ -2677,10 +2657,6 @@ jest-docblock@^21.0.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
 
-js-sha3@0.5.5:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.5.tgz#baf0c0e8c54ad5903447df96ade7a4a1bca79a4a"
-
 js-sha3@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.3.1.tgz#86122802142f0828502a0d1dee1d95e253bb0243"
@@ -2799,10 +2775,6 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
-
-left-pad@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.2.0.tgz#d30a73c6b8201d8f7d8e7956ba9616087a68e0ee"
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -4125,16 +4097,6 @@ solidity-parser-sc@0.4.4:
     pegjs "^0.10.0"
     yargs "^4.6.0"
 
-solidity-sha3@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/solidity-sha3/-/solidity-sha3-0.4.1.tgz#17577e93f6cfd58489c4ec7f2da3047530329ec1"
-  dependencies:
-    babel-cli "*"
-    babel-preset-es2015 "*"
-    babel-register "*"
-    left-pad "^1.1.1"
-    web3 "^0.16.0"
-
 solium-plugin-security@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/solium-plugin-security/-/solium-plugin-security-0.1.1.tgz#2a87bcf8f8c3abf7d198e292e4ac080284e3f3f6"
@@ -4434,33 +4396,6 @@ trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
 
-truffle-blockchain-utils@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.3.tgz#ae8a111ec124d96504f0e042c6f205c0b3817e29"
-  dependencies:
-    web3 "^0.20.1"
-
-truffle-contract-schema@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/truffle-contract-schema/-/truffle-contract-schema-1.0.1.tgz#08ceaefe71062a8ac9ab881a77a30fda3744176e"
-  dependencies:
-    ajv "^5.1.1"
-    crypto-js "^3.1.9-1"
-
-truffle-contract@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/truffle-contract/-/truffle-contract-3.0.3.tgz#b14fb318f9a743db8b061046e24978d91f31dbfb"
-  dependencies:
-    ethjs-abi "0.1.8"
-    truffle-blockchain-utils "^0.0.3"
-    truffle-contract-schema "^1.0.0"
-    truffle-error "0.0.2"
-    web3 "^0.20.1"
-
-truffle-error@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/truffle-error/-/truffle-error-0.0.2.tgz#01b189b78505566ae1689c239c7ca2dd121cfe4c"
-
 truffle@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/truffle/-/truffle-4.0.6.tgz#04a23b4c75336f325804d262317f901dbab4f729"
@@ -4629,30 +4564,11 @@ web3-utils@^1.0.0-beta.29:
     underscore "1.8.3"
     utf8 "2.1.1"
 
-web3@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/web3/-/web3-0.16.0.tgz#a4554175cd462943035b1f1d39432f741c6b6019"
-  dependencies:
-    bignumber.js "git+https://github.com/debris/bignumber.js#master"
-    crypto-js "^3.1.4"
-    utf8 "^2.1.1"
-    xmlhttprequest "*"
-
 web3@^0.18.4:
   version "0.18.4"
   resolved "https://registry.yarnpkg.com/web3/-/web3-0.18.4.tgz#81ec1784145491f2eaa8955b31c06049e07c5e7d"
   dependencies:
     bignumber.js "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-    crypto-js "^3.1.4"
-    utf8 "^2.1.1"
-    xhr2 "*"
-    xmlhttprequest "*"
-
-web3@^0.20.1:
-  version "0.20.4"
-  resolved "https://registry.yarnpkg.com/web3/-/web3-0.20.4.tgz#400e6579a65bb4a3dde71a6ebf6509afadc33a04"
-  dependencies:
-    bignumber.js "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
     crypto-js "^3.1.4"
     utf8 "^2.1.1"
     xhr2 "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,11 +58,7 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@colony/eslint-config-colony/-/eslint-config-colony-4.0.1.tgz#74495655bf461ef196edc262983c471b42cf2d75"
 
-abbrev@1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
-
-abbrev@1.0.x:
+abbrev@1, abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
@@ -108,7 +104,7 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0, ajv@^5.1.5, ajv@^5.2.2, ajv@^5.2.3, ajv@^5.3.0:
+ajv@^5.1.0, ajv@^5.1.1, ajv@^5.1.5, ajv@^5.2.2, ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -271,7 +267,7 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-cli@^6.26.0:
+babel-cli@*, babel-cli@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.26.0.tgz#502ab54874d7db88ad00b887a06383ce03d002f1"
   dependencies:
@@ -755,7 +751,7 @@ babel-polyfill@^6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-preset-es2015@^6.24.1:
+babel-preset-es2015@*, babel-preset-es2015@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
   dependencies:
@@ -803,7 +799,7 @@ babel-preset-stage-3@^6.24.1:
     babel-plugin-transform-exponentiation-operator "^6.24.1"
     babel-plugin-transform-object-rest-spread "^6.22.0"
 
-babel-register@^6.26.0:
+babel-register@*, babel-register@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
   dependencies:
@@ -885,6 +881,14 @@ big.js@^3.1.3:
   version "2.0.7"
   resolved "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
 
+"bignumber.js@git+https://github.com/debris/bignumber.js.git#master":
+  version "2.0.7"
+  resolved "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+
+"bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git":
+  version "2.0.7"
+  resolved "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+
 binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
@@ -937,8 +941,8 @@ boom@5.x.x:
     hoek "4.x.x"
 
 brace-expansion@^1.1.7:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.9.tgz#acdc7dde0e939fb3b32fe933336573e2a7dc2b7c"
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -1226,8 +1230,8 @@ commander@2.9.0:
     graceful-readlink ">= 1.0.0"
 
 commander@^2.11.0, commander@^2.9.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1365,6 +1369,10 @@ crypto-js@^3.1.4:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.8.tgz#715f070bf6014f2ae992a98b3929258b713f08d5"
 
+crypto-js@^3.1.9-1:
+  version "3.1.9-1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
+
 d@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
@@ -1391,13 +1399,13 @@ debug@2.2.0:
   dependencies:
     ms "0.7.1"
 
-debug@2.6.8:
+debug@2.6.8, debug@^2.2.0, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
     ms "2.0.0"
 
-debug@2.6.9, debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -1697,8 +1705,8 @@ eslint-module-utils@^2.1.1:
     pkg-dir "^1.0.0"
 
 eslint-plugin-flowtype@^2.42.0:
-  version "2.42.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.42.0.tgz#7fcc98df4ed9482a22ac10ba4ca48d649c4c733a"
+  version "2.43.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.43.0.tgz#47cdac5f01cda53f1c3e8477f0c83fee66a1606e"
   dependencies:
     lodash "^4.15.0"
 
@@ -1843,6 +1851,14 @@ ethereumjs-testrpc-sc@6.0.7:
   dependencies:
     webpack "^3.0.0"
 
+ethjs-abi@0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/ethjs-abi/-/ethjs-abi-0.1.8.tgz#cd288583ed628cdfadaf8adefa3ba1dbcbca6c18"
+  dependencies:
+    bn.js "4.11.6"
+    js-sha3 "0.5.5"
+    number-to-bn "1.7.0"
+
 ethjs-unit@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-unit/-/ethjs-unit-0.1.6.tgz#c665921e476e87bce2a9d588a6fe0405b2c41699"
@@ -1945,13 +1961,9 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
-extsprintf@1.3.0:
+extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-
-extsprintf@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
 fast-deep-equal@^1.0.0:
   version "1.0.0"
@@ -2128,12 +2140,11 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-ganache-cli@^6.1.0-beta.0:
-  version "6.1.0-beta.0"
-  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.1.0-beta.0.tgz#0d112fe36af84031b5f638d1d7300393996c3e25"
+ganache-cli@6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.0.3.tgz#8b9da149707daa29c69da26f0582b89c90113b9c"
   dependencies:
-    source-map-support "^0.5.0"
-    webpack "^3.10.0"
+    webpack "^3.0.0"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -2666,6 +2677,10 @@ jest-docblock@^21.0.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
 
+js-sha3@0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.5.tgz#baf0c0e8c54ad5903447df96ade7a4a1bca79a4a"
+
 js-sha3@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.3.1.tgz#86122802142f0828502a0d1dee1d95e253bb0243"
@@ -2784,6 +2799,10 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
+
+left-pad@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.2.0.tgz#d30a73c6b8201d8f7d8e7956ba9616087a68e0ee"
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -3028,17 +3047,13 @@ minimatch@0.3:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@0.3.0:
   version "0.3.0"
@@ -4110,6 +4125,16 @@ solidity-parser-sc@0.4.4:
     pegjs "^0.10.0"
     yargs "^4.6.0"
 
+solidity-sha3@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/solidity-sha3/-/solidity-sha3-0.4.1.tgz#17577e93f6cfd58489c4ec7f2da3047530329ec1"
+  dependencies:
+    babel-cli "*"
+    babel-preset-es2015 "*"
+    babel-register "*"
+    left-pad "^1.1.1"
+    web3 "^0.16.0"
+
 solium-plugin-security@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/solium-plugin-security/-/solium-plugin-security-0.1.1.tgz#2a87bcf8f8c3abf7d198e292e4ac080284e3f3f6"
@@ -4148,12 +4173,6 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.0:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.3.tgz#2b3d5fff298cfa4d1afd7d4352d569e9a0158e76"
-  dependencies:
-    source-map "^0.6.0"
-
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -4164,15 +4183,15 @@ source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.6.0, source-map@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-
 source-map@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
   dependencies:
     amdefine ">=0.0.4"
+
+source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spawn-sync@^1.0.15:
   version "1.0.15"
@@ -4213,11 +4232,7 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-"statuses@>= 1.3.1 < 2":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
-
-statuses@~1.3.1:
+"statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 
@@ -4313,7 +4328,7 @@ supports-color@3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@4.4.0:
+supports-color@4.4.0, supports-color@^4.0.0, supports-color@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
   dependencies:
@@ -4328,12 +4343,6 @@ supports-color@^3.1.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
-
-supports-color@^4.0.0, supports-color@^4.2.1:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
-  dependencies:
-    has-flag "^2.0.0"
 
 table@^4.0.1:
   version "4.0.2"
@@ -4424,6 +4433,33 @@ trim-right@^1.0.1:
 trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+
+truffle-blockchain-utils@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.3.tgz#ae8a111ec124d96504f0e042c6f205c0b3817e29"
+  dependencies:
+    web3 "^0.20.1"
+
+truffle-contract-schema@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/truffle-contract-schema/-/truffle-contract-schema-1.0.1.tgz#08ceaefe71062a8ac9ab881a77a30fda3744176e"
+  dependencies:
+    ajv "^5.1.1"
+    crypto-js "^3.1.9-1"
+
+truffle-contract@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/truffle-contract/-/truffle-contract-3.0.3.tgz#b14fb318f9a743db8b061046e24978d91f31dbfb"
+  dependencies:
+    ethjs-abi "0.1.8"
+    truffle-blockchain-utils "^0.0.3"
+    truffle-contract-schema "^1.0.0"
+    truffle-error "0.0.2"
+    web3 "^0.20.1"
+
+truffle-error@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/truffle-error/-/truffle-error-0.0.2.tgz#01b189b78505566ae1689c239c7ca2dd121cfe4c"
 
 truffle@^4.0.6:
   version "4.0.6"
@@ -4520,13 +4556,9 @@ user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
 
-utf8@2.1.1:
+utf8@2.1.1, utf8@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/utf8/-/utf8-2.1.1.tgz#2e01db02f7d8d0944f77104f1609eb0c304cf768"
-
-utf8@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/utf8/-/utf8-2.1.2.tgz#1fa0d9270e9be850d9b05027f63519bf46457d96"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -4597,11 +4629,30 @@ web3-utils@^1.0.0-beta.29:
     underscore "1.8.3"
     utf8 "2.1.1"
 
+web3@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/web3/-/web3-0.16.0.tgz#a4554175cd462943035b1f1d39432f741c6b6019"
+  dependencies:
+    bignumber.js "git+https://github.com/debris/bignumber.js#master"
+    crypto-js "^3.1.4"
+    utf8 "^2.1.1"
+    xmlhttprequest "*"
+
 web3@^0.18.4:
   version "0.18.4"
   resolved "https://registry.yarnpkg.com/web3/-/web3-0.18.4.tgz#81ec1784145491f2eaa8955b31c06049e07c5e7d"
   dependencies:
     bignumber.js "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+    crypto-js "^3.1.4"
+    utf8 "^2.1.1"
+    xhr2 "*"
+    xmlhttprequest "*"
+
+web3@^0.20.1:
+  version "0.20.4"
+  resolved "https://registry.yarnpkg.com/web3/-/web3-0.20.4.tgz#400e6579a65bb4a3dde71a6ebf6509afadc33a04"
+  dependencies:
+    bignumber.js "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
     crypto-js "^3.1.4"
     utf8 "^2.1.1"
     xhr2 "*"
@@ -4614,7 +4665,7 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^3.0.0, webpack@^3.10.0:
+webpack@^3.0.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.10.0.tgz#5291b875078cf2abf42bdd23afe3f8f96c17d725"
   dependencies:
@@ -4649,15 +4700,9 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@1.2.x:
+which@1.2.x, which@^1.1.1, which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
-  dependencies:
-    isexe "^2.0.0"
-
-which@^1.1.1, which@^1.2.9:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #56. The functionality removed from #56 can be found in #164. 

Adds the skeleton for #49 and #50 - currently dispute resolution is mocked by a simple function call `invalidateHash`.
* Implements everything, I think, from #47, save for
>  Miners will also be required to have staked their tokens for a few update cycles before they are eligible to submit or support a hash.
* Reimplements some of #43 (see below)

<!--- Summary of changes including design decisions -->

This PR introduces the concept of staking colony tokens, which then allows their owners to take part in the reputation mining process. I include a skeleton of the dispute process, though the disputes are not actually validated - as mentioned, a call to `invalidateHash` is used to 'time out' an opponent.

The first change to existing functionality is that there are now two reputation update logs. Only one of these is active at a time, where the active reputation log is appended to if new tasks are completed or reputation will need to change for any reason. When a new reputation mining cycle begins, this reputation log is frozen so that it is not a 'moving target' for the reputation miners, and the other reputation log is cleared from the previous reputation mining cycle and is set to active. All functions that interact with the reputation logs directly have a `activeLog` parameter, that determines whether the active log is to be read from or the inactive log is to be read from. Any functions that wrote to the reputation update log always write to the active log. 

The new storage variables introduced to ColonyNetwork are
```
uint256 activeReputationUpdateLog; // Tracks whether updateLog 0 or 1 is the active log
bytes32 reputationRootHash; // The reputation root hash of the reputation state tree accepted at the end of the last completed update cycle
mapping (address => uint) stakedBalances; // Mapping containing how much hash been staked by each user
address reputationMiningCycle; // Address of the currently active reputation mining cycle contract
uint256 reputationRootHashNNodes; // The number of nodes in the reputation state tree that was accepted at the end of the last mining cycle
```

The new functionality for the `ColonyNetwork` contract is implemented in `ColonyNetworkStaking.sol`. Note that this also contains a *separate* contract, called `ReputationMiningCycle`. A new instance of this is deployed at the start of each mining cycle by the `ColonyNetwork` contract. This was primarily motivated for gas cost reasons; we do not need to keep the history of all the reputation mining cycles, and so by having this in a separate contract we can `selfdestruct` at the end of each mining cycle to cleanly free all the storage that has been used. 

Miners interact with the `ReputationMiningCycle` contract to submit their own hashes or object to others. A submission takes the form of a hash and the number of nodes the tree that the hash is the root of contains. The contract then adds a `lastResponseTimestamp` and a `challengeStepCompleted` property to make the `Submission` struct. In the below explanation, S_n represents the n*th* submission.

If only one submission is made, S0, then when the submission window expires `confirmNewHash(0)` can be called by any user to set the `ReputationRootHash` property on `ColonyNetwork` to S0.hash, similarly set `ReputationRootHashNNodes`, reward the users that backed that hash with newly minted tokens and reputation (though strictly they will only have their reputation included in the next cycle), deploy a new instance of `ReputationMiningCycle` and destroy the current one. 

Note that the parameter passed to `confirmNewHash` is *not* the index of the submission, but the index of the dispute round that resulted in one hash being left standing. In the case of one submission, it is the first dispute round. Dispute rounds only matter when multiple hashes are submitted, and a worked example is show below.

In the case of multiple hashes being submitted, hashes are paired off against each other. A future PR will introduce challenges involving merkle proofs, but for now `respondToChallenge` is used, which just assumes that a challenge has been passed. For a hash that has not passed its challenge in time, `invalidateHash` is used, which will pass that hash's opponent on to the next round.

Consider five submissions have been made, and `disputeRounds` looks like
```
0: [S0, S1, S2, S3, S4]
```
`S0` will face off against `S1`, `S2` v `S3`. `S4` has no opponent, and so someone (likely someone who submitted `S4`) can call `invalidateHash(5)` to get a 'bye' to the next round. `disputeRounds` now looks like
```
0: [S0, S1, S2, S3, ]
1: [S4]
```
Let's now say that S1 fails a challenge. S0 passes to the next round
```
0: [, S1, S2, S3, ]
1: [S4, S0]
```
Part of the `invalidateHash` call notes that there is now a pairing of `S4` vs `S0` that must be sorted. Their timeout starts immediately, even though `S2` vs `S3` in round 0 hasn't yet resolved. We don't need to wait for them. `S0` fails this challenge.

```
0: [, S1, S2, S3, ]
1: [, S0]
2: [S4]
```
From this point, let's consider two possibilities. Firstly, the case where `S2` and `S3` time out, which increases the `nInvalidatedHashes` counter by two. As this is now one less than `nSubmittedHashes`, we can call `confirmHash(2)` in order to confirm S4 as the new reputation hash.

If instead, `S3` fails, but `S2` passes, we move to 
```
0: [, S1, , S3 , ]
1: [, S0, S2]
2: [S4]
```
S0, S1 and S3 already failed challenges, and `S2` isn't going to get another opponent in round 1. `invalideHash(1, 3)` passes `S2` on to the next round.

```
0: [, S1, , S3 , ]
1: [, S0, ]
2: [S4, S2]
```
`S4` and `S2` face off, with `S2` timing out. `S4` moves on to round 3, and `confirmHash(3)` can now be called to end this reputation cycle and start the next.

This all assumes that one hash submitted is correct that can always pass an on-chain challenge i.e. there is one honest miner. 

**Non-functional changes**

Web3.js 1.0 is removing support for synchronous calls, and for a while with the mining client (not in this PR) I was trying to use web3.js 1.0, which is used by the new ganache beta. `testHelper.currentBlockTime()` was the only sync call that we had, so I've turned it in to an async call and `await`ed where appropriate. 

**Issues**

There are a lot of TODOs floating around, but a big one is that the hash submission window never closes here, which is a problem, and requires that
```
    // TODO Figure out how to uncomment the next line, but not break tests sporadically.
    // require((now-reputationMiningWindowOpenTimestamp) <= 3600);
```

be fixed while maintaining the deterministic nature of the tests. I am open to suggestions on that front!