### PR TITLE
Disable requiring flowtype annotations

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,9 +12,10 @@
   "rules": {
     "import/no-extraneous-dependencies": [2, {"devDependencies": ["**/*.js"]}],
     "max-len": [2, { "code": 150, "ignoreComments": true }],
-    "prettier/prettier": ["error", {"printWidth": 150}]
+    "prettier/prettier": ["error", {"printWidth": 150}],
+    "flowtype/require-valid-file-annotation": "off"
   },
   "parserOptions": {
-   "ecmaVersion": 2017
- }
+    "ecmaVersion": 2017
+  }
 }


### PR DESCRIPTION
We don't use flow, but we want to keep using eslint-config-colony.
So we're disabling it for all javascript files.

Builds weren't broken (this is only a warning), but disabling it stops everyone's client looking like this:

<img width="573" alt="screen shot 2018-02-19 at 10 02 43" src="https://user-images.githubusercontent.com/311812/36376177-0ee4a8b4-156a-11e8-88f5-394e2da6432b.png">
