### PR TITLE
Colony network run Token auctions

### DIFF
--- a/contracts/ColonyNetworkAuction.sol
+++ b/contracts/ColonyNetworkAuction.sol
@@ -1,0 +1,218 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity ^0.4.17;
+pragma experimental "v0.5.0";
+pragma experimental "ABIEncoderV2";
+
+import "../lib/dappsys/math.sol";
+import "./ColonyNetworkStorage.sol";
+import "./ERC20Extended.sol";
+import "./IColony.sol";
+
+
+contract ColonyNetworkAuction is ColonyNetworkStorage {
+  event AuctionCreated(address auction, address token, uint256 quantity);
+
+  function startTokenAuction(address _token) public {
+    address commonColony = _colonies["Common Colony"];
+    address clny = IColony(commonColony).getToken();
+    DutchAuction auction = new DutchAuction(clny, _token);
+    uint availableTokens = ERC20Extended(_token).balanceOf(this);
+    ERC20Extended(_token).transfer(auction, availableTokens);
+    AuctionCreated(address(auction), _token, availableTokens);
+  }
+}
+
+
+contract DutchAuction is DSMath {
+  address public colonyNetwork;
+  ERC20Extended public clnyToken;
+  ERC20Extended public token;
+
+  // Total number of auctioned tokens
+  uint public quantity;
+  bool public started;
+  uint public startTime;
+  uint public endTime;
+  uint public minPrice;
+  uint public constant TOKEN_MULTIPLIER = 10 ** 18;
+  
+  // Keep track of all CLNY wei received
+  uint public receivedTotal;
+  uint public bidCount;
+  uint public claimCount;
+
+  // Final price in CLNY per 10**18 Tokens (min 1, max 1e18)
+  uint public finalPrice;
+  bool public finalized;
+  
+  mapping (address => uint256) public bids;
+
+  modifier auctionNotStarted {
+    require(startTime == 0);
+    require(!started);
+    _;
+  }
+
+  modifier auctionStartedAndOpen {
+    require(started);
+    require(startTime > 0);
+    require(endTime == 0);
+    _;
+  }
+
+  modifier auctionClosed {
+    require(endTime > 0);
+    _;
+  }
+
+  modifier auctionNotFinalized() {
+    require(!finalized);
+    _;
+  }
+
+  modifier auctionFinalized {
+    require(finalized);
+    _;
+  } 
+
+  modifier allBidsClaimed  {
+    require(claimCount == bidCount);
+    _;
+  }
+
+  event AuctionBid(address indexed _sender, uint _amount, uint _missingFunds);
+  event AuctionClaim(address indexed _recipient, uint _sentAmount);
+  event AuctionFinalized(uint _finalPrice);
+
+  function DutchAuction(address _clnyToken, address _token) public {
+    colonyNetwork = msg.sender;
+    require(_clnyToken != 0x0 && _token != 0x0);
+    assert(_token != _clnyToken);
+    clnyToken = ERC20Extended(_clnyToken);
+    token = ERC20Extended(_token);
+  }
+
+  function start() public
+  auctionNotStarted
+  {
+    quantity = token.balanceOf(this);
+    assert(quantity > 0);
+
+    // Set the minimum price as such that it doesn't cause the finalPrice to be 0
+    minPrice = (quantity >= TOKEN_MULTIPLIER) ? 1 : TOKEN_MULTIPLIER / quantity;
+
+    startTime = now;
+    started = true;
+  }
+
+  function totalToEndAuction() public view 
+  auctionStartedAndOpen
+  returns (uint)
+  {
+    return mul(quantity, price()) / TOKEN_MULTIPLIER;
+  }
+
+  // Get the price in CLNY per 10**18 Tokens (min 1 max 1e36)
+  // Starting price is 10**36, after 1 day price is 10**35, after 2 days price is 10**34 and so on
+  function price() public view
+  auctionStartedAndOpen
+  returns (uint)
+  {
+    uint duration = sub(now, startTime);
+    uint daysOpen = duration / 86400;
+    uint r = duration % 86400;
+    uint p = mul(10**sub(36, daysOpen), sub(864000, mul(9,r))) / 864000;
+    p = p < minPrice ? minPrice : p;
+    return p;
+  }
+
+  function bid(uint256 _amount) public
+  auctionStartedAndOpen
+  {
+    require(_amount > 0);
+    uint _totalToEndAuction = totalToEndAuction();
+    uint remainingToEndAuction = sub(_totalToEndAuction, receivedTotal);
+
+    // Adjust the amount for final bid in case that takes us over the offered quantity at current price
+    // Also conditionally set the auction endTime
+    uint amount;
+    if (remainingToEndAuction > _amount) {
+      amount = _amount;
+    } else {
+      amount = remainingToEndAuction;
+      endTime = now;
+    }
+    
+    if (bids[msg.sender] == 0) {
+      bidCount += 1;
+    }
+
+    clnyToken.transferFrom(msg.sender, this, amount);
+    bids[msg.sender] = add(bids[msg.sender], amount);
+    receivedTotal = add(receivedTotal, amount);
+    
+    AuctionBid(msg.sender, amount, sub(remainingToEndAuction, amount));
+  }
+
+  // Finalize the auction and set the final Token price
+  function finalize() public
+  auctionClosed
+  auctionNotFinalized
+  {
+    // Give the network all CLNY sent to the auction in bids
+    clnyToken.transfer(colonyNetwork, receivedTotal);
+    finalPrice = add((mul(receivedTotal, TOKEN_MULTIPLIER) / quantity), 1);
+    finalized = true;
+    AuctionFinalized(finalPrice);
+  }
+
+  function claim() public 
+  auctionFinalized
+  returns (bool)
+  {
+    uint amount = bids[msg.sender];
+    require(amount > 0);
+
+    uint tokens = mul(amount, TOKEN_MULTIPLIER) / finalPrice;
+    claimCount += 1;
+    
+    // Set receiver bid to 0 before transferring the tokens
+    bids[msg.sender] = 0;
+    uint beforeClaimBalance = token.balanceOf(msg.sender);
+    require(token.transfer(msg.sender, tokens));
+    assert(token.balanceOf(msg.sender) == add(beforeClaimBalance, tokens));
+    assert(bids[msg.sender] == 0);
+
+    AuctionClaim(msg.sender, tokens);
+    return true;
+  }
+
+  function close() public
+  auctionFinalized
+  allBidsClaimed
+  {
+    // Transfer token remainder to the network
+    uint auctionTokenBalance = token.balanceOf(this);
+    token.transfer(colonyNetwork, auctionTokenBalance);
+    // Check this contract balances in the working tokens is 0 before we kill it
+    assert(clnyToken.balanceOf(this) == 0);
+    assert(token.balanceOf(this) == 0);
+    selfdestruct(colonyNetwork);
+  }
+}

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -49,15 +49,15 @@ contract ColonyStorage is DSAuth {
   ERC20Extended token;
   mapping (uint256 => Task) tasks;
 
-  // Pots can be tied to tasks or to (in the future) domains, so giving them their own mapping.
-  // Pot 1  can be thought of as the pot belonging to the colony itself that hasn't been assigned
+  // Pots can be tied to tasks or domains, so giving them their own mapping.
+  // Pot 1 can be thought of as the pot belonging to the colony itself that hasn't been assigned
   // to anything yet, but has had some siphoned off in to the reward pot.
-  // Pot 0 is the pot containing funds that can be paid to holders of colony tokens in the future.
+  // Pot 0 is the 'reward' pot containing funds that can be paid to holders of colony tokens in the future.
   mapping (uint256 => Pot) pots;
 
   // This keeps track of how much of the colony's funds that it owns have been moved into pots other than pot 0,
   // which (by definition) have also had the reward amount siphoned off and put in to pot 0.
-  // TODO: This needs to be decremented whenever a payout occurs and the colony loses control of the funds.
+  // This is decremented whenever a payout occurs and the colony loses control of the funds.
   mapping (address => uint256) nonRewardPotsTotal;
 
   mapping (uint256 => RatingSecrets) public taskWorkRatings;

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -199,7 +199,8 @@ contract ColonyTask is ColonyStorage, DSMath {
 
   function revealTaskWorkRating(uint256 _id, uint8 _role, uint8 _rating, bytes32 _salt) public
   taskWorkRatingRevealOpen(_id)
-  {
+  { 
+    // MAYBE: we should hash these the other way around, i.e. generateSecret(_rating, _salt)
     bytes32 ratingSecret = generateSecret(_salt, _rating);
     require(ratingSecret == taskWorkRatings[_id].secret[_role]);
 

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -23,6 +23,7 @@ pragma experimental "ABIEncoderV2";
 contract IColonyNetwork {
   event ColonyAdded(uint256 indexed id);
   event SkillAdded(uint256 skillId, uint256 parentSkillId);
+  event AuctionCreated(address auction, address token, uint256 quantity);
 
   function getColony(bytes32 key) public view returns (address);
   function getColonyCount() public view returns (uint256);
@@ -51,4 +52,5 @@ contract IColonyNetwork {
   function getReputationMiningCycle() public view returns (address);
   function getReputationRootHash() public view returns (bytes32);
   function getReputationRootHashNNodes() public view returns (uint256);
+  function startTokenAuction(address _token) public;
 }

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -59,6 +59,15 @@ export function web3GetFirstTransactionHashFromLastBlock() {
   });
 }
 
+export function web3GetCode(a) {
+  return new Promise((resolve, reject) => {
+    web3.eth.getCode(a, (err, res) => {
+      if (err !== null) return reject(err);
+      return resolve(res);
+    });
+  });
+}
+
 async function checkError(promise, isAssert) {
   // There is a discrepancy between how ganache-cli handles errors
   // (throwing an exception all the way up to these tests) and how geth/parity handle them
@@ -125,6 +134,18 @@ export function hexToUtf8(text) {
 export async function currentBlockTime() {
   const p = new Promise((resolve, reject) => {
     web3.eth.getBlock("latest", (err, res) => {
+      if (err) {
+        return reject(err);
+      }
+      return resolve(res.timestamp);
+    });
+  });
+  return p;
+}
+
+export async function getBlockTime(blockNumber) {
+  const p = new Promise((resolve, reject) => {
+    web3.eth.getBlock(blockNumber, (err, res) => {
       if (err) {
         return reject(err);
       }

--- a/helpers/upgradable-contracts.js
+++ b/helpers/upgradable-contracts.js
@@ -88,10 +88,11 @@ export async function setupColonyVersionResolver(colony, colonyTask, colonyFundi
   assert.equal(version, currentColonyVersion.toNumber());
 }
 
-export async function setupUpgradableColonyNetwork(etherRouter, resolver, colonyNetwork, colonyNetworkStaking) {
+export async function setupUpgradableColonyNetwork(etherRouter, resolver, colonyNetwork, colonyNetworkStaking, colonyNetworkAuction) {
   const deployedImplementations = {};
   deployedImplementations.ColonyNetwork = colonyNetwork.address;
   deployedImplementations.ColonyNetworkStaking = colonyNetworkStaking.address;
+  deployedImplementations.ColonyNetworkAuction = colonyNetworkAuction.address;
 
   await setupEtherRouter("IColonyNetwork", deployedImplementations, resolver);
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -5,6 +5,7 @@ const SafeMath = artifacts.require("./SafeMath");
 const ColonyTask = artifacts.require("./ColonyTask");
 const ColonyNetwork = artifacts.require("./ColonyNetwork");
 const ColonyNetworkStaking = artifacts.require("./ColonyNetworkStaking");
+const ColonyNetworkAuction = artifacts.require("./ColonyNetworkAuction");
 const EtherRouter = artifacts.require("./EtherRouter");
 const Resolver = artifacts.require("./Resolver");
 
@@ -20,6 +21,7 @@ module.exports = (deployer, network) => {
   deployer.link(SafeMath, ColonyTask);
   deployer.deploy([ColonyNetwork]);
   deployer.deploy([ColonyNetworkStaking]);
+  deployer.deploy([ColonyNetworkAuction]);
   deployer.deploy([EtherRouter]);
   deployer.deploy([Resolver]);
 };

--- a/migrations/3_setup_colony_network.js
+++ b/migrations/3_setup_colony_network.js
@@ -4,6 +4,7 @@ const { setupUpgradableColonyNetwork } = require("../helpers/upgradable-contract
 
 const ColonyNetwork = artifacts.require("./ColonyNetwork");
 const ColonyNetworkStaking = artifacts.require("./ColonyNetworkStaking");
+const ColonyNetworkAuction = artifacts.require("./ColonyNetworkAuction");
 const EtherRouter = artifacts.require("./EtherRouter");
 const Resolver = artifacts.require("./Resolver");
 
@@ -12,6 +13,7 @@ module.exports = deployer => {
   let resolver;
   let colonyNetwork;
   let colonyNetworkStaking;
+  let colonyNetworkAuction;
   deployer
     .then(() => ColonyNetwork.deployed())
     .then(instance => {
@@ -20,6 +22,10 @@ module.exports = deployer => {
     })
     .then(instance => {
       colonyNetworkStaking = instance;
+      return ColonyNetworkAuction.deployed();
+    })
+    .then(instance => {
+      colonyNetworkAuction = instance;
       return EtherRouter.deployed();
     })
     .then(instance => {
@@ -28,7 +34,7 @@ module.exports = deployer => {
     })
     .then(instance => {
       resolver = instance;
-      return setupUpgradableColonyNetwork(etherRouter, resolver, colonyNetwork, colonyNetworkStaking);
+      return setupUpgradableColonyNetwork(etherRouter, resolver, colonyNetwork, colonyNetworkStaking, colonyNetworkAuction);
     })
     .then(() => {
       console.log("### Colony Network setup with Resolver", resolver.address, "and EtherRouter", etherRouter.address);

--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -1,0 +1,447 @@
+/* globals artifacts */
+import { BN } from "bn.js";
+
+import { getTokenArgs, web3GetTransactionReceipt, web3GetCode, checkErrorRevert, forwardTime, getBlockTime } from "../helpers/test-helper";
+import { giveUserCLNYTokens } from "../helpers/test-data-generator";
+
+const EtherRouter = artifacts.require("EtherRouter");
+const IColony = artifacts.require("IColony");
+const IColonyNetwork = artifacts.require("IColonyNetwork");
+const DutchAuction = artifacts.require("DutchAuction");
+const Token = artifacts.require("Token");
+
+contract("ColonyNetworkAuction", accounts => {
+  const BIDDER_1 = accounts[1];
+  const BIDDER_2 = accounts[2];
+  const BIDDER_3 = accounts[3];
+
+  let commonColony;
+  let colonyNetwork;
+  let tokenAuction;
+  let quantity;
+  let clnyNeededForMaxPriceAuctionSellout;
+  let clny;
+  let token;
+
+  before(async () => {
+    quantity = new BN(10).pow(new BN(36)).muln(3);
+    clnyNeededForMaxPriceAuctionSellout = new BN(10).pow(new BN(54)).muln(3);
+    const etherRouter = await EtherRouter.deployed();
+    colonyNetwork = IColonyNetwork.at(etherRouter.address);
+
+    const commonColonyAddress = await colonyNetwork.getColony("Common Colony");
+    commonColony = IColony.at(commonColonyAddress);
+  });
+
+  beforeEach(async () => {
+    clny = await Token.new("Colony Network Token", "CLNY", 18);
+    await commonColony.setToken(clny.address);
+    await clny.setOwner(commonColony.address);
+
+    const args = getTokenArgs();
+    token = await Token.new(...args);
+    await token.mint(quantity.toString());
+    await token.transfer(colonyNetwork.address, quantity.toString());
+    const { logs } = await colonyNetwork.startTokenAuction(token.address);
+    const auctionAddress = logs[0].args.auction;
+    tokenAuction = DutchAuction.at(auctionAddress);
+  });
+
+  describe("when initialising an auction", async () => {
+    it("should initialise auction with correct given parameters", async () => {
+      const clnyAddress = await tokenAuction.clnyToken.call();
+      assert.equal(clnyAddress, clny.address);
+      const tokenAddress = await tokenAuction.token.call();
+      assert.equal(tokenAddress, token.address);
+    });
+
+    it("should fail with 0x0 token", async () => {
+      await checkErrorRevert(colonyNetwork.startTokenAuction("0x0"));
+    });
+
+    it("should fail if auction is initialised for the CLNY token", async () => {
+      await checkErrorRevert(colonyNetwork.startTokenAuction(clny.address));
+    });
+
+    it("should fail with zero quantity", async () => {
+      const args = getTokenArgs();
+      const otherToken = await Token.new(...args);
+      const { logs } = await colonyNetwork.startTokenAuction(otherToken.address);
+      const auctionAddress = logs[0].args.auction;
+      tokenAuction = DutchAuction.at(auctionAddress);
+      await checkErrorRevert(tokenAuction.start());
+    });
+  });
+
+  describe("when starting an auction", async () => {
+    it("should set the `quantity` correctly and minPrice to 1", async () => {
+      await tokenAuction.start();
+      const quantityNow = await tokenAuction.quantity.call();
+      assert.equal(quantityNow.toString(10), quantity.toString());
+
+      const minPrice = await tokenAuction.minPrice.call();
+      assert.equal(minPrice.toString(10), 1);
+    });
+
+    it("should set the minimum price correctly for quantity < 1e18", async () => {
+      const args = getTokenArgs();
+      const otherToken = await Token.new(...args);
+      await otherToken.mint(1e17);
+      await otherToken.transfer(colonyNetwork.address, 1e17);
+      const { logs } = await colonyNetwork.startTokenAuction(otherToken.address);
+      const auctionAddress = logs[0].args.auction;
+      tokenAuction = DutchAuction.at(auctionAddress);
+      await tokenAuction.start();
+      const minPrice = await tokenAuction.minPrice.call();
+      assert.equal(minPrice.toString(10), 10);
+    });
+
+    it("should set the `startTime` correctly", async () => {
+      const tx = await tokenAuction.start();
+      const txReceiptBlockNumber = tx.receipt.blockNumber;
+      const blockTime = await getBlockTime(txReceiptBlockNumber);
+
+      const startTime = await tokenAuction.startTime.call();
+      assert.equal(startTime.toNumber(), blockTime);
+    });
+
+    it("should set the `started` property correctly", async () => {
+      await tokenAuction.start();
+
+      const started = await tokenAuction.started.call();
+      assert.isTrue(started);
+    });
+
+    it("should fail starting the auction twice", async () => {
+      await tokenAuction.start();
+      await checkErrorRevert(tokenAuction.start());
+    });
+
+    it("cannot bid before the auction is open", async () => {
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_1, "1000000000000000000");
+      await clny.approve(tokenAuction.address, "1000000000000000000", { from: BIDDER_1 });
+      await checkErrorRevert(tokenAuction.bid("1000000000000000000", { from: BIDDER_1 }));
+    });
+
+    const auctionProps = [
+      {
+        duration: 1000,
+        price: new BN("989583333333333333333333333333333333")
+      },
+      {
+        duration: 72000,
+        price: new BN("250000000000000000000000000000000000")
+      },
+      {
+        duration: 86400,
+        price: new BN(10).pow(new BN(35))
+      },
+      {
+        duration: 144000,
+        price: new BN("40000000000000000000000000000000000")
+      },
+      {
+        duration: 172800,
+        price: new BN(10).pow(new BN(34))
+      },
+      {
+        duration: 259200,
+        price: new BN(10).pow(new BN(33))
+      },
+      {
+        duration: 345600,
+        price: new BN(10).pow(new BN(32))
+      },
+      {
+        duration: 432000,
+        price: new BN(10).pow(new BN(31))
+      },
+      {
+        duration: 518400,
+        price: new BN(10).pow(new BN(30))
+      },
+      {
+        duration: 1382400,
+        price: new BN(10).pow(new BN(20))
+      },
+      {
+        duration: 2937600,
+        price: new BN(100)
+      },
+      {
+        duration: 3110400,
+        price: new BN(1)
+      },
+      {
+        duration: 3193200, // Crosses the boundary where price of 1 is always returned (for quantity > 1e18)
+        price: new BN(1)
+      }
+    ];
+
+    auctionProps.forEach(async auctionProp => {
+      it(`should correctly calculate price and remaining CLNY amount to end auction at duration ${auctionProp.duration}`, async () => {
+        await tokenAuction.start();
+
+        await forwardTime(auctionProp.duration, this);
+        const currentPrice = await tokenAuction.price.call();
+        // Expect up to 1% error margin because of forwarding block time inaccuracies
+        const errorMarginPrice = auctionProp.price.divn(100);
+        const currentPriceString = currentPrice.toString(10);
+        // Chai assert.closeTo does not work with Big Numbers so some manual comaring to error margin is required
+        const differencePrices = auctionProp.price.sub(new BN(currentPriceString));
+        assert.isTrue(differencePrices.lte(errorMarginPrice));
+
+        const totalToEndAuction = await tokenAuction.totalToEndAuction.call();
+        const amount = new BN(currentPriceString).mul(quantity).div(new BN(10).pow(new BN(18)));
+        const errorMarginQuantity = amount.divn(100);
+        const differenceQuantity = totalToEndAuction.sub(amount);
+        assert.isTrue(differenceQuantity.lte(errorMarginQuantity));
+      });
+    });
+  });
+
+  describe("when bidding", async () => {
+    beforeEach(async () => {
+      await tokenAuction.start();
+    });
+
+    it("can bid", async () => {
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_1, "1000000000000000000");
+      await clny.approve(tokenAuction.address, "1000000000000000000", { from: BIDDER_1 });
+      await tokenAuction.bid("1000000000000000000", { from: BIDDER_1 });
+      const bid = await tokenAuction.bids.call(BIDDER_1);
+      assert.equal(bid, "1000000000000000000");
+      const bidCount = await tokenAuction.bidCount.call();
+      assert.equal(bidCount.toNumber(), 1);
+    });
+
+    it("bid tokens are locked", async () => {
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_1, "1000000000000000000");
+      await clny.approve(tokenAuction.address, "1000000000000000000", { from: BIDDER_1 });
+      await tokenAuction.bid("1000000000000000000", { from: BIDDER_1 });
+      const lockedTokens = await clny.balanceOf.call(tokenAuction.address);
+      assert.equal(lockedTokens.toString(), "1000000000000000000");
+    });
+
+    it("can bid more than once", async () => {
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_1, "2000000000000000000");
+      await clny.approve(tokenAuction.address, "2000000000000000000", { from: BIDDER_1 });
+      await tokenAuction.bid("1100000000000000000", { from: BIDDER_1 });
+      await tokenAuction.bid("900000000000000000", { from: BIDDER_1 });
+      const bidCount = await tokenAuction.bidCount.call();
+      assert.equal(bidCount.toNumber(), 1);
+    });
+
+    it("once target reached, endTime is set correctly", async () => {
+      const amount = clnyNeededForMaxPriceAuctionSellout.divn(3).toString();
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_1, amount);
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_2, amount);
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_3, amount);
+      await clny.approve(tokenAuction.address, amount, { from: BIDDER_1 });
+      await clny.approve(tokenAuction.address, amount, { from: BIDDER_2 });
+      await clny.approve(tokenAuction.address, amount, { from: BIDDER_3 });
+      await tokenAuction.bid(amount, { from: BIDDER_1 });
+      await tokenAuction.bid(amount, { from: BIDDER_2 });
+
+      const { tx } = await tokenAuction.bid(amount, { from: BIDDER_3 });
+      const receipt = await web3GetTransactionReceipt(tx);
+      const bidReceiptBlock = receipt.blockNumber;
+      const blockTime = await getBlockTime(bidReceiptBlock);
+      const endTime = await tokenAuction.endTime.call();
+      assert.equal(endTime.toString(), blockTime);
+
+      const bidCount = await tokenAuction.bidCount.call();
+      assert.equal(bidCount.toNumber(), 3);
+    });
+
+    it("if bid overshoots the target quantity, it is only partially accepted", async () => {
+      const amount = clnyNeededForMaxPriceAuctionSellout.addn(20).toString();
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_1, amount);
+      await clny.approve(tokenAuction.address, amount, { from: BIDDER_1 });
+      const totalToEndAuction = await tokenAuction.totalToEndAuction.call();
+      await tokenAuction.bid(amount, { from: BIDDER_1 });
+      const receivedTotal = await tokenAuction.receivedTotal.call();
+      const bid = await tokenAuction.bids.call(BIDDER_1);
+      assert.equal(bid.toString(), totalToEndAuction.toString());
+      assert.equal(receivedTotal.toString(), totalToEndAuction.toString());
+    });
+
+    it("after target is sold, bid is rejected", async () => {
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_1, clnyNeededForMaxPriceAuctionSellout.addn(1).toString());
+      await clny.approve(tokenAuction.address, clnyNeededForMaxPriceAuctionSellout.addn(1).toString(), { from: BIDDER_1 });
+      await tokenAuction.bid(clnyNeededForMaxPriceAuctionSellout.toString(), { from: BIDDER_1 });
+      await checkErrorRevert(tokenAuction.bid(1, { from: BIDDER_1 }));
+    });
+
+    it("cannot finalize when target not reached", async () => {
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_1, "3000");
+      await clny.approve(tokenAuction.address, "3000", { from: BIDDER_1 });
+      await tokenAuction.bid("3000", { from: BIDDER_1 });
+      await checkErrorRevert(tokenAuction.finalize());
+    });
+
+    it("cannot bid with 0 tokens", async () => {
+      await checkErrorRevert(tokenAuction.bid(0));
+    });
+  });
+
+  describe("when finalizing auction", async () => {
+    beforeEach(async () => {
+      await tokenAuction.start();
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_1, clnyNeededForMaxPriceAuctionSellout.toString());
+      await clny.approve(tokenAuction.address, clnyNeededForMaxPriceAuctionSellout.toString(), { from: BIDDER_1 });
+      await tokenAuction.bid(clnyNeededForMaxPriceAuctionSellout.toString(), { from: BIDDER_1 });
+    });
+
+    it("sets correct final token price", async () => {
+      await tokenAuction.finalize();
+      const receivedTotal = await tokenAuction.receivedTotal.call();
+      const endPrice = new BN(10)
+        .pow(new BN(18))
+        .mul(new BN(receivedTotal.toString(10)))
+        .div(quantity)
+        .addn(1);
+      const finalPrice = await tokenAuction.finalPrice.call();
+      assert.equal(endPrice.toString(), finalPrice.toString(10));
+    });
+
+    it("sets the finalized property", async () => {
+      await tokenAuction.finalize();
+      const finalized = await tokenAuction.finalized.call();
+      assert.isTrue(finalized);
+    });
+
+    it("Colony network gets all CLNY sent to the auction in bids", async () => {
+      const balanceBefore = await clny.balanceOf.call(colonyNetwork.address);
+      await tokenAuction.finalize();
+      const receivedTotal = await tokenAuction.receivedTotal.call();
+      assert.notEqual(receivedTotal.toNumber(), 0);
+      const balanceAfter = await clny.balanceOf.call(colonyNetwork.address);
+      assert.equal(balanceBefore.add(receivedTotal).toString(), balanceAfter.toString());
+    });
+
+    it("cannot bid after finalized", async () => {
+      await tokenAuction.finalize();
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_1, 1000);
+      await clny.approve(tokenAuction.address, 1000, { from: BIDDER_1 });
+      await checkErrorRevert(tokenAuction.bid(1000, { from: BIDDER_1 }));
+    });
+
+    it("cannot finalize after finalized once", async () => {
+      await tokenAuction.finalize();
+      await checkErrorRevert(tokenAuction.finalize());
+    });
+
+    it("cannot claim if not finalized", async () => {
+      await checkErrorRevert(tokenAuction.claim({ from: BIDDER_1 }));
+    });
+  });
+
+  describe("when claiming tokens", async () => {
+    it("should transfer to bidder correct number of tokens at finalPrice", async () => {
+      const bidAmount1 = new BN(10).pow(new BN(36));
+      const bidAmount2 = new BN(10).pow(new BN(38));
+      const bidAmount3 = new BN(10).pow(new BN(36)).muln(199);
+
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_1, bidAmount1.toString());
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_2, bidAmount2.toString());
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_3, bidAmount3.toString());
+      await clny.approve(tokenAuction.address, bidAmount1.toString(), { from: BIDDER_1 });
+      await clny.approve(tokenAuction.address, bidAmount2.toString(), { from: BIDDER_2 });
+      await clny.approve(tokenAuction.address, bidAmount3.toString(), { from: BIDDER_3 });
+
+      await tokenAuction.start();
+      await tokenAuction.bid(bidAmount1.toString(), { from: BIDDER_1 }); // Bids at near max price of 1e36 CLNY per 1e18 Tokens
+      await forwardTime(1382400, this); // Gets us near price of 1e20 CLNY per 1e18 Tokens
+      await tokenAuction.bid(bidAmount2.toString(), { from: BIDDER_2 });
+      await tokenAuction.bid(bidAmount3.toString(), { from: BIDDER_3 });
+
+      await tokenAuction.finalize();
+      const finalPrice = await tokenAuction.finalPrice.call();
+      const finalPriceString = finalPrice.toString();
+
+      let claimCount;
+      let tokenBidderBalance;
+      let tokensToClaim;
+
+      await tokenAuction.claim({ from: BIDDER_1 });
+      claimCount = await tokenAuction.claimCount.call();
+      assert.equal(claimCount.toNumber(), 1);
+
+      tokenBidderBalance = await token.balanceOf.call(BIDDER_1);
+      tokensToClaim = new BN(10)
+        .pow(new BN(18))
+        .mul(bidAmount1)
+        .div(new BN(finalPriceString));
+      assert.equal(tokenBidderBalance.toString(10), tokensToClaim.toString());
+
+      await tokenAuction.claim({ from: BIDDER_2 });
+      claimCount = await tokenAuction.claimCount.call();
+      assert.equal(claimCount.toNumber(), 2);
+      tokenBidderBalance = await token.balanceOf.call(BIDDER_2);
+      tokensToClaim = new BN(10)
+        .pow(new BN(18))
+        .mul(bidAmount2)
+        .div(new BN(finalPriceString));
+      assert.equal(tokenBidderBalance.toString(10), tokensToClaim.toString());
+
+      const bid3 = await tokenAuction.bids.call(BIDDER_3);
+      await tokenAuction.claim({ from: BIDDER_3 });
+      claimCount = await tokenAuction.claimCount.call();
+      assert.equal(claimCount.toNumber(), 3);
+      tokenBidderBalance = await token.balanceOf.call(BIDDER_3);
+      const bid3BN = new BN(bid3.toString(10));
+      tokensToClaim = new BN(10)
+        .pow(new BN(18))
+        .mul(bid3BN)
+        .div(new BN(finalPriceString));
+      assert.equal(tokenBidderBalance.toString(10), tokensToClaim.toString());
+    });
+
+    it("should set the bid amount to 0", async () => {
+      await tokenAuction.start();
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_1, clnyNeededForMaxPriceAuctionSellout.toString());
+      await clny.approve(tokenAuction.address, clnyNeededForMaxPriceAuctionSellout.toString(), { from: BIDDER_1 });
+      await tokenAuction.bid(clnyNeededForMaxPriceAuctionSellout.toString(), { from: BIDDER_1 });
+      await tokenAuction.finalize();
+      await tokenAuction.claim({ from: BIDDER_1 });
+      const bid = await tokenAuction.bids.call(BIDDER_1);
+      assert.equal(bid.toNumber(), 0);
+    });
+  });
+
+  describe("when closing the auction", async () => {
+    beforeEach(async () => {
+      await tokenAuction.start();
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_1, clnyNeededForMaxPriceAuctionSellout.toString());
+      await clny.approve(tokenAuction.address, clnyNeededForMaxPriceAuctionSellout.toString(), { from: BIDDER_1 });
+      await tokenAuction.bid(clnyNeededForMaxPriceAuctionSellout.toString(), { from: BIDDER_1 });
+    });
+
+    it("should be able to close the auction and kill the auction contract", async () => {
+      await tokenAuction.finalize();
+      await tokenAuction.claim({ from: BIDDER_1 });
+      await tokenAuction.close();
+      const code = await web3GetCode(tokenAuction.address);
+      assert.equal(code, 0);
+    });
+
+    it("should fail if auction not finalized", async () => {
+      await checkErrorRevert(tokenAuction.close());
+    });
+
+    it("should fail if not all bids have been claimed", async () => {
+      await tokenAuction.finalize();
+      await checkErrorRevert(tokenAuction.close());
+    });
+
+    it("should fail if there are CLNY tokens left owned by the auction", async () => {
+      await tokenAuction.finalize();
+      await tokenAuction.claim({ from: BIDDER_1 });
+      await commonColony.mintTokens(100);
+      await giveUserCLNYTokens(colonyNetwork, BIDDER_1, 100);
+      await clny.transfer(tokenAuction.address, 100, { from: BIDDER_1 });
+      await checkErrorRevert(tokenAuction.close());
+    });
+  });
+});

--- a/test/colony-network-staking.js
+++ b/test/colony-network-staking.js
@@ -21,11 +21,11 @@ contract("ColonyNetworkStaking", accounts => {
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
-
     const commonColonyAddress = await colonyNetwork.getColony("Common Colony");
     commonColony = IColony.at(commonColonyAddress);
-    const clnyAddress = await commonColony.getToken.call();
-    clny = Token.at(clnyAddress);
+    clny = await Token.new("Colony Network Token", "CLNY", 18);
+    await commonColony.setToken(clny.address);
+    await clny.setOwner(commonColony.address);
     await colonyNetwork.startNextCycle();
   });
 
@@ -122,7 +122,7 @@ contract("ColonyNetworkStaking", accounts => {
       await colonyNetwork.deposit("1000000000000000000");
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await forwardTime(3600, this);
+      await forwardTime(3600);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       const submitterAddress = await repCycle.submittedHashes.call("0x12345678", 10, 0);
@@ -144,7 +144,7 @@ contract("ColonyNetworkStaking", accounts => {
       await colonyNetwork.deposit("1000000000000000000");
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await forwardTime(3600);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       let stakedBalance = await colonyNetwork.getStakedBalance.call(MAIN_ACCOUNT);

--- a/test/colony.js
+++ b/test/colony.js
@@ -409,7 +409,7 @@ contract("Colony", () => {
       const taskPotId = task[6];
       const domainPotId = domain[1];
 
-      // Our testDataGenerator already set up some task fund with tokens,
+      // Our test-data-generator already set up some task fund with tokens,
       // but we need some Ether, too
       await colony.send(101);
       await colony.claimColonyFunds(0x0);


### PR DESCRIPTION
Closes #97 

Implements Dutch auction model for auctioning tokens earned by the Common Colony in exchange for CLNY. The auction model is inspired by a version of that used at [Raiden](https://github.com/raiden-network/raiden-token/blob/master/contracts/auction.sol) and earlier at [Gnosis](https://github.com/miladmostavi/gnosis-contracts/blob/master/contracts/solidity/DAO/DAODutchAuction.sol) ICOs.

The following auction rules apply:
- A new Auction is started via the `colonyNetwork.startTokenAuction` function which creates a new 
`DutchAuction` instance for a given Token X. Note that **ALL Token X** owned by the ColonyNetwork is transferred to the Auction contract here for selling.
- Auction is explicitly started via the `start` function where the `startTime`, `quantity` of token sold are set.
- Users can submit no-limit bids and multiple bids per account are allowed
- Before a bid is submitted the user has to have approved the `DutchAuction` contract address to transfer their bid CLNY amount. The bid will fail if this is not met.
- The auction is complete when it has received enough CLNY to sell its token quantity at the current price. No more bids are accepted after this point and `finalize` can be called.
- Current price can be gotten via the `price` function while the auction is open for bids. After closing the `finalPrice` should be queried. The current price is calculated as 
```
uint daysOpen = duration / 86400;
uint r = duration % 86400;
10^(36-daysOpen) * (864000 - 9r) / 864000;
```
We also limit the price to never go below 1 with 
```
    if (duration > 3110400) {
      return 1;
    }
```
Visualised `log(price) / elapsed time` graph
![screen shot 2018-03-18 at 10 37 19](https://user-images.githubusercontent.com/703848/37564141-60f4704c-2a98-11e8-8b32-5f892c036d69.png)

- After all tokens have been claimed, the token contract can be killed and storage refunded via `close`