### PR TITLE
ES6 exports, storage constants, helper functions arguments

### DIFF
--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -41,15 +41,15 @@ contract ColonyFunding is ColonyStorage, DSMath {
   }
 
   function setTaskManagerPayout(uint256 _id, address _token, uint256 _amount) public isManager(_id) {
-    setTaskPayout(_id, 0, _token, _amount);
+    setTaskPayout(_id, MANAGER, _token, _amount);
   }
 
   function setTaskEvaluatorPayout(uint256 _id, address _token, uint256 _amount) public self {
-    setTaskPayout(_id, 1, _token, _amount);
+    setTaskPayout(_id, EVALUATOR, _token, _amount);
   }
 
   function setTaskWorkerPayout(uint256 _id, address _token, uint256 _amount) public self {
-    setTaskPayout(_id, 2, _token, _amount);
+    setTaskPayout(_id, WORKER, _token, _amount);
   }
 
   // To get all payouts for a task iterate over roles.length

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -67,6 +67,10 @@ contract ColonyStorage is DSAuth {
   uint256 potCount;
   uint256 domainCount;
 
+  uint8 constant MANAGER = 0;
+  uint8 constant EVALUATOR = 1;
+  uint8 constant WORKER = 2;
+
   struct Task {
     bytes32 specificationHash;
     bytes32 deliverableHash;

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -27,10 +27,6 @@ import "./SafeMath.sol";
 
 
 contract ColonyTask is ColonyStorage, DSMath {
-  uint8 constant MANAGER = 0;
-  uint8 constant EVALUATOR = 1;
-  uint8 constant WORKER = 2;
-
   uint256 constant RATING_COMMIT_TIMEOUT = 432000;
   uint256 constant RATING_REVEAL_TIMEOUT = 432000;
 

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -1,5 +1,5 @@
 import web3Utils from "web3-utils";
-import testHelper from "../helpers/test-helper";
+import { getRandomString } from "../helpers/test-helper";
 
 let MANAGER;
 let EVALUATOR;
@@ -19,8 +19,8 @@ const WORKER_PAYOUT = web3Utils.toBN(200 * 1e18);
 const MANAGER_RATING = 30;
 const WORKER_RATING = 40;
 const SECONDS_PER_DAY = 86400;
-const RATING_1_SALT = web3Utils.soliditySha3(testHelper.getRandomString(10));
-const RATING_2_SALT = web3Utils.soliditySha3(testHelper.getRandomString(10));
+const RATING_1_SALT = web3Utils.soliditySha3(getRandomString(10));
+const RATING_2_SALT = web3Utils.soliditySha3(getRandomString(10));
 const RATING_1_SECRET = web3Utils.soliditySha3(RATING_1_SALT, MANAGER_RATING);
 const RATING_2_SECRET = web3Utils.soliditySha3(RATING_2_SALT, WORKER_RATING);
 

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -18,166 +18,166 @@ import {
   WORKER_ROLE,
   SPECIFICATION_HASH
 } from "../helpers/constants";
-import testHelper from "../helpers/test-helper";
+import { currentBlockTime } from "../helpers/test-helper";
 
 const IColony = artifacts.require("IColony");
 const Token = artifacts.require("Token");
 
-module.exports = {
-  async giveUserCLNYTokens(colonyNetwork, address, _amount) {
-    const commonColonyAddress = await colonyNetwork.getColony("Common Colony");
-    const commonColony = IColony.at(commonColonyAddress);
-    const clnyAddress = await commonColony.getToken.call();
-    const clny = Token.at(clnyAddress);
-    const amount = new BN(_amount);
-    const mainStartingBalance = await clny.balanceOf.call(MANAGER);
-    const targetStartingBalance = await clny.balanceOf.call(address);
-    await commonColony.mintTokens(amount * 3);
-    await commonColony.claimColonyFunds(clny.address);
-    const taskId = await this.setupRatedTask(
-      colonyNetwork,
-      commonColony,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      amount.mul(new BN("2")),
-      new BN("0"),
-      new BN("0")
-    );
-    await commonColony.finalizeTask(taskId);
-    await commonColony.claimPayout(taskId, 0, clny.address);
-
-    let mainBalance = await clny.balanceOf.call(MANAGER);
-    await clny.transfer(
-      0x0,
-      mainBalance
-        .sub(amount)
-        .sub(mainStartingBalance)
-        .toString()
-    );
-    await clny.transfer(address, amount.toString());
-    mainBalance = await clny.balanceOf.call(MANAGER);
-    if (address !== MANAGER) {
-      await clny.transfer(0x0, mainBalance.sub(mainStartingBalance).toString());
-    }
-    const userBalance = await clny.balanceOf.call(address);
-    assert.equal(targetStartingBalance.add(amount).toString(), userBalance.toString());
-  },
-  async setupAssignedTask(colonyNetwork, colony, dueDate, domain = 1, skill = 0, evaluator = EVALUATOR, worker = WORKER) {
-    let dueDateTimestamp = dueDate;
-    if (!dueDateTimestamp) {
-      dueDateTimestamp = await testHelper.currentBlockTime();
-    }
-    await colony.makeTask(SPECIFICATION_HASH, domain);
-    let taskId = await colony.getTaskCount.call();
-    taskId = taskId.toNumber();
-    // If the skill is not specified, default to the root global skill
-    if (skill === 0) {
-      const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId.call();
-      if (rootGlobalSkill === 0) throw new Error("Common Colony is not setup and therefore the root global skill does not exist");
-      await colony.setTaskSkill(taskId, rootGlobalSkill);
-    } else {
-      await colony.setTaskSkill(taskId, skill);
-    }
-    await colony.setTaskRoleUser(taskId, EVALUATOR_ROLE, evaluator);
-    await colony.setTaskRoleUser(taskId, WORKER_ROLE, worker);
-    const txData = await colony.contract.setTaskDueDate.getData(taskId, dueDateTimestamp);
-    await colony.proposeTaskChange(txData, 0, MANAGER_ROLE);
-    const transactionId = await colony.getTransactionCount.call();
-    await colony.approveTaskChange(transactionId, WORKER_ROLE, { from: worker });
-    return taskId;
-  },
-  async setupFundedTask(
-    colonyNetwork,
-    colony,
-    token,
-    dueDate,
-    domain,
-    skill,
-    evaluator = EVALUATOR,
-    worker = WORKER,
-    manager_payout = MANAGER_PAYOUT,
-    evaluator_payout = EVALUATOR_PAYOUT,
-    worker_payout = WORKER_PAYOUT
-  ) {
-    let tokenAddress;
-    if (token === undefined) {
-      tokenAddress = await colony.getToken.call();
-    } else {
-      tokenAddress = token === 0x0 ? 0x0 : token.address;
-    }
-    const taskId = await this.setupAssignedTask(colonyNetwork, colony, dueDate, domain, skill, evaluator, worker);
-    const task = await colony.getTask.call(taskId);
-    const potId = task[6].toNumber();
-    const managerPayout = new BN(manager_payout);
-    const workerPayout = new BN(worker_payout);
-    const evaluatorPayout = new BN(evaluator_payout);
-    const totalPayouts = managerPayout.add(workerPayout).add(evaluatorPayout);
-    await colony.moveFundsBetweenPots(1, potId, totalPayouts.toString(), tokenAddress);
-
-    await colony.setTaskManagerPayout(taskId, tokenAddress, managerPayout.toString());
-
-    let txData = await colony.contract.setTaskEvaluatorPayout.getData(taskId, tokenAddress, evaluatorPayout.toString());
-    await colony.proposeTaskChange(txData, 0, MANAGER_ROLE);
-    let transactionId = await colony.getTransactionCount.call();
-    await colony.approveTaskChange(transactionId, EVALUATOR_ROLE, { from: evaluator });
-
-    txData = await colony.contract.setTaskWorkerPayout.getData(taskId, tokenAddress, workerPayout.toString());
-    await colony.proposeTaskChange(txData, 0, MANAGER_ROLE);
-    transactionId = await colony.getTransactionCount.call();
-    await colony.approveTaskChange(transactionId, WORKER_ROLE, { from: worker });
-
-    return taskId;
-  },
-  async setupRatedTask(
-    colonyNetwork,
-    colony,
-    token,
-    dueDate,
-    domain,
-    skill,
-    evaluator = EVALUATOR,
-    worker = WORKER,
-    manager_payout = MANAGER_PAYOUT,
-    evaluator_payout = EVALUATOR_PAYOUT,
-    worker_payout = WORKER_PAYOUT,
-    manager_rating = MANAGER_RATING,
-    manager_rating_salt = RATING_1_SALT,
-    worker_rating = WORKER_RATING,
-    worker_rating_salt = RATING_2_SALT
-  ) {
-    const taskId = await this.setupFundedTask(
-      colonyNetwork,
-      colony,
-      token,
-      dueDate,
-      domain,
-      skill,
-      evaluator,
-      worker,
-      manager_payout,
-      evaluator_payout,
-      worker_payout
-    );
-    const WORKER_RATING_SECRET = web3Utils.soliditySha3(worker_rating_salt, worker_rating);
-    const MANAGER_RATING_SECRET = web3Utils.soliditySha3(manager_rating_salt, manager_rating);
-    await colony.submitTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING_SECRET, { from: evaluator });
-    await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, MANAGER_RATING_SECRET, { from: worker });
-    await colony.revealTaskWorkRating(taskId, WORKER_ROLE, worker_rating, worker_rating_salt, { from: evaluator });
-    await colony.revealTaskWorkRating(taskId, MANAGER_ROLE, manager_rating, manager_rating_salt, { from: worker });
-    return taskId;
-  },
-  async fundColonyWithTokens(colony, token, tokenAmount) {
-    const colonyToken = await colony.getToken.call();
-    if (colonyToken === token.address) {
-      await colony.mintTokens(tokenAmount);
-    } else {
-      await token.mint(tokenAmount);
-      await token.transfer(colony.address, tokenAmount);
-    }
-    await colony.claimColonyFunds(token.address);
+export async function setupAssignedTask({
+  colonyNetwork,
+  colony,
+  dueDate = currentBlockTime(),
+  domain = 1,
+  skill = 0,
+  evaluator = EVALUATOR,
+  worker = WORKER
+}) {
+  await colony.makeTask(SPECIFICATION_HASH, domain);
+  let taskId = await colony.getTaskCount.call();
+  taskId = taskId.toNumber();
+  // If the skill is not specified, default to the root global skill
+  if (skill === 0) {
+    const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId.call();
+    if (rootGlobalSkill === 0) throw new Error("Common Colony is not setup and therefore the root global skill does not exist");
+    await colony.setTaskSkill(taskId, rootGlobalSkill);
+  } else {
+    await colony.setTaskSkill(taskId, skill);
   }
-};
+  await colony.setTaskRoleUser(taskId, EVALUATOR_ROLE, evaluator);
+  await colony.setTaskRoleUser(taskId, WORKER_ROLE, worker);
+  const txData = await colony.contract.setTaskDueDate.getData(taskId, dueDate);
+  await colony.proposeTaskChange(txData, 0, MANAGER_ROLE);
+  const transactionId = await colony.getTransactionCount.call();
+  await colony.approveTaskChange(transactionId, WORKER_ROLE, { from: worker });
+  return taskId;
+}
+
+export async function setupFundedTask({
+  colonyNetwork,
+  colony,
+  token,
+  dueDate,
+  domain,
+  skill,
+  evaluator = EVALUATOR,
+  worker = WORKER,
+  managerPayout = MANAGER_PAYOUT,
+  evaluatorPayout = EVALUATOR_PAYOUT,
+  workerPayout = WORKER_PAYOUT
+}) {
+  let tokenAddress;
+  if (token === undefined) {
+    tokenAddress = await colony.getToken.call();
+  } else {
+    tokenAddress = token === 0x0 ? 0x0 : token.address;
+  }
+  const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate, domain, skill, evaluator, worker });
+  const task = await colony.getTask.call(taskId);
+  const potId = task[6].toNumber();
+  const managerPayoutBN = new BN(managerPayout);
+  const evaluatorPayoutBN = new BN(evaluatorPayout);
+  const workerPayoutBN = new BN(workerPayout);
+  const totalPayouts = managerPayoutBN.add(workerPayoutBN).add(evaluatorPayoutBN);
+  await colony.moveFundsBetweenPots(1, potId, totalPayouts.toString(), tokenAddress);
+
+  await colony.setTaskManagerPayout(taskId, tokenAddress, managerPayout.toString());
+
+  let txData = await colony.contract.setTaskEvaluatorPayout.getData(taskId, tokenAddress, evaluatorPayout.toString());
+  await colony.proposeTaskChange(txData, 0, MANAGER_ROLE);
+  let transactionId = await colony.getTransactionCount.call();
+  await colony.approveTaskChange(transactionId, EVALUATOR_ROLE, { from: evaluator });
+
+  txData = await colony.contract.setTaskWorkerPayout.getData(taskId, tokenAddress, workerPayout.toString());
+  await colony.proposeTaskChange(txData, 0, MANAGER_ROLE);
+  transactionId = await colony.getTransactionCount.call();
+  await colony.approveTaskChange(transactionId, WORKER_ROLE, { from: worker });
+
+  return taskId;
+}
+
+export async function setupRatedTask({
+  colonyNetwork,
+  colony,
+  token,
+  dueDate,
+  domain,
+  skill,
+  evaluator = EVALUATOR,
+  worker = WORKER,
+  managerPayout = MANAGER_PAYOUT,
+  evaluatorPayout = EVALUATOR_PAYOUT,
+  workerPayout = WORKER_PAYOUT,
+  managerRating = MANAGER_RATING,
+  managerRatingSalt = RATING_1_SALT,
+  workerRating = WORKER_RATING,
+  workerRatingSalt = RATING_2_SALT
+}) {
+  const taskId = await setupFundedTask({
+    colonyNetwork,
+    colony,
+    token,
+    dueDate,
+    domain,
+    skill,
+    evaluator,
+    worker,
+    managerPayout,
+    evaluatorPayout,
+    workerPayout
+  });
+  const WORKER_RATING_SECRET = web3Utils.soliditySha3(workerRatingSalt, workerRating);
+  const MANAGER_RATING_SECRET = web3Utils.soliditySha3(managerRatingSalt, managerRating);
+  await colony.submitTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING_SECRET, { from: evaluator });
+  await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, MANAGER_RATING_SECRET, { from: worker });
+  await colony.revealTaskWorkRating(taskId, WORKER_ROLE, workerRating, workerRatingSalt, { from: evaluator });
+  await colony.revealTaskWorkRating(taskId, MANAGER_ROLE, managerRating, managerRatingSalt, { from: worker });
+  return taskId;
+}
+
+export async function giveUserCLNYTokens(colonyNetwork, address, _amount) {
+  const commonColonyAddress = await colonyNetwork.getColony("Common Colony");
+  const commonColony = IColony.at(commonColonyAddress);
+  const clnyAddress = await commonColony.getToken.call();
+  const clny = Token.at(clnyAddress);
+  const amount = new BN(_amount);
+  const mainStartingBalance = await clny.balanceOf.call(MANAGER);
+  const targetStartingBalance = await clny.balanceOf.call(address);
+  await commonColony.mintTokens(amount * 3);
+  await commonColony.claimColonyFunds(clny.address);
+  const taskId = await setupRatedTask({
+    colonyNetwork,
+    colony: commonColony,
+    managerPayout: amount.mul(new BN("2")),
+    evaluatorPayout: new BN("0"),
+    workerPayout: new BN("0")
+  });
+  await commonColony.finalizeTask(taskId);
+  await commonColony.claimPayout(taskId, 0, clny.address);
+
+  let mainBalance = await clny.balanceOf.call(MANAGER);
+  await clny.transfer(
+    0x0,
+    mainBalance
+      .sub(amount)
+      .sub(mainStartingBalance)
+      .toString()
+  );
+  await clny.transfer(address, amount.toString());
+  mainBalance = await clny.balanceOf.call(MANAGER);
+  if (address !== MANAGER) {
+    await clny.transfer(0x0, mainBalance.sub(mainStartingBalance).toString());
+  }
+  const userBalance = await clny.balanceOf.call(address);
+  assert.equal(targetStartingBalance.add(amount).toString(), userBalance.toString());
+}
+
+export async function fundColonyWithTokens(colony, token, tokenAmount) {
+  const colonyToken = await colony.getToken.call();
+  if (colonyToken === token.address) {
+    await colony.mintTokens(tokenAmount);
+  } else {
+    await token.mint(tokenAmount);
+    await token.transfer(colony.address, tokenAmount);
+  }
+  await colony.claimColonyFunds(token.address);
+}

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -1,154 +1,159 @@
 import shortid from "shortid";
 import { assert } from "chai";
 
-module.exports = {
-  web3GetNetwork() {
-    return new Promise((resolve, reject) => {
-      web3.version.getNetwork((err, res) => {
-        if (err !== null) return reject(err);
-        return resolve(res);
-      });
+export function web3GetNetwork() {
+  return new Promise((resolve, reject) => {
+    web3.version.getNetwork((err, res) => {
+      if (err !== null) return reject(err);
+      return resolve(res);
     });
-  },
-  web3GetClient() {
-    return new Promise((resolve, reject) => {
-      web3.version.getNode((err, res) => {
-        if (err !== null) return reject(err);
-        return resolve(res);
-      });
-    });
-  },
-  web3GetBalance(account) {
-    return new Promise((resolve, reject) => {
-      web3.eth.getBalance(account, (err, res) => {
-        if (err !== null) return reject(err);
-        return resolve(res);
-      });
-    });
-  },
-  web3GetTransaction(txid) {
-    return new Promise((resolve, reject) => {
-      web3.eth.getTransaction(txid, (err, res) => {
-        if (err !== null) return reject(err);
-        return resolve(res);
-      });
-    });
-  },
-  web3GetTransactionReceipt(txid) {
-    return new Promise((resolve, reject) => {
-      web3.eth.getTransactionReceipt(txid, (err, res) => {
-        if (err !== null) return reject(err);
-        return resolve(res);
-      });
-    });
-  },
-  web3GetFirstTransactionHashFromLastBlock() {
-    return new Promise((resolve, reject) => {
-      web3.eth.getBlock("latest", true, (err, res) => {
-        if (err !== null) return reject(err);
-        return resolve(res.transactions[0].hash);
-      });
-    });
-  },
-  async checkErrorRevert(promise) {
-    return this.checkError(promise, false);
-  },
-  async checkErrorAssert(promise) {
-    return this.checkError(promise, true);
-  },
-  async checkError(promise, isAssert) {
-    // TODO: Remove this complexity when solidity-coverage moves up to ganache beta as
-    // Solidity error handling there no longer throws on contract error
-    // See release notes for details https://github.com/trufflesuite/ganache-cli/releases/tag/v7.0.0-beta.0
-    // There is a discrepancy between how testrpc handles errors
-    // (throwing an exception all the way up to these tests) and how geth/parity handle them
-    // (still making a valid transaction and returning a txid). For the explanation of why
-    // See https://github.com/ethereumjs/testrpc/issues/39
-    //
-    // Obviously, we want our tests to pass on all, so this is a bit of a problem.
-    // We have to have this special function that we use to catch the error.
-    // For testrpc we additionally check the error returned is from a `require` failure.
-    let txHash;
-    try {
-      const tx = await promise;
-      txHash = tx.tx;
-    } catch (err) {
-      // Make sure this is a revert (returned from EtherRouter)
-      if (err.message.indexOf("VM Exception while processing transaction: revert") === -1) {
-        throw err;
-      }
+  });
+}
 
-      txHash = await this.web3GetFirstTransactionHashFromLastBlock();
+export function web3GetClient() {
+  return new Promise((resolve, reject) => {
+    web3.version.getNode((err, res) => {
+      if (err !== null) return reject(err);
+      return resolve(res);
+    });
+  });
+}
+
+export function web3GetBalance(account) {
+  return new Promise((resolve, reject) => {
+    web3.eth.getBalance(account, (err, res) => {
+      if (err !== null) return reject(err);
+      return resolve(res);
+    });
+  });
+}
+
+export function web3GetTransaction(txid) {
+  return new Promise((resolve, reject) => {
+    web3.eth.getTransaction(txid, (err, res) => {
+      if (err !== null) return reject(err);
+      return resolve(res);
+    });
+  });
+}
+
+export function web3GetTransactionReceipt(txid) {
+  return new Promise((resolve, reject) => {
+    web3.eth.getTransactionReceipt(txid, (err, res) => {
+      if (err !== null) return reject(err);
+      return resolve(res);
+    });
+  });
+}
+
+export function web3GetFirstTransactionHashFromLastBlock() {
+  return new Promise((resolve, reject) => {
+    web3.eth.getBlock("latest", true, (err, res) => {
+      if (err !== null) return reject(err);
+      return resolve(res.transactions[0].hash);
+    });
+  });
+}
+
+export async function checkError(promise, isAssert) {
+  // TODO: Remove this complexity when solidity-coverage moves up to ganache beta as
+  // Solidity error handling there no longer throws on contract error
+  // See release notes for details https://github.com/trufflesuite/ganache-cli/releases/tag/v7.0.0-beta.0
+  // There is a discrepancy between how testrpc handles errors
+  // (throwing an exception all the way up to these tests) and how geth/parity handle them
+  // (still making a valid transaction and returning a txid). For the explanation of why
+  // See https://github.com/ethereumjs/testrpc/issues/39
+  //
+  // Obviously, we want our tests to pass on all, so this is a bit of a problem.
+  // We have to have this special function that we use to catch the error.
+  // For testrpc we additionally check the error returned is from a `require` failure.
+  let txHash;
+  try {
+    const tx = await promise;
+    txHash = tx.tx;
+  } catch (err) {
+    // Make sure this is a revert (returned from EtherRouter)
+    if (err.message.indexOf("VM Exception while processing transaction: revert") === -1) {
+      throw err;
     }
 
-    const receipt = await this.web3GetTransactionReceipt(txHash);
-    // Check the receipt `status` to ensure transaction failed.
-    assert.equal(receipt.status, 0x00);
+    txHash = await web3GetFirstTransactionHashFromLastBlock();
+  }
 
-    if (isAssert) {
-      const network = await this.web3GetNetwork();
-      const transaction = await this.web3GetTransaction(txHash);
-      if (network !== "coverage") {
-        // When a transaction throws, all the gas sent is spent. So let's check that we spent all the gas that we sent.
-        // When using EtherRouter not all sent gas is spent, it is 73000 gas less than the total.
-        assert.closeTo(transaction.gas, receipt.gasUsed, 73000, "didnt fail - didn't throw and use all gas");
-      }
-    }
-  },
-  checkErrorNonPayableFunction(tx) {
-    assert.equal(tx, "Error: Cannot send value to non-payable function");
-  },
-  getRandomString(_length) {
-    const length = _length || 7;
-    let randString = "";
-    while (randString.length < length) {
-      randString += shortid
-        .generate()
-        .replace(/_/g, "")
-        .toLowerCase();
-    }
-    return randString.slice(0, length);
-  },
-  getTokenArgs() {
-    return [this.getRandomString(5), this.getRandomString(3), 18];
-  },
-  hexToUtf8(text) {
-    return web3.toAscii(text).replace(/\u0000/g, "");
-  },
-  currentBlockTime() {
-    const p = new Promise((resolve, reject) => {
-      web3.eth.getBlock("latest", (err, res) => {
-        if (err) {
-          return reject(err);
-        }
-        return resolve(res.timestamp);
-      });
-    });
-    return p;
-  },
-  async expectEvent(tx, eventName) {
-    const { logs } = await tx;
-    const event = logs.find(e => e.event === eventName);
-    return assert.exists(event);
-  },
-  async forwardTime(seconds, test) {
-    const client = await this.web3GetClient();
-    if (client.indexOf("TestRPC") === -1) {
-      test.skip();
-    } else {
-      // console.log('Forwarding time with ' + seconds + 's ...');
-      await web3.currentProvider.send({
-        jsonrpc: "2.0",
-        method: "evm_increaseTime",
-        params: [seconds],
-        id: 0
-      });
-      await web3.currentProvider.send({
-        jsonrpc: "2.0",
-        method: "evm_mine",
-        params: [],
-        id: 0
-      });
+  const receipt = await web3GetTransactionReceipt(txHash);
+  // Check the receipt `status` to ensure transaction failed.
+  assert.equal(receipt.status, 0x00);
+
+  if (isAssert) {
+    const network = await web3GetNetwork();
+    const transaction = await web3GetTransaction(txHash);
+    if (network !== "coverage") {
+      // When a transaction throws, all the gas sent is spent. So let's check that we spent all the gas that we sent.
+      // When using EtherRouter not all sent gas is spent, it is 73000 gas less than the total.
+      assert.closeTo(transaction.gas, receipt.gasUsed, 73000, "didnt fail - didn't throw and use all gas");
     }
   }
-};
+}
+
+export async function checkErrorRevert(promise) {
+  return checkError(promise, false);
+}
+
+export async function checkErrorAssert(promise) {
+  return checkError(promise, true);
+}
+
+export function checkErrorNonPayableFunction(tx) {
+  assert.equal(tx, "Error: Cannot send value to non-payable function");
+}
+
+export function getRandomString(_length) {
+  const length = _length || 7;
+  let randString = "";
+  while (randString.length < length) {
+    randString += shortid
+      .generate()
+      .replace(/_/g, "")
+      .toLowerCase();
+  }
+  return randString.slice(0, length);
+}
+
+export function getTokenArgs() {
+  return [getRandomString(5), getRandomString(3), 18];
+}
+
+export function hexToUtf8(text) {
+  return web3.toAscii(text).replace(/\u0000/g, "");
+}
+
+export function currentBlockTime() {
+  return web3.eth.getBlock("latest").timestamp;
+}
+
+export async function expectEvent(tx, eventName) {
+  const { logs } = await tx;
+  const event = logs.find(e => e.event === eventName);
+  return assert.exists(event);
+}
+
+export async function forwardTime(seconds, test) {
+  const client = await web3GetClient();
+  if (client.indexOf("TestRPC") === -1) {
+    test.skip();
+  } else {
+    // console.log('Forwarding time with ' + seconds + 's ...');
+    web3.currentProvider.send({
+      jsonrpc: "2.0",
+      method: "evm_increaseTime",
+      params: [seconds],
+      id: 0
+    });
+    web3.currentProvider.send({
+      jsonrpc: "2.0",
+      method: "evm_mine",
+      params: [],
+      id: 0
+    });
+  }
+}

--- a/helpers/upgradable-contracts.js
+++ b/helpers/upgradable-contracts.js
@@ -2,100 +2,99 @@ import web3Utils from "web3-utils";
 import assert from "assert";
 import fs from "fs";
 
-module.exports = {
-  async setupUpgradableToken(token, resolver, etherRouter) {
-    const deployedImplementations = {};
-    deployedImplementations.Token = token.address;
-    await this.setupEtherRouter("ERC20Extended", deployedImplementations, resolver);
-
-    await etherRouter.setResolver(resolver.address);
-    const registeredResolver = await etherRouter.resolver.call();
-    assert.equal(registeredResolver, resolver.address);
-  },
-  async setupColonyVersionResolver(colony, colonyTask, colonyFunding, colonyTransactionReviewer, resolver, colonyNetwork) {
-    const deployedImplementations = {};
-    deployedImplementations.Colony = colony.address;
-    deployedImplementations.ColonyTask = colonyTask.address;
-    deployedImplementations.ColonyFunding = colonyFunding.address;
-    deployedImplementations.ColonyTransactionReviewer = colonyTransactionReviewer.address;
-
-    await this.setupEtherRouter("IColony", deployedImplementations, resolver);
-
-    const version = await colony.version.call();
-    await colonyNetwork.addColonyVersion(version.toNumber(), resolver.address);
-    const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
-    assert.equal(version, currentColonyVersion.toNumber());
-  },
-  async setupUpgradableColonyNetwork(etherRouter, resolver, colonyNetwork, colonyNetworkStaking) {
-    const deployedImplementations = {};
-    deployedImplementations.ColonyNetwork = colonyNetwork.address;
-    deployedImplementations.ColonyNetworkStaking = colonyNetworkStaking.address;
-
-    await this.setupEtherRouter("IColonyNetwork", deployedImplementations, resolver);
-
-    await etherRouter.setResolver(resolver.address);
-  },
-  async setupEtherRouter(interfaceContract, deployedImplementations, resolver) {
-    const that = this;
-    const functionsToResolve = {};
-
-    // Load ABI of the interface of the contract we're trying to stich together
-    const iAbi = JSON.parse(fs.readFileSync(`./build/contracts/${interfaceContract}.json`, "utf8")).abi;
-    iAbi.map(value => {
-      const fName = value.name;
-      const fType = value.type;
-      // These are from DSAuth, and so are on EtherRouter itself without any more help.
-      if (fName !== "authority" && fName !== "owner") {
-        // We only care about functions.
-        if (fType === "function") {
-          // Gets the types of the parameters, which is all we care about for function signatures.
-          const fInputs = value.inputs.map(parameter => parameter.type);
-          const fOutputSize = value.outputs.length * 32;
-          // Record function name and how much data is returned
-          functionsToResolve[fName] = { inputs: fInputs, outputSize: fOutputSize, definedIn: "" };
-        }
+export function parseImplementation(contractName, functionsToResolve, deployedImplementations) {
+  // Goes through a contract, and sees if anything in it is in the interface. If it is, then wire up the resolver to point at it
+  const { abi } = JSON.parse(fs.readFileSync(`./build/contracts/${contractName}.json`));
+  abi.map(value => {
+    const fName = value.name;
+    if (functionsToResolve[fName]) {
+      if (functionsToResolve[fName].definedIn !== "") {
+        // It's a Friday afternoon, and I can't be bothered to deal with same name, different signature.
+        // Let's just resolve to not do it? We'd probably just trip ourselves up later.
+        // eslint-disable-next-line no-console
+        console.log(
+          "What are you doing!? Defining functions with the same name in different files!? You are going to do yourself a mischief. ",
+          "You seem to have two ",
+          fName,
+          " in ",
+          contractName,
+          "and ",
+          functionsToResolve[fName].definedIn
+        );
+        process.exit(1);
       }
-      return functionsToResolve;
-    });
+      functionsToResolve[fName].definedIn = deployedImplementations[contractName]; // eslint-disable-line no-param-reassign
+    }
+    return functionsToResolve[fName];
+  });
+}
 
-    Object.keys(deployedImplementations).map(name => that.parseImplementation(name, functionsToResolve, deployedImplementations));
+export async function setupEtherRouter(interfaceContract, deployedImplementations, resolver) {
+  const functionsToResolve = {};
 
-    const promises = Object.keys(functionsToResolve).map(async fName => {
-      const sig = `${fName}(${functionsToResolve[fName].inputs.join(",")})`;
-      const address = functionsToResolve[fName].definedIn;
-      const { outputSize } = functionsToResolve[fName];
-      const sigHash = web3Utils.soliditySha3(sig).substr(0, 10);
-      await resolver.register(sig, address, outputSize);
-      const response = await resolver.lookup.call(sigHash);
-      assert.equal(response[0], address, `${sig} has not been registered correctly. Is it defined?`);
-      assert.equal(response[1], outputSize, `${sig} has the wrong output size.`);
-    });
-    return Promise.all(promises);
-  },
-  parseImplementation(contractName, functionsToResolve, deployedImplementations) {
-    // Goes through a contract, and sees if anything in it is in the interface. If it is, then wire up the resolver to point at it
-    const { abi } = JSON.parse(fs.readFileSync(`./build/contracts/${contractName}.json`));
-    abi.map(value => {
-      const fName = value.name;
-      if (functionsToResolve[fName]) {
-        if (functionsToResolve[fName].definedIn !== "") {
-          // It's a Friday afternoon, and I can't be bothered to deal with same name, different signature.
-          // Let's just resolve to not do it? We'd probably just trip ourselves up later.
-          // eslint-disable-next-line no-console
-          console.log(
-            "What are you doing defining functions with the same name in different files!? You are going to do yourself a mischief. ",
-            "You seem to have two ",
-            fName,
-            " in ",
-            contractName,
-            "and ",
-            functionsToResolve[fName].definedIn
-          );
-          process.exit(1);
-        }
-        functionsToResolve[fName].definedIn = deployedImplementations[contractName]; // eslint-disable-line no-param-reassign
+  // Load ABI of the interface of the contract we're trying to stich together
+  const iAbi = JSON.parse(fs.readFileSync(`./build/contracts/${interfaceContract}.json`, "utf8")).abi;
+  iAbi.map(value => {
+    const fName = value.name;
+    const fType = value.type;
+    // These are from DSAuth, and so are on EtherRouter itself without any more help.
+    if (fName !== "authority" && fName !== "owner") {
+      // We only care about functions.
+      if (fType === "function") {
+        // Gets the types of the parameters, which is all we care about for function signatures.
+        const fInputs = value.inputs.map(parameter => parameter.type);
+        const fOutputSize = value.outputs.length * 32;
+        // Record function name and how much data is returned
+        functionsToResolve[fName] = { inputs: fInputs, outputSize: fOutputSize, definedIn: "" };
       }
-      return functionsToResolve[fName];
-    });
-  }
-};
+    }
+    return functionsToResolve;
+  });
+  Object.keys(deployedImplementations).map(name => parseImplementation(name, functionsToResolve, deployedImplementations));
+  const promises = Object.keys(functionsToResolve).map(async fName => {
+    const sig = `${fName}(${functionsToResolve[fName].inputs.join(",")})`;
+    const address = functionsToResolve[fName].definedIn;
+    const { outputSize } = functionsToResolve[fName];
+    const sigHash = web3Utils.soliditySha3(sig).substr(0, 10);
+    await resolver.register(sig, address, outputSize);
+    const response = await resolver.lookup.call(sigHash);
+    assert.equal(response[0], address, `${sig} has not been registered correctly. Is it defined?`);
+    assert.equal(response[1], outputSize, `${sig} has the wrong output size.`);
+  });
+  return Promise.all(promises);
+}
+
+export async function setupUpgradableToken(token, resolver, etherRouter) {
+  const deployedImplementations = {};
+  deployedImplementations.Token = token.address;
+  await setupEtherRouter("ERC20Extended", deployedImplementations, resolver);
+
+  await etherRouter.setResolver(resolver.address);
+  const registeredResolver = await etherRouter.resolver.call();
+  assert.equal(registeredResolver, resolver.address);
+}
+
+export async function setupColonyVersionResolver(colony, colonyTask, colonyFunding, colonyTransactionReviewer, resolver, colonyNetwork) {
+  const deployedImplementations = {};
+  deployedImplementations.Colony = colony.address;
+  deployedImplementations.ColonyTask = colonyTask.address;
+  deployedImplementations.ColonyFunding = colonyFunding.address;
+  deployedImplementations.ColonyTransactionReviewer = colonyTransactionReviewer.address;
+
+  await setupEtherRouter("IColony", deployedImplementations, resolver);
+
+  const version = await colony.version.call();
+  await colonyNetwork.addColonyVersion(version.toNumber(), resolver.address);
+  const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
+  assert.equal(version, currentColonyVersion.toNumber());
+}
+
+export async function setupUpgradableColonyNetwork(etherRouter, resolver, colonyNetwork, colonyNetworkStaking) {
+  const deployedImplementations = {};
+  deployedImplementations.ColonyNetwork = colonyNetwork.address;
+  deployedImplementations.ColonyNetworkStaking = colonyNetworkStaking.address;
+
+  await setupEtherRouter("IColonyNetwork", deployedImplementations, resolver);
+
+  await etherRouter.setResolver(resolver.address);
+}

--- a/migrations/3_setup_colony_network.js
+++ b/migrations/3_setup_colony_network.js
@@ -1,6 +1,6 @@
 /* globals artifacts */
 /* eslint-disable no-console */
-const upgradableContracts = require("../helpers/upgradable-contracts");
+const { setupUpgradableColonyNetwork } = require("../helpers/upgradable-contracts");
 
 const ColonyNetwork = artifacts.require("./ColonyNetwork");
 const ColonyNetworkStaking = artifacts.require("./ColonyNetworkStaking");
@@ -28,7 +28,7 @@ module.exports = deployer => {
     })
     .then(instance => {
       resolver = instance;
-      return upgradableContracts.setupUpgradableColonyNetwork(etherRouter, resolver, colonyNetwork, colonyNetworkStaking);
+      return setupUpgradableColonyNetwork(etherRouter, resolver, colonyNetwork, colonyNetworkStaking);
     })
     .then(() => {
       console.log("### Colony Network setup with Resolver", resolver.address, "and EtherRouter", etherRouter.address);

--- a/migrations/4_setup_colony_version_resolver.js
+++ b/migrations/4_setup_colony_version_resolver.js
@@ -1,7 +1,7 @@
 /* globals artifacts */
 /* eslint-disable no-console */
 
-const upgradableContracts = require("../helpers/upgradable-contracts");
+const { setupColonyVersionResolver } = require("../helpers/upgradable-contracts");
 
 const Colony = artifacts.require("./Colony");
 const ColonyFunding = artifacts.require("./ColonyFunding");
@@ -50,7 +50,7 @@ module.exports = deployer => {
     .then(instance => {
       colonyNetwork = instance;
       // Register the new Colony contract version with the newly setup Resolver
-      return upgradableContracts.setupColonyVersionResolver(colony, colonyTask, colonyFunding, colonyTransactionReviewer, resolver, colonyNetwork);
+      return setupColonyVersionResolver(colony, colonyTask, colonyFunding, colonyTransactionReviewer, resolver, colonyNetwork);
     })
     .then(() => {
       console.log("### Colony version", version, "set to Resolver", resolver.address);

--- a/test/colony-network-staking.js
+++ b/test/colony-network-staking.js
@@ -1,6 +1,6 @@
 /* globals artifacts */
-import testHelper from "../helpers/test-helper";
-import testDataGenerator from "../helpers/test-data-generator";
+import { forwardTime, checkErrorRevert } from "../helpers/test-helper";
+import { giveUserCLNYTokens, setupRatedTask, fundColonyWithTokens } from "../helpers/test-data-generator";
 
 const EtherRouter = artifacts.require("EtherRouter");
 const IColony = artifacts.require("IColony");
@@ -36,7 +36,7 @@ contract("ColonyNetworkStaking", accounts => {
     if (respondToChallenge) {
       const oppIdx = idx % 2 === 1 ? idx - 1 : idx + 1;
       await repCycle.respondToChallenge(round, oppIdx);
-      await testHelper.forwardTime(600, test);
+      await forwardTime(600, test);
     }
     return repCycle.invalidateHash(round, idx);
   }
@@ -74,7 +74,7 @@ contract("ColonyNetworkStaking", accounts => {
 
   describe("when initialised", () => {
     it("should allow miners to stake CLNY", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, 9000);
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, 9000);
       await clny.approve(colonyNetwork.address, 5000, { from: OTHER_ACCOUNT });
       await colonyNetwork.deposit(5000, { from: OTHER_ACCOUNT });
       const userBalance = await clny.balanceOf.call(OTHER_ACCOUNT);
@@ -84,7 +84,7 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should allow miners to withdraw staked CLNY", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, 9000);
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, 9000);
       await clny.approve(colonyNetwork.address, 5000, { from: OTHER_ACCOUNT });
       await colonyNetwork.deposit(5000, { from: OTHER_ACCOUNT });
       await colonyNetwork.withdraw(5000, { from: OTHER_ACCOUNT });
@@ -93,9 +93,9 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow miners to deposit more CLNY than they have", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, 9000);
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, 9000);
       await clny.approve(colonyNetwork.address, 10000, { from: OTHER_ACCOUNT });
-      await testHelper.checkErrorRevert(colonyNetwork.deposit(10000, { from: OTHER_ACCOUNT }));
+      await checkErrorRevert(colonyNetwork.deposit(10000, { from: OTHER_ACCOUNT }));
       const userBalance = await clny.balanceOf.call(OTHER_ACCOUNT);
       assert.equal(userBalance.toNumber(), 9000);
       const stakedBalance = await colonyNetwork.getStakedBalance.call(OTHER_ACCOUNT);
@@ -103,13 +103,13 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow miners to withdraw more CLNY than they staked, even if enough has been staked total", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, 9000);
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, 9000);
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, 9000);
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, 9000);
       await clny.approve(colonyNetwork.address, 9000, { from: OTHER_ACCOUNT });
       await clny.approve(colonyNetwork.address, 9000, { from: MAIN_ACCOUNT });
       await colonyNetwork.deposit(9000, { from: OTHER_ACCOUNT });
       await colonyNetwork.deposit(9000, { from: MAIN_ACCOUNT });
-      await testHelper.checkErrorRevert(colonyNetwork.withdraw(10000, { from: OTHER_ACCOUNT }));
+      await checkErrorRevert(colonyNetwork.withdraw(10000, { from: OTHER_ACCOUNT }));
       const stakedBalance = await colonyNetwork.getStakedBalance.call(OTHER_ACCOUNT);
       assert.equal(stakedBalance.toNumber(), 9000);
       const userBalance = await clny.balanceOf.call(OTHER_ACCOUNT);
@@ -117,12 +117,12 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should allow a new reputation hash to be submitted", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       const submitterAddress = await repCycle.submittedHashes.call("0x12345678", 10, 0);
@@ -131,35 +131,35 @@ contract("ColonyNetworkStaking", accounts => {
 
     it("should not allow someone to submit a new reputation hash if they are not staking", async () => {
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600);
+      await forwardTime(3600);
       const repCycle = ReputationMiningCycle.at(addr);
-      await testHelper.checkErrorRevert(repCycle.submitNewHash("0x12345678", 10, 0));
+      await checkErrorRevert(repCycle.submitNewHash("0x12345678", 10, 0));
       const nSubmittedHashes = await repCycle.nSubmittedHashes.call();
       assert(nSubmittedHashes.equals(0));
     });
 
     it("should not allow someone to withdraw their stake if they have submitted a hash this round", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600);
+      await forwardTime(3600);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       let stakedBalance = await colonyNetwork.getStakedBalance.call(MAIN_ACCOUNT);
-      await testHelper.checkErrorRevert(colonyNetwork.withdraw(stakedBalance.toNumber(), { from: MAIN_ACCOUNT }));
+      await checkErrorRevert(colonyNetwork.withdraw(stakedBalance.toNumber(), { from: MAIN_ACCOUNT }));
       stakedBalance = await colonyNetwork.getStakedBalance.call(MAIN_ACCOUNT);
       assert(stakedBalance.equals("1000000000000000000"));
     });
 
     it("should allow a new reputation hash to be set if only one was submitted", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       await repCycle.confirmNewHash(0);
@@ -174,8 +174,8 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should allow a new reputation hash to be set if all but one submitted have been elimintated", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, new BN("1000000000000000000"));
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, new BN("1000000000000000000"));
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -183,7 +183,7 @@ contract("ColonyNetworkStaking", accounts => {
       await colonyNetwork.deposit("1000000000000000000", { from: OTHER_ACCOUNT });
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       await repCycle.submitNewHash("0x87654321", 10, 10, { from: OTHER_ACCOUNT });
@@ -200,9 +200,9 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should allow a new reputation hash to be moved to the next stage of competition even if it does not have a partner", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, accounts[2], "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, accounts[2], "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -212,7 +212,7 @@ contract("ColonyNetworkStaking", accounts => {
       await colonyNetwork.deposit("1000000000000000000", { from: accounts[2] });
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       await repCycle.submitNewHash("0x87654321", 11, 10, { from: OTHER_ACCOUNT });
@@ -233,18 +233,18 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow a new reputation hash to be set if more than one was submitted and they have not been elimintated", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000", { from: OTHER_ACCOUNT });
       await colonyNetwork.deposit("1000000000000000000", { from: OTHER_ACCOUNT });
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       await repCycle.submitNewHash("0x87654321", 10, 10, { from: OTHER_ACCOUNT });
-      await testHelper.checkErrorRevert(repCycle.confirmNewHash(0));
+      await checkErrorRevert(repCycle.confirmNewHash(0));
       const newAddr = await colonyNetwork.getReputationMiningCycle.call();
       assert(newAddr !== 0x0);
       assert(addr !== 0x0);
@@ -254,8 +254,8 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow the last reputation hash to be eliminated", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, new BN("1000000000000000000"));
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, new BN("1000000000000000000"));
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -263,30 +263,30 @@ contract("ColonyNetworkStaking", accounts => {
       await colonyNetwork.deposit("1000000000000000000", { from: OTHER_ACCOUNT });
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       await repCycle.submitNewHash("0x87654321", 10, 10, { from: OTHER_ACCOUNT });
       await accommodateChallengeAndInvalidateHash(this, 0, 1);
-      await testHelper.checkErrorRevert(accommodateChallengeAndInvalidateHash(this, 1, 1, false));
+      await checkErrorRevert(accommodateChallengeAndInvalidateHash(this, 1, 1, false));
     });
 
     it("should not allow someone to submit a new reputation hash if they are ineligible", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, new BN("1000000000000000000"));
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
       const repCycle = ReputationMiningCycle.at(addr);
-      await testHelper.checkErrorRevert(repCycle.submitNewHash("0x12345678", 10, 10));
+      await checkErrorRevert(repCycle.submitNewHash("0x12345678", 10, 10));
       const nSubmittedHashes = await repCycle.nSubmittedHashes.call();
       assert(nSubmittedHashes.equals(0));
     });
 
     it("should punish all stakers if they misbehave (and report a bad hash)", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, accounts[2], "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, accounts[2], "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -300,7 +300,7 @@ contract("ColonyNetworkStaking", accounts => {
       assert(balance.equals("1000000000000000000"));
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       await repCycle.submitNewHash("0x87654321", 10, 10, { from: OTHER_ACCOUNT });
@@ -313,9 +313,9 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should reward all stakers if they submitted the agreed new hash", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, accounts[2], "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, accounts[2], "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -323,7 +323,7 @@ contract("ColonyNetworkStaking", accounts => {
       await colonyNetwork.deposit("1000000000000000000", { from: OTHER_ACCOUNT });
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       await repCycle.submitNewHash("0x12345678", 10, 8, { from: OTHER_ACCOUNT });
@@ -357,56 +357,56 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow a user to back more than one hash in a single cycle", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
       const repCycle = ReputationMiningCycle.at(addr);
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       await repCycle.submitNewHash("0x12345678", 10, 10);
-      await testHelper.checkErrorRevert(repCycle.submitNewHash("0x87654321", 10, 10));
+      await checkErrorRevert(repCycle.submitNewHash("0x87654321", 10, 10));
       const nSubmittedHashes = await repCycle.nSubmittedHashes.call();
       assert(nSubmittedHashes.equals(1));
     });
 
     it("should not allow a user to back the same hash with different number of nodes in a single cycle", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
       const repCycle = ReputationMiningCycle.at(addr);
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       await repCycle.submitNewHash("0x12345678", 10, 10);
 
-      await testHelper.checkErrorRevert(repCycle.submitNewHash("0x12345678", 11, 9));
+      await checkErrorRevert(repCycle.submitNewHash("0x12345678", 11, 9));
       const nSubmittedHashes = await repCycle.nSubmittedHashes.call();
       assert(nSubmittedHashes.equals(1));
     });
 
     it("should not allow a user to submit the same entry for the same hash twice in a single cycle", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
       const repCycle = ReputationMiningCycle.at(addr);
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       await repCycle.submitNewHash("0x12345678", 10, 10);
-      await testHelper.checkErrorRevert(repCycle.submitNewHash("0x12345678", 10, 10));
+      await checkErrorRevert(repCycle.submitNewHash("0x12345678", 10, 10));
       const nSubmittedHashes = await repCycle.nSubmittedHashes.call();
       assert(nSubmittedHashes.equals(1));
     });
 
     it("should allow a user to back the same hash more than once in a same cycle with different entries, and be rewarded", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
       const repCycle = ReputationMiningCycle.at(addr);
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       await repCycle.submitNewHash("0x12345678", 10, 9);
       const nSubmittedHashes = await repCycle.nSubmittedHashes.call();
@@ -439,12 +439,12 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should only allow 12 entries to back a single hash in each cycle", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 1);
       await repCycle.submitNewHash("0x12345678", 10, 2);
@@ -458,13 +458,13 @@ contract("ColonyNetworkStaking", accounts => {
       await repCycle.submitNewHash("0x12345678", 10, 10);
       await repCycle.submitNewHash("0x12345678", 10, 11);
       await repCycle.submitNewHash("0x12345678", 10, 12);
-      await testHelper.checkErrorRevert(repCycle.submitNewHash("0x12345678", 10, 13));
+      await checkErrorRevert(repCycle.submitNewHash("0x12345678", 10, 13));
     });
 
     it("should cope with many hashes being submitted and eliminated before a winner is assigned", async () => {
       // TODO: This test probably needs to be written more carefully to make sure all possible edge cases are dealt with
       for (let i = 0; i < accounts.length; i += 1) {
-        await testDataGenerator.giveUserCLNYTokens(colonyNetwork, accounts[i], "1000000000000000000"); // eslint-disable-line no-await-in-loop
+        await giveUserCLNYTokens(colonyNetwork, accounts[i], "1000000000000000000"); // eslint-disable-line no-await-in-loop
         // These have to be done sequentially because this function uses the total number of tasks as a proxy for getting the
         // right taskId, so if they're all created at once it messes up.
       }
@@ -473,7 +473,7 @@ contract("ColonyNetworkStaking", accounts => {
 
       const reputationMiningCycleAddress = await colonyNetwork.getReputationMiningCycle.call();
       const repCycle = ReputationMiningCycle.at(reputationMiningCycleAddress);
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       await Promise.all(accounts.map(addr => repCycle.submitNewHash(addr, 10, 1, { from: addr })));
       // We're submitting hashes equal to their addresses for ease, though they will get zero padded.
 
@@ -503,7 +503,7 @@ contract("ColonyNetworkStaking", accounts => {
       assert(accounts.length >= 8, "Not enough accounts for test to run");
       const accountsForTest = accounts.slice(0, 8);
       for (let i = 0; i < 8; i += 1) {
-        await testDataGenerator.giveUserCLNYTokens(colonyNetwork, accountsForTest[i], "1000000000000000000"); // eslint-disable-line no-await-in-loop
+        await giveUserCLNYTokens(colonyNetwork, accountsForTest[i], "1000000000000000000"); // eslint-disable-line no-await-in-loop
         // These have to be done sequentially because this function uses the total number of tasks as a proxy for getting the
         // right taskId, so if they're all created at once it messes up.
       }
@@ -512,13 +512,13 @@ contract("ColonyNetworkStaking", accounts => {
 
       const reputationMiningCycleAddress = await colonyNetwork.getReputationMiningCycle.call();
       const repCycle = ReputationMiningCycle.at(reputationMiningCycleAddress);
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       await Promise.all(accountsForTest.map(addr => repCycle.submitNewHash(addr, 10, 1, { from: addr })));
       await accommodateChallengeAndInvalidateHash(this, 0, 1);
       await accommodateChallengeAndInvalidateHash(this, 0, 3);
       await accommodateChallengeAndInvalidateHash(this, 0, 5);
       await accommodateChallengeAndInvalidateHash(this, 1, 1);
-      await testHelper.checkErrorRevert(accommodateChallengeAndInvalidateHash(this, 1, 3, false));
+      await checkErrorRevert(accommodateChallengeAndInvalidateHash(this, 1, 3, false));
       // Now clean up
       await accommodateChallengeAndInvalidateHash(this, 0, 7);
       await accommodateChallengeAndInvalidateHash(this, 1, 3);
@@ -527,8 +527,8 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should not allow a hash to be invalidated multiple times, which would move extra copies of its opponent to the next stage", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -536,18 +536,18 @@ contract("ColonyNetworkStaking", accounts => {
       await colonyNetwork.deposit("1000000000000000000", { from: OTHER_ACCOUNT });
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       await repCycle.submitNewHash("0x87654321", 10, 10, { from: OTHER_ACCOUNT });
       await accommodateChallengeAndInvalidateHash(this, 0, 1);
-      await testHelper.checkErrorRevert(accommodateChallengeAndInvalidateHash(this, 0, 1));
+      await checkErrorRevert(accommodateChallengeAndInvalidateHash(this, 0, 1));
     });
 
     it("should invalidate a hash and its partner if both have timed out", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, accounts[2], "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, accounts[2], "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -557,20 +557,20 @@ contract("ColonyNetworkStaking", accounts => {
       await colonyNetwork.deposit("1000000000000000000", { from: accounts[2] });
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       await repCycle.submitNewHash("0x87654321", 10, 10, { from: OTHER_ACCOUNT });
       await repCycle.submitNewHash("0x99999999", 10, 10, { from: accounts[2] });
-      await testHelper.forwardTime(600, this);
+      await forwardTime(600, this);
       await accommodateChallengeAndInvalidateHash(this, 0, 1, false);
       await accommodateChallengeAndInvalidateHash(this, 0, 3, false);
       await repCycle.confirmNewHash(1);
     });
 
     it("should prevent invalidation of hashes before they have timed out on a challenge", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -578,19 +578,19 @@ contract("ColonyNetworkStaking", accounts => {
       await colonyNetwork.deposit("1000000000000000000", { from: OTHER_ACCOUNT });
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       await repCycle.submitNewHash("0x87654321", 10, 10, { from: OTHER_ACCOUNT });
-      await testHelper.checkErrorRevert(repCycle.invalidateHash(0, 1));
-      await testHelper.checkErrorRevert(repCycle.confirmNewHash(1));
+      await checkErrorRevert(repCycle.invalidateHash(0, 1));
+      await checkErrorRevert(repCycle.confirmNewHash(1));
       await accommodateChallengeAndInvalidateHash(this, 0, 1);
       await repCycle.confirmNewHash(1);
     });
 
     it("should prevent submission of hashes with an invalid entry for the balance of a user", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -598,41 +598,41 @@ contract("ColonyNetworkStaking", accounts => {
       await colonyNetwork.deposit("1000000000000000000", { from: OTHER_ACCOUNT });
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
-      await testHelper.checkErrorRevert(repCycle.submitNewHash("0x12345678", 10, 1000000000000));
+      await checkErrorRevert(repCycle.submitNewHash("0x12345678", 10, 1000000000000));
       await repCycle.submitNewHash("0x87654321", 10, 10, { from: OTHER_ACCOUNT });
     });
 
     it("should prevent submission of hashes with a valid entry, but invalid hash for the current time", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
       const repCycle = ReputationMiningCycle.at(addr);
-      await testHelper.checkErrorRevert(repCycle.submitNewHash("0x12345678", 10, 1));
+      await checkErrorRevert(repCycle.submitNewHash("0x12345678", 10, 1));
     });
 
     it('should not allow "setReputationRootHash" to be called from an account that is not not reputationMiningCycle', async () => {
-      await testHelper.checkErrorRevert(colonyNetwork.setReputationRootHash("0x000001", 10, [accounts[0], accounts[1]]));
+      await checkErrorRevert(colonyNetwork.setReputationRootHash("0x000001", 10, [accounts[0], accounts[1]]));
     });
 
     it('should not allow "punishStakers" to be called from an account that is not not reputationMiningCycle', async () => {
-      await testHelper.checkErrorRevert(colonyNetwork.punishStakers([accounts[0], accounts[1]]));
+      await checkErrorRevert(colonyNetwork.punishStakers([accounts[0], accounts[1]]));
     });
 
     it('should not allow "startNextCycle" to be called if a cycle is in progress', async () => {
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       assert(parseInt(addr, 16) !== 0);
-      await testHelper.checkErrorRevert(colonyNetwork.startNextCycle());
+      await checkErrorRevert(colonyNetwork.startNextCycle());
     });
 
     it("should allow submitted hashes to go through multiple responses to a challenge", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -640,7 +640,7 @@ contract("ColonyNetworkStaking", accounts => {
       await colonyNetwork.deposit("1000000000000000000", { from: OTHER_ACCOUNT });
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       await repCycle.submitNewHash("0x87654321", 10, 10, { from: OTHER_ACCOUNT });
@@ -653,26 +653,26 @@ contract("ColonyNetworkStaking", accounts => {
     });
 
     it("should only allow the last hash standing to be confirmed", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000", { from: OTHER_ACCOUNT });
       await colonyNetwork.deposit("1000000000000000000", { from: OTHER_ACCOUNT });
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       await repCycle.submitNewHash("0x87654321", 10, 10, { from: OTHER_ACCOUNT });
       await accommodateChallengeAndInvalidateHash(this, 0, 0);
-      await testHelper.checkErrorRevert(repCycle.confirmNewHash(0));
+      await checkErrorRevert(repCycle.confirmNewHash(0));
       await repCycle.confirmNewHash(1);
     });
 
     it("should fail if one tries to invalidate a hash that does not exist", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, accounts[2], "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, accounts[2], "1000000000000000000");
 
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
@@ -682,7 +682,7 @@ contract("ColonyNetworkStaking", accounts => {
       await colonyNetwork.deposit("1000000000000000000", { from: accounts[2] });
 
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
       await repCycle.submitNewHash("0x87654321", 11, 10, { from: OTHER_ACCOUNT });
@@ -690,22 +690,22 @@ contract("ColonyNetworkStaking", accounts => {
       await accommodateChallengeAndInvalidateHash(this, 0, 1);
       await accommodateChallengeAndInvalidateHash(this, 0, 3, false); // Invalidate the 'null' that partners the third hash submitted
       // No response to a challenge required.
-      await testHelper.checkErrorRevert(accommodateChallengeAndInvalidateHash(this, 1, 2, false));
+      await checkErrorRevert(accommodateChallengeAndInvalidateHash(this, 1, 2, false));
       // Cleanup after test
       await accommodateChallengeAndInvalidateHash(this, 1, 0);
       await repCycle.confirmNewHash(2);
     });
 
     it("should keep reputation updates that occur during one update window for the next window", async () => {
-      await testDataGenerator.giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await clny.approve(colonyNetwork.address, "1000000000000000000");
       await colonyNetwork.deposit("1000000000000000000");
       const addr = await colonyNetwork.getReputationMiningCycle.call();
-      await testHelper.forwardTime(3600, this);
+      await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitNewHash("0x12345678", 10, 10);
-      await testDataGenerator.fundColonyWithTokens(commonColony, clny, "300000000000000000000");
-      const taskId1 = await testDataGenerator.setupRatedTask(colonyNetwork, commonColony);
+      await fundColonyWithTokens(commonColony, clny, "350000000000000000000");
+      const taskId1 = await setupRatedTask({ colonyNetwork, colony: commonColony });
       await commonColony.finalizeTask(taskId1); // Creates an entry in the reputation log for the worker and manager
       const initialRepLogLength = await colonyNetwork.getReputationUpdateLogLength.call(true);
       await repCycle.confirmNewHash(0);

--- a/test/colony.js
+++ b/test/colony.js
@@ -19,8 +19,8 @@ import {
   RATING_1_SECRET,
   RATING_2_SECRET
 } from "../helpers/constants";
-import testHelper from "../helpers/test-helper";
-import testDataGenerator from "../helpers/test-data-generator";
+import { getRandomString, getTokenArgs, web3GetBalance, checkErrorRevert, hexToUtf8, expectEvent, currentBlockTime } from "../helpers/test-helper";
+import { fundColonyWithTokens, setupRatedTask, setupAssignedTask, setupFundedTask } from "../helpers/test-data-generator";
 
 const EtherRouter = artifacts.require("EtherRouter");
 const IColony = artifacts.require("IColony");
@@ -42,8 +42,8 @@ contract("Colony", () => {
   });
 
   beforeEach(async () => {
-    COLONY_KEY = testHelper.getRandomString(7);
-    const tokenArgs = testHelper.getTokenArgs();
+    COLONY_KEY = getRandomString(7);
+    const tokenArgs = getTokenArgs();
     await colonyNetwork.createColony(COLONY_KEY, ...tokenArgs);
     const address = await colonyNetwork.getColony.call(COLONY_KEY);
     colony = await IColony.at(address);
@@ -51,14 +51,14 @@ contract("Colony", () => {
     authority = await Authority.at(authorityAddress);
     const tokenAddress = await colony.getToken.call();
     token = await Token.at(tokenAddress);
-    const otherTokenArgs = testHelper.getTokenArgs();
+    const otherTokenArgs = getTokenArgs();
     otherToken = await Token.new(...otherTokenArgs);
   });
 
   describe("when initialised", () => {
     it("should accept ether", async () => {
       await colony.send(1);
-      const colonyBalance = await testHelper.web3GetBalance(colony.address);
+      const colonyBalance = await web3GetBalance(colony.address);
       assert.equal(colonyBalance.toNumber(), 1);
     });
 
@@ -73,11 +73,11 @@ contract("Colony", () => {
     });
 
     it("should fail if a non-admin tries to mint tokens", async () => {
-      await testHelper.checkErrorRevert(colony.mintTokens(100, { from: OTHER }));
+      await checkErrorRevert(colony.mintTokens(100, { from: OTHER }));
     });
 
     it("should not allow reinitialisation", async () => {
-      await testHelper.checkErrorRevert(colony.initialiseColony(0x0));
+      await checkErrorRevert(colony.initialiseColony(0x0));
     });
 
     it("should correctly generate a rating secret", async () => {
@@ -120,8 +120,8 @@ contract("Colony", () => {
     it("should allow admins to make task", async () => {
       await colony.makeTask(SPECIFICATION_HASH, 1);
       const task = await colony.getTask.call(1);
-      assert.equal(testHelper.hexToUtf8(task[0]), SPECIFICATION_HASH);
-      assert.equal(testHelper.hexToUtf8(task[1]), "");
+      assert.equal(hexToUtf8(task[0]), SPECIFICATION_HASH);
+      assert.equal(hexToUtf8(task[1]), "");
       assert.isFalse(task[2]);
       assert.isFalse(task[3]);
       assert.equal(task[4].toNumber(), 0);
@@ -129,7 +129,7 @@ contract("Colony", () => {
     });
 
     it("should fail if a non-admin user tries to make a task", async () => {
-      await testHelper.checkErrorRevert(colony.makeTask(SPECIFICATION_HASH, 1, { from: OTHER }));
+      await checkErrorRevert(colony.makeTask(SPECIFICATION_HASH, 1, { from: OTHER }));
       const taskCount = await colony.getTaskCount.call();
       assert.equal(taskCount.toNumber(), 0);
     });
@@ -162,7 +162,7 @@ contract("Colony", () => {
     });
 
     it("should log a TaskAdded event", async () => {
-      await testHelper.expectEvent(colony.makeTask(SPECIFICATION_HASH, 1), "TaskAdded");
+      await expectEvent(colony.makeTask(SPECIFICATION_HASH, 1), "TaskAdded");
     });
   });
 
@@ -186,11 +186,11 @@ contract("Colony", () => {
       await colony.approveTaskChange(1, WORKER_ROLE, { from: WORKER });
 
       const task = await colony.getTask.call(1);
-      assert.equal(testHelper.hexToUtf8(task[0]), SPECIFICATION_HASH_UPDATED);
+      assert.equal(hexToUtf8(task[0]), SPECIFICATION_HASH_UPDATED);
     });
 
     it("should allow manager to submit an update of task due date and worker to approve it", async () => {
-      const dueDate = await testHelper.currentBlockTime();
+      const dueDate = currentBlockTime();
 
       await colony.makeTask(SPECIFICATION_HASH, 1);
       await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
@@ -204,7 +204,7 @@ contract("Colony", () => {
 
     it("should fail if a non-colony call is made to the task update functions", async () => {
       await colony.makeTask(SPECIFICATION_HASH, 1);
-      await testHelper.checkErrorRevert(colony.setTaskBrief(1, SPECIFICATION_HASH_UPDATED, { from: OTHER }));
+      await checkErrorRevert(colony.setTaskBrief(1, SPECIFICATION_HASH_UPDATED, { from: OTHER }));
     });
 
     it("should fail if non-registered role tries to submit an update of task brief", async () => {
@@ -212,7 +212,7 @@ contract("Colony", () => {
       await colony.setTaskRoleUser(1, EVALUATOR_ROLE, EVALUATOR);
 
       const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
-      await testHelper.checkErrorRevert(colony.proposeTaskChange(txData, 0, 0, { from: OTHER }));
+      await checkErrorRevert(colony.proposeTaskChange(txData, 0, 0, { from: OTHER }));
     });
 
     it("should fail if evaluator tries to submit an update of task brief", async () => {
@@ -221,7 +221,7 @@ contract("Colony", () => {
       await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
 
       const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
-      await testHelper.checkErrorRevert(colony.proposeTaskChange(txData, 0, EVALUATOR_ROLE, { from: EVALUATOR }));
+      await checkErrorRevert(colony.proposeTaskChange(txData, 0, EVALUATOR_ROLE, { from: EVALUATOR }));
     });
 
     it("should fail if non-registered role tries to approve an update of task brief", async () => {
@@ -230,7 +230,7 @@ contract("Colony", () => {
 
       const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
       await colony.proposeTaskChange(txData, 0, MANAGER_ROLE);
-      await testHelper.checkErrorRevert(colony.approveTaskChange(1, WORKER_ROLE, { from: WORKER }));
+      await checkErrorRevert(colony.approveTaskChange(1, WORKER_ROLE, { from: WORKER }));
     });
 
     it("should fail if evaluator tries to approve an update of task brief", async () => {
@@ -240,13 +240,13 @@ contract("Colony", () => {
 
       const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
       await colony.proposeTaskChange(txData, 0, MANAGER_ROLE);
-      await testHelper.checkErrorRevert(colony.approveTaskChange(1, EVALUATOR_ROLE, { from: EVALUATOR }));
+      await checkErrorRevert(colony.approveTaskChange(1, EVALUATOR_ROLE, { from: EVALUATOR }));
     });
 
     it("should fail to submit a task update for a non-registered function signature", async () => {
       await colony.makeTask(SPECIFICATION_HASH, 1);
       const txData = await colony.contract.getTaskRole.getData(1, 0);
-      await testHelper.checkErrorRevert(colony.proposeTaskChange(txData, 0, 0));
+      await checkErrorRevert(colony.proposeTaskChange(txData, 0, 0));
       const transactionCount = await colony.getTransactionCount.call();
       assert.equal(transactionCount.toNumber(), 0);
     });
@@ -255,18 +255,18 @@ contract("Colony", () => {
       await colony.makeTask(SPECIFICATION_HASH, 1);
       const txData = await colony.contract.setTaskBrief.getData(10, SPECIFICATION_HASH_UPDATED);
 
-      await testHelper.checkErrorRevert(colony.proposeTaskChange(txData, 0, 0));
+      await checkErrorRevert(colony.proposeTaskChange(txData, 0, 0));
       const transactionCount = await colony.getTransactionCount.call();
       assert.equal(transactionCount.toNumber(), 0);
     });
 
     it("should fail to submit update of task brief, if the task was already finalized", async () => {
-      await testDataGenerator.fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await testDataGenerator.setupRatedTask(colonyNetwork, colony, token);
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      const taskId = await setupRatedTask({ colonyNetwork, colony, token });
       await colony.finalizeTask(taskId);
 
       const txData = await colony.contract.setTaskBrief.getData(taskId, SPECIFICATION_HASH_UPDATED);
-      await testHelper.checkErrorRevert(colony.proposeTaskChange(txData, 0, MANAGER_ROLE));
+      await checkErrorRevert(colony.proposeTaskChange(txData, 0, MANAGER_ROLE));
     });
 
     it("should fail to approve task update, using an invalid transaction id", async () => {
@@ -275,7 +275,7 @@ contract("Colony", () => {
       const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
       await colony.proposeTaskChange(txData, 0, MANAGER_ROLE);
 
-      await testHelper.checkErrorRevert(colony.approveTaskChange(10, WORKER_ROLE, { from: WORKER }));
+      await checkErrorRevert(colony.approveTaskChange(10, WORKER_ROLE, { from: WORKER }));
     });
 
     it("should fail to approve task update twice", async () => {
@@ -285,104 +285,101 @@ contract("Colony", () => {
       await colony.proposeTaskChange(txData, 0, MANAGER_ROLE);
       await colony.approveTaskChange(1, WORKER_ROLE, { from: WORKER });
 
-      await testHelper.checkErrorRevert(colony.approveTaskChange(1, WORKER_ROLE, { from: WORKER }));
+      await checkErrorRevert(colony.approveTaskChange(1, WORKER_ROLE, { from: WORKER }));
     });
   });
 
   describe("when submitting task deliverable", () => {
     it("should update task", async () => {
-      let dueDate = await testHelper.currentBlockTime();
-      dueDate += SECONDS_PER_DAY * 4;
-      await testDataGenerator.setupAssignedTask(colonyNetwork, colony, dueDate);
+      const dueDate = currentBlockTime() + SECONDS_PER_DAY * 4;
+      await setupAssignedTask({ colonyNetwork, colony, dueDate });
 
       let task = await colony.getTask.call(1);
-      assert.equal(testHelper.hexToUtf8(task[1]), "");
+      assert.equal(hexToUtf8(task[1]), "");
 
-      const currentTime = await testHelper.currentBlockTime();
+      const currentTime = currentBlockTime();
       await colony.submitTaskDeliverable(1, DELIVERABLE_HASH, { from: WORKER });
       task = await colony.getTask.call(1);
-      assert.equal(testHelper.hexToUtf8(task[1]), DELIVERABLE_HASH);
+      assert.equal(hexToUtf8(task[1]), DELIVERABLE_HASH);
       assert.closeTo(task[7].toNumber(), currentTime, 2);
     });
 
     it("should fail if I try to submit work for a task that is finalized", async () => {
-      await testDataGenerator.fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await testDataGenerator.setupRatedTask(colonyNetwork, colony, token);
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      const taskId = await setupRatedTask({ colonyNetwork, colony, token });
       await colony.finalizeTask(taskId);
-      await testHelper.checkErrorRevert(colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH));
+      await checkErrorRevert(colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH));
     });
 
     it("should fail if I try to submit work for a task that is past its due date", async () => {
-      const dueDate = testHelper.currentBlockTime() - 1;
-      await testDataGenerator.setupAssignedTask(colonyNetwork, colony, dueDate);
-      await testHelper.checkErrorRevert(colony.submitTaskDeliverable(1, DELIVERABLE_HASH));
+      const dueDate = currentBlockTime() - 1;
+      await setupAssignedTask({ colonyNetwork, colony, dueDate });
+      await checkErrorRevert(colony.submitTaskDeliverable(1, DELIVERABLE_HASH));
     });
 
     it("should fail if I try to submit work for a task using an invalid id", async () => {
-      await testHelper.checkErrorRevert(colony.submitTaskDeliverable(10, DELIVERABLE_HASH));
+      await checkErrorRevert(colony.submitTaskDeliverable(10, DELIVERABLE_HASH));
     });
 
     it("should fail if I try to submit work twice", async () => {
-      let dueDate = await testHelper.currentBlockTime();
-      dueDate += SECONDS_PER_DAY * 4;
-      await testDataGenerator.setupAssignedTask(colonyNetwork, colony, dueDate);
+      const dueDate = currentBlockTime() + SECONDS_PER_DAY * 4;
+      await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.submitTaskDeliverable(1, DELIVERABLE_HASH, { from: WORKER });
 
-      await testHelper.checkErrorRevert(colony.submitTaskDeliverable(1, SPECIFICATION_HASH, { from: WORKER }));
+      await checkErrorRevert(colony.submitTaskDeliverable(1, SPECIFICATION_HASH, { from: WORKER }));
       const task = await colony.getTask.call(1);
-      assert.equal(testHelper.hexToUtf8(task[1]), DELIVERABLE_HASH);
+      assert.equal(hexToUtf8(task[1]), DELIVERABLE_HASH);
     });
 
     it("should fail if I try to submit work if I'm not the assigned worker", async () => {
-      let dueDate = await testHelper.currentBlockTime();
-      dueDate += SECONDS_PER_DAY * 4;
-      await testDataGenerator.setupAssignedTask(colonyNetwork, colony, dueDate);
+      const dueDate = currentBlockTime() + SECONDS_PER_DAY * 4;
+      await setupAssignedTask({ colonyNetwork, colony, dueDate });
 
-      await testHelper.checkErrorRevert(colony.submitTaskDeliverable(1, SPECIFICATION_HASH, { from: OTHER }));
+      await checkErrorRevert(colony.submitTaskDeliverable(1, SPECIFICATION_HASH, { from: OTHER }));
       const task = await colony.getTask.call(1);
-      assert.notEqual(testHelper.hexToUtf8(task[1]), DELIVERABLE_HASH);
+      assert.notEqual(hexToUtf8(task[1]), DELIVERABLE_HASH);
     });
   });
 
   describe("when finalizing a task", () => {
     it('should set the task "finalized" property to "true"', async () => {
-      await testDataGenerator.fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await testDataGenerator.setupRatedTask(colonyNetwork, colony, token);
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      const taskId = await setupRatedTask({ colonyNetwork, colony, token });
       await colony.finalizeTask(taskId);
       const task = await colony.getTask.call(taskId);
       assert.isTrue(task[2]);
     });
 
     it("should fail if the task work ratings have not been assigned", async () => {
-      await testDataGenerator.fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await testDataGenerator.setupFundedTask(colonyNetwork, colony, token);
-      await testHelper.checkErrorRevert(colony.finalizeTask(taskId));
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      const taskId = await setupFundedTask({ colonyNetwork, colony, token });
+      await checkErrorRevert(colony.finalizeTask(taskId));
     });
 
     it("should fail if a non-admin tries to accept the task", async () => {
-      await testDataGenerator.fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await testDataGenerator.setupRatedTask(colonyNetwork, colony, token);
-      await testHelper.checkErrorRevert(colony.finalizeTask(taskId, { from: OTHER }));
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      const taskId = await setupRatedTask({ colonyNetwork, colony, token });
+      await checkErrorRevert(colony.finalizeTask(taskId, { from: OTHER }));
     });
 
     it("should fail if I try to accept a task that was finalized before", async () => {
-      await testDataGenerator.fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await testDataGenerator.setupRatedTask(colonyNetwork, colony, token);
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      const taskId = await setupRatedTask({ colonyNetwork, colony, token });
       await colony.finalizeTask(taskId);
-      await testHelper.checkErrorRevert(colony.finalizeTask(taskId));
+      await checkErrorRevert(colony.finalizeTask(taskId));
     });
 
     it("should fail if I try to accept a task using an invalid id", async () => {
-      await testDataGenerator.fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      await testDataGenerator.setupRatedTask(colonyNetwork, colony, token);
-      await testHelper.checkErrorRevert(colony.finalizeTask(10));
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      await setupRatedTask({ colonyNetwork, colony, token });
+      await checkErrorRevert(colony.finalizeTask(10));
     });
   });
 
   describe("when cancelling a task", () => {
     it('should set the task "cancelled" property to "true"', async () => {
-      await testDataGenerator.fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await testDataGenerator.setupRatedTask(colonyNetwork, colony, token);
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      const taskId = await setupRatedTask({ colonyNetwork, colony, token });
 
       await colony.cancelTask(taskId);
       const task = await colony.getTask.call(taskId);
@@ -390,8 +387,8 @@ contract("Colony", () => {
     });
 
     it("should be possible to return funds back to the domain", async () => {
-      await testDataGenerator.fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await testDataGenerator.setupFundedTask(colonyNetwork, colony, token);
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      const taskId = await setupFundedTask({ colonyNetwork, colony, token });
       const task = await colony.getTask.call(taskId);
       const domainId = await colony.getTaskDomain.call(taskId, 0);
       const domain = await colony.getDomain.call(domainId);
@@ -447,14 +444,14 @@ contract("Colony", () => {
     });
 
     it("should fail if manager tries to cancel a task that was finalized", async () => {
-      await testDataGenerator.fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await testDataGenerator.setupRatedTask(colonyNetwork, colony, token);
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      const taskId = await setupRatedTask({ colonyNetwork, colony, token });
       await colony.finalizeTask(taskId);
-      await testHelper.checkErrorRevert(colony.cancelTask(taskId));
+      await checkErrorRevert(colony.cancelTask(taskId));
     });
 
     it("should fail if manager tries to cancel a task with invalid id", async () => {
-      await testHelper.checkErrorRevert(colony.cancelTask(10));
+      await checkErrorRevert(colony.cancelTask(10));
     });
   });
 
@@ -506,8 +503,8 @@ contract("Colony", () => {
 
   describe("when claiming payout for a task", () => {
     it("should payout agreed tokens for a task", async () => {
-      await testDataGenerator.fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await testDataGenerator.setupRatedTask(colonyNetwork, colony, token);
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      const taskId = await setupRatedTask({ colonyNetwork, colony, token });
       await colony.finalizeTask(taskId);
       const networkBalanceBefore = await token.balanceOf.call(colonyNetwork.address);
       await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
@@ -522,27 +519,23 @@ contract("Colony", () => {
     it("should payout agreed ether for a task", async () => {
       await colony.send(353);
       await colony.claimColonyFunds(0x0);
-      const dueDate = testHelper.currentBlockTime() - 1;
-      const taskId = await testDataGenerator.setupRatedTask(
+      const dueDate = currentBlockTime() - 1;
+      const taskId = await setupRatedTask({
         colonyNetwork,
         colony,
-        0x0,
+        token: 0x0,
         dueDate,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        100,
-        50,
-        200
-      );
+        managerPayout: 100,
+        evaluatorPayout: 50,
+        workerPayout: 200
+      });
       await colony.finalizeTask(taskId);
       const commonColonyAddress = await colonyNetwork.getColony.call("Common Colony");
-      const balanceBefore = await testHelper.web3GetBalance(MANAGER);
-      const commonBalanceBefore = await testHelper.web3GetBalance(commonColonyAddress);
+      const balanceBefore = await web3GetBalance(MANAGER);
+      const commonBalanceBefore = await web3GetBalance(commonColonyAddress);
       await colony.claimPayout(taskId, MANAGER_ROLE, 0x0, { gasPrice: 0 });
-      const balanceAfter = await testHelper.web3GetBalance(MANAGER);
-      const commonBalanceAfter = await testHelper.web3GetBalance(commonColonyAddress);
+      const balanceAfter = await web3GetBalance(MANAGER);
+      const commonBalanceAfter = await web3GetBalance(commonColonyAddress);
       assert.equal(balanceAfter.minus(balanceBefore).toNumber(), 99);
       assert.equal(commonBalanceAfter.minus(commonBalanceBefore).toNumber(), 1);
       const potBalance = await colony.getPotBalance.call(2, 0x0);
@@ -550,17 +543,17 @@ contract("Colony", () => {
     });
 
     it("should return error when task is not finalized", async () => {
-      await testDataGenerator.fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await testDataGenerator.setupRatedTask(colonyNetwork, colony, token);
-      await testHelper.checkErrorRevert(colony.claimPayout(taskId, MANAGER_ROLE, token.address));
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      const taskId = await setupRatedTask({ colonyNetwork, colony, token });
+      await checkErrorRevert(colony.claimPayout(taskId, MANAGER_ROLE, token.address));
     });
 
     it("should return error when called by account that doesn't match the role", async () => {
-      await testDataGenerator.fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await testDataGenerator.setupRatedTask(colonyNetwork, colony, token);
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      const taskId = await setupRatedTask({ colonyNetwork, colony, token });
       await colony.finalizeTask(taskId);
 
-      await testHelper.checkErrorRevert(colony.claimPayout(taskId, MANAGER_ROLE, token.address, { from: OTHER }));
+      await checkErrorRevert(colony.claimPayout(taskId, MANAGER_ROLE, token.address, { from: OTHER }));
     });
   });
 });

--- a/test/router-resolver.js
+++ b/test/router-resolver.js
@@ -1,5 +1,5 @@
 /* globals artifacts */
-import testHelper from "../helpers/test-helper";
+import { checkErrorRevert } from "../helpers/test-helper";
 
 const MultiSigWallet = artifacts.require("gnosis/MultiSigWallet");
 const EtherRouter = artifacts.require("EtherRouter");
@@ -28,7 +28,7 @@ contract("EtherRouter / Resolver", accounts => {
 
   describe("EtherRouter", () => {
     it("should revert if non-owner tries to change the Resolver on EtherRouter", async () => {
-      await testHelper.checkErrorRevert(etherRouter.setResolver("0xb3e2b6020926af4763d706b5657446b95795de57", { from: COINBASE_ACCOUNT }));
+      await checkErrorRevert(etherRouter.setResolver("0xb3e2b6020926af4763d706b5657446b95795de57", { from: COINBASE_ACCOUNT }));
       const resolverUpdated = await etherRouter.resolver.call();
       assert.equal(resolverUpdated, resolver.address);
     });

--- a/upgrade-test/colony-network-upgrade.js
+++ b/upgrade-test/colony-network-upgrade.js
@@ -1,5 +1,5 @@
 /* globals artifacts */
-import testHelper from "../helpers/test-helper";
+import { getRandomString, getTokenArgs } from "../helpers/test-helper";
 
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const EtherRouter = artifacts.require("EtherRouter");
@@ -19,12 +19,12 @@ contract("ColonyNetwork contract upgrade", () => {
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
 
     // Setup 2 test colonies
-    colonyKey1 = testHelper.getRandomString(7);
-    const tokenArgs1 = testHelper.getTokenArgs();
+    colonyKey1 = getRandomString(7);
+    const tokenArgs1 = getTokenArgs();
     await colonyNetwork.createColony(colonyKey1, ...tokenArgs1);
     colonyAddress1 = await colonyNetwork.getColony(colonyKey1);
-    colonyKey2 = testHelper.getRandomString(7);
-    const tokenArgs2 = testHelper.getTokenArgs();
+    colonyKey2 = getRandomString(7);
+    const tokenArgs2 = getTokenArgs();
     await colonyNetwork.createColony(colonyKey2, ...tokenArgs2);
     colonyAddress2 = await colonyNetwork.getColony(colonyKey2);
 

--- a/upgrade-test/colony-upgrade.js
+++ b/upgrade-test/colony-upgrade.js
@@ -1,6 +1,6 @@
 /* globals artifacts */
-import testHelper from "../helpers/test-helper";
-import upgradableContracts from "../helpers/upgradable-contracts";
+import { getRandomString, getTokenArgs, hexToUtf8 } from "../helpers/test-helper";
+import { setupColonyVersionResolver } from "../helpers/upgradable-contracts";
 
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const EtherRouter = artifacts.require("EtherRouter");
@@ -36,8 +36,8 @@ contract("Colony contract upgrade", accounts => {
     const etherRouterColonyNetwork = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouterColonyNetwork.address);
 
-    COLONY_KEY = testHelper.getRandomString(7);
-    const tokenArgs = testHelper.getTokenArgs();
+    COLONY_KEY = getRandomString(7);
+    const tokenArgs = getTokenArgs();
     await colonyNetwork.createColony(COLONY_KEY, ...tokenArgs);
     etherRouter = await colonyNetwork.getColony(COLONY_KEY);
     colony = await IColony.at(etherRouter);
@@ -56,14 +56,7 @@ contract("Colony contract upgrade", accounts => {
     const updatedColonyContract = await UpdatedColony.new();
     const resolver = await Resolver.new();
     await resolver.register("isUpdated()", updatedColonyContract.address, 32);
-    await upgradableContracts.setupColonyVersionResolver(
-      updatedColonyContract,
-      colonyTask,
-      colonyFunding,
-      colonyTransactionReviewer,
-      resolver,
-      colonyNetwork
-    );
+    await setupColonyVersionResolver(updatedColonyContract, colonyTask, colonyFunding, colonyTransactionReviewer, resolver, colonyNetwork);
     // Check new Colony contract version is registered successfully
     updatedColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
 
@@ -90,14 +83,14 @@ contract("Colony contract upgrade", accounts => {
 
     it("should return correct tasks", async () => {
       const task1 = await updatedColony.getTask.call(1);
-      assert.equal(testHelper.hexToUtf8(task1[0]), specificationHash);
+      assert.equal(hexToUtf8(task1[0]), specificationHash);
       assert.isFalse(task1[2]);
       assert.isFalse(task1[3]);
       assert.equal(task1[4].toNumber(), 0);
       assert.equal(task1[5].toNumber(), 0);
 
       const task2 = await updatedColony.getTask.call(2);
-      assert.equal(testHelper.hexToUtf8(task2[0]), newSpecificationHash);
+      assert.equal(hexToUtf8(task2[0]), newSpecificationHash);
       assert.isFalse(task2[2]);
       assert.isFalse(task2[3]);
       assert.equal(task2[4].toNumber(), 0);

--- a/upgrade-test/token-upgrade.js
+++ b/upgrade-test/token-upgrade.js
@@ -1,7 +1,7 @@
 /* globals artifacts */
 
-import upgradableContracts from "../helpers/upgradable-contracts";
-import testHelpers from "../helpers/test-helper";
+import { setupUpgradableToken } from "../helpers/upgradable-contracts";
+import { getTokenArgs } from "../helpers/test-helper";
 
 const EtherRouter = artifacts.require("EtherRouter");
 const Resolver = artifacts.require("Resolver");
@@ -20,12 +20,12 @@ contract("Token contract upgrade", accounts => {
   let updatedToken;
 
   beforeEach(async () => {
-    const tokenArgs = testHelpers.getTokenArgs();
+    const tokenArgs = getTokenArgs();
     tokenContract = await Token.new(...tokenArgs);
     resolver = await Resolver.new();
     // Instantiate a new EtherRouter to clear the data
     etherRouter = await EtherRouter.new();
-    await upgradableContracts.setupUpgradableToken(tokenContract, resolver, etherRouter);
+    await setupUpgradableToken(tokenContract, resolver, etherRouter);
     token = await Token.at(etherRouter.address);
   });
 
@@ -42,9 +42,9 @@ contract("Token contract upgrade", accounts => {
       await token.approve(ACCOUNT_THREE, 10, { from: ACCOUNT_TWO });
 
       // Upgrade Token
-      const tokenArgs = testHelpers.getTokenArgs();
+      const tokenArgs = getTokenArgs();
       const updatedTokenContract = await UpdatedToken.new(...tokenArgs);
-      await upgradableContracts.setupUpgradableToken(updatedTokenContract, resolver, etherRouter);
+      await setupUpgradableToken(updatedTokenContract, resolver, etherRouter);
       await resolver.register("isUpdated()", updatedTokenContract.address, 32);
       updatedToken = await UpdatedToken.at(etherRouter.address);
     });


### PR DESCRIPTION
- Moved role constants to ColonyStorage.
- Using es6 exports.
- Passing object instead of list to `setupAssignedTask `, `setupFundedTask `, `setupRatedTask `..