### PR TITLE
Allow colonies to be created with existing tokens

### DIFF
--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -108,21 +108,15 @@ contract ColonyNetwork is ColonyNetworkStorage {
     return reputationRootHashNNodes;
   }
 
-  function createColony(
-    bytes32 _name,
-    bytes32 _tokenName,
-    bytes32 _tokenSymbol,
-    uint256 _tokenDecimals
-  ) public colonyKeyUnique(_name)
+  function createColony(bytes32 _name, address _tokenAddress) public
+  colonyKeyUnique(_name)
   {
-    var token = new Token(_tokenName, _tokenSymbol, _tokenDecimals);
     var etherRouter = new EtherRouter();
     var resolverForLatestColonyVersion = colonyVersionResolver[currentColonyVersion];
     etherRouter.setResolver(resolverForLatestColonyVersion);
 
     var colony = IColony(etherRouter);
-    colony.setToken(token);
-    token.setOwner(colony);
+    colony.setToken(_tokenAddress);
 
     var authority = new Authority(colony);
     var dsauth = DSAuth(etherRouter);

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -32,7 +32,7 @@ contract IColonyNetwork {
   function appendReputationUpdateLog(address _user, int256 _amount, uint256 _skillId) public;
   function getSkillCount() public view returns (uint256);
   function getRootGlobalSkillId() public view returns (uint256);
-  function createColony(bytes32 _name, bytes32 _tokenName, bytes32 _tokenSymbol, uint256 _tokenDecimals) public;
+  function createColony(bytes32 _name, address _tokenAddress) public;
   function addColonyVersion(uint256 _version, address _resolver) public;
   function getColonyAt(uint256 _idx) public view returns (address);
   function getCurrentColonyVersion() public view returns (uint256);

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -20,6 +20,7 @@ import { getTokenArgs, currentBlockTime } from "../helpers/test-helper";
 import { setupColonyVersionResolver } from "../helpers/upgradable-contracts";
 
 const Colony = artifacts.require("Colony");
+const Token = artifacts.require("Token");
 const IColony = artifacts.require("IColony");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const ColonyTask = artifacts.require("ColonyTask");
@@ -52,8 +53,10 @@ contract("All", () => {
 
     await setupColonyVersionResolver(colony, colonyTask, colonyFunding, colonyTransactionReviewer, resolver, colonyNetwork);
     const tokenArgs = getTokenArgs();
-    await colonyNetwork.createColony("Antz", ...tokenArgs);
+    const token = await Token.new(...tokenArgs);
+    await colonyNetwork.createColony("Antz", token.address);
     const address = await colonyNetwork.getColony.call("Antz");
+    await token.setOwner(address);
     colony = await IColony.at(address);
     tokenAddress = await colony.getToken.call();
     const authorityAddress = await colony.authority.call();
@@ -68,7 +71,8 @@ contract("All", () => {
   describe("Gas costs", () => {
     it("when working with the Colony Network", async () => {
       const tokenArgs = getTokenArgs();
-      await colonyNetwork.createColony("Test", ...tokenArgs);
+      const token = await Token.new(...tokenArgs);
+      await colonyNetwork.createColony("Test", token.address);
     });
 
     it("when working with the Common Colony", async () => {

--- a/migrations/5_setup_common_colony.js
+++ b/migrations/5_setup_common_colony.js
@@ -5,23 +5,31 @@ const assert = require("assert");
 
 const IColonyNetwork = artifacts.require("./IColonyNetwork");
 const EtherRouter = artifacts.require("./EtherRouter");
+const Token = artifacts.require("./Token");
 
 module.exports = deployer => {
   // Create the common colony
   let colonyNetwork;
+  let token;
   deployer
     .then(() => EtherRouter.deployed())
     .then(_etherRouter => IColonyNetwork.at(_etherRouter.address))
     .then(instance => {
       colonyNetwork = instance;
-      return colonyNetwork.createColony("Common Colony", "Colony Network Token", "CLNY", 18);
+      return Token.new("Colony Network Token", "CLNY", 18);
+    })
+    .then(tokenInstance => {
+      token = tokenInstance;
+      return colonyNetwork.createColony("Common Colony", token.address);
     })
     .then(() => colonyNetwork.getSkillCount.call())
     .then(skillCount => {
       assert.equal(skillCount.toNumber(), 2);
       return colonyNetwork.getColony.call("Common Colony");
     })
+    .then(() => colonyNetwork.getColony.call("Common Colony"))
     .then(commonColonyAddress => {
+      token.setOwner(commonColonyAddress);
       console.log("### Common Colony created at", commonColonyAddress);
     })
     .catch(err => {

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -33,11 +33,11 @@ contract("Colony Funding", () => {
   beforeEach(async () => {
     COLONY_KEY = getRandomString(7);
     const tokenArgs = getTokenArgs();
-    await colonyNetwork.createColony(COLONY_KEY, ...tokenArgs);
+    token = await Token.new(...tokenArgs);
+    await colonyNetwork.createColony(COLONY_KEY, token.address);
     const address = await colonyNetwork.getColony.call(COLONY_KEY);
+    await token.setOwner(address);
     colony = await IColony.at(address);
-    const tokenAddress = await colony.getToken.call();
-    token = await Token.at(tokenAddress);
     const otherTokenArgs = getTokenArgs();
     otherToken = await Token.new(...otherTokenArgs);
   });

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -40,7 +40,8 @@ contract("Colony Task Work Rating", () => {
   beforeEach(async () => {
     COLONY_KEY = getRandomString(7);
     const tokenArgs = getTokenArgs();
-    await colonyNetwork.createColony(COLONY_KEY, ...tokenArgs);
+    const colonyToken = await Token.new(...tokenArgs);
+    await colonyNetwork.createColony(COLONY_KEY, colonyToken.address);
     const address = await colonyNetwork.getColony.call(COLONY_KEY);
     colony = await IColony.at(address);
     const otherTokenArgs = getTokenArgs();

--- a/test/colony.js
+++ b/test/colony.js
@@ -44,13 +44,13 @@ contract("Colony", () => {
   beforeEach(async () => {
     COLONY_KEY = getRandomString(7);
     const tokenArgs = getTokenArgs();
-    await colonyNetwork.createColony(COLONY_KEY, ...tokenArgs);
+    token = await Token.new(...tokenArgs);
+    await colonyNetwork.createColony(COLONY_KEY, token.address);
     const address = await colonyNetwork.getColony.call(COLONY_KEY);
+    await token.setOwner(address);
     colony = await IColony.at(address);
     const authorityAddress = await colony.authority.call();
     authority = await Authority.at(authorityAddress);
-    const tokenAddress = await colony.getToken.call();
-    token = await Token.at(tokenAddress);
     const otherTokenArgs = getTokenArgs();
     otherToken = await Token.new(...otherTokenArgs);
   });

--- a/test/common-colony.js
+++ b/test/common-colony.js
@@ -46,11 +46,10 @@ contract("Common Colony", () => {
       resolver,
       colonyNetwork
     );
-    await colonyNetwork.createColony("Common Colony", "Colony Network Token", "CLNY", 18);
+    commonColonyToken = await Token.new("Colony Network Token", "CLNY", 18);
+    await colonyNetwork.createColony("Common Colony", commonColonyToken.address);
     const commonColonyAddress = await colonyNetwork.getColony.call("Common Colony");
     commonColony = await IColony.at(commonColonyAddress);
-    const commonColonyTokenAddress = await commonColony.getToken.call();
-    commonColonyToken = await Token.at(commonColonyTokenAddress);
   });
 
   describe("when working with ERC20 properties of Common Colony token", () => {
@@ -300,7 +299,8 @@ contract("Common Colony", () => {
     beforeEach(async () => {
       COLONY_KEY = getRandomString(7);
       TOKEN_ARGS = getTokenArgs();
-      await colonyNetwork.createColony(COLONY_KEY, ...TOKEN_ARGS);
+      const newToken = await Token.new(...TOKEN_ARGS);
+      await colonyNetwork.createColony(COLONY_KEY, newToken.address);
       const address = await colonyNetwork.getColony.call(COLONY_KEY);
       colony = await IColony.at(address);
       const tokenAddress = await colony.getToken.call();
@@ -380,11 +380,11 @@ contract("Common Colony", () => {
     beforeEach(async () => {
       COLONY_KEY = getRandomString(7);
       TOKEN_ARGS = getTokenArgs();
-      await colonyNetwork.createColony(COLONY_KEY, ...TOKEN_ARGS);
+      token = await Token.new(...TOKEN_ARGS);
+      await colonyNetwork.createColony(COLONY_KEY, token.address);
       const address = await colonyNetwork.getColony.call(COLONY_KEY);
+      await token.setOwner(address);
       colony = await IColony.at(address);
-      const tokenAddress = await colony.getToken.call();
-      token = await Token.at(tokenAddress);
     });
 
     it("should be able to set domain on task", async () => {

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -39,11 +39,11 @@ contract("Colony Reputation Updates", () => {
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
     await setupColonyVersionResolver(colony, colonyTask, colonyFunding, colonyTransactionReviewer, resolver, colonyNetwork);
     const tokenArgs = getTokenArgs();
-    await colonyNetwork.createColony("Common Colony", ...tokenArgs);
+    colonyToken = await Token.new(...tokenArgs);
+    await colonyNetwork.createColony("Common Colony", colonyToken.address);
     const commonColonyAddress = await colonyNetwork.getColony.call("Common Colony");
+    await colonyToken.setOwner(commonColonyAddress);
     commonColony = await IColony.at(commonColonyAddress);
-    const tokenAddress = await commonColony.getToken.call();
-    colonyToken = await Token.at(tokenAddress);
     const amount = new BN(10)
       .pow(new BN(18))
       .mul(new BN(1000))

--- a/upgrade-test/colony-network-upgrade.js
+++ b/upgrade-test/colony-network-upgrade.js
@@ -1,6 +1,7 @@
 /* globals artifacts */
 import { getRandomString, getTokenArgs } from "../helpers/test-helper";
 
+const Token = artifacts.require("Token");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const EtherRouter = artifacts.require("EtherRouter");
 const Resolver = artifacts.require("Resolver");
@@ -21,11 +22,13 @@ contract("ColonyNetwork contract upgrade", () => {
     // Setup 2 test colonies
     colonyKey1 = getRandomString(7);
     const tokenArgs1 = getTokenArgs();
-    await colonyNetwork.createColony(colonyKey1, ...tokenArgs1);
+    const newToken = await Token.new(...tokenArgs1);
+    await colonyNetwork.createColony(colonyKey1, newToken.address);
     colonyAddress1 = await colonyNetwork.getColony(colonyKey1);
     colonyKey2 = getRandomString(7);
     const tokenArgs2 = getTokenArgs();
-    await colonyNetwork.createColony(colonyKey2, ...tokenArgs2);
+    const newToken2 = await Token.new(...tokenArgs2);
+    await colonyNetwork.createColony(colonyKey2, newToken2.address);
     colonyAddress2 = await colonyNetwork.getColony(colonyKey2);
 
     // Setup new Colony contract version on the Network

--- a/upgrade-test/colony-upgrade.js
+++ b/upgrade-test/colony-upgrade.js
@@ -38,7 +38,8 @@ contract("Colony contract upgrade", accounts => {
 
     COLONY_KEY = getRandomString(7);
     const tokenArgs = getTokenArgs();
-    await colonyNetwork.createColony(COLONY_KEY, ...tokenArgs);
+    const colonyToken = await Token.new(...tokenArgs);
+    await colonyNetwork.createColony(COLONY_KEY, colonyToken.address);
     etherRouter = await colonyNetwork.getColony(COLONY_KEY);
     colony = await IColony.at(etherRouter);
     colonyTask = await ColonyTask.new();


### PR DESCRIPTION
Closes #160

- Token is no longer created inside `createColony` function. Token address is passed instead.
Checking if token has ERC20 interface is not implemented in this task.

