### PR TITLE
Bootstrapping reputation

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -61,6 +61,20 @@ contract Colony is ColonyStorage {
     });
   }
 
+  function bootstrapColony(address[] _users, int[] _amounts) public
+  auth
+  isInBootstrapPhase
+  {
+    require(_users.length == _amounts.length);
+
+    for (uint i = 0; i < _users.length; i++) {
+      require(_amounts[i] >= 0);
+
+      token.transfer(_users[i], uint(_amounts[i]));
+      IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_users[i], _amounts[i], domains[1].skillId);
+    }
+  }
+
   function mintTokens(uint _wad) public
   auth
   {

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -151,6 +151,11 @@ contract ColonyStorage is DSAuth {
     _;
   }
 
+  modifier isInBootstrapPhase() {
+    require(taskCount == 0);
+    _;
+  }
+
   modifier self() {
     require(address(this) == msg.sender);
     _;

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -30,6 +30,7 @@ contract IColony {
   function setToken(address _token) public;
   function getToken() public view returns (address);
   function initialiseColony(address _network) public;
+  function bootstrapColony(address[] _users, int[] _amount) public;
   function mintTokens(uint256 _wad) public;
   function mintTokensForColonyNetwork(uint256 _wad) public;
   function addGlobalSkill(uint256 _parentSkillId) public returns (uint256);

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -166,7 +166,7 @@ export async function forwardTime(seconds, test) {
   if (client.indexOf("TestRPC") === -1) {
     test.skip();
   } else {
-    console.log(`Forwarding time with ${seconds}s ...`);
+    // console.log(`Forwarding time with ${seconds}s ...`);
     await web3.currentProvider.send({
       jsonrpc: "2.0",
       method: "evm_increaseTime",


### PR DESCRIPTION
Closes #40

Added function for bootstrapping the colony.
- Function expects array of addresses and amount of reputation/tokens for every address.
- Function can be called:
  - Only by the authorized address
  - When the colony is in 'bootstrap phase' i.e. when `taskCount` is `0`.
- Reputation is assigned in the root domain.
- It is assumed that there is enough tokens to be transferred.

***Updated**