### PR TITLE
Use EtherRouter for functions with dynamic return data size

### DIFF
--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -71,7 +71,7 @@ contract ColonyStorage is DSAuth {
     uint256 payoutsWeCannotMake;
     uint256 potId;
     uint256 deliverableTimestamp;
-    uint256[] domains;
+    uint256 domainId;
     uint256[] skills;
 
     // TODO switch this mapping to a uint8 when all role instances are uint8-s specifically ColonyFunding source

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -30,23 +30,13 @@ contract ColonyStorage is DSAuth {
   // and add it to IColony.sol
 
   address resolver;
-
-  mapping (uint256 => Transaction) transactions;
-  // Mapping function signature to 2 task roles whose approval is needed to execute
-  mapping (bytes4 => uint8[2]) reviewers;
-  // Maps transactions to roles and whether they've confirmed the transaction
-  mapping (uint256 => mapping (uint256 => bool)) confirmations;
-  uint256 transactionCount;
-  uint256 taskChangeNonce;
-
-  struct Transaction {
-    bytes data;
-    uint256 value;
-    bool executed;
-  }
-
   address colonyNetworkAddress;
   ERC20Extended token;
+
+  // Mapping function signature to 2 task roles whose approval is needed to execute
+  mapping (bytes4 => uint8[2]) reviewers;
+  uint256 taskChangeNonce;
+  
   mapping (uint256 => Task) tasks;
 
   // Pots can be tied to tasks or domains, so giving them their own mapping.

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -118,7 +118,7 @@ contract ColonyTask is ColonyStorage, DSMath {
     Task memory task;
     task.specificationHash = _specificationHash;
     task.potId = potCount;
-    task.domains = new uint256[](1);
+    task.domainId = _domainId;
     task.skills = new uint256[](1);
     tasks[taskCount] = task;
     tasks[taskCount].roles[MANAGER] = Role({
@@ -128,7 +128,6 @@ contract ColonyTask is ColonyStorage, DSMath {
     });
 
     pots[potCount].taskId = taskCount;
-    setTaskDomain(taskCount, _domainId);
 
     TaskAdded(taskCount);
   }
@@ -260,7 +259,7 @@ contract ColonyTask is ColonyStorage, DSMath {
   taskNotFinalized(_id)
   domainExists(_domainId)
   {
-    tasks[_id].domains[0] = _domainId;
+    tasks[_id].domainId = _domainId;
   }
 
   // TODO: Restrict function visibility to whoever submits the approved Transaction from Client
@@ -318,7 +317,7 @@ contract ColonyTask is ColonyStorage, DSMath {
       int divider = (roleId == WORKER) ? 30 : 50;
 
       int reputation = SafeMath.mulInt(int(payout), (int(rating)*2 - 50)) / divider;
-      colonyNetworkContract.appendReputationUpdateLog(role.user, reputation, task.domains[0]);
+      colonyNetworkContract.appendReputationUpdateLog(role.user, reputation, task.domainId);
 
       if (roleId == WORKER) {
         colonyNetworkContract.appendReputationUpdateLog(role.user, reputation, task.skills[0]);
@@ -341,9 +340,9 @@ contract ColonyTask is ColonyStorage, DSMath {
     tasks[_id].cancelled = true;
   }
 
-  function getTask(uint256 _id) public view returns (bytes32, bytes32, bool, bool, uint256, uint256, uint256, uint256, uint256[], uint256[]) {
+  function getTask(uint256 _id) public view returns (bytes32, bytes32, bool, bool, uint256, uint256, uint256, uint256, uint256, uint256[]) {
     Task storage t = tasks[_id];
-    return (t.specificationHash, t.deliverableHash, t.finalized, t.cancelled, t.dueDate, t.payoutsWeCannotMake, t.potId, t.deliverableTimestamp, t.domains, t.skills);
+    return (t.specificationHash, t.deliverableHash, t.finalized, t.cancelled, t.dueDate, t.payoutsWeCannotMake, t.potId, t.deliverableTimestamp, t.domainId, t.skills);
   }
 
   function getTaskRole(uint256 _id, uint8 _idx) public view returns (address, bool, uint8) {

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -341,22 +341,14 @@ contract ColonyTask is ColonyStorage, DSMath {
     tasks[_id].cancelled = true;
   }
 
-  function getTask(uint256 _id) public view returns (bytes32, bytes32, bool, bool, uint256, uint256, uint256, uint256) {
+  function getTask(uint256 _id) public view returns (bytes32, bytes32, bool, bool, uint256, uint256, uint256, uint256, uint256[], uint256[]) {
     Task storage t = tasks[_id];
-    return (t.specificationHash, t.deliverableHash, t.finalized, t.cancelled, t.dueDate, t.payoutsWeCannotMake, t.potId, t.deliverableTimestamp);
+    return (t.specificationHash, t.deliverableHash, t.finalized, t.cancelled, t.dueDate, t.payoutsWeCannotMake, t.potId, t.deliverableTimestamp, t.domains, t.skills);
   }
 
   function getTaskRole(uint256 _id, uint8 _idx) public view returns (address, bool, uint8) {
     Role storage role = tasks[_id].roles[_idx];
     return (role.user, role.rated, role.rating);
-  }
-
-  function getTaskSkill(uint256 _id, uint256 _idx) public view returns (uint256) {
-    return tasks[_id].skills[_idx];
-  }
-
-  function getTaskDomain(uint256 _id, uint256 _idx) public view returns (uint256) {
-    return tasks[_id].domains[_idx];
   }
 
   // Get the function signature and task id from the transaction bytes data

--- a/contracts/EtherRouter.sol
+++ b/contracts/EtherRouter.sol
@@ -45,24 +45,17 @@ contract EtherRouter is DSAuth {
     // If we wish to have such a fallback function for a Colony, it could be in a separate
     // contract.
 
-    uint r;
-
     // Get routing information for the called function
     address destination = resolver.lookup(msg.sig);
 
     // Make the call
     assembly {
       calldatacopy(mload(0x40), 0, calldatasize)
-      r := delegatecall(sub(gas, 700), destination, mload(0x40), calldatasize, mload(0x40), 0)
+      let result := delegatecall(sub(gas, 700), destination, mload(0x40), calldatasize, mload(0x40), 0)
       returndatacopy(mload(0x40), 0, returndatasize)
-    }
-
-    // Check the call is successful
-    require(r == 1);
-
-    // Pass on the return value
-    assembly {
-      return(mload(0x40), returndatasize)
+      switch result
+      case 1 { return(mload(0x40), returndatasize) }
+      default { revert(mload(0x40), returndatasize) }
     }
   }
 

--- a/contracts/EtherRouter.sol
+++ b/contracts/EtherRouter.sol
@@ -48,12 +48,13 @@ contract EtherRouter is DSAuth {
     uint r;
 
     // Get routing information for the called function
-    var (destination, outsize) = resolver.lookup(msg.sig);
+    address destination = resolver.lookup(msg.sig);
 
     // Make the call
     assembly {
       calldatacopy(mload(0x40), 0, calldatasize)
-      r := delegatecall(sub(gas, 700), destination, mload(0x40), calldatasize, mload(0x40), outsize)
+      r := delegatecall(sub(gas, 700), destination, mload(0x40), calldatasize, mload(0x40), 0)
+      returndatacopy(mload(0x40), 0, returndatasize)
     }
 
     // Check the call is successful
@@ -61,7 +62,7 @@ contract EtherRouter is DSAuth {
 
     // Pass on the return value
     assembly {
-      return(mload(0x40), outsize)
+      return(mload(0x40), returndatasize)
     }
   }
 

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -56,7 +56,7 @@ contract IColony {
   function submitTaskDeliverable(uint256 _id, bytes32 _deliverableHash) public;
   function finalizeTask(uint256 _id) public;
   function cancelTask(uint256 _id) public;
-  function getTask(uint256 _id) public view returns (bytes32, bytes32, bool, bool, uint256, uint256, uint256, uint256, uint256[], uint256[]);
+  function getTask(uint256 _id) public view returns (bytes32, bytes32, bool, bool, uint256, uint256, uint256, uint256, uint256, uint256[]);
   function getTaskRole(uint256 _id, uint8 _idx) public view returns (address, bool, uint8);
   
   // ColonyFunding.sol

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -56,11 +56,9 @@ contract IColony {
   function submitTaskDeliverable(uint256 _id, bytes32 _deliverableHash) public;
   function finalizeTask(uint256 _id) public;
   function cancelTask(uint256 _id) public;
-  function getTask(uint256 _id) public view returns (bytes32, bytes32, bool, bool, uint256, uint256, uint256, uint256);
+  function getTask(uint256 _id) public view returns (bytes32, bytes32, bool, bool, uint256, uint256, uint256, uint256, uint256[], uint256[]);
   function getTaskRole(uint256 _id, uint8 _idx) public view returns (address, bool, uint8);
-  function getTaskSkill(uint256 _id, uint256 _idx) public view returns (uint256);
-  function getTaskDomain(uint256 _id, uint256 _idx) public view returns (uint256);
-
+  
   // ColonyFunding.sol
   function getFeeInverse() public pure returns (uint256);
   function getRewardInverse() public pure returns (uint256);

--- a/contracts/Resolver.sol
+++ b/contracts/Resolver.sol
@@ -23,33 +23,16 @@ import "../lib/dappsys/auth.sol";
 
 
 contract Resolver is DSAuth {
-  struct Pointer { address destination; uint outsize; }
-  mapping (bytes4 => Pointer) public pointers;
+  mapping (bytes4 => address) public pointers;
 
-  function register(string signature, address destination, uint outsize) public
+  function register(string signature, address destination) public
   auth
   {
-    pointers[stringToSig(signature)] = Pointer(destination, outsize);
+    pointers[stringToSig(signature)] = destination;
   }
 
-  // Public API
-  function lookup(bytes4 sig) public view returns(address, uint) {
-    return (destination(sig), outsize(sig));
-  }
-
-  // Helpers
-  function destination(bytes4 sig) public view returns(address) {
-    return pointers[sig].destination;
-  }
-
-  function outsize(bytes4 sig) public view returns(uint) {
-    if (pointers[sig].destination != 0) {
-      // Stored destination and outsize
-      return pointers[sig].outsize;
-    } else {
-      // Default
-      return 32;
-    }
+  function lookup(bytes4 sig) public view returns(address) {
+    return pointers[sig];
   }
 
   function stringToSig(string signature) public pure returns(bytes4) {

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -76,13 +76,13 @@ async function checkError(promise, isAssert) {
   //
   // Obviously, we want our tests to pass on all, so this is a bit of a problem.
   // We have to have this special function that we use to catch the error.
-  let txHash;
+  let tx;
   let receipt;
   try {
-    txHash = await promise;
-    receipt = await web3GetTransactionReceipt(txHash);
+    tx = await promise;
+    receipt = await web3GetTransactionReceipt(tx);
   } catch (err) {
-    ({ txHash, receipt } = err);
+    ({ tx, receipt } = err);
   }
 
   // Check the receipt `status` to ensure transaction failed.
@@ -90,7 +90,7 @@ async function checkError(promise, isAssert) {
 
   if (isAssert) {
     const network = await web3GetNetwork();
-    const transaction = await web3GetTransaction(txHash);
+    const transaction = await web3GetTransaction(tx);
     if (network !== "coverage") {
       // When a transaction `throws`, all the gas sent is spent. So let's check that we spent all the gas that we sent.
       // When using EtherRouter not all sent gas is spent, it is 73000 gas less than the total.

--- a/parity-genesis.template.json
+++ b/parity-genesis.template.json
@@ -9,7 +9,10 @@
         "maximumExtraDataSize": "0x20",
         "minGasLimit": "0x1388",
         "networkID" : "0x2",
-        "eip658Transition": 0
+        "eip658Transition": "0x0",
+        "eip140Transition": "0x0",
+        "eip211Transition": "0x0",
+        "eip214Transition": "0x0"
     },
     "genesis": {
         "seal": {

--- a/test/colony.js
+++ b/test/colony.js
@@ -171,8 +171,8 @@ contract("Colony", () => {
       const skillCount = await colonyNetwork.getSkillCount.call();
       await colony.addDomain(skillCount.toNumber());
       await colony.makeTask(SPECIFICATION_HASH, 2);
-      const taskDomain = await colony.getTaskDomain.call(1, 0);
-      assert.equal(taskDomain.toNumber(), 2);
+      const task = await colony.getTask.call(1);
+      assert.equal(task[8][0].toNumber(), 2);
     });
 
     it("should log a TaskAdded event", async () => {
@@ -404,7 +404,7 @@ contract("Colony", () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupFundedTask({ colonyNetwork, colony, token });
       const task = await colony.getTask.call(taskId);
-      const domainId = await colony.getTaskDomain.call(taskId, 0);
+      const domainId = task[8][0].toNumber();
       const domain = await colony.getDomain.call(domainId);
       const taskPotId = task[6];
       const domainPotId = domain[1];

--- a/test/colony.js
+++ b/test/colony.js
@@ -172,7 +172,7 @@ contract("Colony", () => {
       await colony.addDomain(skillCount.toNumber());
       await colony.makeTask(SPECIFICATION_HASH, 2);
       const task = await colony.getTask.call(1);
-      assert.equal(task[8][0].toNumber(), 2);
+      assert.equal(task[8].toNumber(), 2);
     });
 
     it("should log a TaskAdded event", async () => {
@@ -404,7 +404,7 @@ contract("Colony", () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupFundedTask({ colonyNetwork, colony, token });
       const task = await colony.getTask.call(taskId);
-      const domainId = task[8][0].toNumber();
+      const domainId = task[8].toNumber();
       const domain = await colony.getDomain.call(domainId);
       const taskPotId = task[6];
       const domainPotId = domain[1];

--- a/test/common-colony.js
+++ b/test/common-colony.js
@@ -383,8 +383,8 @@ contract("Common Colony", () => {
       await colony.addDomain(3);
       await colony.makeTask(SPECIFICATION_HASH, 1);
       await colony.setTaskDomain(1, 2);
-      const taskDomain = await colony.getTaskDomain.call(1, 0);
-      assert.equal(taskDomain.toNumber(), 2);
+      const task = await colony.getTask.call(1);
+      assert.equal(task[8][0].toNumber(), 2);
     });
 
     it("should NOT be able to set a domain on nonexistent task", async () => {
@@ -395,8 +395,8 @@ contract("Common Colony", () => {
       await colony.makeTask(SPECIFICATION_HASH, 1);
       await checkErrorRevert(colony.setTaskDomain(1, 20));
 
-      const taskDomain = await colony.getTaskDomain.call(1, 0);
-      assert.equal(taskDomain.toNumber(), 1);
+      const task = await colony.getTask.call(1);
+      assert.equal(task[8][0].toNumber(), 1);
     });
 
     it("should NOT be able to set a domain on finalized task", async () => {
@@ -412,8 +412,8 @@ contract("Common Colony", () => {
 
       await colony.makeTask(SPECIFICATION_HASH, 1);
       await colony.setTaskSkill(1, 5);
-      const taskSkill = await colony.getTaskSkill.call(1, 0);
-      assert.equal(taskSkill.toNumber(), 5);
+      const task = await colony.getTask.call(1);
+      assert.equal(task[9][0].toNumber(), 5);
     });
 
     it("should NOT be able to set global skill on nonexistent task", async () => {
@@ -428,8 +428,8 @@ contract("Common Colony", () => {
       await colony.finalizeTask(taskId);
       await checkErrorRevert(colony.setTaskSkill(taskId, 5));
 
-      const taskSkill = await colony.getTaskSkill.call(taskId, 0);
-      assert.equal(taskSkill.toNumber(), 1);
+      const task = await colony.getTask.call(taskId);
+      assert.equal(task[9][0].toNumber(), 1);
     });
 
     it("should NOT be able to set nonexistent skill on task", async () => {

--- a/test/common-colony.js
+++ b/test/common-colony.js
@@ -384,7 +384,7 @@ contract("Common Colony", () => {
       await colony.makeTask(SPECIFICATION_HASH, 1);
       await colony.setTaskDomain(1, 2);
       const task = await colony.getTask.call(1);
-      assert.equal(task[8][0].toNumber(), 2);
+      assert.equal(task[8].toNumber(), 2);
     });
 
     it("should NOT be able to set a domain on nonexistent task", async () => {
@@ -396,7 +396,7 @@ contract("Common Colony", () => {
       await checkErrorRevert(colony.setTaskDomain(1, 20));
 
       const task = await colony.getTask.call(1);
-      assert.equal(task[8][0].toNumber(), 1);
+      assert.equal(task[8].toNumber(), 1);
     });
 
     it("should NOT be able to set a domain on finalized task", async () => {

--- a/test/router-resolver.js
+++ b/test/router-resolver.js
@@ -4,6 +4,7 @@ import { checkErrorRevert } from "../helpers/test-helper";
 const MultiSigWallet = artifacts.require("gnosis/MultiSigWallet");
 const EtherRouter = artifacts.require("EtherRouter");
 const Resolver = artifacts.require("Resolver");
+const ColonyNetwork = artifacts.require("ColonyNetwork");
 
 contract("EtherRouter / Resolver", accounts => {
   const COINBASE_ACCOUNT = accounts[0];
@@ -15,7 +16,7 @@ contract("EtherRouter / Resolver", accounts => {
   let multisig;
 
   before(async () => {
-    resolver = await Resolver.new();
+    resolver = await Resolver.deployed();
   });
 
   beforeEach(async () => {
@@ -45,14 +46,16 @@ contract("EtherRouter / Resolver", accounts => {
   });
 
   describe("Resolver", () => {
-    it("when checking outsize, should return correct return param size for given function", async () => {
-      const outsize = await resolver.outsize.call("0x18160ddd");
-      assert.equal(outsize, 32);
+    it("should return correct destination for given function", async () => {
+      const deployedColonyNetwork = await ColonyNetwork.deployed();
+      const signature = await resolver.stringToSig.call("createColony(bytes32,address)");
+      const destination = await resolver.lookup.call(signature);
+      assert.equal(destination, deployedColonyNetwork.address);
     });
 
-    it("when checking outsize for a function that doesn't exist, should return default of 32", async () => {
-      const outsize = await resolver.outsize.call("0x18118aaa");
-      assert.equal(outsize, 32);
+    it("when checking destination for a function that doesn't exist, should return 0", async () => {
+      const destination = await resolver.lookup.call("0xdeadbeef");
+      assert.equal(destination, 0);
     });
 
     it("should return correctly encoded function signature", async () => {

--- a/test/token.js
+++ b/test/token.js
@@ -1,5 +1,5 @@
 /* globals artifacts */
-import { getTokenArgs, expectEvent, checkErrorRevert, web3GetBalance, checkErrorNonPayableFunction } from "../helpers/test-helper";
+import { getTokenArgs, expectEvent, checkErrorAssert, checkErrorRevert, web3GetBalance, checkErrorNonPayableFunction } from "../helpers/test-helper";
 import { setupUpgradableToken } from "../helpers/upgradable-contracts";
 
 const EtherRouter = artifacts.require("EtherRouter");
@@ -61,7 +61,7 @@ contract("Token", accounts => {
     });
 
     it("should NOT be able to transfer more tokens than they have", async () => {
-      await checkErrorRevert(etherRouterToken.transfer(ACCOUNT_TWO, 1500001));
+      await checkErrorAssert(etherRouterToken.transfer(ACCOUNT_TWO, 1500001));
       const balanceAccount2 = await etherRouterToken.balanceOf.call(ACCOUNT_TWO);
       assert.equal(0, balanceAccount2.toNumber());
     });
@@ -81,14 +81,14 @@ contract("Token", accounts => {
     });
 
     it("should NOT be able to transfer tokens from another address if NOT pre-approved", async () => {
-      await checkErrorRevert(etherRouterToken.transferFrom(COINBASE_ACCOUNT, ACCOUNT_TWO, 300000, { from: ACCOUNT_TWO }));
+      await checkErrorAssert(etherRouterToken.transferFrom(COINBASE_ACCOUNT, ACCOUNT_TWO, 300000, { from: ACCOUNT_TWO }));
       const balanceAccount2 = await etherRouterToken.balanceOf.call(ACCOUNT_TWO);
       assert.equal(0, balanceAccount2.toNumber());
     });
 
     it("should NOT be able to transfer from another address more tokens than pre-approved", async () => {
       await etherRouterToken.approve(ACCOUNT_TWO, 300000);
-      await checkErrorRevert(etherRouterToken.transferFrom(COINBASE_ACCOUNT, ACCOUNT_TWO, 300001, { from: ACCOUNT_TWO }));
+      await checkErrorAssert(etherRouterToken.transferFrom(COINBASE_ACCOUNT, ACCOUNT_TWO, 300001, { from: ACCOUNT_TWO }));
 
       const balanceAccount2 = await etherRouterToken.balanceOf.call(ACCOUNT_TWO);
       assert.equal(0, balanceAccount2.toNumber());
@@ -98,7 +98,7 @@ contract("Token", accounts => {
       await etherRouterToken.approve(ACCOUNT_TWO, 300000);
       await etherRouterToken.transfer(ACCOUNT_THREE, 1500000);
 
-      await checkErrorRevert(etherRouterToken.transferFrom(COINBASE_ACCOUNT, ACCOUNT_TWO, 300000, { from: ACCOUNT_TWO }));
+      await checkErrorAssert(etherRouterToken.transferFrom(COINBASE_ACCOUNT, ACCOUNT_TWO, 300000, { from: ACCOUNT_TWO }));
       const balanceAccount2 = await etherRouterToken.balanceOf.call(ACCOUNT_TWO);
       assert.equal(0, balanceAccount2.toNumber());
     });

--- a/upgrade-test/colony-network-upgrade.js
+++ b/upgrade-test/colony-network-upgrade.js
@@ -34,7 +34,7 @@ contract("ColonyNetwork contract upgrade", () => {
     // Setup new Colony contract version on the Network
     const updatedColonyNetworkContract = await UpdatedColonyNetwork.new();
     const resolver = await Resolver.deployed();
-    await resolver.register("isUpdated()", updatedColonyNetworkContract.address, 32);
+    await resolver.register("isUpdated()", updatedColonyNetworkContract.address);
 
     updatedColonyNetwork = await UpdatedColonyNetwork.at(etherRouter.address);
   });

--- a/upgrade-test/colony-upgrade.js
+++ b/upgrade-test/colony-upgrade.js
@@ -53,7 +53,7 @@ contract("Colony contract upgrade", accounts => {
     // Setup new Colony contract version on the Network
     const updatedColonyContract = await UpdatedColony.new();
     const resolver = await Resolver.new();
-    await resolver.register("isUpdated()", updatedColonyContract.address, 32);
+    await resolver.register("isUpdated()", updatedColonyContract.address);
     await setupColonyVersionResolver(updatedColonyContract, colonyTask, colonyFunding, resolver, colonyNetwork);
     // Check new Colony contract version is registered successfully
     updatedColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();

--- a/upgrade-test/token-upgrade.js
+++ b/upgrade-test/token-upgrade.js
@@ -45,7 +45,7 @@ contract("Token contract upgrade", accounts => {
       const tokenArgs = getTokenArgs();
       const updatedTokenContract = await UpdatedToken.new(...tokenArgs);
       await setupUpgradableToken(updatedTokenContract, resolver, etherRouter);
-      await resolver.register("isUpdated()", updatedTokenContract.address, 32);
+      await resolver.register("isUpdated()", updatedTokenContract.address);
       updatedToken = await UpdatedToken.at(etherRouter.address);
     });
 


### PR DESCRIPTION
- Use `returndatasize` and `returndatacopy` opcodes introduced in Byzantium hard fork which give us access to the size of the return data for a call
http://solidity.readthedocs.io/en/v0.4.21/assembly.html#opcodes 
This also simplifies the `Resolver` requirements as we no longer need to track return data size for functions.

- Byzantium EIPs are allowed in prity config

- Since the above is now possible we've extended the `getTask` function to return the task domains and skills too instead of relying on recursive calls to `getTaskDomain` and `getTaskSkill` both of which have been removed. 

- Task model has been switched to use a single domain only.

- We remove leftover storage variables from `ColonyStorage` related to the old method of reviewing task updates.

