### PR TITLE
Upgrades contracts to solc 0.4.21

### DIFF
--- a/contracts/Authority.sol
+++ b/contracts/Authority.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 
@@ -23,28 +23,28 @@ import "../lib/dappsys/roles.sol";
 
 
 contract Authority is DSRoles {
-  uint8 owner_role = 0;
-  uint8 admin_role = 1;
+  uint8 ownerRole = 0;
+  uint8 adminRole = 1;
 
   function Authority(address colony) public {
     bytes4 makeTaskSig = bytes4(keccak256("makeTask(bytes32,uint256)"));
-    setRoleCapability(owner_role, colony, makeTaskSig, true);
-    setRoleCapability(admin_role, colony, makeTaskSig, true);
+    setRoleCapability(ownerRole, colony, makeTaskSig, true);
+    setRoleCapability(adminRole, colony, makeTaskSig, true);
 
     bytes4 acceptTaskSig = bytes4(keccak256("finalizeTask(uint256)"));
-    setRoleCapability(owner_role, colony, acceptTaskSig, true);
-    setRoleCapability(admin_role, colony, acceptTaskSig, true);
+    setRoleCapability(ownerRole, colony, acceptTaskSig, true);
+    setRoleCapability(adminRole, colony, acceptTaskSig, true);
 
     bytes4 setTaskDueDateSig = bytes4(keccak256("setTaskDueDate(uint256,uint256)"));
-    setRoleCapability(owner_role, colony, setTaskDueDateSig, true);
-    setRoleCapability(admin_role, colony, setTaskDueDateSig, true);
+    setRoleCapability(ownerRole, colony, setTaskDueDateSig, true);
+    setRoleCapability(adminRole, colony, setTaskDueDateSig, true);
 
     bytes4 setTaskPayoutSig = bytes4(keccak256("setTaskPayout(uint256,uint256,address,uint256)"));
-    setRoleCapability(owner_role, colony, setTaskPayoutSig, true);
-    setRoleCapability(admin_role, colony, setTaskPayoutSig, true);
+    setRoleCapability(ownerRole, colony, setTaskPayoutSig, true);
+    setRoleCapability(adminRole, colony, setTaskPayoutSig, true);
 
     bytes4 moveFundsBetweenPotsSig = bytes4(keccak256("moveFundsBetweenPots(uint256,uint256,uint256,address)"));
-    setRoleCapability(owner_role, colony, moveFundsBetweenPotsSig, true);
-    setRoleCapability(admin_role, colony, moveFundsBetweenPotsSig, true);
+    setRoleCapability(ownerRole, colony, moveFundsBetweenPotsSig, true);
+    setRoleCapability(adminRole, colony, moveFundsBetweenPotsSig, true);
   }
 }

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 
@@ -96,7 +96,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
     if (!active) {
       logIdx = (logIdx + 1) % 2;
     }
-    ReputationLogEntry storage x = ReputationUpdateLogs[logIdx][_id];
+    ReputationLogEntry storage x = reputationUpdateLogs[logIdx][_id];
     return (x.user, x.amount, x.skillId, x.colony, x.nUpdates, x.nPreviousUpdates);
   }
 
@@ -111,15 +111,15 @@ contract ColonyNetwork is ColonyNetworkStorage {
   function createColony(bytes32 _name, address _tokenAddress) public
   colonyKeyUnique(_name)
   {
-    var etherRouter = new EtherRouter();
-    var resolverForLatestColonyVersion = colonyVersionResolver[currentColonyVersion];
+    EtherRouter etherRouter = new EtherRouter();
+    address resolverForLatestColonyVersion = colonyVersionResolver[currentColonyVersion];
     etherRouter.setResolver(resolverForLatestColonyVersion);
 
-    var colony = IColony(etherRouter);
+    IColony colony = IColony(etherRouter);
     colony.setToken(_tokenAddress);
 
-    var authority = new Authority(colony);
-    var dsauth = DSAuth(etherRouter);
+    Authority authority = new Authority(colony);
+    DSAuth dsauth = DSAuth(etherRouter);
     dsauth.setAuthority(authority);
     authority.setRootUser(msg.sender, true);
     authority.setOwner(msg.sender);
@@ -141,7 +141,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
     _isColony[colony] = true;
 
     colony.initialiseColony(this);
-    ColonyAdded(colonyCount);
+    emit ColonyAdded(colonyCount);
   }
 
   function addColonyVersion(uint _version, address _resolver) public
@@ -227,7 +227,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
       treeWalkingCounter += 1;
     }
 
-    SkillAdded(skillCount, _parentSkillId);
+    emit SkillAdded(skillCount, _parentSkillId);
     return skillCount;
   }
 
@@ -245,17 +245,17 @@ contract ColonyNetwork is ColonyNetworkStorage {
   calledByColony
   skillExists(_skillId)
   {
-    uint reputationUpdateLogLength = ReputationUpdateLogs[activeReputationUpdateLog].length;
+    uint reputationUpdateLogLength = reputationUpdateLogs[activeReputationUpdateLog].length;
     uint nPreviousUpdates = 0;
     if (reputationUpdateLogLength > 0) {
-      nPreviousUpdates = ReputationUpdateLogs[activeReputationUpdateLog][reputationUpdateLogLength-1].nPreviousUpdates + ReputationUpdateLogs[activeReputationUpdateLog][reputationUpdateLogLength-1].nUpdates;
+      nPreviousUpdates = reputationUpdateLogs[activeReputationUpdateLog][reputationUpdateLogLength-1].nPreviousUpdates + reputationUpdateLogs[activeReputationUpdateLog][reputationUpdateLogLength-1].nUpdates;
     }
     uint nUpdates = (skills[_skillId].nParents + 1) * 2;
     if (_amount < 0) {
       //TODO: Never true currently. _amount needs to be an int.
       nUpdates += 2 * skills[_skillId].nChildren;
     }
-    ReputationUpdateLogs[activeReputationUpdateLog].push(ReputationLogEntry(
+    reputationUpdateLogs[activeReputationUpdateLog].push(ReputationLogEntry(
       _user,
       _amount,
       _skillId,
@@ -269,6 +269,6 @@ contract ColonyNetwork is ColonyNetworkStorage {
     if (!active) {
       logIdx = (logIdx + 1 ) % 2;
     }
-    return ReputationUpdateLogs[logIdx].length;
+    return reputationUpdateLogs[logIdx].length;
   }
 }

--- a/contracts/ColonyNetworkAuction.sol
+++ b/contracts/ColonyNetworkAuction.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 
@@ -34,7 +34,7 @@ contract ColonyNetworkAuction is ColonyNetworkStorage {
     DutchAuction auction = new DutchAuction(clny, _token);
     uint availableTokens = ERC20Extended(_token).balanceOf(this);
     ERC20Extended(_token).transfer(auction, availableTokens);
-    AuctionCreated(address(auction), _token, availableTokens);
+    emit AuctionCreated(address(auction), _token, availableTokens);
   }
 }
 
@@ -167,7 +167,7 @@ contract DutchAuction is DSMath {
     bids[msg.sender] = add(bids[msg.sender], amount);
     receivedTotal = add(receivedTotal, amount);
     
-    AuctionBid(msg.sender, amount, sub(remainingToEndAuction, amount));
+    emit AuctionBid(msg.sender, amount, sub(remainingToEndAuction, amount));
   }
 
   // Finalize the auction and set the final Token price
@@ -179,7 +179,7 @@ contract DutchAuction is DSMath {
     clnyToken.transfer(colonyNetwork, receivedTotal);
     finalPrice = add((mul(receivedTotal, TOKEN_MULTIPLIER) / quantity), 1);
     finalized = true;
-    AuctionFinalized(finalPrice);
+    emit AuctionFinalized(finalPrice);
   }
 
   function claim() public 
@@ -199,7 +199,7 @@ contract DutchAuction is DSMath {
     assert(token.balanceOf(msg.sender) == add(beforeClaimBalance, tokens));
     assert(bids[msg.sender] == 0);
 
-    AuctionClaim(msg.sender, tokens);
+    emit AuctionClaim(msg.sender, tokens);
     return true;
   }
 

--- a/contracts/ColonyNetworkStaking.sol
+++ b/contracts/ColonyNetworkStaking.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 
@@ -54,7 +54,7 @@ contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
     reputationRootHash = newHash;
     reputationRootHashNNodes = newNNodes;
     // Clear out the inactive reputation log. We're setting a new root hash, so we're done with it.
-    delete ReputationUpdateLogs[(activeReputationUpdateLog + 1) % 2];
+    delete reputationUpdateLogs[(activeReputationUpdateLog + 1) % 2];
     // The active reputation update log is now switched to be the one we've just cleared out.
     // The old activeReputationUpdateLog will be used for the next reputation mining cycle
     activeReputationUpdateLog = (activeReputationUpdateLog + 1) % 2;
@@ -108,7 +108,7 @@ contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
     for (uint256 i = 0; i < stakers.length; i++) {
       // We *know* we're the first entries in this reputation update log, so we don't need all the bookkeeping in
       // the AppendReputationUpdateLog function
-      ReputationUpdateLogs[activeReputationUpdateLog].push(ReputationLogEntry(
+      reputationUpdateLogs[activeReputationUpdateLog].push(ReputationLogEntry(
         stakers[i], //The staker getting the reward
         int256(reward),
         0, //TODO: Work out what skill this should be. This should be a special 'mining' skill.

--- a/contracts/ColonyNetworkStorage.sol
+++ b/contracts/ColonyNetworkStorage.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 
@@ -63,7 +63,7 @@ contract ColonyNetworkStorage is DSAuth {
     uint256 nPreviousUpdates;
   }
 
-  mapping (uint => ReputationLogEntry[]) ReputationUpdateLogs;
+  mapping (uint => ReputationLogEntry[]) reputationUpdateLogs;
   uint256 activeReputationUpdateLog;
 
   bytes32 reputationRootHash;

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 
@@ -129,7 +129,7 @@ contract ColonyTask is ColonyStorage, DSMath {
 
     pots[potCount].taskId = taskCount;
 
-    TaskAdded(taskCount);
+    emit TaskAdded(taskCount);
   }
 
   function getTaskCount() public view returns (uint256) {
@@ -152,7 +152,9 @@ contract ColonyTask is ColonyStorage, DSMath {
     require(_sigR.length == 2);
     require(_sigR.length == _sigS.length && _sigR.length == _sigV.length);
 
-    var (sig, taskId) = deconstructCall(_data);
+    bytes4 sig;
+    uint256 taskId;
+    (sig, taskId) = deconstructCall(_data);
     Task storage task = tasks[taskId];
     require(!task.finalized);
     

--- a/contracts/ERC20Extended.sol
+++ b/contracts/ERC20Extended.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 

--- a/contracts/EtherRouter.sol
+++ b/contracts/EtherRouter.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 

--- a/contracts/Resolver.sol
+++ b/contracts/Resolver.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 

--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.21;
 pragma experimental "v0.5.0";
 pragma experimental "ABIEncoderV2";
 
@@ -59,7 +59,7 @@ contract Token is DSAuth, DSMath, ERC20Extended {
     _balances[msg.sender] = sub(_balances[msg.sender], wad);
     _balances[dst] = add(_balances[dst], wad);
 
-    Transfer(msg.sender, dst, wad);
+    emit Transfer(msg.sender, dst, wad);
 
     return true;
   }
@@ -72,7 +72,7 @@ contract Token is DSAuth, DSMath, ERC20Extended {
     _balances[src] = sub(_balances[src], wad);
     _balances[dst] = add(_balances[dst], wad);
 
-    Transfer(src, dst, wad);
+    emit Transfer(src, dst, wad);
 
     return true;
   }
@@ -80,7 +80,7 @@ contract Token is DSAuth, DSMath, ERC20Extended {
   function approve(address guy, uint256 wad) public returns (bool) {
     _approvals[msg.sender][guy] = wad;
 
-    Approval(msg.sender, guy, wad);
+    emit Approval(msg.sender, guy, wad);
 
     return true;
   }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "prettier": "^1.11.1",
     "rimraf": "^2.6.2",
     "shortid": "^2.2.8",
-    "solidity-coverage": "0.4.15",
+    "solidity-coverage": "0.5.0",
     "solidity-parser-antlr": "^0.2.8",
     "solium": "^1.1.6",
     "truffle": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -68,9 +68,9 @@
     "rimraf": "^2.6.2",
     "shortid": "^2.2.8",
     "solidity-coverage": "0.4.15",
-    "solidity-parser-antlr": "^0.2.7",
-    "solium": "^1.1.5",
-    "truffle": "^4.1.3",
+    "solidity-parser-antlr": "^0.2.8",
+    "solium": "^1.1.6",
+    "truffle": "^4.1.5",
     "web3-utils": "^1.0.0-beta.30"
   },
   "dependencies": {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5744,9 +5744,9 @@ sol-explore@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/sol-explore/-/sol-explore-1.6.2.tgz#43ae8c419fd3ac056a05f8a9d1fb1022cd41ecc2"
 
-solc@0.4.19:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.19.tgz#1af1c4c292a0365a6977d4cbe3fbee7139b4b561"
+solc@0.4.21:
+  version "0.4.21"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.21.tgz#6a7ecd505bfa0fc268330d5de6b9ae65c8c68264"
   dependencies:
     fs-extra "^0.30.0"
     memorystream "^0.3.1"
@@ -5768,9 +5768,9 @@ solidity-coverage@0.4.15:
     solidity-parser-sc "0.4.7"
     web3 "^0.18.4"
 
-solidity-parser-antlr@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/solidity-parser-antlr/-/solidity-parser-antlr-0.2.7.tgz#4c72e5f052fdd54fec363f1156533703e84a8325"
+solidity-parser-antlr@^0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/solidity-parser-antlr/-/solidity-parser-antlr-0.2.8.tgz#8eb8547a88dfeaf6cf4c7811e3824084214244d4"
 
 solidity-parser-sc@0.4.7:
   version "0.4.7"
@@ -5784,9 +5784,9 @@ solium-plugin-security@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/solium-plugin-security/-/solium-plugin-security-0.1.1.tgz#2a87bcf8f8c3abf7d198e292e4ac080284e3f3f6"
 
-solium@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/solium/-/solium-1.1.5.tgz#761ff9f2f374cf10e5febe96c2dcdbbe5d542088"
+solium@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/solium/-/solium-1.1.6.tgz#af3591ba2709c34470e4678ed27026e81c5161d8"
   dependencies:
     ajv "^5.2.2"
     chokidar "^1.6.0"
@@ -5797,12 +5797,12 @@ solium@^1.1.5:
     sol-digger "0.0.2"
     sol-explore "1.6.1"
     solium-plugin-security "0.1.1"
-    solparse "2.2.3"
+    solparse "2.2.4"
     text-table "^0.2.0"
 
-solparse@2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/solparse/-/solparse-2.2.3.tgz#77553393a085039b67c6d96bc830ea9a01fcc65f"
+solparse@2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/solparse/-/solparse-2.2.4.tgz#3980b4db131fa3e17c010d67e1016436f5d46306"
   dependencies:
     mocha "^4.0.1"
     pegjs "^0.10.0"
@@ -6248,13 +6248,13 @@ trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
 
-truffle@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-4.1.3.tgz#55b7095bcd2cd3751bc874601affa3ceb70df672"
+truffle@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-4.1.5.tgz#763c8175fe5ea1ada92aa7a02eff84b4ab272f72"
   dependencies:
     mocha "^3.4.2"
     original-require "^1.0.1"
-    solc "0.4.19"
+    solc "0.4.21"
 
 tty-browserify@0.0.0:
   version "0.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5754,9 +5754,9 @@ solc@0.4.21:
     semver "^5.3.0"
     yargs "^4.7.1"
 
-solidity-coverage@0.4.15:
-  version "0.4.15"
-  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.4.15.tgz#0902ae362ec4a9eb746cdaa18a60d8b9f7fd27ae"
+solidity-coverage@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.5.0.tgz#af15375113979eef640ef7564016b05e924fcb7a"
   dependencies:
     death "^1.1.0"
     ethereumjs-testrpc-sc "6.1.2"
@@ -5765,16 +5765,16 @@ solidity-coverage@0.4.15:
     req-cwd "^1.0.1"
     shelljs "^0.7.4"
     sol-explore "^1.6.2"
-    solidity-parser-sc "0.4.7"
+    solidity-parser-sc "0.4.8"
     web3 "^0.18.4"
 
 solidity-parser-antlr@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/solidity-parser-antlr/-/solidity-parser-antlr-0.2.8.tgz#8eb8547a88dfeaf6cf4c7811e3824084214244d4"
 
-solidity-parser-sc@0.4.7:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/solidity-parser-sc/-/solidity-parser-sc-0.4.7.tgz#047a9e83684657992b6d4d35d04ea32070e1bee8"
+solidity-parser-sc@0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/solidity-parser-sc/-/solidity-parser-sc-0.4.8.tgz#b2d14f0effe638f78b38b489cb4a763ad88613cd"
   dependencies:
     mocha "^2.4.5"
     pegjs "^0.10.0"


### PR DESCRIPTION
Upgrades contracts to [`solc 0.4.21`](https://github.com/ethereum/solidity/releases/tag/v0.4.21)

Upgrades related packages: [`truffle`](https://github.com/trufflesuite/truffle/releases/tag/v4.1.5), [`solidity-parser-antlr`](https://github.com/federicobond/solidity-parser-antlr/commit/2dc25a29b4c1f426a300dd57a92800df814aae70), [`solium`] (https://github.com/duaraghav8/Solium/releases/tag/v1.1.6) and `solidity-coverage` to `0.5.0` which move to solc 0.4.21 and add support for new log `emit` keyword in Solidity.

Also https://github.com/trufflesuite/truffle-migrate/pull/18 is fixed by the version upgrade here