### PR TITLE
Updating reputation in task domain skill id instead of domain id

### DIFF
--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -174,7 +174,7 @@ contract ColonyFunding is ColonyStorage, DSMath {
     emit RewardPayoutCycleStarted(globalRewardPayoutCount);
   }
 
-  function claimRewardPayout(uint256 _payoutId, uint256[7] squareRoots, uint256 _userReputation, uint256 _totalReputation) public {
+  function claimRewardPayout(uint256 _payoutId, uint256[7] _squareRoots, uint256 _userReputation, uint256 _totalReputation) public {
     RewardPayoutCycle memory payout = rewardPayoutCycles[_payoutId];
     require(block.timestamp - payout.blockTimestamp <= 60 days, "colony-reward-payout-not-active");
     require(_payoutId - userRewardPayoutCount[msg.sender] == 1, "colony-reward-payout-bad-id");
@@ -195,18 +195,18 @@ contract ColonyFunding is ColonyStorage, DSMath {
     // squareRoots[5] - square root of denominator
     // squareRoots[6] - square root of payout.amount
 
-    require(mul(squareRoots[0], squareRoots[0]) <= _userReputation, "colony-reward-payout-invalid-parametar-user-reputation");
-    require(mul(squareRoots[1], squareRoots[1]) <= userTokens, "colony-reward-payout-invalid-parametar-user-token");
-    require(mul(squareRoots[2], squareRoots[2]) <= _totalReputation, "colony-reward-payout-invalid-parametar-total-reputation");
-    require(mul(squareRoots[3], squareRoots[3]) <= payout.totalTokens, "colony-reward-payout-invalid-parametar-total-tokens");
-    require(mul(squareRoots[6], squareRoots[6]) <= payout.amount, "colony-reward-payout-invalid-parametar-amount");
-    uint256 numerator = mul(squareRoots[0], squareRoots[1]);
-    uint256 denominator = mul(squareRoots[2], squareRoots[3]);
+    require(mul(_squareRoots[0], _squareRoots[0]) <= _userReputation, "colony-reward-payout-invalid-parametar-user-reputation");
+    require(mul(_squareRoots[1], _squareRoots[1]) <= userTokens, "colony-reward-payout-invalid-parametar-user-token");
+    require(mul(_squareRoots[2], _squareRoots[2]) <= _totalReputation, "colony-reward-payout-invalid-parametar-total-reputation");
+    require(mul(_squareRoots[3], _squareRoots[3]) <= payout.totalTokens, "colony-reward-payout-invalid-parametar-total-tokens");
+    require(mul(_squareRoots[6], _squareRoots[6]) <= payout.amount, "colony-reward-payout-invalid-parametar-amount");
+    uint256 numerator = mul(_squareRoots[0], _squareRoots[1]);
+    uint256 denominator = mul(_squareRoots[2], _squareRoots[3]);
 
-    require(mul(squareRoots[4], squareRoots[4]) <= numerator, "colony-reward-payout-invalid-parametar-numerator");
-    require(mul(squareRoots[5], squareRoots[5]) <= denominator, "colony-reward-payout-invalid-parametar-denominator");
+    require(mul(_squareRoots[4], _squareRoots[4]) <= numerator, "colony-reward-payout-invalid-parametar-numerator");
+    require(mul(_squareRoots[5], _squareRoots[5]) <= denominator, "colony-reward-payout-invalid-parametar-denominator");
 
-    uint256 reward = (mul(squareRoots[4], squareRoots[6]) / (squareRoots[5] + 1)) ** 2;
+    uint256 reward = (mul(_squareRoots[4], _squareRoots[6]) / (_squareRoots[5] + 1)) ** 2;
 
     pots[0].balance[payout.tokenAddress] = sub(pots[0].balance[payout.tokenAddress], reward);
 

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -300,20 +300,20 @@ contract IColony {
 
   /// @notice Claim the reward payout at `_payoutId`. User needs to provide their reputation and colony-wide reputation
   /// which will be proven via Merkle proof inside this function.
-  /// Can only be called if payout is active, i.e when 60 days have passed from its creation.
+  /// Can only be called if payout is active, i.e if 60 days have not passed from its creation.
   /// Can only be called if next in queue
   /// @param _payoutId Id of the reward payout
-  /// @param squareRoots Square roots of values used in equation
-  /// 0 - square root of user reputation
-  /// 1 - square root of user tokens
-  /// 2 - square root of total reputation
-  /// 3 - square root of total tokens
-  /// 4 - square root of numerator (user reputation * user tokens)
-  /// 5 - square root of denominator (total reputation * total tokens)
-  /// 6 - square root of payout amount
+  /// @param _squareRoots Square roots of values used in equation
+  /// _squareRoots[0] - square root of user reputation
+  /// _squareRoots[1] - square root of user tokens
+  /// _squareRoots[2] - square root of total reputation
+  /// _squareRoots[3] - square root of total tokens
+  /// _squareRoots[4] - square root of numerator (user reputation * user tokens)
+  /// _squareRoots[5] - square root of denominator (total reputation * total tokens)
+  /// _squareRoots[6] - square root of payout amount
   /// @param _userReputation User reputation at the point of creation of reward payout cycle
   /// @param _totalReputation Total reputation at the point of creation of reward payout cycle
-  function claimRewardPayout(uint256 _payoutId, uint256[7] squareRoots, uint256 _userReputation, uint256 _totalReputation) public;
+  function claimRewardPayout(uint256 _payoutId, uint256[7] _squareRoots, uint256 _userReputation, uint256 _totalReputation) public;
 
   /// @notice Waive reward payouts. This will unlock the sender's tokens and increment users reward payout counter,
   /// allowing them to claim next reward payout

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -30,7 +30,7 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
   // If the skill is not specified, default to the root global skill
   if (skill === 0) {
     const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId.call();
-    if (rootGlobalSkill === 0) throw new Error("Common Colony is not setup and therefore the root global skill does not exist");
+    if (rootGlobalSkill.toNumber() === 0) throw new Error("Common Colony is not setup and therefore the root global skill does not exist");
     await colony.setTaskSkill(taskId, rootGlobalSkill);
   } else {
     await colony.setTaskSkill(taskId, skill);

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -429,20 +429,20 @@ contract("Colony Funding", addresses => {
       const totalReputationSqrt = bnSqrt(totalReputation);
       const totalTokensSqrt = bnSqrt(userReputation1.add(userReputation2));
 
-      const numerator1 = bnSqrt(userReputation1Sqrt.mul(userReputation1Sqrt));
-      const numerator2 = bnSqrt(userReputation2Sqrt.mul(userReputation2Sqrt));
-      const denominator = bnSqrt(totalReputationSqrt.mul(totalTokensSqrt));
+      const numerator1Sqrt = bnSqrt(userReputation1Sqrt.mul(userReputation1Sqrt));
+      const numerator2Sqrt = bnSqrt(userReputation2Sqrt.mul(userReputation2Sqrt));
+      const denominatorSqrt = bnSqrt(totalReputationSqrt.mul(totalTokensSqrt));
 
-      const totalAmount = bnSqrt(initialFunding.div(toBN(100)));
+      const totalAmountSqrt = bnSqrt(initialFunding.div(toBN(100)));
 
       initialSquareRoots1 = [
         userReputation1Sqrt.toString(),
         userReputation1Sqrt.toString(),
         totalReputationSqrt.toString(),
         totalTokensSqrt.toString(),
-        numerator1.toString(),
-        denominator.toString(),
-        totalAmount.toString()
+        numerator1Sqrt.toString(),
+        denominatorSqrt.toString(),
+        totalAmountSqrt.toString()
       ];
 
       initialSquareRoots2 = [
@@ -450,9 +450,9 @@ contract("Colony Funding", addresses => {
         userReputation2Sqrt.toString(),
         totalReputationSqrt.toString(),
         totalTokensSqrt.toString(),
-        numerator2.toString(),
-        denominator.toString(),
-        totalAmount.toString()
+        numerator2Sqrt.toString(),
+        denominatorSqrt.toString(),
+        totalAmountSqrt.toString()
       ];
     });
 
@@ -515,7 +515,7 @@ contract("Colony Funding", addresses => {
       const totalReputation3 = userReputation1.add(userReputation2).add(userReputation3);
       const totalReputationSqrt = bnSqrt(totalReputation3);
       const totalTokensSqrt = bnSqrt(userReputation1.add(userReputation2));
-      const denominator = bnSqrt(totalReputation.mul(totalReputation3));
+      const denominatorSqrt = bnSqrt(totalReputation.mul(totalReputation3));
       const info = await colony.getRewardPayoutInfo(payoutId);
       const amountSqrt = bnSqrt(info[2]);
 
@@ -525,7 +525,7 @@ contract("Colony Funding", addresses => {
         totalReputationSqrt.toString(),
         totalTokensSqrt.toString(),
         0,
-        denominator.toString(),
+        denominatorSqrt.toString(),
         amountSqrt.toString()
       ];
 
@@ -547,7 +547,7 @@ contract("Colony Funding", addresses => {
       const userTokens3Sqrt = bnSqrt(userTokens3);
       const totalReputationSqrt = bnSqrt(totalReputation);
       const totalTokensSqrt = bnSqrt(userReputation1.add(userReputation2).add(userTokens3));
-      const denominator = bnSqrt(totalReputation.mul(totalTokensSqrt));
+      const denominatorSqrt = bnSqrt(totalReputation.mul(totalTokensSqrt));
       const info = await colony.getRewardPayoutInfo(payoutId);
       const amountSqrt = bnSqrt(info[2]);
 
@@ -557,7 +557,7 @@ contract("Colony Funding", addresses => {
         totalReputationSqrt.toString(),
         totalTokensSqrt.toString(),
         0,
-        denominator.toString(),
+        denominatorSqrt.toString(),
         amountSqrt.toString()
       ];
 
@@ -751,14 +751,22 @@ contract("Colony Funding", addresses => {
         const a = numerator.mul(factor).div(denominator);
         const reward = amount.mul(a).div(factor);
 
+        const userReputationSqrt = bnSqrt(userReputation);
+        const userTokensSqrt = bnSqrt(userTokens);
+        const totalReputationSqrt = bnSqrt(data.totalReputation);
+        const totalTokensSqrt = bnSqrt(totalTokens);
+        const numeratorSqrt = bnSqrt(numerator);
+        const denominatorSqrt = bnSqrt(denominator);
+        const amountSqrt = bnSqrt(amount);
+
         const squareRoots = [
-          bnSqrt(userReputation).toString(),
-          userTokens.sqrt().toString(),
-          bnSqrt(data.totalReputation).toString(),
-          totalTokens.sqrt().toString(),
-          numerator.sqrt().toString(),
-          denominator.sqrt().toString(),
-          amount.sqrt().toString()
+          userReputationSqrt.toString(),
+          userTokensSqrt.toString(),
+          totalReputationSqrt.toString(),
+          totalTokensSqrt.toString(),
+          numeratorSqrt.toString(),
+          denominatorSqrt.toString(),
+          amountSqrt.toString()
         ];
 
         await newColony.claimRewardPayout(payoutId, squareRoots, userReputation.toString(), data.totalReputation.toString(), {

--- a/test/colony-network-staking.js
+++ b/test/colony-network-staking.js
@@ -796,7 +796,7 @@ contract("ColonyNetworkStaking", accounts => {
 
       await goodClient.addLogContentsToReputationTree();
 
-      badClient = new MaliciousReputationMiningClient(OTHER_ACCOUNT, realProviderPort, 4, "0xfffffffff");
+      badClient = new MaliciousReputationMiningClient(OTHER_ACCOUNT, realProviderPort, 5, "0xfffffffff");
       await badClient.initialise(colonyNetwork.address);
       await badClient.addLogContentsToReputationTree();
 
@@ -863,19 +863,19 @@ contract("ColonyNetworkStaking", accounts => {
       await badClient.respondToBinarySearchForChallenge();
       goodSubmission = await repCycle.disputeRounds(0, 0);
       badSubmission = await repCycle.disputeRounds(0, 1);
-      assert.equal(goodSubmission[8].toNumber(), 4);
-      assert.equal(goodSubmission[9].toNumber(), 5);
-      assert.equal(badSubmission[8].toNumber(), 4);
-      assert.equal(badSubmission[9].toNumber(), 5);
+      assert.equal(goodSubmission[8].toNumber(), 6);
+      assert.equal(goodSubmission[9].toNumber(), 7);
+      assert.equal(badSubmission[8].toNumber(), 6);
+      assert.equal(badSubmission[9].toNumber(), 7);
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
       goodSubmission = await repCycle.disputeRounds(0, 0);
       badSubmission = await repCycle.disputeRounds(0, 1);
-      assert.equal(goodSubmission[8].toNumber(), 5);
-      assert.equal(goodSubmission[9].toNumber(), 5);
-      assert.equal(badSubmission[8].toNumber(), 5);
-      assert.equal(badSubmission[9].toNumber(), 5);
+      assert.equal(goodSubmission[8].toNumber(), 6);
+      assert.equal(goodSubmission[9].toNumber(), 6);
+      assert.equal(badSubmission[8].toNumber(), 6);
+      assert.equal(badSubmission[9].toNumber(), 6);
 
       // TODO: Split off in to  another test here, but can't be bothered to refactor right now.
       await goodClient.respondToChallenge();
@@ -922,7 +922,7 @@ contract("ColonyNetworkStaking", accounts => {
 
       await goodClient.addLogContentsToReputationTree();
 
-      badClient = new MaliciousReputationMiningClient2(OTHER_ACCOUNT, realProviderPort, 4, "0xfffffffff");
+      badClient = new MaliciousReputationMiningClient2(OTHER_ACCOUNT, realProviderPort, 5, "0xfffffffff");
       await badClient.initialise(colonyNetwork.address);
       await badClient.addLogContentsToReputationTree();
 
@@ -1354,8 +1354,9 @@ contract("ColonyNetworkStaking", accounts => {
       await client.initialise(colonyNetwork.address);
       await client.addLogContentsToReputationTree();
 
-      // Check the client's tree has three entries.
-      assert.equal(Object.keys(client.reputations).length, 4);
+      // Check the client's tree has four entries.
+      // manager, worker (domain skill and task skill), evalutator + last log used for disputes
+      assert.equal(Object.keys(client.reputations).length, 5);
       // These should be:
       // 1. Reputation reward for MAIN_ACCOUNT for submitting the previous reputaiton hash
       //   (currently skill 0, needs to change to indicate a special mining skill)
@@ -1368,7 +1369,7 @@ contract("ColonyNetworkStaking", accounts => {
       );
       // 2. Reputation reward for MAIN_ACCOUNT for being the manager for the tasks created by giveUserCLNYTokens
       let key2 = `0x${new BN(commonColony.address.slice(2), 16).toString(16, 40)}`;
-      key2 += `${new BN("1").toString(16, 64)}`;
+      key2 += `${new BN("2").toString(16, 64)}`;
       key2 += `${new BN(MAIN_ACCOUNT.slice(2), 16).toString(16, 40)}`;
       assert.equal(
         client.reputations[key2],
@@ -1376,7 +1377,7 @@ contract("ColonyNetworkStaking", accounts => {
       );
       // 3. Reputation reward for OTHER_ACCOUNT for being the evaluator for the tasks created by giveUserCLNYTokens
       let key3 = `0x${new BN(commonColony.address.slice(2), 16).toString(16, 40)}`;
-      key3 += `${new BN("1").toString(16, 64)}`;
+      key3 += `${new BN("2").toString(16, 64)}`;
       key3 += `${new BN(OTHER_ACCOUNT.slice(2), 16).toString(16, 40)}`;
       assert.equal(
         client.reputations[key3],
@@ -1385,7 +1386,7 @@ contract("ColonyNetworkStaking", accounts => {
       // 4. Reputation reward for accounts[2] for being the worker for the tasks created by giveUserCLNYTokens
       // NB at the moment, the reputation reward for the worker is 0.
       let key4 = `0x${new BN(commonColony.address.slice(2), 16).toString(16, 40)}`;
-      key4 += `${new BN("1").toString(16, 64)}`;
+      key4 += `${new BN("2").toString(16, 64)}`;
       key4 += `${new BN(accounts[2].slice(2), 16).toString(16, 40)}`;
       assert.equal(
         client.reputations[key4],
@@ -1419,7 +1420,7 @@ contract("ColonyNetworkStaking", accounts => {
       await repCycle.submitRootHash(newRootHash, 10, 10);
       await repCycle.confirmNewHash(0);
       let key = `0x${new BN(commonColony.address.slice(2), 16).toString(16, 40)}`; // Colony address as bytes
-      key += `${new BN("1").toString(16, 64)}`; // SkillId as uint256
+      key += `${new BN("2").toString(16, 64)}`; // SkillId as uint256
       key += `${new BN(MAIN_ACCOUNT.slice(2), 16).toString(16, 40)}`; // User address as bytes
 
       const value = client.reputations[key];

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -56,7 +56,7 @@ contract("Colony Reputation Updates", () => {
       const repLogEntryManager = await colonyNetwork.getReputationUpdateLogEntry.call(0, true);
       assert.equal(repLogEntryManager[0], MANAGER);
       assert.equal(repLogEntryManager[1].toNumber(), 1000 * 1e18 / 50);
-      assert.equal(repLogEntryManager[2].toNumber(), 1);
+      assert.equal(repLogEntryManager[2].toNumber(), 2);
       assert.equal(repLogEntryManager[3], commonColony.address);
       assert.equal(repLogEntryManager[4].toNumber(), 2);
       assert.equal(repLogEntryManager[5].toNumber(), 0);
@@ -64,7 +64,7 @@ contract("Colony Reputation Updates", () => {
       const repLogEntryEvaluator = await colonyNetwork.getReputationUpdateLogEntry.call(1, true);
       assert.equal(repLogEntryEvaluator[0], EVALUATOR);
       assert.equal(repLogEntryEvaluator[1].toNumber(), 50 * 1e18);
-      assert.equal(repLogEntryEvaluator[2].toNumber(), 1);
+      assert.equal(repLogEntryEvaluator[2].toNumber(), 2);
       assert.equal(repLogEntryEvaluator[3], commonColony.address);
       assert.equal(repLogEntryEvaluator[4].toNumber(), 2);
       assert.equal(repLogEntryEvaluator[5].toNumber(), 2);
@@ -72,7 +72,7 @@ contract("Colony Reputation Updates", () => {
       const repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(2, true);
       assert.equal(repLogEntryWorker[0], WORKER);
       assert.equal(repLogEntryWorker[1].toNumber(), 200 * 1e18);
-      assert.equal(repLogEntryWorker[2].toNumber(), 1);
+      assert.equal(repLogEntryWorker[2].toNumber(), 2);
       assert.equal(repLogEntryWorker[3], commonColony.address);
       assert.equal(repLogEntryWorker[4].toNumber(), 2);
       assert.equal(repLogEntryWorker[5].toNumber(), 4);
@@ -148,7 +148,7 @@ contract("Colony Reputation Updates", () => {
         const repLogEntryManager = await colonyNetwork.getReputationUpdateLogEntry.call(0, true);
         assert.equal(repLogEntryManager[0], MANAGER);
         assert.equal(repLogEntryManager[1].toString(), rating.reputationChangeManager.toString());
-        assert.equal(repLogEntryManager[2].toNumber(), 1);
+        assert.equal(repLogEntryManager[2].toNumber(), 2);
         assert.equal(repLogEntryManager[3], commonColony.address);
         assert.equal(repLogEntryManager[4].toNumber(), 2);
         assert.equal(repLogEntryManager[5].toNumber(), 0);
@@ -156,7 +156,7 @@ contract("Colony Reputation Updates", () => {
         const repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(2, true);
         assert.equal(repLogEntryWorker[0], WORKER);
         assert.equal(repLogEntryWorker[1].toString(), rating.reputationChangeWorker.toString());
-        assert.equal(repLogEntryWorker[2].toNumber(), 1);
+        assert.equal(repLogEntryWorker[2].toNumber(), 2);
         assert.equal(repLogEntryWorker[3], commonColony.address);
         assert.equal(repLogEntryWorker[4].toNumber(), 2);
         assert.equal(repLogEntryWorker[5].toNumber(), 4);


### PR DESCRIPTION
Closes #193 

Changes include:
- Due to stack depth error, removed `taskExists ` modifier.
- Updating reputation in task domain skill id instead of domain id, and changed the tests accordingly.
- Improved variable names in tests for reward payouts.
- By changing the skill id for the reputation update, one more reputation key was added in client. This will result changing [this](https://github.com/JoinColony/colonyNetwork/pull/202/files#diff-9e591fc7c2149015d27fb59bfd304eacR1359) line from 4 (manager, worker, evaluator, last log for disputes) to 5 (manager, worker **skill** and **domain**, evaluator, last log for disputes)