### PR TITLE
Task change nonce becomes task specific

### DIFF
--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -34,8 +34,10 @@ contract ColonyStorage is DSAuth {
 
   // Mapping function signature to 2 task roles whose approval is needed to execute
   mapping (bytes4 => uint8[2]) reviewers;
-  uint256 taskChangeNonce;
 
+  // Mapping task id to current "active" nonce for executing task changes
+  mapping (uint256 => uint256) taskChangeNonces;
+  
   mapping (uint256 => Task) tasks;
 
   // Pots can be tied to tasks or domains, so giving them their own mapping.

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -34,9 +34,7 @@ contract ColonyStorage is DSAuth {
 
   // Mapping function signature to 2 task roles whose approval is needed to execute
   mapping (bytes4 => uint8[2]) reviewers;
-
-  // Mapping task id to current "active" nonce for executing task changes
-  mapping (uint256 => uint256) taskChangeNonces;
+  uint256 taskChangeNonce; // Made obsolete in #203
   
   mapping (uint256 => Task) tasks;
 
@@ -87,6 +85,9 @@ contract ColonyStorage is DSAuth {
   uint8 constant MANAGER = 0;
   uint8 constant EVALUATOR = 1;
   uint8 constant WORKER = 2;
+
+  // Mapping task id to current "active" nonce for executing task changes
+  mapping (uint256 => uint256) taskChangeNonces;
 
   struct Task {
     bytes32 specificationHash;

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -162,12 +162,12 @@ contract ColonyTask is ColonyStorage, DSMath {
     (sig, taskId) = deconstructCall(_data);
     require(!tasks[taskId].finalized);
 
-    // Checks the two reviewers differ
-    require(tasks[taskId].roles[reviewers[sig][0]].user != tasks[taskId].roles[reviewers[sig][1]].user);
-
     uint8 nSignaturesRequired;
-    // If one of the roles is not set, allow the other one to execute a change with just its signature
     if (tasks[taskId].roles[reviewers[sig][0]].user == address(0) || tasks[taskId].roles[reviewers[sig][1]].user == address(0)) {
+      // When one of the roles is not set, allow the other one to execute a change with just their signature
+      nSignaturesRequired = 1;
+    } else if (tasks[taskId].roles[reviewers[sig][0]].user == tasks[taskId].roles[reviewers[sig][1]].user) {
+      // We support roles being assumed by the same user, in this case, allow them to execute a change with just their signature
       nSignaturesRequired = 1;
     } else {
       nSignaturesRequired = 2;

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -199,7 +199,15 @@ contract ColonyTask is ColonyStorage, DSMath {
     }
     
     taskChangeNonces[taskId]++;
-    require(address(this).call.value(_value)(_data));
+    require(executeCall(address(this), _value, _data));
+  }
+
+  // The address.call() syntax is no longer recommended, see:
+  // https://github.com/ethereum/solidity/issues/2884
+  function executeCall(address to, uint256 value, bytes data) internal returns (bool success) {
+    assembly {
+      success := call(gas, to, value, add(data, 0x20), mload(data), 0, 0)
+      }
   }
 
   function submitTaskWorkRating(uint256 _id, uint8 _role, bytes32 _ratingSecret) public

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -142,12 +142,12 @@ contract ColonyTask is ColonyStorage, DSMath {
     return taskCount;
   }
 
-  function getTaskChangeNonce() public view returns (uint256) {
-    return taskChangeNonce;
+  function getTaskChangeNonce(uint256 _id) public view returns (uint256) {
+    return taskChangeNonces[_id];
   }
 
   function getSignedMessageHash(uint256 _value, bytes _data, uint8 _mode) private returns (bytes32 txHash) {
-    bytes32 msgHash = keccak256(abi.encodePacked(address(this), address(this), _value, _data, taskChangeNonce));
+    bytes32 msgHash = keccak256(abi.encodePacked(address(this), address(this), _value, _data, taskChangeNonce[taskId]));
     if (_mode==0) {
       // 'Normal' mode - geth, etc.
       return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", msgHash));
@@ -192,7 +192,7 @@ contract ColonyTask is ColonyStorage, DSMath {
     require(task.roles[r1].user == reviewerAddresses[0] || task.roles[r1].user == reviewerAddresses[1]);
     require(task.roles[r2].user == reviewerAddresses[0] || task.roles[r2].user == reviewerAddresses[1]);
 
-    taskChangeNonce = taskChangeNonce + 1;
+    taskChangeNonces[taskId]++;
     require(address(this).call.value(_value)(_data));
   }
 

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -146,18 +146,6 @@ contract ColonyTask is ColonyStorage, DSMath {
     return taskChangeNonces[_id];
   }
 
-  function getSignedMessageHash(uint256 _value, bytes _data, uint8 _mode) private returns (bytes32 txHash) {
-    bytes32 msgHash = keccak256(abi.encodePacked(address(this), address(this), _value, _data, taskChangeNonce[taskId]));
-    if (_mode==0) {
-      // 'Normal' mode - geth, etc.
-      return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", msgHash));
-    } else {
-      // Trezor mode
-      // Correct incantation helpfully cribbed from https://github.com/trezor/trezor-mcu/issues/163#issuecomment-368435292
-      return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n\x20", msgHash));
-    }
-  }
-
   function executeTaskChange(
     uint8[] _sigV,
     bytes32[] _sigR,
@@ -167,31 +155,49 @@ contract ColonyTask is ColonyStorage, DSMath {
     bytes _data) public
   {
     require(_value == 0);
-    // Allow for 2 reviewers
-    require(_sigR.length == 2);
     require(_sigR.length == _sigS.length && _sigR.length == _sigV.length);
 
     bytes4 sig;
     uint256 taskId;
     (sig, taskId) = deconstructCall(_data);
-    Task storage task = tasks[taskId];
-    require(!task.finalized);
+    require(!tasks[taskId].finalized);
 
-    uint8[2] storage _reviewers = reviewers[sig];
-    uint8 r1 = _reviewers[0];
-    uint8 r2 = _reviewers[1];
-    // Prevent calls to non registered /arbitrary function on the contract
-    // Checks at least one of the two reviewers registered is different to the task manager
-    require(r1 != MANAGER || r2 != MANAGER);
+    // Checks the two reviewers differ
+    require(tasks[taskId].roles[reviewers[sig][0]].user != tasks[taskId].roles[reviewers[sig][1]].user);
 
-    address[] memory reviewerAddresses = new address[](2);
-    for (uint i = 0; i < 2; i++) {
-      reviewerAddresses[i] = ecrecover(getSignedMessageHash(_value, _data, _mode[i]), _sigV[i], _sigR[i], _sigS[i]);
+    uint8 nSignaturesRequired;
+    // If one of the roles is not set, allow the other one to execute a change with just its signature
+    if (tasks[taskId].roles[reviewers[sig][0]].user == address(0) || tasks[taskId].roles[reviewers[sig][1]].user == address(0)) {
+      nSignaturesRequired = 1;
+    } else {
+      nSignaturesRequired = 2;
+    }
+    
+    require(_sigR.length == nSignaturesRequired);
+
+    bytes32 msgHash = keccak256(abi.encodePacked(address(this), address(this), _value, _data, taskChangeNonces[taskId]));
+    address[] memory reviewerAddresses = new address[](nSignaturesRequired);
+    for (uint i = 0; i < nSignaturesRequired; i++) {
+      // 0 'Normal' mode - geth, etc. 
+      // >0 'Trezor' mode
+      // Correct incantation helpfully cribbed from https://github.com/trezor/trezor-mcu/issues/163#issuecomment-368435292
+      bytes32 txHash;
+      if (_mode[i] == 0) {
+        txHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", msgHash));
+      } else {
+        txHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n\x20", msgHash));
+      }
+    
+      reviewerAddresses[i] = ecrecover(txHash, _sigV[i], _sigR[i], _sigS[i]);
     }
 
-    require(task.roles[r1].user == reviewerAddresses[0] || task.roles[r1].user == reviewerAddresses[1]);
-    require(task.roles[r2].user == reviewerAddresses[0] || task.roles[r2].user == reviewerAddresses[1]);
-
+    require(reviewerAddresses[0] == tasks[taskId].roles[reviewers[sig][0]].user || reviewerAddresses[0] == tasks[taskId].roles[reviewers[sig][1]].user);
+    
+    if (nSignaturesRequired == 2) {
+      require(reviewerAddresses[0] != reviewerAddresses[1]);
+      require(reviewerAddresses[1] == tasks[taskId].roles[reviewers[sig][0]].user || reviewerAddresses[1] == tasks[taskId].roles[reviewers[sig][1]].user);
+    }
+    
     taskChangeNonces[taskId]++;
     require(address(this).call.value(_value)(_data));
   }

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -168,7 +168,7 @@ contract IColony {
   /// @notice Executes a task update transaction `_data` which is approved and signed by two of its roles (e.g. manager and worker)
   /// using the detached signatures for these users.
   /// @dev The Colony functions which require approval and the task roles to review these are set in `IColony.initialiseColony` at colony creation
-  /// Upon successful execution the respective `taskChangeNonces` is incremented
+  /// Upon successful execution the `taskChangeNonces` entry for the task is incremented
   /// @param _sigV recovery id
   /// @param _sigR r output of the ECDSA signature of the transaction
   /// @param _sigS s output of the ECDSA signature of the transaction

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -161,13 +161,14 @@ contract IColony {
   function getTaskCount() public view returns (uint256);
 
   /// @notice Starts from 0 and is incremented on every co-reviewed task change via `executeTaskChange` call
+  /// @param _id Id of the task
   /// @return The current task change nonce value
-  function getTaskChangeNonce() public view returns (uint256);
+  function getTaskChangeNonce(uint256 _id) public view returns (uint256);
 
   /// @notice Executes a task update transaction `_data` which is approved and signed by two of its roles (e.g. manager and worker)
   /// using the detached signatures for these users.
   /// @dev The Colony functions which require approval and the task roles to review these are set in `IColony.initialiseColony` at colony creation
-  /// Upon successful execution the `taskChangeNonce` is incremented
+  /// Upon successful execution the respective `taskChangeNonces` is incremented
   /// @param _sigV recovery id
   /// @param _sigR r output of the ECDSA signature of the transaction
   /// @param _sigS s output of the ECDSA signature of the transaction

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -121,14 +121,14 @@ contract("All", accounts => {
 
       // setTaskBrief
       txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH);
-      sigs = await createSignatures(colony, [MANAGER, WORKER], 0, txData);
+      sigs = await createSignatures(colony, 1, [MANAGER, WORKER], 0, txData);
       await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
       // setTaskDueDate
       let dueDate = await currentBlockTime();
       dueDate += SECONDS_PER_DAY * 5;
       txData = await colony.contract.setTaskDueDate.getData(1, dueDate);
-      sigs = await createSignatures(colony, [MANAGER, WORKER], 0, txData);
+      sigs = await createSignatures(colony, 1, [MANAGER, WORKER], 0, txData);
       await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
       // moveFundsBetweenPots
@@ -139,12 +139,12 @@ contract("All", accounts => {
 
       // setTaskEvaluatorPayout
       txData = await colony.contract.setTaskEvaluatorPayout.getData(1, tokenAddress, 40);
-      sigs = await createSignatures(colony, [MANAGER, EVALUATOR], 0, txData);
+      sigs = await createSignatures(colony, 1, [MANAGER, EVALUATOR], 0, txData);
       await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
       // setTaskWorkerPayout
       txData = await colony.contract.setTaskWorkerPayout.getData(1, tokenAddress, 100);
-      sigs = await createSignatures(colony, [MANAGER, WORKER], 0, txData);
+      sigs = await createSignatures(colony, 1, [MANAGER, WORKER], 0, txData);
       await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
       // submitTaskDeliverable

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -44,9 +44,10 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
     dueDateTimestamp = await currentBlockTime();
   }
   const txData = await colony.contract.setTaskDueDate.getData(taskId, dueDateTimestamp);
-  const signers = [MANAGER, worker];
+  const signers = MANAGER === worker ? [MANAGER] : [MANAGER, worker];
   const sigs = await createSignatures(colony, taskId, signers, 0, txData);
-  await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
+  const signatureTypes = Array.from({ length: signers.length }, () => 0);
+  await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, signatureTypes, 0, txData);
   return taskId;
 }
 
@@ -84,12 +85,16 @@ export async function setupFundedTask({
   await colony.setTaskManagerPayout(taskId, tokenAddress, managerPayout.toString());
 
   txData = await colony.contract.setTaskEvaluatorPayout.getData(taskId, tokenAddress, evaluatorPayout.toString());
-  sigs = await createSignatures(colony, taskId, [MANAGER, EVALUATOR], 0, txData);
-  await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
+  let signers = MANAGER === evaluator ? [MANAGER] : [MANAGER, evaluator];
+  sigs = await createSignatures(colony, taskId, signers, 0, txData);
+  let signatureTypes = Array.from({ length: signers.length }, () => 0);
+  await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, signatureTypes, 0, txData);
 
   txData = await colony.contract.setTaskWorkerPayout.getData(taskId, tokenAddress, workerPayout.toString());
-  sigs = await createSignatures(colony, taskId, [MANAGER, worker], 0, txData);
-  await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
+  signers = MANAGER === worker ? [MANAGER] : [MANAGER, worker];
+  sigs = await createSignatures(colony, taskId, signers, 0, txData);
+  signatureTypes = Array.from({ length: signers.length }, () => 0);
+  await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, signatureTypes, 0, txData);
   return taskId;
 }
 

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -45,7 +45,7 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
   }
   const txData = await colony.contract.setTaskDueDate.getData(taskId, dueDateTimestamp);
   const signers = [MANAGER, worker];
-  const sigs = await createSignatures(colony, signers, 0, txData);
+  const sigs = await createSignatures(colony, taskId, signers, 0, txData);
   await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
   return taskId;
 }
@@ -84,11 +84,11 @@ export async function setupFundedTask({
   await colony.setTaskManagerPayout(taskId, tokenAddress, managerPayout.toString());
 
   txData = await colony.contract.setTaskEvaluatorPayout.getData(taskId, tokenAddress, evaluatorPayout.toString());
-  sigs = await createSignatures(colony, [MANAGER, EVALUATOR], 0, txData);
+  sigs = await createSignatures(colony, taskId, [MANAGER, EVALUATOR], 0, txData);
   await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
   txData = await colony.contract.setTaskWorkerPayout.getData(taskId, tokenAddress, workerPayout.toString());
-  sigs = await createSignatures(colony, [MANAGER, worker], 0, txData);
+  sigs = await createSignatures(colony, taskId, [MANAGER, worker], 0, txData);
   await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
   return taskId;
 }

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -207,7 +207,7 @@ export async function createSignatures(colony, taskId, signers, value, data) {
   return { sigV, sigR, sigS };
 }
 
-export async function createSignaturesTrezor(colony, signers, value, data) {
+export async function createSignaturesTrezor(colony, taskId, signers, value, data) {
   const sourceAddress = colony.address;
   const destinationAddress = colony.address;
   const nonce = await colony.getTaskChangeNonce.call(taskId);

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -180,10 +180,10 @@ export async function forwardTime(seconds, test) {
   return p;
 }
 
-export async function createSignatures(colony, signers, value, data) {
+export async function createSignatures(colony, taskId, signers, value, data) {
   const sourceAddress = colony.address;
   const destinationAddress = colony.address;
-  const nonce = await colony.getTaskChangeNonce.call();
+  const nonce = await colony.getTaskChangeNonce.call(taskId);
   const accountsJson = JSON.parse(fs.readFileSync("./ganache-accounts.json", "utf8"));
   const input = `0x${sourceAddress.slice(2)}${destinationAddress.slice(2)}${web3Utils.padLeft(value.toString("16"), "64", "0")}${data.slice(
     2
@@ -210,7 +210,7 @@ export async function createSignatures(colony, signers, value, data) {
 export async function createSignaturesTrezor(colony, signers, value, data) {
   const sourceAddress = colony.address;
   const destinationAddress = colony.address;
-  const nonce = await colony.getTaskChangeNonce.call();
+  const nonce = await colony.getTaskChangeNonce.call(taskId);
   const accountsJson = JSON.parse(fs.readFileSync("./ganache-accounts.json", "utf8"));
   const input = `0x${sourceAddress.slice(2)}${destinationAddress.slice(2)}${web3Utils.padLeft(value.toString("16"), "64", "0")}${data.slice(
     2

--- a/test/colony.js
+++ b/test/colony.js
@@ -504,33 +504,21 @@ contract("Colony", addresses => {
 
     it("should log a TaskBriefChanged event, if the task brief gets changed", async () => {
       await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
-
-      // Change the task brief
-      const signers = [MANAGER, WORKER];
       const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
-      const sigs = await createSignatures(colony, signers, 0, txData);
-
-      await expectEvent(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData), "TaskBriefChanged");
+      const sigs = await createSignatures(colony, 1, [MANAGER], 0, txData);
+      await expectEvent(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0], 0, txData), "TaskBriefChanged");
     });
 
     it("should log a TaskDueDateChanged event, if the task due date gets changed", async () => {
       await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
-
-      // Change the due date
       const dueDate = await currentBlockTime();
-      const signers = [MANAGER, WORKER];
       const txData = await colony.contract.setTaskDueDate.getData(1, dueDate);
-      const sigs = await createSignatures(colony, signers, 0, txData);
-
+      const sigs = await createSignatures(colony, 1, [MANAGER], 0, txData);
       await expectEvent(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData), "TaskDueDateChanged");
     });
 
     it("should log a TaskSkillChanged event, if the task skill gets changed", async () => {
       await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
-
       // Acquire meta colony, create new global skill, assign new task's skill
       const metaColonyAddress = await colonyNetwork.getMetaColony.call();
       const metaColony = await IColony.at(metaColonyAddress);
@@ -542,8 +530,6 @@ contract("Colony", addresses => {
 
     it("should log a TaskDomainChanged event, if the task domain gets changed", async () => {
       await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
-
       // Create a domain, change task's domain
       const skillCount = await colonyNetwork.getSkillCount.call();
       await colony.addDomain(skillCount.toNumber());
@@ -793,7 +779,7 @@ contract("Colony", addresses => {
 
       // Set the evaluator payout as 1000 ethers
       const txData = await colony.contract.setTaskWorkerPayout.getData(1, 0x0, 98000);
-      const sigs = await createSignatures(colony, [MANAGER, WORKER], 0, txData);
+      const sigs = await createSignatures(colony, 1, [MANAGER, WORKER], 0, txData);
 
       await expectEvent(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData), "TaskWorkerPayoutChanged");
     });


### PR DESCRIPTION
Closes #192 

There is still the limitation that there can only be 1 ongoing change per task as there is one _current_ nonce per task.

In addition here we implement logic to support task changes signed by one reviewer only for cases where:
1) second reviewer role user has not been assigned yet. e.g. a worker hasn't been assigned and the manager wants to change the task brief or due date
2) The same user is assigned to both roles, i.e. evaluator and manager are the same person 

We have also aligned the implementation with the original to depreciate `.call` as a result of https://github.com/ethereum/solidity/issues/2884 https://github.com/christianlundkvist/simple-multisig/commit/e010fbbe67c1237f574f1edbfdb64388cff0de24