### PR TITLE
Sign messages in a way that real-world wallets expect

### DIFF
--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -139,9 +139,8 @@ contract ColonyTask is ColonyStorage, DSMath {
     return taskChangeNonce;
   }
 
-
   function getSignedMessageHash(uint256 _value, bytes _data, uint8 _mode) private returns (bytes32 txHash) {
-    bytes32 hash = keccak256(
+    bytes32 msgHash = keccak256(
       address(this),
       address(this),
       _value,
@@ -150,11 +149,11 @@ contract ColonyTask is ColonyStorage, DSMath {
     );
     if (_mode==0) {
       // 'Normal' mode - geth, etc.
-      return keccak256("\x19Ethereum Signed Message:\n32", hash);
+      return keccak256("\x19Ethereum Signed Message:\n32", msgHash);
     } else {
       // Trezor mode
-      // Correct incantation helpfull cribbed from https://github.com/trezor/trezor-mcu/issues/163#issuecomment-368435292
-      return keccak256("\x19Ethereum Signed Message:\n\x20", hash);
+      // Correct incantation helpfully cribbed from https://github.com/trezor/trezor-mcu/issues/163#issuecomment-368435292
+      return keccak256("\x19Ethereum Signed Message:\n\x20", msgHash);
     }
   }
 

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -131,10 +131,11 @@ contract IColony {
   /// @param _sigV recovery id
   /// @param _sigR r output of the ECDSA signature of the transaction
   /// @param _sigS s output of the ECDSA signature of the transaction
+  /// @param _mode How the signature was generated - 0 for Geth-style (usual), 1 for Trezor-style (only Trezor does this)
   /// @param _value The transaction value, i.e. number of wei to be sent when the transaction is executed
   /// Currently we only accept 0 value transactions but this is kept as a future option
   /// @param _data The transaction data
-  function executeTaskChange(uint8[] _sigV, bytes32[] _sigR, bytes32[] _sigS, uint256 _value, bytes _data) public;
+  function executeTaskChange(uint8[] _sigV, bytes32[] _sigR, bytes32[] _sigS, uint8[] _mode, uint256 _value, bytes _data) public;
 
   /// @notice Submit a hashed secret of the rating for work in task `_id` which was performed by user with task role id `_role`
   /// Allowed within 5 days period starting which whichever is first from either the deliverable being submitted or the dueDate been reached

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -116,14 +116,14 @@ contract("All", accounts => {
       // setTaskBrief
       txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH);
       sigs = await createSignatures(colony, [MANAGER, WORKER], 0, txData);
-      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData);
+      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
       // setTaskDueDate
       let dueDate = await currentBlockTime();
       dueDate += SECONDS_PER_DAY * 5;
       txData = await colony.contract.setTaskDueDate.getData(1, dueDate);
       sigs = await createSignatures(colony, [MANAGER, WORKER], 0, txData);
-      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData);
+      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
       // moveFundsBetweenPots
       await colony.moveFundsBetweenPots(1, 2, 150, tokenAddress);
@@ -134,12 +134,12 @@ contract("All", accounts => {
       // setTaskEvaluatorPayout
       txData = await colony.contract.setTaskEvaluatorPayout.getData(1, tokenAddress, 40);
       sigs = await createSignatures(colony, [MANAGER, EVALUATOR], 0, txData);
-      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData);
+      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
       // setTaskWorkerPayout
       txData = await colony.contract.setTaskWorkerPayout.getData(1, tokenAddress, 100);
       sigs = await createSignatures(colony, [MANAGER, WORKER], 0, txData);
-      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData);
+      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
       // submitTaskDeliverable
       await colony.submitTaskDeliverable(1, DELIVERABLE_HASH, { from: WORKER, gasPrice });

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -45,7 +45,7 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
   const txData = await colony.contract.setTaskDueDate.getData(taskId, dueDateTimestamp);
   const signers = [MANAGER, WORKER];
   const sigs = await createSignatures(colony, signers, 0, txData);
-  await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData);
+  await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
   return taskId;
 }
@@ -85,11 +85,11 @@ export async function setupFundedTask({
 
   txData = await colony.contract.setTaskEvaluatorPayout.getData(taskId, tokenAddress, evaluatorPayout.toString());
   sigs = await createSignatures(colony, [MANAGER, EVALUATOR], 0, txData);
-  await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData);
+  await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
   txData = await colony.contract.setTaskWorkerPayout.getData(taskId, tokenAddress, workerPayout.toString());
   sigs = await createSignatures(colony, [MANAGER, WORKER], 0, txData);
-  await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData);
+  await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
   return taskId;
 }
 

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -208,7 +208,6 @@ export async function createSignatures(colony, signers, value, data) {
     "64",
     "0"
   )}${data.slice(2)}${web3Utils.padLeft(nonce.toString("16"), "64", "0")}`; // eslint-disable-line max-len
-  const msgHash = web3Utils.soliditySha3(input);
 
   const sigV = [];
   const sigR = [];
@@ -217,7 +216,8 @@ export async function createSignatures(colony, signers, value, data) {
   for (let i = 0; i < signers.length; i += 1) {
     const user = signers[i].toString();
     const privKey = accountsJson.private_keys[user];
-    const sig = ethUtils.ecsign(Buffer.from(msgHash.slice(2), "hex"), Buffer.from(privKey, "hex"));
+    const prefixedMessage = ethUtils.hashPersonalMessage(Buffer.from(input.slice(2), "hex"));
+    const sig = ethUtils.ecsign(prefixedMessage, Buffer.from(privKey, "hex"));
 
     sigV.push(sig.v);
     sigR.push(`0x${sig.r.toString("hex")}`);

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -225,6 +225,32 @@ export async function createSignatures(colony, signers, value, data) {
   return { sigV, sigR, sigS };
 }
 
+export async function createSignaturesTrezor(colony, signers, value, data) {
+  const sourceAddress = colony.address;
+  const destinationAddress = colony.address;
+  const nonce = await colony.getTaskChangeNonce.call();
+  const accountsJson = JSON.parse(fs.readFileSync("./test-accounts.json", "utf8"));
+  const input = `0x${sourceAddress.slice(2)}${destinationAddress.slice(2)}${web3Utils.padLeft(value.toString("16"), "64", "0")}${data.slice(
+    2
+  )}${web3Utils.padLeft(nonce.toString("16"), "64", "0")}`; // eslint-disable-line max-len
+  const sigV = [];
+  const sigR = [];
+  const sigS = [];
+  const msgHash = web3Utils.soliditySha3(input);
+
+  for (let i = 0; i < signers.length; i += 1) {
+    const user = signers[i].toString();
+    const privKey = accountsJson.private_keys[user];
+    const prefixedMessageHash = web3Utils.soliditySha3("\x19Ethereum Signed Message:\n\x20", msgHash);
+    const sig = ethUtils.ecsign(Buffer.from(prefixedMessageHash.slice(2), "hex"), Buffer.from(privKey, "hex"));
+    sigV.push(sig.v);
+    sigR.push(`0x${sig.r.toString("hex")}`);
+    sigS.push(`0x${sig.s.toString("hex")}`);
+  }
+
+  return { sigV, sigR, sigS };
+}
+
 export function bnSqrt(bn) {
   let a = bn.add(web3Utils.toBN(1)).div(web3Utils.toBN(2));
   let b = bn;

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -203,21 +203,19 @@ export async function createSignatures(colony, signers, value, data) {
   const destinationAddress = colony.address;
   const nonce = await colony.getTaskChangeNonce.call();
   const accountsJson = JSON.parse(fs.readFileSync("./test-accounts.json", "utf8"));
-  const input = `${"0x19"}${"00"}${sourceAddress.slice(2)}${destinationAddress.slice(2)}${web3Utils.padLeft(
-    value.toString("16"),
-    "64",
-    "0"
-  )}${data.slice(2)}${web3Utils.padLeft(nonce.toString("16"), "64", "0")}`; // eslint-disable-line max-len
-
+  const input = `0x${sourceAddress.slice(2)}${destinationAddress.slice(2)}${web3Utils.padLeft(value.toString("16"), "64", "0")}${data.slice(
+    2
+  )}${web3Utils.padLeft(nonce.toString("16"), "64", "0")}`; // eslint-disable-line max-len
   const sigV = [];
   const sigR = [];
   const sigS = [];
+  const msgHash = web3Utils.soliditySha3(input);
 
   for (let i = 0; i < signers.length; i += 1) {
     const user = signers[i].toString();
     const privKey = accountsJson.private_keys[user];
-    const prefixedMessage = ethUtils.hashPersonalMessage(Buffer.from(input.slice(2), "hex"));
-    const sig = ethUtils.ecsign(prefixedMessage, Buffer.from(privKey, "hex"));
+    const prefixedMessageHash = ethUtils.hashPersonalMessage(Buffer.from(msgHash.slice(2), "hex"));
+    const sig = ethUtils.ecsign(prefixedMessageHash, Buffer.from(privKey, "hex"));
 
     sigV.push(sig.v);
     sigR.push(`0x${sig.r.toString("hex")}`);

--- a/test/colony.js
+++ b/test/colony.js
@@ -299,7 +299,7 @@ contract("Colony", addresses => {
       let txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
       const signers = [MANAGER, WORKER];
       let sigs = await createSignatures(colony, signers, 0, txData);
-      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData);
+      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
       let taskChangeNonce = await colony.getTaskChangeNonce.call();
       assert.equal(taskChangeNonce, 1);
@@ -308,7 +308,7 @@ contract("Colony", addresses => {
       const dueDate = await currentBlockTime();
       txData = await colony.contract.setTaskDueDate.getData(1, dueDate);
       sigs = await createSignatures(colony, signers, 0, txData);
-      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData);
+      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
       taskChangeNonce = await colony.getTaskChangeNonce.call();
       assert.equal(taskChangeNonce, 2);
@@ -320,7 +320,7 @@ contract("Colony", addresses => {
       const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
       const signers = [MANAGER, WORKER];
       const sigs = await createSignatures(colony, signers, 0, txData);
-      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData);
+      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
       const task = await colony.getTask.call(1);
       assert.equal(hexToUtf8(task[0]), SPECIFICATION_HASH_UPDATED);
     });
@@ -333,7 +333,7 @@ contract("Colony", addresses => {
       const txData = await colony.contract.setTaskDueDate.getData(1, dueDate);
       const signers = [MANAGER, WORKER];
       const sigs = await createSignatures(colony, signers, 0, txData);
-      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData);
+      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
       const task = await colony.getTask.call(1);
       assert.equal(task[4], dueDate);
@@ -352,7 +352,7 @@ contract("Colony", addresses => {
       const signers = [MANAGER, OTHER];
       const sigs = await createSignatures(colony, signers, 0, txData);
 
-      await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData));
+      await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData));
     });
 
     it("should fail update of task brief signed by manager and evaluator", async () => {
@@ -364,7 +364,7 @@ contract("Colony", addresses => {
       const signers = [MANAGER, EVALUATOR];
       const sigs = await createSignatures(colony, signers, 0, txData);
 
-      await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData));
+      await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData));
     });
 
     it("should fail to execute task change for a non-registered function signature", async () => {
@@ -373,7 +373,7 @@ contract("Colony", addresses => {
       const signers = [MANAGER, EVALUATOR];
       const sigs = await createSignatures(colony, signers, 0, txData);
 
-      await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData));
+      await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData));
     });
 
     it("should fail to execute change of task brief, using an invalid task id", async () => {
@@ -382,7 +382,7 @@ contract("Colony", addresses => {
       const signers = [MANAGER, EVALUATOR];
       const sigs = await createSignatures(colony, signers, 0, txData);
 
-      await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData));
+      await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData));
     });
 
     it("should fail to execute task change, if the task is already finalized", async () => {
@@ -394,7 +394,7 @@ contract("Colony", addresses => {
       const signers = [MANAGER, EVALUATOR];
       const sigs = await createSignatures(colony, signers, 0, txData);
 
-      await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData));
+      await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData));
     });
   });
 
@@ -581,21 +581,21 @@ contract("Colony", addresses => {
       // Set the evaluator payout as 1000 ethers
       const txData1 = await colony.contract.setTaskEvaluatorPayout.getData(1, 0x0, 1000);
       const sigs = await createSignatures(colony, [MANAGER, EVALUATOR], 0, txData1);
-      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, 0, txData1);
+      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData1);
 
       // Set the evaluator payout as 40 colony tokens
       const txData2 = await colony.contract.setTaskEvaluatorPayout.getData(1, token.address, 40);
       const sigs2 = await createSignatures(colony, [MANAGER, EVALUATOR], 0, txData2);
-      await colony.executeTaskChange(sigs2.sigV, sigs2.sigR, sigs2.sigS, 0, txData2);
+      await colony.executeTaskChange(sigs2.sigV, sigs2.sigR, sigs2.sigS, [0, 0], 0, txData2);
 
       // Set the worker payout as 98000 wei and 200 colony tokens
       const txData3 = await colony.contract.setTaskWorkerPayout.getData(1, 0x0, 98000);
       const sigs3 = await createSignatures(colony, [MANAGER, WORKER], 0, txData3);
-      await colony.executeTaskChange(sigs3.sigV, sigs3.sigR, sigs3.sigS, 0, txData3);
+      await colony.executeTaskChange(sigs3.sigV, sigs3.sigR, sigs3.sigS, [0, 0], 0, txData3);
 
       const txData4 = await colony.contract.setTaskWorkerPayout.getData(1, token.address, 200);
       const sigs4 = await createSignatures(colony, [MANAGER, WORKER], 0, txData4);
-      await colony.executeTaskChange(sigs4.sigV, sigs4.sigR, sigs4.sigS, 0, txData4);
+      await colony.executeTaskChange(sigs4.sigV, sigs4.sigR, sigs4.sigS, [0, 0], 0, txData4);
 
       const taskPayoutManager1 = await colony.getTaskPayout.call(1, MANAGER_ROLE, 0x0);
       assert.equal(taskPayoutManager1.toNumber(), 5000);


### PR DESCRIPTION
While testing the MultiSig implementation @JamesLefrere and I encountered that the ecsign method used in createSignatures (in test-helpers.js) works differently from the ones used by web3 or ethers (or any wallet implementation, really). The latter prepend a prefix `("\x19Ethereum Signed Message:\n" + len(message))` to the message hash which is to sign, while the former does not. The prefix can also be found in the ERC191 specification: https://github.com/ethereum/EIPs/issues/191.

In order to add support across all wallets (including MetaMask and Hardware wallets) we should use this method of signing as it's the only one those support.

The proposed change fixes the MultiSig (executeTaskChange) for us when using it in the browser (with an ethers wallet), although it breaks a whole lot of other tests. Maybe we're doing something stupid on the Solidity side of things so we'd like for someone more proficient in this to help us out (@elenadimitrova, @area?).