### PR TITLE
Remove Colony name from storage and rename "Common Colony" to "Meta Colony"

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -84,7 +84,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
   function mintTokensForColonyNetwork(uint _wad) public {
     require(msg.sender == colonyNetworkAddress, "colony-access-denied-only-network-allowed"); // Only the colony Network can call this function
-    require(this == IColonyNetwork(colonyNetworkAddress).getColony("Common Colony"), "colony-access-denied-only-common-colony-allowed"); // Function only valid on the Common Colony
+    require(this == IColonyNetwork(colonyNetworkAddress).getColony("Meta Colony"), "colony-access-denied-only-meta-colony-allowed"); // Function only valid on the Meta Colony
     token.mint(_wad);
     token.transfer(colonyNetworkAddress, _wad);
   }

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -84,7 +84,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
   function mintTokensForColonyNetwork(uint _wad) public {
     require(msg.sender == colonyNetworkAddress, "colony-access-denied-only-network-allowed"); // Only the colony Network can call this function
-    require(this == IColonyNetwork(colonyNetworkAddress).getColony("Meta Colony"), "colony-access-denied-only-meta-colony-allowed"); // Function only valid on the Meta Colony
+    require(this == IColonyNetwork(colonyNetworkAddress).getMetaColony(), "colony-access-denied-only-meta-colony-allowed"); // Function only valid on the Meta Colony
     token.mint(_wad);
     token.transfer(colonyNetworkAddress, _wad);
   }

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -74,13 +74,13 @@ contract ColonyFunding is ColonyStorage, DSMath {
     if (_token == 0x0) {
       // Payout ether
       task.roles[_role].user.transfer(remainder);
-      // Fee goes directly to Common Colony
+      // Fee goes directly to Meta Colony
       IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
-      address commonColonyAddress = colonyNetworkContract.getColony("Common Colony");
-      commonColonyAddress.transfer(fee);
+      address metaColonyAddress = colonyNetworkContract.getColony("Meta Colony");
+      metaColonyAddress.transfer(fee);
     } else {
       // Payout token
-      // TODO: If it's a whitelisted token, it goes straight to the commonColony
+      // TODO: If it's a whitelisted token, it goes straight to the metaColony
       // If it's any other token, goes to the colonyNetwork contract first to be auctioned.
       ERC20Extended payoutToken = ERC20Extended(_token);
       payoutToken.transfer(task.roles[_role].user, remainder);

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -76,7 +76,7 @@ contract ColonyFunding is ColonyStorage, DSMath {
       task.roles[_role].user.transfer(remainder);
       // Fee goes directly to Meta Colony
       IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
-      address metaColonyAddress = colonyNetworkContract.getColony("Meta Colony");
+      address metaColonyAddress = colonyNetworkContract.getMetaColony();
       metaColonyAddress.transfer(fee);
     } else {
       // Payout token

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -105,8 +105,9 @@ contract ColonyNetwork is ColonyNetworkStorage {
     return reputationRootHashNNodes;
   }
 
-  // TODO secure
-  function createMetaColony(address _tokenAddress) public {
+  function createMetaColony(address _tokenAddress) public 
+  auth
+  {
     // Add the root global skill
     skillCount += 1;
     Skill memory rootGlobalSkill;

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -135,7 +135,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
     // Initialise the root (domain) local skill with defaults by just incrementing the skillCount
     skillCount += 1;
     colonyCount += 1;
-    _coloniesIndex[colonyCount] = colony;
+    colonies[colonyCount] = colony;
     _isColony[colony] = true;
 
     colony.initialiseColony(this);
@@ -153,12 +153,12 @@ contract ColonyNetwork is ColonyNetworkStorage {
     }
   }
 
-  function getColonyAt(uint _idx) public view returns (address) {
-    return _coloniesIndex[_idx];
+  function getColony(uint256 _id) public view returns (address) {
+    return colonies[_id];
   }
 
   function upgradeColony(uint256 _id, uint _newVersion) public {
-    address etherRouter = _coloniesIndex[_id];
+    address etherRouter = colonies[_id];
     // Check the calling user is authorised
     DSAuth auth = DSAuth(etherRouter);
     DSAuthority authority = auth.authority();

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -30,12 +30,12 @@ contract ColonyNetwork is ColonyNetworkStorage {
   event ColonyAdded(uint256 indexed id);
   event SkillAdded(uint256 skillId, uint256 parentSkillId);
 
-  // Common Colony allowed to manage Global skills
+  // Meta Colony allowed to manage Global skills
   // All colonies are able to manage their Local (domain associated) skills
   modifier allowedToAddSkill(bool globalSkill) {
     if (globalSkill) {
-      address commonColony = getColony("Common Colony");
-      require(msg.sender == commonColony);
+      address metaColony = getColony("Meta Colony");
+      require(msg.sender == metaColony);
     } else {
       require(_isColony[msg.sender]);
     }
@@ -123,14 +123,14 @@ contract ColonyNetwork is ColonyNetworkStorage {
     authority.setRootUser(msg.sender, true);
     authority.setOwner(msg.sender);
 
-    // For the Common Colony add the root global skill
-    if (_name == "Common Colony") {
+    // For the Meta Colony add the root global skill
+    if (_name == "Meta Colony") {
       skillCount += 1;
       Skill memory rootGlobalSkill;
       rootGlobalSkill.globalSkill = true;
       skills[skillCount] = rootGlobalSkill;
       rootGlobalSkillId = skillCount;
-      // TODO: add the special 'mining' skill, which is local to the common Colony.
+      // TODO: add the special 'mining' skill, which is local to the meta Colony.
     }
 
     // For all colonies initialise the root (domain) local skill with defaults by just incrementing the skillCount

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -108,6 +108,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
   function createMetaColony(address _tokenAddress) public 
   auth
   {
+    require(metaColony == 0);
     // Add the root global skill
     skillCount += 1;
     Skill memory rootGlobalSkill;

--- a/contracts/ColonyNetworkAuction.sol
+++ b/contracts/ColonyNetworkAuction.sol
@@ -28,7 +28,6 @@ contract ColonyNetworkAuction is ColonyNetworkStorage {
   event AuctionCreated(address auction, address token, uint256 quantity);
 
   function startTokenAuction(address _token) public {
-    address metaColony = _colonies["Meta Colony"];
     address clny = IColony(metaColony).getToken();
     DutchAuction auction = new DutchAuction(clny, _token);
     uint availableTokens = ERC20Extended(_token).balanceOf(this);

--- a/contracts/ColonyNetworkAuction.sol
+++ b/contracts/ColonyNetworkAuction.sol
@@ -28,8 +28,8 @@ contract ColonyNetworkAuction is ColonyNetworkStorage {
   event AuctionCreated(address auction, address token, uint256 quantity);
 
   function startTokenAuction(address _token) public {
-    address commonColony = _colonies["Common Colony"];
-    address clny = IColony(commonColony).getToken();
+    address metaColony = _colonies["Meta Colony"];
+    address clny = IColony(metaColony).getToken();
     DutchAuction auction = new DutchAuction(clny, _token);
     uint availableTokens = ERC20Extended(_token).balanceOf(this);
     ERC20Extended(_token).transfer(auction, availableTokens);

--- a/contracts/ColonyNetworkStaking.sol
+++ b/contracts/ColonyNetworkStaking.sol
@@ -38,7 +38,7 @@ contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
 
   function deposit(uint256 _amount) public {
     // Get CLNY address
-    ERC20Extended clny = ERC20Extended(IColony(_colonies["Common Colony"]).getToken());
+    ERC20Extended clny = ERC20Extended(IColony(_colonies["Meta Colony"]).getToken());
     uint256 networkBalance = clny.balanceOf(this);
     // Move some over.
     clny.transferFrom(msg.sender, this, _amount);
@@ -56,7 +56,7 @@ contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
     bool hasRequesterSubmitted = submittedHash == 0x0 ? false : true;
     require(hasRequesterSubmitted==false);
     stakedBalances[msg.sender] -= _amount;
-    ERC20Extended clny = ERC20Extended(IColony(_colonies["Common Colony"]).getToken());
+    ERC20Extended clny = ERC20Extended(IColony(_colonies["Meta Colony"]).getToken());
     clny.transfer(msg.sender, _amount);
   }
 
@@ -111,7 +111,7 @@ contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
     // TODO: Actually think about this function
     // Passing an array so that we don't incur the EtherRouter overhead for each staker if we looped over
     // it in ReputationMiningCycle.confirmNewHash;
-    address commonColonyAddress = _colonies["Common Colony"];
+    address metaColonyAddress = _colonies["Meta Colony"];
     uint256 reward = 10**18; //TODO: Actually work out how much reputation they earn, based on activity elsewhere in the colony.
     if (reward >= uint256(int256(-1))/2) {
       reward = uint256(int256(-1))/2;
@@ -120,7 +120,7 @@ contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
     // Something like the above cap is an adequate short-term solution, but at the very least need to double check the limits
     // (which I've fingered-in-the-air, but could easily have an OBOE hiding inside).
     assert(reward < uint256(int256(-1))); // We do a cast later, so make sure we don't overflow.
-    IColony(commonColonyAddress).mintTokensForColonyNetwork(stakers.length * reward); // This should be the total amount of new tokens we're awarding.
+    IColony(metaColonyAddress).mintTokensForColonyNetwork(stakers.length * reward); // This should be the total amount of new tokens we're awarding.
     for (uint256 i = 0; i < stakers.length; i++) {
       // We *know* we're the first entries in this reputation update log, so we don't need all the bookkeeping in
       // the AppendReputationUpdateLog function
@@ -128,7 +128,7 @@ contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
         stakers[i], //The staker getting the reward
         int256(reward),
         0, //TODO: Work out what skill this should be. This should be a special 'mining' skill.
-        commonColonyAddress, // They earn this reputation in the common colony.
+        metaColonyAddress, // They earn this reputation in the meta colony.
         4, // Updates the user's skill, and the colony's skill, both globally and for the special 'mining' skill
         i*4)//We're zero indexed, so this is the number of updates that came before in the reputation log.
       );

--- a/contracts/ColonyNetworkStaking.sol
+++ b/contracts/ColonyNetworkStaking.sol
@@ -38,7 +38,7 @@ contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
 
   function deposit(uint256 _amount) public {
     // Get CLNY address
-    ERC20Extended clny = ERC20Extended(IColony(_colonies["Meta Colony"]).getToken());
+    ERC20Extended clny = ERC20Extended(IColony(metaColony).getToken());
     uint256 networkBalance = clny.balanceOf(this);
     // Move some over.
     clny.transferFrom(msg.sender, this, _amount);
@@ -56,7 +56,7 @@ contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
     bool hasRequesterSubmitted = submittedHash == 0x0 ? false : true;
     require(hasRequesterSubmitted==false);
     stakedBalances[msg.sender] -= _amount;
-    ERC20Extended clny = ERC20Extended(IColony(_colonies["Meta Colony"]).getToken());
+    ERC20Extended clny = ERC20Extended(IColony(metaColony).getToken());
     clny.transfer(msg.sender, _amount);
   }
 
@@ -111,7 +111,6 @@ contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
     // TODO: Actually think about this function
     // Passing an array so that we don't incur the EtherRouter overhead for each staker if we looped over
     // it in ReputationMiningCycle.confirmNewHash;
-    address metaColonyAddress = _colonies["Meta Colony"];
     uint256 reward = 10**18; //TODO: Actually work out how much reputation they earn, based on activity elsewhere in the colony.
     if (reward >= uint256(int256(-1))/2) {
       reward = uint256(int256(-1))/2;
@@ -120,7 +119,7 @@ contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
     // Something like the above cap is an adequate short-term solution, but at the very least need to double check the limits
     // (which I've fingered-in-the-air, but could easily have an OBOE hiding inside).
     assert(reward < uint256(int256(-1))); // We do a cast later, so make sure we don't overflow.
-    IColony(metaColonyAddress).mintTokensForColonyNetwork(stakers.length * reward); // This should be the total amount of new tokens we're awarding.
+    IColony(metaColony).mintTokensForColonyNetwork(stakers.length * reward); // This should be the total amount of new tokens we're awarding.
     for (uint256 i = 0; i < stakers.length; i++) {
       // We *know* we're the first entries in this reputation update log, so we don't need all the bookkeeping in
       // the AppendReputationUpdateLog function
@@ -128,7 +127,7 @@ contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
         stakers[i], //The staker getting the reward
         int256(reward),
         0, //TODO: Work out what skill this should be. This should be a special 'mining' skill.
-        metaColonyAddress, // They earn this reputation in the meta colony.
+        metaColony, // They earn this reputation in the meta colony.
         4, // Updates the user's skill, and the colony's skill, both globally and for the special 'mining' skill
         i*4)//We're zero indexed, so this is the number of updates that came before in the reputation log.
       );

--- a/contracts/ColonyNetworkStorage.sol
+++ b/contracts/ColonyNetworkStorage.sol
@@ -35,8 +35,8 @@ contract ColonyNetworkStorage is DSAuth {
   uint256 currentColonyVersion;
   // Address of the Meta Colony
   address metaColony;
-  
-  mapping (uint256 => address) _coloniesIndex;
+  // Maps index to colony address
+  mapping (uint256 => address) colonies;
   mapping (address => bool) _isColony;
   // Maps colony contract versions to respective resolvers
   mapping (uint256 => address) colonyVersionResolver;

--- a/contracts/ColonyNetworkStorage.sol
+++ b/contracts/ColonyNetworkStorage.sol
@@ -33,9 +33,10 @@ contract ColonyNetworkStorage is DSAuth {
   uint256 colonyCount;
   // uint256 version number of the latest deployed Colony contract, used in creating new colonies
   uint256 currentColonyVersion;
-  // TODO: We can probably do better than having three colony-related mappings
+  // Address of the Meta Colony
+  address metaColony;
+  
   mapping (uint256 => address) _coloniesIndex;
-  mapping (bytes32 => address) _colonies;
   mapping (address => bool) _isColony;
   // Maps colony contract versions to respective resolvers
   mapping (uint256 => address) colonyVersionResolver;

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -71,13 +71,13 @@ contract IColony {
   /// @param _wad Amount to mint
   function mintTokens(uint256 _wad) public;
 
-  /// @notice Mints CLNY in the Common Colony and transfers them to the colony network
-  /// Only allowed to be called on the Common Colony by the colony network
+  /// @notice Mints CLNY in the Meta Colony and transfers them to the colony network
+  /// Only allowed to be called on the Meta Colony by the colony network
   /// @param _wad Amount to mint and transfer to the colony network
   function mintTokensForColonyNetwork(uint256 _wad) public;
 
   /// @notice Add a new global skill, under skill `_parentSkillId`
-  /// Can only be called from the Common Colony
+  /// Can only be called from the Meta Colony
   /// @dev Calls `IColonyNetwork.addSkill`
   /// @param _parentSkillId Id of the skill under which the new skill will be added
   /// @return Id of the added skill
@@ -287,7 +287,7 @@ contract IColony {
 
   /// @notice Claim the payout in `_token` denomination for work completed in task `_id` by contributor with role `_role`
   /// Allowed only by the contributors themselves after task is finalized. Here the network receives its fee from each payout.
-  /// Ether fees go straight to the Common Colony whereas Token fees go to the Network to be auctioned off.
+  /// Ether fees go straight to the Meta Colony whereas Token fees go to the Network to be auctioned off.
   /// @param _id Id of the task
   /// @param _role Id of the role, as defined in `ColonyStorage` `MANAGER`, `EVALUATOR` and `WORKER` constants
   /// @param _token Address of the token, `0x0` value indicates Ether

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -25,8 +25,9 @@ contract IColonyNetwork {
 
   /// @notice Event logged when a new colony is added
   /// @dev Emitted from `IColonyNetwork.createColony` function
-  /// @param id The colony id in the network
-  event ColonyAdded(uint256 indexed id);
+  /// @param colonyId The colony id in the network
+  /// @param colonyAddress The colony address in the network
+  event ColonyAdded(uint256 indexed colonyId, address indexed colonyAddress);
 
   /// @notice Event logged when a new skill is added
   /// @dev Emitted from `IColonyNetwork.addSkill` function
@@ -41,10 +42,9 @@ contract IColonyNetwork {
   /// @param quantity Quantity of `token` to auction
   event AuctionCreated(address auction, address token, uint256 quantity);
 
-  /// @notice Get the colony address by its `key`
-  /// @param key The unique key of the required colony
-  /// @return The colony address, if no colony was found, returns 0x0
-  function getColony(bytes32 key) public view returns (address);
+  /// @notice Get the Meta Colony address
+  /// @return The Meta colony address, if no colony was found, returns 0x0
+  function getMetaColony() public view returns (address);
 
   /// @notice Get the number of colonies in the network
   /// @return The colony count
@@ -86,14 +86,18 @@ contract IColonyNetwork {
   /// @return The root global skill id
   function getRootGlobalSkillId() public view returns (uint256);
 
+  /// @notice Create the Meta Colony, same as a normal colony plus the root skill
+  /// @param _tokenAddress Address of the CLNY token
+  function createMetaColony(address _tokenAddress) public;
+
   /// @notice Creates a new colony in the network
   /// @dev Errors if there is already a colony with the specified `_name`
   /// Note that the token ownership (if there is one) has to be transferred to the newly created colony
-  /// @param _name A unique key for the new colony
   /// @param _tokenAddress Address of an ERC20 token to serve as the colony token
   /// Additionally token can optionally support `mint` as defined in `ERC20Extended`
   /// Support for `mint` in mandatory only for the Meta Colony Token
-  function createColony(bytes32 _name, address _tokenAddress) public;
+  /// @return Address of the newly created colony
+  function createColony(address _tokenAddress) public returns (address);
 
   /// @notice Adds a new Colony contract version and the address of associated `_resolver` contract. Secured function to authorised members
   /// @param _version The new Colony contract version
@@ -111,9 +115,9 @@ contract IColonyNetwork {
 
   /// @notice Upgrades a colony with key identifier: `_name` to a new Colony contract version `_newVersion`
   /// @dev Downgrades are not allowed, i.e. `_newVersion` should be higher than the currect colony version
-  /// @param _name The unique colony identifier in the network
+  /// @param _id The colony identifier in the network
   /// @param _newVersion The target version for the upgrade
-  function upgradeColony(bytes32 _name, uint256 _newVersion) public;
+  function upgradeColony(uint256 _id, uint _newVersion) public;
 
   /// @notice Get the id of the parent skill at index `_parentSkillIndex` for skill with Id `_skillId`
   /// @param _skillId Id of the skill

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -91,7 +91,6 @@ contract IColonyNetwork {
   function createMetaColony(address _tokenAddress) public;
 
   /// @notice Creates a new colony in the network
-  /// @dev Errors if there is already a colony with the specified `_name`
   /// Note that the token ownership (if there is one) has to be transferred to the newly created colony
   /// @param _tokenAddress Address of an ERC20 token to serve as the colony token
   /// Additionally token can optionally support `mint` as defined in `ERC20Extended`
@@ -113,7 +112,7 @@ contract IColonyNetwork {
   /// @return The current / latest Colony contract version
   function getCurrentColonyVersion() public view returns (uint256);
 
-  /// @notice Upgrades a colony with key identifier: `_name` to a new Colony contract version `_newVersion`
+  /// @notice Upgrades a colony with identifier: `_id` to a new Colony contract version `_newVersion`
   /// @dev Downgrades are not allowed, i.e. `_newVersion` should be higher than the currect colony version
   /// @param _id The colony identifier in the network
   /// @param _newVersion The target version for the upgrade

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -51,7 +51,7 @@ contract IColonyNetwork {
   function getColonyCount() public view returns (uint256);
 
   /// @notice Adds a new skill to the global or local skills tree, under skill `_parentSkillId`
-  /// Only the Common Colony is allowed to add a global skill, called via `IColony.addGlobalSkill`
+  /// Only the Meta Colony is allowed to add a global skill, called via `IColony.addGlobalSkill`
   /// Any colony is allowed to add a local skill and which is associated with a new domain via `IColony.addDomain`
   /// @dev Errors if the parent skill does not exist or if this is called by an unauthorised sender
   /// @param _parentSkillId Id of the skill under which the new skill will be added
@@ -82,7 +82,7 @@ contract IColonyNetwork {
   function getSkillCount() public view returns (uint256);
 
   /// @notice Get the id of the root global skill
-  /// @dev This is set once when the Common Colony is created
+  /// @dev This is set once when the Meta Colony is created
   /// @return The root global skill id
   function getRootGlobalSkillId() public view returns (uint256);
 
@@ -92,7 +92,7 @@ contract IColonyNetwork {
   /// @param _name A unique key for the new colony
   /// @param _tokenAddress Address of an ERC20 token to serve as the colony token
   /// Additionally token can optionally support `mint` as defined in `ERC20Extended`
-  /// Support for `mint` in mandatory only for the Common Colony Token
+  /// Support for `mint` in mandatory only for the Meta Colony Token
   function createColony(bytes32 _name, address _tokenAddress) public;
 
   /// @notice Adds a new Colony contract version and the address of associated `_resolver` contract. Secured function to authorised members

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -105,9 +105,9 @@ contract IColonyNetwork {
   function addColonyVersion(uint256 _version, address _resolver) public;
 
   /// @notice Get a colony address by its Id in the network
-  /// @param _idx Id of the colony to get
+  /// @param _id Id of the colony to get
   /// @return The colony address, if no colony was found, returns 0x0
-  function getColonyAt(uint256 _idx) public view returns (address);
+  function getColony(uint256 _id) public view returns (address);
 
   /// @notice Returns the latest Colony contract version. This is the version used to create all new colonies
   /// @return The current / latest Colony contract version

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -51,7 +51,7 @@ contract("All", accounts => {
   let otherToken;
   let colonyTask;
   let colonyFunding;
-  let commonColony;
+  let metaColony;
   let authority;
   let colonyNetwork;
 
@@ -75,8 +75,8 @@ contract("All", accounts => {
     authority = await Authority.at(authorityAddress);
     await IColony.defaults({ gasPrice });
 
-    const commonColonyAddress = await colonyNetwork.getColony.call("Common Colony");
-    commonColony = await IColony.at(commonColonyAddress);
+    const metaColonyAddress = await colonyNetwork.getColony.call("Meta Colony");
+    metaColony = await IColony.at(metaColonyAddress);
 
     const otherTokenArgs = getTokenArgs();
     otherToken = await Token.new(...otherTokenArgs);
@@ -90,11 +90,11 @@ contract("All", accounts => {
       await colonyNetwork.createColony("Test", colonyToken.address);
     });
 
-    it("when working with the Common Colony", async () => {
-      await commonColony.addGlobalSkill(1);
-      await commonColony.addGlobalSkill(5);
-      await commonColony.addGlobalSkill(6);
-      await commonColony.addGlobalSkill(7);
+    it("when working with the Meta Colony", async () => {
+      await metaColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(5);
+      await metaColony.addGlobalSkill(6);
+      await metaColony.addGlobalSkill(7);
     });
 
     it("when working with a Colony", async () => {

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -30,7 +30,7 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
   // If the skill is not specified, default to the root global skill
   if (skill === 0) {
     const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId.call();
-    if (rootGlobalSkill.toNumber() === 0) throw new Error("Common Colony is not setup and therefore the root global skill does not exist");
+    if (rootGlobalSkill.toNumber() === 0) throw new Error("Meta Colony is not setup and therefore the root global skill does not exist");
     await colony.setTaskSkill(taskId, rootGlobalSkill);
   } else {
     await colony.setTaskSkill(taskId, skill);
@@ -133,24 +133,24 @@ export async function setupRatedTask({
 }
 
 export async function giveUserCLNYTokens(colonyNetwork, address, _amount) {
-  const commonColonyAddress = await colonyNetwork.getColony("Common Colony");
-  const commonColony = IColony.at(commonColonyAddress);
-  const clnyAddress = await commonColony.getToken.call();
+  const metaColonyAddress = await colonyNetwork.getColony("Meta Colony");
+  const metaColony = IColony.at(metaColonyAddress);
+  const clnyAddress = await metaColony.getToken.call();
   const clny = Token.at(clnyAddress);
   const amount = new BN(_amount);
   const mainStartingBalance = await clny.balanceOf.call(MANAGER);
   const targetStartingBalance = await clny.balanceOf.call(address);
-  await commonColony.mintTokens(amount * 3);
-  await commonColony.claimColonyFunds(clny.address);
+  await metaColony.mintTokens(amount * 3);
+  await metaColony.claimColonyFunds(clny.address);
   const taskId = await setupRatedTask({
     colonyNetwork,
-    colony: commonColony,
+    colony: metaColony,
     managerPayout: amount.mul(new BN("2")),
     evaluatorPayout: new BN("0"),
     workerPayout: new BN("0")
   });
-  await commonColony.finalizeTask(taskId);
-  await commonColony.claimPayout(taskId, 0, clny.address);
+  await metaColony.finalizeTask(taskId);
+  await metaColony.claimPayout(taskId, 0, clny.address);
 
   let mainBalance = await clny.balanceOf.call(MANAGER);
   await clny.transfer(
@@ -170,9 +170,9 @@ export async function giveUserCLNYTokens(colonyNetwork, address, _amount) {
 }
 
 export async function giveUserCLNYTokensAndStake(colonyNetwork, address, _amount) {
-  const commonColonyAddress = await colonyNetwork.getColony("Common Colony");
-  const commonColony = IColony.at(commonColonyAddress);
-  const clnyAddress = await commonColony.getToken.call();
+  const metaColonyAddress = await colonyNetwork.getColony("Meta Colony");
+  const metaColony = IColony.at(metaColonyAddress);
+  const clnyAddress = await metaColony.getToken.call();
   const clny = Token.at(clnyAddress);
 
   await giveUserCLNYTokens(colonyNetwork, address, _amount);

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -133,7 +133,7 @@ export async function setupRatedTask({
 }
 
 export async function giveUserCLNYTokens(colonyNetwork, address, _amount) {
-  const metaColonyAddress = await colonyNetwork.getColony("Meta Colony");
+  const metaColonyAddress = await colonyNetwork.getMetaColony();
   const metaColony = IColony.at(metaColonyAddress);
   const clnyAddress = await metaColony.getToken.call();
   const clny = Token.at(clnyAddress);
@@ -170,7 +170,7 @@ export async function giveUserCLNYTokens(colonyNetwork, address, _amount) {
 }
 
 export async function giveUserCLNYTokensAndStake(colonyNetwork, address, _amount) {
-  const metaColonyAddress = await colonyNetwork.getColony("Meta Colony");
+  const metaColonyAddress = await colonyNetwork.getMetaColony.call();
   const metaColony = IColony.at(metaColonyAddress);
   const clnyAddress = await metaColony.getToken.call();
   const clny = Token.at(clnyAddress);

--- a/migrations/5_setup_meta_colony.js
+++ b/migrations/5_setup_meta_colony.js
@@ -8,7 +8,7 @@ const EtherRouter = artifacts.require("./EtherRouter");
 const Token = artifacts.require("./Token");
 
 module.exports = deployer => {
-  // Create the common colony
+  // Create the meta colony
   let colonyNetwork;
   let token;
   deployer
@@ -20,17 +20,17 @@ module.exports = deployer => {
     })
     .then(tokenInstance => {
       token = tokenInstance;
-      return colonyNetwork.createColony("Common Colony", token.address);
+      return colonyNetwork.createColony("Meta Colony", token.address);
     })
     .then(() => colonyNetwork.getSkillCount.call())
     .then(skillCount => {
       assert.equal(skillCount.toNumber(), 2);
-      return colonyNetwork.getColony.call("Common Colony");
+      return colonyNetwork.getColony.call("Meta Colony");
     })
-    .then(() => colonyNetwork.getColony.call("Common Colony"))
-    .then(commonColonyAddress => {
-      token.setOwner(commonColonyAddress);
-      console.log("### Common Colony created at", commonColonyAddress);
+    .then(() => colonyNetwork.getColony.call("Meta Colony"))
+    .then(metaColonyAddress => {
+      token.setOwner(metaColonyAddress);
+      console.log("### Meta Colony created at", metaColonyAddress);
     })
     .catch(err => {
       console.log("### Error occurred ", err);

--- a/migrations/5_setup_meta_colony.js
+++ b/migrations/5_setup_meta_colony.js
@@ -20,14 +20,13 @@ module.exports = deployer => {
     })
     .then(tokenInstance => {
       token = tokenInstance;
-      return colonyNetwork.createColony("Meta Colony", token.address);
+      return colonyNetwork.createMetaColony(token.address);
     })
     .then(() => colonyNetwork.getSkillCount.call())
     .then(skillCount => {
       assert.equal(skillCount.toNumber(), 2);
-      return colonyNetwork.getColony.call("Meta Colony");
+      return colonyNetwork.getMetaColony.call();
     })
-    .then(() => colonyNetwork.getColony.call("Meta Colony"))
     .then(metaColonyAddress => {
       token.setOwner(metaColonyAddress);
       console.log("### Meta Colony created at", metaColonyAddress);

--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -15,7 +15,7 @@ contract("ColonyNetworkAuction", accounts => {
   const BIDDER_2 = accounts[2];
   const BIDDER_3 = accounts[3];
 
-  let commonColony;
+  let metaColony;
   let colonyNetwork;
   let tokenAuction;
   let quantity;
@@ -29,14 +29,14 @@ contract("ColonyNetworkAuction", accounts => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = IColonyNetwork.at(etherRouter.address);
 
-    const commonColonyAddress = await colonyNetwork.getColony("Common Colony");
-    commonColony = IColony.at(commonColonyAddress);
+    const metaColonyAddress = await colonyNetwork.getColony("Meta Colony");
+    metaColony = IColony.at(metaColonyAddress);
   });
 
   beforeEach(async () => {
     clny = await Token.new("Colony Network Token", "CLNY", 18);
-    await commonColony.setToken(clny.address);
-    await clny.setOwner(commonColony.address);
+    await metaColony.setToken(clny.address);
+    await clny.setOwner(metaColony.address);
 
     const args = getTokenArgs();
     token = await Token.new(...args);
@@ -438,7 +438,7 @@ contract("ColonyNetworkAuction", accounts => {
     it("should fail if there are CLNY tokens left owned by the auction", async () => {
       await tokenAuction.finalize();
       await tokenAuction.claim({ from: BIDDER_1 });
-      await commonColony.mintTokens(100);
+      await metaColony.mintTokens(100);
       await giveUserCLNYTokens(colonyNetwork, BIDDER_1, 100);
       await clny.transfer(tokenAuction.address, 100, { from: BIDDER_1 });
       await checkErrorRevert(tokenAuction.close());

--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -29,7 +29,7 @@ contract("ColonyNetworkAuction", accounts => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = IColonyNetwork.at(etherRouter.address);
 
-    const metaColonyAddress = await colonyNetwork.getColony("Meta Colony");
+    const metaColonyAddress = await colonyNetwork.getMetaColony.call();
     metaColony = IColony.at(metaColonyAddress);
   });
 

--- a/test/colony-network-staking.js
+++ b/test/colony-network-staking.js
@@ -29,7 +29,7 @@ contract("ColonyNetworkStaking", accounts => {
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
-    const metaColonyAddress = await colonyNetwork.getColony("Meta Colony");
+    const metaColonyAddress = await colonyNetwork.getMetaColony.call();
     metaColony = IColony.at(metaColonyAddress);
     clny = await Token.new("Colony Network Token", "CLNY", 18);
     await metaColony.setToken(clny.address);

--- a/test/colony-network-staking.js
+++ b/test/colony-network-staking.js
@@ -18,7 +18,7 @@ contract("ColonyNetworkStaking", accounts => {
   const MAIN_ACCOUNT = accounts[0];
   const OTHER_ACCOUNT = accounts[1];
 
-  let commonColony;
+  let metaColony;
   let colonyNetwork;
   let clny;
   let goodClient;
@@ -29,11 +29,11 @@ contract("ColonyNetworkStaking", accounts => {
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
-    const commonColonyAddress = await colonyNetwork.getColony("Common Colony");
-    commonColony = IColony.at(commonColonyAddress);
+    const metaColonyAddress = await colonyNetwork.getColony("Meta Colony");
+    metaColony = IColony.at(metaColonyAddress);
     clny = await Token.new("Colony Network Token", "CLNY", 18);
-    await commonColony.setToken(clny.address);
-    await clny.setOwner(commonColony.address);
+    await metaColony.setToken(clny.address);
+    await clny.setOwner(metaColony.address);
     await colonyNetwork.startNextCycle();
   });
 
@@ -560,7 +560,7 @@ contract("ColonyNetworkStaking", accounts => {
       assert.equal(repLogEntryMiner[0], MAIN_ACCOUNT);
       assert.equal(repLogEntryMiner[1].toString(), new BN("1").mul(new BN("10").pow(new BN("18"))).toString());
       assert.equal(repLogEntryMiner[2].toString(), "0");
-      assert.equal(repLogEntryMiner[3], commonColony.address);
+      assert.equal(repLogEntryMiner[3], metaColony.address);
       assert.equal(repLogEntryMiner[4].toString(), "4");
       assert.equal(repLogEntryMiner[5].toString(), "0");
 
@@ -568,7 +568,7 @@ contract("ColonyNetworkStaking", accounts => {
       assert.equal(repLogEntryMiner[0], MAIN_ACCOUNT);
       assert.equal(repLogEntryMiner[1].toString(), new BN("1").mul(new BN("10").pow(new BN("18"))).toString());
       assert.equal(repLogEntryMiner[2].toString(), "0");
-      assert.equal(repLogEntryMiner[3], commonColony.address);
+      assert.equal(repLogEntryMiner[3], metaColony.address);
       assert.equal(repLogEntryMiner[4].toString(), "4");
       assert.equal(repLogEntryMiner[5].toString(), "4");
 
@@ -672,7 +672,7 @@ contract("ColonyNetworkStaking", accounts => {
       assert.equal(repLogEntryMiner[0], MAIN_ACCOUNT);
       assert.equal(repLogEntryMiner[1].toString(), new BN("1").mul(new BN("10").pow(new BN("18"))).toString());
       assert.equal(repLogEntryMiner[2].toString(), "0");
-      assert.equal(repLogEntryMiner[3], commonColony.address);
+      assert.equal(repLogEntryMiner[3], metaColony.address);
       assert.equal(repLogEntryMiner[4].toString(), "4");
       assert.equal(repLogEntryMiner[5].toString(), "0");
 
@@ -680,7 +680,7 @@ contract("ColonyNetworkStaking", accounts => {
       assert.equal(repLogEntryMiner[0], OTHER_ACCOUNT);
       assert.equal(repLogEntryMiner[1].toString(), new BN("1").mul(new BN("10").pow(new BN("18"))).toString());
       assert.equal(repLogEntryMiner[2].toString(), "0");
-      assert.equal(repLogEntryMiner[3], commonColony.address);
+      assert.equal(repLogEntryMiner[3], metaColony.address);
       assert.equal(repLogEntryMiner[4].toString(), "4");
       assert.equal(repLogEntryMiner[5].toString(), "4");
 
@@ -1311,9 +1311,9 @@ contract("ColonyNetworkStaking", accounts => {
       await forwardTime(3600, this);
       const repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitRootHash("0x12345678", 10, 10);
-      await fundColonyWithTokens(commonColony, clny, "350000000000000000000");
-      const taskId1 = await setupRatedTask({ colonyNetwork, colony: commonColony });
-      await commonColony.finalizeTask(taskId1); // Creates an entry in the reputation log for the worker and manager
+      await fundColonyWithTokens(metaColony, clny, "350000000000000000000");
+      const taskId1 = await setupRatedTask({ colonyNetwork, colony: metaColony });
+      await metaColony.finalizeTask(taskId1); // Creates an entry in the reputation log for the worker and manager
       const initialRepLogLength = await colonyNetwork.getReputationUpdateLogLength.call(true);
       await repCycle.confirmNewHash(0);
       // This confirmation should freeze the reputation log that we added the above task entries to
@@ -1360,7 +1360,7 @@ contract("ColonyNetworkStaking", accounts => {
       // These should be:
       // 1. Reputation reward for MAIN_ACCOUNT for submitting the previous reputaiton hash
       //   (currently skill 0, needs to change to indicate a special mining skill)
-      let key1 = `0x${new BN(commonColony.address.slice(2), 16).toString(16, 40)}`; // Colony address as bytes
+      let key1 = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`; // Colony address as bytes
       key1 += `${new BN("0").toString(16, 64)}`; // SkillId as uint256
       key1 += `${new BN(MAIN_ACCOUNT.slice(2), 16).toString(16, 40)}`; // User address as bytes
       assert.equal(
@@ -1368,7 +1368,7 @@ contract("ColonyNetworkStaking", accounts => {
         "0x0000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000000000000000001"
       );
       // 2. Reputation reward for MAIN_ACCOUNT for being the manager for the tasks created by giveUserCLNYTokens
-      let key2 = `0x${new BN(commonColony.address.slice(2), 16).toString(16, 40)}`;
+      let key2 = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`;
       key2 += `${new BN("2").toString(16, 64)}`;
       key2 += `${new BN(MAIN_ACCOUNT.slice(2), 16).toString(16, 40)}`;
       assert.equal(
@@ -1376,7 +1376,7 @@ contract("ColonyNetworkStaking", accounts => {
         "0x00000000000000000000000000000000000000000000000010a741a4627800000000000000000000000000000000000000000000000000000000000000000002"
       );
       // 3. Reputation reward for OTHER_ACCOUNT for being the evaluator for the tasks created by giveUserCLNYTokens
-      let key3 = `0x${new BN(commonColony.address.slice(2), 16).toString(16, 40)}`;
+      let key3 = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`;
       key3 += `${new BN("2").toString(16, 64)}`;
       key3 += `${new BN(OTHER_ACCOUNT.slice(2), 16).toString(16, 40)}`;
       assert.equal(
@@ -1385,7 +1385,7 @@ contract("ColonyNetworkStaking", accounts => {
       );
       // 4. Reputation reward for accounts[2] for being the worker for the tasks created by giveUserCLNYTokens
       // NB at the moment, the reputation reward for the worker is 0.
-      let key4 = `0x${new BN(commonColony.address.slice(2), 16).toString(16, 40)}`;
+      let key4 = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`;
       key4 += `${new BN("2").toString(16, 64)}`;
       key4 += `${new BN(accounts[2].slice(2), 16).toString(16, 40)}`;
       assert.equal(
@@ -1419,14 +1419,14 @@ contract("ColonyNetworkStaking", accounts => {
       repCycle = ReputationMiningCycle.at(addr);
       await repCycle.submitRootHash(newRootHash, 10, 10);
       await repCycle.confirmNewHash(0);
-      let key = `0x${new BN(commonColony.address.slice(2), 16).toString(16, 40)}`; // Colony address as bytes
+      let key = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`; // Colony address as bytes
       key += `${new BN("2").toString(16, 64)}`; // SkillId as uint256
       key += `${new BN(MAIN_ACCOUNT.slice(2), 16).toString(16, 40)}`; // User address as bytes
 
       const value = client.reputations[key];
       const proof = await client.getProof(key);
       const [branchMask, siblings] = proof;
-      const validProof = await commonColony.verifyReputationProof(`${key}`, `${value}`, branchMask, siblings);
+      const validProof = await metaColony.verifyReputationProof(`${key}`, `${value}`, branchMask, siblings);
       assert.equal(validProof, true);
     });
 

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -124,9 +124,9 @@ contract("ColonyNetwork", accounts => {
       assert.equal(colonyCount.toNumber(), 7);
     });
 
-    it("when common colony is created, should have the root global and local skills initialised", async () => {
+    it("when meta colony is created, should have the root global and local skills initialised", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await colonyNetwork.createColony("Common Colony", token.address);
+      await colonyNetwork.createColony("Meta Colony", token.address);
       const skillCount = await colonyNetwork.getSkillCount.call();
       assert.equal(skillCount.toNumber(), 2);
       const rootGlobalSkill = await colonyNetwork.getSkill.call(1);
@@ -272,7 +272,7 @@ contract("ColonyNetwork", accounts => {
       await token.setOwner(colony);
     });
 
-    it("should not be able to add a global skill, by an address that is not the common colony ", async () => {
+    it("should not be able to add a global skill, by an address that is not the meta colony ", async () => {
       await checkErrorRevert(colonyNetwork.addSkill(1, true));
       const skillCount = await colonyNetwork.getSkillCount.call();
       assert.equal(skillCount.toNumber(), 1);

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -122,6 +122,16 @@ contract("ColonyNetwork", accounts => {
       assert.equal(rootGlobalSkillId, 1);
     });
 
+    it("should fail to create meta colony if it already exists", async () => {
+      const token = await Token.new(...TOKEN_ARGS);
+      await colonyNetwork.createMetaColony(token.address);
+      const metaColonyAddress1 = await colonyNetwork.getMetaColony.call();
+
+      await checkErrorRevert(colonyNetwork.createMetaColony(token.address));
+      const metaColonyAddress2 = await colonyNetwork.getMetaColony.call();
+      assert.equal(metaColonyAddress1, metaColonyAddress2);
+    });
+
     it("when any colony is created, should have the root local skill initialised", async () => {
       const token = await Token.new(...TOKEN_ARGS);
       const { logs } = await colonyNetwork.createColony(token.address);

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -165,12 +165,12 @@ contract("ColonyNetwork", accounts => {
       await colonyNetwork.createColony(token.address);
       await colonyNetwork.createColony(token.address);
       await colonyNetwork.createColony(token.address);
-      const colonyAddress = await colonyNetwork.getColonyAt.call(3);
+      const colonyAddress = await colonyNetwork.getColony.call(3);
       assert.notEqual(colonyAddress, "0x0000000000000000000000000000000000000000");
     });
 
     it("should return an empty address if there is no colony for the index provided", async () => {
-      const colonyAddress = await colonyNetwork.getColonyAt.call(15);
+      const colonyAddress = await colonyNetwork.getColony.call(15);
       assert.equal(colonyAddress, "0x0000000000000000000000000000000000000000");
     });
 

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -1,13 +1,5 @@
 /* globals artifacts */
-import {
-  getTokenArgs,
-  web3GetNetwork,
-  web3GetBalance,
-  checkErrorRevert,
-  getRandomString,
-  checkErrorNonPayableFunction,
-  expectEvent
-} from "../helpers/test-helper";
+import { getTokenArgs, web3GetNetwork, web3GetBalance, checkErrorRevert, checkErrorNonPayableFunction, expectEvent } from "../helpers/test-helper";
 
 import { setupColonyVersionResolver } from "../helpers/upgradable-contracts";
 
@@ -20,7 +12,6 @@ const IColonyNetwork = artifacts.require("IColonyNetwork");
 const Resolver = artifacts.require("Resolver");
 
 contract("ColonyNetwork", accounts => {
-  const COLONY_KEY = "COLONY_TEST";
   const TOKEN_ARGS = getTokenArgs();
   const OTHER_ACCOUNT = accounts[1];
   let colonyFunding;
@@ -92,41 +83,29 @@ contract("ColonyNetwork", accounts => {
   describe("when creating new colonies", () => {
     it("should allow users to create new colonies", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await colonyNetwork.createColony(COLONY_KEY, token.address);
-      const address = await colonyNetwork.getColony.call(COLONY_KEY);
+      const { logs } = await colonyNetwork.createColony(token.address);
+      const { colonyAddress } = logs[0].args;
       const colonyCount = await colonyNetwork.getColonyCount.call();
-      assert.notEqual(address, 0x0);
+      assert.notEqual(colonyAddress, 0x0);
       assert.equal(colonyCount.toNumber(), 1);
-    });
-
-    it("should revert if colony key is not unique", async () => {
-      const token = await Token.new(...TOKEN_ARGS);
-      await colonyNetwork.createColony(COLONY_KEY, token.address);
-      const colonyAddress1 = await colonyNetwork.getColony.call(COLONY_KEY);
-
-      await checkErrorRevert(colonyNetwork.createColony(COLONY_KEY, token.address, { gas: createColonyGas }));
-      const colonyCount = await colonyNetwork.getColonyCount.call();
-      assert.equal(colonyCount.toNumber(), 1);
-      const colonyAddress2 = await colonyNetwork.getColony.call(COLONY_KEY);
-      assert.equal(colonyAddress2, colonyAddress1);
     });
 
     it("should maintain correct count of colonies", async () => {
       const token = await Token.new(...getTokenArgs());
-      await colonyNetwork.createColony(getRandomString(7), token.address);
-      await colonyNetwork.createColony(getRandomString(7), token.address);
-      await colonyNetwork.createColony(getRandomString(7), token.address);
-      await colonyNetwork.createColony(getRandomString(7), token.address);
-      await colonyNetwork.createColony(getRandomString(7), token.address);
-      await colonyNetwork.createColony(getRandomString(7), token.address);
-      await colonyNetwork.createColony(getRandomString(7), token.address);
+      await colonyNetwork.createColony(token.address);
+      await colonyNetwork.createColony(token.address);
+      await colonyNetwork.createColony(token.address);
+      await colonyNetwork.createColony(token.address);
+      await colonyNetwork.createColony(token.address);
+      await colonyNetwork.createColony(token.address);
+      await colonyNetwork.createColony(token.address);
       const colonyCount = await colonyNetwork.getColonyCount.call();
       assert.equal(colonyCount.toNumber(), 7);
     });
 
     it("when meta colony is created, should have the root global and local skills initialised", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await colonyNetwork.createColony("Meta Colony", token.address);
+      await colonyNetwork.createMetaColony(token.address);
       const skillCount = await colonyNetwork.getSkillCount.call();
       assert.equal(skillCount.toNumber(), 2);
       const rootGlobalSkill = await colonyNetwork.getSkill.call(1);
@@ -145,7 +124,7 @@ contract("ColonyNetwork", accounts => {
 
     it("when any colony is created, should have the root local skill initialised", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await colonyNetwork.createColony(COLONY_KEY, token.address);
+      const { logs } = await colonyNetwork.createColony(token.address);
       const rootLocalSkill = await colonyNetwork.getSkill.call(1);
       assert.equal(rootLocalSkill[0].toNumber(), 0);
       assert.equal(rootLocalSkill[1].toNumber(), 0);
@@ -153,7 +132,7 @@ contract("ColonyNetwork", accounts => {
       const isGlobal = await colonyNetwork.isGlobalSkill.call(2);
       assert.isFalse(isGlobal);
 
-      const colonyAddress = await colonyNetwork.getColony.call(COLONY_KEY);
+      const { colonyAddress } = logs[0].args;
       const colony = await Colony.at(colonyAddress);
       const rootDomain = await colony.getDomain.call(1);
       assert.equal(rootDomain[0].toNumber(), 1);
@@ -166,7 +145,7 @@ contract("ColonyNetwork", accounts => {
     it("should fail if ETH is sent", async () => {
       try {
         const token = await Token.new(...TOKEN_ARGS);
-        await colonyNetwork.createColony(COLONY_KEY, token.address, { value: 1, gas: createColonyGas });
+        await colonyNetwork.createColony(token.address, { value: 1, gas: createColonyGas });
       } catch (err) {
         checkErrorNonPayableFunction(err);
       }
@@ -176,16 +155,16 @@ contract("ColonyNetwork", accounts => {
 
     it("should log a ColonyAdded event", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await expectEvent(colonyNetwork.createColony(COLONY_KEY, token.address), "ColonyAdded");
+      await expectEvent(colonyNetwork.createColony(token.address), "ColonyAdded");
     });
   });
 
   describe("when getting existing colonies", () => {
     it("should allow users to get the address of a colony by its index", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await colonyNetwork.createColony("Colony1", token.address);
-      await colonyNetwork.createColony("Colony2", token.address);
-      await colonyNetwork.createColony("Colony3", token.address);
+      await colonyNetwork.createColony(token.address);
+      await colonyNetwork.createColony(token.address);
+      await colonyNetwork.createColony(token.address);
       const colonyAddress = await colonyNetwork.getColonyAt.call(3);
       assert.notEqual(colonyAddress, "0x0000000000000000000000000000000000000000");
     });
@@ -197,8 +176,8 @@ contract("ColonyNetwork", accounts => {
 
     it("should be able to get the Colony version", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await colonyNetwork.createColony(COLONY_KEY, token.address);
-      const colonyAddress = await colonyNetwork.getColony.call(COLONY_KEY);
+      const { logs } = await colonyNetwork.createColony(token.address);
+      const { colonyAddress } = logs[0].args;
       const colony = await Colony.at(colonyAddress);
       const actualColonyVersion = await colony.version.call();
       assert.equal(version.toNumber(), actualColonyVersion.toNumber());
@@ -208,8 +187,8 @@ contract("ColonyNetwork", accounts => {
   describe("when upgrading a colony", () => {
     it("should be able to upgrade a colony, if a colony owner", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await colonyNetwork.createColony(COLONY_KEY, token.address);
-      const colonyAddress = await colonyNetwork.getColony.call(COLONY_KEY);
+      const { logs } = await colonyNetwork.createColony(token.address);
+      const { colonyId, colonyAddress } = logs[0].args;
       const colony = await EtherRouter.at(colonyAddress);
 
       const sampleResolver = "0x65a760e7441cf435086ae45e14a0c8fc1080f54c";
@@ -217,15 +196,15 @@ contract("ColonyNetwork", accounts => {
       const newVersion = currentColonyVersion.add(1).toNumber();
       await colonyNetwork.addColonyVersion(newVersion, sampleResolver);
 
-      await colonyNetwork.upgradeColony(COLONY_KEY, newVersion);
+      await colonyNetwork.upgradeColony(colonyId, newVersion);
       const colonyResolver = await colony.resolver.call();
       assert.equal(colonyResolver, sampleResolver);
     });
 
     it("should NOT be able to upgrade a colony to a lower version", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await colonyNetwork.createColony(COLONY_KEY, token.address);
-      const colonyAddress = await colonyNetwork.getColony.call(COLONY_KEY);
+      const { logs } = await colonyNetwork.createColony(token.address);
+      const { colonyId, colonyAddress } = logs[0].args;
       await Colony.at(colonyAddress);
 
       const sampleResolver = "0x65a760e7441cf435086ae45e14a0c8fc1080f54c";
@@ -233,24 +212,25 @@ contract("ColonyNetwork", accounts => {
       const newVersion = currentColonyVersion.sub(1).toNumber();
       await colonyNetwork.addColonyVersion(newVersion, sampleResolver);
 
-      await checkErrorRevert(colonyNetwork.upgradeColony(COLONY_KEY, newVersion));
+      await checkErrorRevert(colonyNetwork.upgradeColony(colonyId, newVersion));
       assert.equal(version.toNumber(), currentColonyVersion.toNumber());
     });
 
     it("should NOT be able to upgrade a colony to a nonexistent version", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await colonyNetwork.createColony(COLONY_KEY, token.address);
+      const { logs } = await colonyNetwork.createColony(token.address);
+      const { colonyId } = logs[0].args;
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
       const newVersion = currentColonyVersion.add(1).toNumber();
 
-      await checkErrorRevert(colonyNetwork.upgradeColony(COLONY_KEY, newVersion));
+      await checkErrorRevert(colonyNetwork.upgradeColony(colonyId, newVersion));
       assert.equal(version.toNumber(), currentColonyVersion.toNumber());
     });
 
     it("should NOT be able to upgrade a colony if not a colony owner", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await colonyNetwork.createColony(COLONY_KEY, token.address);
-      const colonyAddress = await colonyNetwork.getColony.call(COLONY_KEY);
+      const { logs } = await colonyNetwork.createColony(token.address);
+      const { colonyId, colonyAddress } = logs[0].args;
       const colony = await EtherRouter.at(colonyAddress);
       const colonyResolver = await colony.resolver.call();
 
@@ -259,7 +239,7 @@ contract("ColonyNetwork", accounts => {
       const newVersion = currentColonyVersion.add(1).toNumber();
       await colonyNetwork.addColonyVersion(newVersion, sampleResolver);
 
-      await checkErrorRevert(colonyNetwork.upgradeColony(COLONY_KEY, newVersion, { from: OTHER_ACCOUNT }));
+      await checkErrorRevert(colonyNetwork.upgradeColony(colonyId, newVersion, { from: OTHER_ACCOUNT }));
       assert.notEqual(colonyResolver, sampleResolver);
     });
   });
@@ -267,9 +247,9 @@ contract("ColonyNetwork", accounts => {
   describe("when adding a skill", () => {
     beforeEach(async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await colonyNetwork.createColony(COLONY_KEY, token.address);
-      const colony = await colonyNetwork.getColony.call(COLONY_KEY);
-      await token.setOwner(colony);
+      const { logs } = await colonyNetwork.createColony(token.address);
+      const { colonyAddress } = logs[0].args;
+      await token.setOwner(colonyAddress);
     });
 
     it("should not be able to add a global skill, by an address that is not the meta colony ", async () => {

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -18,7 +18,7 @@ import {
   INITIAL_FUNDING,
   SECONDS_PER_DAY
 } from "../helpers/constants";
-import { getRandomString, getTokenArgs, currentBlockTime, checkErrorRevert, forwardTime } from "../helpers/test-helper";
+import { getTokenArgs, currentBlockTime, checkErrorRevert, forwardTime } from "../helpers/test-helper";
 import { fundColonyWithTokens, setupAssignedTask, setupRatedTask } from "../helpers/test-data-generator";
 
 const IColony = artifacts.require("IColony");
@@ -27,7 +27,6 @@ const EtherRouter = artifacts.require("EtherRouter");
 const Token = artifacts.require("Token");
 
 contract("Colony Task Work Rating", () => {
-  let COLONY_KEY;
   let colony;
   let colonyNetwork;
   let token;
@@ -38,12 +37,11 @@ contract("Colony Task Work Rating", () => {
   });
 
   beforeEach(async () => {
-    COLONY_KEY = getRandomString(7);
     const tokenArgs = getTokenArgs();
     const colonyToken = await Token.new(...tokenArgs);
-    await colonyNetwork.createColony(COLONY_KEY, colonyToken.address);
-    const address = await colonyNetwork.getColony.call(COLONY_KEY);
-    colony = await IColony.at(address);
+    const { logs } = await colonyNetwork.createColony(colonyToken.address);
+    const { colonyAddress } = logs[0].args;
+    colony = await IColony.at(colonyAddress);
     const otherTokenArgs = getTokenArgs();
     token = await Token.new(...otherTokenArgs);
   });

--- a/test/colony.js
+++ b/test/colony.js
@@ -66,7 +66,7 @@ contract("Colony", addresses => {
     await setupColonyVersionResolver(colonyTemplate, colonyTask, colonyFunding, resolver, colonyNetwork);
 
     const clnyToken = await Token.new("Colony Network Token", "CLNY", 18);
-    await colonyNetwork.createColony("Common Colony", clnyToken.address);
+    await colonyNetwork.createColony("Meta Colony", clnyToken.address);
   });
 
   beforeEach(async () => {
@@ -696,14 +696,14 @@ contract("Colony", addresses => {
         workerPayout: 200
       });
       await colony.finalizeTask(taskId);
-      const commonColonyAddress = await colonyNetwork.getColony.call("Common Colony");
+      const metaColonyAddress = await colonyNetwork.getColony.call("Meta Colony");
       const balanceBefore = await web3GetBalance(MANAGER);
-      const commonBalanceBefore = await web3GetBalance(commonColonyAddress);
+      const metaBalanceBefore = await web3GetBalance(metaColonyAddress);
       await colony.claimPayout(taskId, MANAGER_ROLE, 0x0, { gasPrice: 0 });
       const balanceAfter = await web3GetBalance(MANAGER);
-      const commonBalanceAfter = await web3GetBalance(commonColonyAddress);
+      const metaBalanceAfter = await web3GetBalance(metaColonyAddress);
       assert.equal(balanceAfter.minus(balanceBefore).toNumber(), 99);
-      assert.equal(commonBalanceAfter.minus(commonBalanceBefore).toNumber(), 1);
+      assert.equal(metaBalanceAfter.minus(metaBalanceBefore).toNumber(), 1);
       const potBalance = await colony.getPotBalance.call(2, 0x0);
       assert.equal(potBalance.toNumber(), 250);
     });

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -14,11 +14,11 @@ const ColonyFunding = artifacts.require("ColonyFunding");
 const ColonyTask = artifacts.require("ColonyTask");
 const Token = artifacts.require("Token");
 
-contract("Common Colony", () => {
+contract("Meta Colony", () => {
   let COLONY_KEY;
   let TOKEN_ARGS;
-  let commonColony;
-  let commonColonyToken;
+  let metaColony;
+  let metaColonyToken;
   let colony;
   let token;
   let colonyNetwork;
@@ -38,32 +38,32 @@ contract("Common Colony", () => {
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
     await upgradableContracts.setupColonyVersionResolver(colonyTemplate, colonyTask, colonyFunding, resolver, colonyNetwork);
 
-    commonColonyToken = await Token.new("Colony Network Token", "CLNY", 18);
-    await colonyNetwork.createColony("Common Colony", commonColonyToken.address);
-    const commonColonyAddress = await colonyNetwork.getColony.call("Common Colony");
-    commonColony = await IColony.at(commonColonyAddress);
+    metaColonyToken = await Token.new("Colony Network Token", "CLNY", 18);
+    await colonyNetwork.createColony("Meta Colony", metaColonyToken.address);
+    const metaColonyAddress = await colonyNetwork.getColony.call("Meta Colony");
+    metaColony = await IColony.at(metaColonyAddress);
   });
 
-  describe("when working with ERC20 properties of Common Colony token", () => {
+  describe("when working with ERC20 properties of Meta Colony token", () => {
     it("token `symbol` property is correct", async () => {
-      const tokenSymbol = await commonColonyToken.symbol();
+      const tokenSymbol = await metaColonyToken.symbol();
       assert.equal(web3.toUtf8(tokenSymbol), "CLNY");
     });
 
     it("token `decimals` property is correct", async () => {
-      const tokenDecimals = await commonColonyToken.decimals.call();
+      const tokenDecimals = await metaColonyToken.decimals.call();
       assert.equal(tokenDecimals.toString(), "18");
     });
 
     it("token `name` property is correct", async () => {
-      const tokenName = await commonColonyToken.name.call();
+      const tokenName = await metaColonyToken.name.call();
       assert.equal(web3.toUtf8(tokenName), "Colony Network Token");
     });
   });
 
   describe("when adding a new global skill", () => {
     it("should be able to add a new skill as a child to the root skill", async () => {
-      await commonColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(1);
 
       const skillCount = await colonyNetwork.getSkillCount.call();
       assert.equal(skillCount.toNumber(), 3);
@@ -82,9 +82,9 @@ contract("Common Colony", () => {
     });
 
     it("should be able to add multiple child skills to the root global skill", async () => {
-      await commonColony.addGlobalSkill(1);
-      await commonColony.addGlobalSkill(1);
-      await commonColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(1);
 
       const skillCount = await colonyNetwork.getSkillCount.call();
       assert.equal(skillCount.toNumber(), 5);
@@ -116,10 +116,10 @@ contract("Common Colony", () => {
 
     it("should be able to add child skills a few levels down the skills tree", async () => {
       // Add 2 skill nodes to root skill
-      await commonColony.addGlobalSkill(1);
-      await commonColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(1);
       // Add a child skill to skill id 3
-      await commonColony.addGlobalSkill(3);
+      await metaColony.addGlobalSkill(3);
 
       const newDeepSkill = await colonyNetwork.getSkill.call(5);
       assert.equal(newDeepSkill[0].toNumber(), 2);
@@ -134,27 +134,27 @@ contract("Common Colony", () => {
 
     it("should NOT be able to add a child skill for a non existent parent", async () => {
       // Add 2 skill nodes to root skill
-      await commonColony.addGlobalSkill(1);
-      await commonColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(1);
 
-      await checkErrorRevert(commonColony.addGlobalSkill(5));
+      await checkErrorRevert(metaColony.addGlobalSkill(5));
       const skillCount = await colonyNetwork.getSkillCount.call();
       assert.equal(skillCount.toNumber(), 4);
     });
 
     it("should NOT be able to add a child skill to a local skill parent", async () => {
-      await checkErrorRevert(commonColony.addGlobalSkill(2));
+      await checkErrorRevert(metaColony.addGlobalSkill(2));
       const skillCount = await colonyNetwork.getSkillCount.call();
       assert.equal(skillCount.toNumber(), 2);
     });
 
     it("should be able to add skills in the middle of the skills tree", async () => {
-      await commonColony.addGlobalSkill(1);
-      await commonColony.addGlobalSkill(1);
-      await commonColony.addGlobalSkill(4);
-      await commonColony.addGlobalSkill(1);
-      await commonColony.addGlobalSkill(3);
-      await commonColony.addGlobalSkill(4);
+      await metaColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(4);
+      await metaColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(3);
+      await metaColony.addGlobalSkill(4);
 
       const rootSkill = await colonyNetwork.getSkill.call(1);
       assert.equal(rootSkill[0].toNumber(), 0);
@@ -222,15 +222,15 @@ contract("Common Colony", () => {
     });
 
     it("when N parents are there, should record parent skill ids for N = integer powers of 2", async () => {
-      await commonColony.addGlobalSkill(1);
-      await commonColony.addGlobalSkill(3);
-      await commonColony.addGlobalSkill(4);
-      await commonColony.addGlobalSkill(5);
-      await commonColony.addGlobalSkill(6);
-      await commonColony.addGlobalSkill(7);
-      await commonColony.addGlobalSkill(8);
-      await commonColony.addGlobalSkill(9);
-      await commonColony.addGlobalSkill(10);
+      await metaColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(3);
+      await metaColony.addGlobalSkill(4);
+      await metaColony.addGlobalSkill(5);
+      await metaColony.addGlobalSkill(6);
+      await metaColony.addGlobalSkill(7);
+      await metaColony.addGlobalSkill(8);
+      await metaColony.addGlobalSkill(9);
+      await metaColony.addGlobalSkill(10);
 
       const skill11 = await colonyNetwork.getSkill.call(11);
       assert.equal(skill11[0].toNumber(), 9);
@@ -247,23 +247,23 @@ contract("Common Colony", () => {
     });
 
     it("should NOT be able to add a new root global skill", async () => {
-      await checkErrorRevert(commonColony.addGlobalSkill(0));
+      await checkErrorRevert(metaColony.addGlobalSkill(0));
 
       const skillCount = await colonyNetwork.getSkillCount.call();
       assert.equal(skillCount.toNumber(), 2);
     });
   });
 
-  describe("when adding domains in the common colony", () => {
+  describe("when adding domains in the meta colony", () => {
     it("should be able to add new domains as children to the root domain", async () => {
-      await commonColony.addDomain(2);
+      await metaColony.addDomain(2);
 
       const skillCount = await colonyNetwork.getSkillCount.call();
       assert.equal(skillCount.toNumber(), 3);
-      const domainCount = await commonColony.getDomainCount.call();
+      const domainCount = await metaColony.getDomainCount.call();
       assert.equal(domainCount.toNumber(), 2);
 
-      const newDomain = await commonColony.getDomain.call(1);
+      const newDomain = await metaColony.getDomain.call(1);
       assert.equal(newDomain[0].toNumber(), 2);
       assert.equal(newDomain[1].toNumber(), 1);
 
@@ -277,12 +277,12 @@ contract("Common Colony", () => {
     });
 
     it("should NOT be able to add a child local skill more than one level from the root local skill", async () => {
-      await commonColony.addDomain(2);
-      await checkErrorRevert(commonColony.addDomain(3));
+      await metaColony.addDomain(2);
+      await checkErrorRevert(metaColony.addDomain(3));
 
       const skillCount = await colonyNetwork.getSkillCount.call();
       assert.equal(skillCount.toNumber(), 3);
-      const domainCount = await commonColony.getDomainCount.call();
+      const domainCount = await metaColony.getDomainCount.call();
       assert.equal(domainCount.toNumber(), 2);
     });
   });
@@ -407,8 +407,8 @@ contract("Common Colony", () => {
     });
 
     it("should be able to set global skill on task", async () => {
-      await commonColony.addGlobalSkill(1);
-      await commonColony.addGlobalSkill(4);
+      await metaColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(4);
 
       await colony.makeTask(SPECIFICATION_HASH, 1);
       await colony.setTaskSkill(1, 5);
@@ -421,8 +421,8 @@ contract("Common Colony", () => {
     });
 
     it("should NOT be able to set global skill on finalized task", async () => {
-      await commonColony.addGlobalSkill(1);
-      await commonColony.addGlobalSkill(4);
+      await metaColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(4);
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony });
       await colony.finalizeTask(taskId);

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -19,7 +19,7 @@ const Token = artifacts.require("Token");
 
 contract("Colony Reputation Updates", () => {
   let colonyNetwork;
-  let commonColony;
+  let metaColony;
   let resolverColonyNetworkDeployed;
   let colonyToken;
 
@@ -38,42 +38,66 @@ contract("Colony Reputation Updates", () => {
     await setupColonyVersionResolver(colony, colonyTask, colonyFunding, resolver, colonyNetwork);
     const tokenArgs = getTokenArgs();
     colonyToken = await Token.new(...tokenArgs);
-    await colonyNetwork.createColony("Common Colony", colonyToken.address);
-    const commonColonyAddress = await colonyNetwork.getColony.call("Common Colony");
-    await colonyToken.setOwner(commonColonyAddress);
-    commonColony = await IColony.at(commonColonyAddress);
+    await colonyNetwork.createColony("Meta Colony", colonyToken.address);
+    const metaColonyAddress = await colonyNetwork.getColony.call("Meta Colony");
+    await colonyToken.setOwner(metaColonyAddress);
+    metaColony = await IColony.at(metaColonyAddress);
     const amount = new BN(10)
       .pow(new BN(18))
       .mul(new BN(1000))
       .toString();
-    await fundColonyWithTokens(commonColony, colonyToken, amount);
+    await fundColonyWithTokens(metaColony, colonyToken, amount);
   });
 
   describe("when added", () => {
     it("should be readable", async () => {
-      const taskId = await setupRatedTask({ colonyNetwork, colony: commonColony });
-      await commonColony.finalizeTask(taskId);
+      const taskId = await setupRatedTask({ colonyNetwork, colony: metaColony });
+      await metaColony.finalizeTask(taskId);
       const repLogEntryManager = await colonyNetwork.getReputationUpdateLogEntry.call(0, true);
       assert.equal(repLogEntryManager[0], MANAGER);
       assert.equal(repLogEntryManager[1].toNumber(), 1000 * 1e18 / 50);
+<<<<<<< HEAD
       assert.equal(repLogEntryManager[2].toNumber(), 2);
       assert.equal(repLogEntryManager[3], commonColony.address);
+||||||| merged common ancestors
+      assert.equal(repLogEntryManager[2].toNumber(), 1);
+      assert.equal(repLogEntryManager[3], commonColony.address);
+=======
+      assert.equal(repLogEntryManager[2].toNumber(), 1);
+      assert.equal(repLogEntryManager[3], metaColony.address);
+>>>>>>> Rename Common Colony to Meta Colony
       assert.equal(repLogEntryManager[4].toNumber(), 2);
       assert.equal(repLogEntryManager[5].toNumber(), 0);
 
       const repLogEntryEvaluator = await colonyNetwork.getReputationUpdateLogEntry.call(1, true);
       assert.equal(repLogEntryEvaluator[0], EVALUATOR);
       assert.equal(repLogEntryEvaluator[1].toNumber(), 50 * 1e18);
+<<<<<<< HEAD
       assert.equal(repLogEntryEvaluator[2].toNumber(), 2);
       assert.equal(repLogEntryEvaluator[3], commonColony.address);
+||||||| merged common ancestors
+      assert.equal(repLogEntryEvaluator[2].toNumber(), 1);
+      assert.equal(repLogEntryEvaluator[3], commonColony.address);
+=======
+      assert.equal(repLogEntryEvaluator[2].toNumber(), 1);
+      assert.equal(repLogEntryEvaluator[3], metaColony.address);
+>>>>>>> Rename Common Colony to Meta Colony
       assert.equal(repLogEntryEvaluator[4].toNumber(), 2);
       assert.equal(repLogEntryEvaluator[5].toNumber(), 2);
 
       const repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(2, true);
       assert.equal(repLogEntryWorker[0], WORKER);
       assert.equal(repLogEntryWorker[1].toNumber(), 200 * 1e18);
+<<<<<<< HEAD
       assert.equal(repLogEntryWorker[2].toNumber(), 2);
       assert.equal(repLogEntryWorker[3], commonColony.address);
+||||||| merged common ancestors
+      assert.equal(repLogEntryWorker[2].toNumber(), 1);
+      assert.equal(repLogEntryWorker[3], commonColony.address);
+=======
+      assert.equal(repLogEntryWorker[2].toNumber(), 1);
+      assert.equal(repLogEntryWorker[3], metaColony.address);
+>>>>>>> Rename Common Colony to Meta Colony
       assert.equal(repLogEntryWorker[4].toNumber(), 2);
       assert.equal(repLogEntryWorker[5].toNumber(), 4);
     });
@@ -139,25 +163,41 @@ contract("Colony Reputation Updates", () => {
       it(`should set the correct reputation change amount in log for rating ${rating.worker}`, async () => {
         const taskId = await setupRatedTask({
           colonyNetwork,
-          colony: commonColony,
+          colony: metaColony,
           managerRating: rating.manager,
           workerRating: rating.worker
         });
-        await commonColony.finalizeTask(taskId);
+        await metaColony.finalizeTask(taskId);
 
         const repLogEntryManager = await colonyNetwork.getReputationUpdateLogEntry.call(0, true);
         assert.equal(repLogEntryManager[0], MANAGER);
         assert.equal(repLogEntryManager[1].toString(), rating.reputationChangeManager.toString());
+<<<<<<< HEAD
         assert.equal(repLogEntryManager[2].toNumber(), 2);
         assert.equal(repLogEntryManager[3], commonColony.address);
+||||||| merged common ancestors
+        assert.equal(repLogEntryManager[2].toNumber(), 1);
+        assert.equal(repLogEntryManager[3], commonColony.address);
+=======
+        assert.equal(repLogEntryManager[2].toNumber(), 1);
+        assert.equal(repLogEntryManager[3], metaColony.address);
+>>>>>>> Rename Common Colony to Meta Colony
         assert.equal(repLogEntryManager[4].toNumber(), 2);
         assert.equal(repLogEntryManager[5].toNumber(), 0);
 
         const repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(2, true);
         assert.equal(repLogEntryWorker[0], WORKER);
         assert.equal(repLogEntryWorker[1].toString(), rating.reputationChangeWorker.toString());
+<<<<<<< HEAD
         assert.equal(repLogEntryWorker[2].toNumber(), 2);
         assert.equal(repLogEntryWorker[3], commonColony.address);
+||||||| merged common ancestors
+        assert.equal(repLogEntryWorker[2].toNumber(), 1);
+        assert.equal(repLogEntryWorker[3], commonColony.address);
+=======
+        assert.equal(repLogEntryWorker[2].toNumber(), 1);
+        assert.equal(repLogEntryWorker[3], metaColony.address);
+>>>>>>> Rename Common Colony to Meta Colony
         assert.equal(repLogEntryWorker[4].toNumber(), 2);
         assert.equal(repLogEntryWorker[5].toNumber(), 4);
       });
@@ -173,30 +213,30 @@ contract("Colony Reputation Updates", () => {
     it("should populate nPreviousUpdates correctly", async () => {
       let initialRepLogLength = await colonyNetwork.getReputationUpdateLogLength.call(true);
       initialRepLogLength = initialRepLogLength.toNumber();
-      const taskId1 = await setupRatedTask({ colonyNetwork, colony: commonColony });
-      await commonColony.finalizeTask(taskId1);
+      const taskId1 = await setupRatedTask({ colonyNetwork, colony: metaColony });
+      await metaColony.finalizeTask(taskId1);
       let repLogEntry = await colonyNetwork.getReputationUpdateLogEntry.call(initialRepLogLength, true);
       const nPrevious = repLogEntry[5].toNumber();
       repLogEntry = await colonyNetwork.getReputationUpdateLogEntry.call(initialRepLogLength + 1, true);
       assert.equal(repLogEntry[5].toNumber(), 2 + nPrevious);
 
-      const taskId2 = await setupRatedTask({ colonyNetwork, colony: commonColony });
-      await commonColony.finalizeTask(taskId2);
+      const taskId2 = await setupRatedTask({ colonyNetwork, colony: metaColony });
+      await metaColony.finalizeTask(taskId2);
       repLogEntry = await colonyNetwork.getReputationUpdateLogEntry.call(initialRepLogLength + 2, true);
       assert.equal(repLogEntry[5].toNumber(), 4 + nPrevious);
     });
 
     it("should calculate nUpdates correctly when making a log", async () => {
-      await commonColony.addGlobalSkill(1);
-      await commonColony.addGlobalSkill(3);
-      await commonColony.addGlobalSkill(4);
-      await commonColony.addGlobalSkill(5);
+      await metaColony.addGlobalSkill(1);
+      await metaColony.addGlobalSkill(3);
+      await metaColony.addGlobalSkill(4);
+      await metaColony.addGlobalSkill(5);
       const taskId1 = await setupRatedTask({
         colonyNetwork,
-        colony: commonColony,
+        colony: metaColony,
         skill: 4
       });
-      await commonColony.finalizeTask(taskId1);
+      await metaColony.finalizeTask(taskId1);
 
       let repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(3, true);
       const result = web3Utils.toBN("1").mul(WORKER_PAYOUT);
@@ -205,10 +245,10 @@ contract("Colony Reputation Updates", () => {
 
       const taskId2 = await setupRatedTask({
         colonyNetwork,
-        colony: commonColony,
+        colony: metaColony,
         skill: 5
       });
-      await commonColony.finalizeTask(taskId2);
+      await metaColony.finalizeTask(taskId2);
       repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(7, true);
       assert.equal(repLogEntryWorker[1].toString(), result.toString());
       assert.equal(repLogEntryWorker[4].toNumber(), 8); // Negative reputation change means children change as well.
@@ -220,14 +260,14 @@ contract("Colony Reputation Updates", () => {
         .pow(new BN(255))
         .sub(new BN(1))
         .toString(10);
-      await fundColonyWithTokens(commonColony, colonyToken, maxUIntNumber);
+      await fundColonyWithTokens(metaColony, colonyToken, maxUIntNumber);
       // Split the tokens as payouts between the manager and worker
       const managerPayout = new BN("2");
       const evaluatorPayout = new BN("1");
       const workerPayout = new BN(maxUIntNumber).sub(managerPayout).sub(evaluatorPayout);
       const taskId = await setupRatedTask({
         colonyNetwork,
-        colony: commonColony,
+        colony: metaColony,
         token: colonyToken,
         managerPayout,
         evaluatorPayout,
@@ -236,10 +276,10 @@ contract("Colony Reputation Updates", () => {
       });
 
       // Check the task pot is correctly funded with the max amount
-      const taskPotBalance = await commonColony.getPotBalance.call(2, colonyToken.address);
+      const taskPotBalance = await metaColony.getPotBalance.call(2, colonyToken.address);
       assert.isTrue(taskPotBalance.equals(maxUIntNumber));
 
-      await checkErrorRevert(commonColony.finalizeTask(taskId));
+      await checkErrorRevert(metaColony.finalizeTask(taskId));
     });
   });
 });

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -38,8 +38,8 @@ contract("Colony Reputation Updates", () => {
     await setupColonyVersionResolver(colony, colonyTask, colonyFunding, resolver, colonyNetwork);
     const tokenArgs = getTokenArgs();
     colonyToken = await Token.new(...tokenArgs);
-    await colonyNetwork.createColony("Meta Colony", colonyToken.address);
-    const metaColonyAddress = await colonyNetwork.getColony.call("Meta Colony");
+    await colonyNetwork.createMetaColony(colonyToken.address);
+    const metaColonyAddress = await colonyNetwork.getMetaColony.call();
     await colonyToken.setOwner(metaColonyAddress);
     metaColony = await IColony.at(metaColonyAddress);
     const amount = new BN(10)

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -56,48 +56,24 @@ contract("Colony Reputation Updates", () => {
       const repLogEntryManager = await colonyNetwork.getReputationUpdateLogEntry.call(0, true);
       assert.equal(repLogEntryManager[0], MANAGER);
       assert.equal(repLogEntryManager[1].toNumber(), 1000 * 1e18 / 50);
-<<<<<<< HEAD
       assert.equal(repLogEntryManager[2].toNumber(), 2);
-      assert.equal(repLogEntryManager[3], commonColony.address);
-||||||| merged common ancestors
-      assert.equal(repLogEntryManager[2].toNumber(), 1);
-      assert.equal(repLogEntryManager[3], commonColony.address);
-=======
-      assert.equal(repLogEntryManager[2].toNumber(), 1);
       assert.equal(repLogEntryManager[3], metaColony.address);
->>>>>>> Rename Common Colony to Meta Colony
       assert.equal(repLogEntryManager[4].toNumber(), 2);
       assert.equal(repLogEntryManager[5].toNumber(), 0);
 
       const repLogEntryEvaluator = await colonyNetwork.getReputationUpdateLogEntry.call(1, true);
       assert.equal(repLogEntryEvaluator[0], EVALUATOR);
       assert.equal(repLogEntryEvaluator[1].toNumber(), 50 * 1e18);
-<<<<<<< HEAD
       assert.equal(repLogEntryEvaluator[2].toNumber(), 2);
-      assert.equal(repLogEntryEvaluator[3], commonColony.address);
-||||||| merged common ancestors
-      assert.equal(repLogEntryEvaluator[2].toNumber(), 1);
-      assert.equal(repLogEntryEvaluator[3], commonColony.address);
-=======
-      assert.equal(repLogEntryEvaluator[2].toNumber(), 1);
       assert.equal(repLogEntryEvaluator[3], metaColony.address);
->>>>>>> Rename Common Colony to Meta Colony
       assert.equal(repLogEntryEvaluator[4].toNumber(), 2);
       assert.equal(repLogEntryEvaluator[5].toNumber(), 2);
 
       const repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(2, true);
       assert.equal(repLogEntryWorker[0], WORKER);
       assert.equal(repLogEntryWorker[1].toNumber(), 200 * 1e18);
-<<<<<<< HEAD
       assert.equal(repLogEntryWorker[2].toNumber(), 2);
-      assert.equal(repLogEntryWorker[3], commonColony.address);
-||||||| merged common ancestors
-      assert.equal(repLogEntryWorker[2].toNumber(), 1);
-      assert.equal(repLogEntryWorker[3], commonColony.address);
-=======
-      assert.equal(repLogEntryWorker[2].toNumber(), 1);
       assert.equal(repLogEntryWorker[3], metaColony.address);
->>>>>>> Rename Common Colony to Meta Colony
       assert.equal(repLogEntryWorker[4].toNumber(), 2);
       assert.equal(repLogEntryWorker[5].toNumber(), 4);
     });
@@ -172,32 +148,16 @@ contract("Colony Reputation Updates", () => {
         const repLogEntryManager = await colonyNetwork.getReputationUpdateLogEntry.call(0, true);
         assert.equal(repLogEntryManager[0], MANAGER);
         assert.equal(repLogEntryManager[1].toString(), rating.reputationChangeManager.toString());
-<<<<<<< HEAD
         assert.equal(repLogEntryManager[2].toNumber(), 2);
-        assert.equal(repLogEntryManager[3], commonColony.address);
-||||||| merged common ancestors
-        assert.equal(repLogEntryManager[2].toNumber(), 1);
-        assert.equal(repLogEntryManager[3], commonColony.address);
-=======
-        assert.equal(repLogEntryManager[2].toNumber(), 1);
         assert.equal(repLogEntryManager[3], metaColony.address);
->>>>>>> Rename Common Colony to Meta Colony
         assert.equal(repLogEntryManager[4].toNumber(), 2);
         assert.equal(repLogEntryManager[5].toNumber(), 0);
 
         const repLogEntryWorker = await colonyNetwork.getReputationUpdateLogEntry.call(2, true);
         assert.equal(repLogEntryWorker[0], WORKER);
         assert.equal(repLogEntryWorker[1].toString(), rating.reputationChangeWorker.toString());
-<<<<<<< HEAD
         assert.equal(repLogEntryWorker[2].toNumber(), 2);
-        assert.equal(repLogEntryWorker[3], commonColony.address);
-||||||| merged common ancestors
-        assert.equal(repLogEntryWorker[2].toNumber(), 1);
-        assert.equal(repLogEntryWorker[3], commonColony.address);
-=======
-        assert.equal(repLogEntryWorker[2].toNumber(), 1);
         assert.equal(repLogEntryWorker[3], metaColony.address);
->>>>>>> Rename Common Colony to Meta Colony
         assert.equal(repLogEntryWorker[4].toNumber(), 2);
         assert.equal(repLogEntryWorker[5].toNumber(), 4);
       });

--- a/test/router-resolver.js
+++ b/test/router-resolver.js
@@ -48,7 +48,7 @@ contract("EtherRouter / Resolver", accounts => {
   describe("Resolver", () => {
     it("should return correct destination for given function", async () => {
       const deployedColonyNetwork = await ColonyNetwork.deployed();
-      const signature = await resolver.stringToSig.call("createColony(bytes32,address)");
+      const signature = await resolver.stringToSig.call("createColony(address)");
       const destination = await resolver.lookup.call(signature);
       assert.equal(destination, deployedColonyNetwork.address);
     });

--- a/upgrade-test/colony-network-upgrade.js
+++ b/upgrade-test/colony-network-upgrade.js
@@ -43,10 +43,10 @@ contract("ColonyNetwork contract upgrade", () => {
     });
 
     it("should return correct colonies by index", async () => {
-      const colony1 = await updatedColonyNetwork.getColonyAt(2);
+      const colony1 = await updatedColonyNetwork.getColony(2);
       assert.equal(colony1, colonyAddress1);
 
-      const colony2 = await updatedColonyNetwork.getColonyAt(3);
+      const colony2 = await updatedColonyNetwork.getColony(3);
       assert.equal(colony2, colonyAddress2);
     });
   });

--- a/upgrade-test/colony-network-upgrade.js
+++ b/upgrade-test/colony-network-upgrade.js
@@ -1,5 +1,5 @@
 /* globals artifacts */
-import { getRandomString, getTokenArgs } from "../helpers/test-helper";
+import { getTokenArgs } from "../helpers/test-helper";
 
 const Token = artifacts.require("Token");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
@@ -8,8 +8,6 @@ const Resolver = artifacts.require("Resolver");
 const UpdatedColonyNetwork = artifacts.require("UpdatedColonyNetwork");
 
 contract("ColonyNetwork contract upgrade", () => {
-  let colonyKey1;
-  let colonyKey2;
   let colonyAddress1;
   let colonyAddress2;
   let colonyNetwork;
@@ -20,16 +18,15 @@ contract("ColonyNetwork contract upgrade", () => {
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
 
     // Setup 2 test colonies
-    colonyKey1 = getRandomString(7);
     const tokenArgs1 = getTokenArgs();
     const newToken = await Token.new(...tokenArgs1);
-    await colonyNetwork.createColony(colonyKey1, newToken.address);
-    colonyAddress1 = await colonyNetwork.getColony(colonyKey1);
-    colonyKey2 = getRandomString(7);
+    let { logs } = await colonyNetwork.createColony(newToken.address);
+    colonyAddress1 = logs[0].args.colonyAddress;
+
     const tokenArgs2 = getTokenArgs();
     const newToken2 = await Token.new(...tokenArgs2);
-    await colonyNetwork.createColony(colonyKey2, newToken2.address);
-    colonyAddress2 = await colonyNetwork.getColony(colonyKey2);
+    ({ logs } = await colonyNetwork.createColony(newToken2.address));
+    colonyAddress2 = logs[0].args.colonyAddress;
 
     // Setup new Colony contract version on the Network
     const updatedColonyNetworkContract = await UpdatedColonyNetwork.new();
@@ -43,14 +40,6 @@ contract("ColonyNetwork contract upgrade", () => {
     it("should return correct total number of colonies", async () => {
       const updatedColonyCount = await updatedColonyNetwork.getColonyCount.call();
       assert.equal(3, updatedColonyCount.toNumber());
-    });
-
-    it("should return correct colonies by name", async () => {
-      const colony1 = await updatedColonyNetwork.getColony(colonyKey1);
-      assert.equal(colony1, colonyAddress1);
-
-      const colony2 = await updatedColonyNetwork.getColony(colonyKey2);
-      assert.equal(colony2, colonyAddress2);
     });
 
     it("should return correct colonies by index", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5083,14 +5083,14 @@ mkdirp@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
 
-mocha-circleci-reporter@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/mocha-circleci-reporter/-/mocha-circleci-reporter-0.0.2.tgz#6cbb3f1a1911ce2365e79461a156370b63790c7e"
+mocha-circleci-reporter@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/mocha-circleci-reporter/-/mocha-circleci-reporter-0.0.3.tgz#5303d722cdb0390c2e03632517055c06146df6a0"
   dependencies:
-    mocha "^3.0.0"
-    mocha-junit-reporter "^1.12.0"
+    mocha "^5.1.1"
+    mocha-junit-reporter "^1.17.0"
 
-mocha-junit-reporter@^1.12.0:
+mocha-junit-reporter@^1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/mocha-junit-reporter/-/mocha-junit-reporter-1.17.0.tgz#2e5149ed40fc5d2e3ca71e42db5ab1fec9c6d85c"
   dependencies:
@@ -5115,7 +5115,7 @@ mocha@^2.4.5:
     supports-color "1.2.0"
     to-iso-string "0.0.2"
 
-mocha@^3.0.0, mocha@^3.4.2, mocha@^3.5.3:
+mocha@^3.4.2, mocha@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
   dependencies:


### PR DESCRIPTION
Here we remove 1 of the 3 mappings of colony addresses in storage which held a colony bytes32 "key" mapping. This has been depreciated as a legacy feature in favour of the colony index which can be used instead to uniquely identify a colony, similarly to the task index.

Additionally the "Common Colony" has been renamed to "Meta Colony" to make clearer its purpose.

Also I've slipped in an update to the lockfile which I forgot in https://github.com/JoinColony/colonyNetwork/pull/204/