### PR TITLE
Add parent reputations and colony-wide reputations to reputation state tree

### DIFF
--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -110,12 +110,15 @@ contract ColonyNetwork is ColonyNetworkStorage {
 
     metaColony = createColony(_tokenAddress);
 
-    // Add mining skill
+    // Add the special mining skill
     skillCount += 1;
     Skill memory miningSkill;
     miningSkill.nParents = 1;
     skills[skillCount] = miningSkill;
     skills[skillCount].parents.push(skillCount-1);
+    // Add it as a child of the parent
+    skills[skillCount-1].nChildren += 1;
+    skills[skillCount-1].children.push(skillCount);
   }
 
   function createColony(address _tokenAddress) public returns (address) {

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -37,7 +37,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
     if (globalSkill) {
       require(msg.sender == metaColony);
     } else {
-      require(_isColony[msg.sender]);
+      require(_isColony[msg.sender] || msg.sender == address(this));
     }
     _;
   }
@@ -111,14 +111,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
     metaColony = createColony(_tokenAddress);
 
     // Add the special mining skill
-    skillCount += 1;
-    Skill memory miningSkill;
-    miningSkill.nParents = 1;
-    skills[skillCount] = miningSkill;
-    skills[skillCount].parents.push(skillCount-1);
-    // Add it as a child of the parent
-    skills[skillCount-1].nChildren += 1;
-    skills[skillCount-1].children.push(skillCount);
+    this.addSkill(skillCount, false);
   }
 
   function createColony(address _tokenAddress) public returns (address) {

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -107,9 +107,15 @@ contract ColonyNetwork is ColonyNetworkStorage {
     rootGlobalSkill.globalSkill = true;
     skills[skillCount] = rootGlobalSkill;
     rootGlobalSkillId = skillCount;
-    // TODO: add the special 'mining' skill, which is local to the meta Colony.
 
     metaColony = createColony(_tokenAddress);
+
+    // Add mining skill
+    skillCount += 1;
+    Skill memory miningSkill;
+    miningSkill.nParents = 1;
+    skills[skillCount] = miningSkill;
+    skills[skillCount].parents.push(skillCount-1);
   }
 
   function createColony(address _tokenAddress) public returns (address) {

--- a/contracts/ColonyNetworkStaking.sol
+++ b/contracts/ColonyNetworkStaking.sol
@@ -127,7 +127,7 @@ contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
 
     IColony(metaColony).mintTokensForColonyNetwork(stakers.length * reward); // This should be the total amount of new tokens we're awarding.
 
-    ReputationMiningCycle(inactiveReputationMiningCycle).rewardStakersWithReputation(stakers, metaColony, reward); // This gives them reputation in the next update cycle.
+    ReputationMiningCycle(inactiveReputationMiningCycle).rewardStakersWithReputation(stakers, metaColony, reward, rootGlobalSkillId + 2); // This gives them reputation in the next update cycle.
 
     for (uint256 i = 0; i < stakers.length; i++) {
       // Also give them some newly minted tokens.

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -63,7 +63,7 @@ contract IReputationMiningCycle {
   function respondToBinarySearchForChallenge(uint256 round, uint256 idx, bytes jhIntermediateValue, uint branchMask, bytes32[] siblings) public;
 
   /// @notice Respond to challenge, to establish which (if either) of the two submissions facing off are correct.
-  /// @param u A `uint256[9]` array. The elements of this array, in order are:
+  /// @param u A `uint256[10]` array. The elements of this array, in order are:
   /// * 1. The current round of the hash being responded on behalf of
   /// * 2. The current index in the round of the hash being responded on behalf of
   /// * 3. The branchMask of the proof that the reputation is in the reputation state tree for the reputation with the disputed change
@@ -73,6 +73,8 @@ contract IReputationMiningCycle {
   /// * 7. The branchMask of the proof that reputation root hash of the first reputation state the two hashes in this challenge disagree on is in this submitted hash's justification tree
   /// * 8. The branchMask of the proof for the most recently added reputation state in this hash's state tree in the last reputation state the two hashes in this challenge agreed on
   /// * 9. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code.
+  /// *10. The index of the log entry that the update in question was implied by. Each log entry can imply multiple reputation updates, and so we expect the clients to pass
+  ///      the log entry index corresponding to the update to avoid us having to iterate over the log.
   /// @param _reputationKey The key of the reputation being changed that the disagreement is over.
   /// @param reputationSiblings The siblings of the Merkle proof that the reputation corresponding to `_reputationKey` is in the reputation state before and after the disagreement
   /// @param agreeStateReputationValue The value of the reputation at key `_reputationKey` in the last reputation state the submitted hashes agreed on
@@ -147,7 +149,7 @@ contract IReputationMiningCycle {
   /// @dev Only callable by colonyNetwork
   /// @dev Note that the same address might be present multiple times in `stakers` - this is acceptable, and indicates the
   /// same address backed the same hash multiple times with different entries.
-  function rewardStakersWithReputation(address[] stakers, address commonColonyAddress, uint reward) public;
+  function rewardStakersWithReputation(address[] stakers, address commonColonyAddress, uint reward, uint miningSkillId) public;
 
   function reputationMiningWindowOpenTimestamp() public view returns (uint);
 }

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -87,7 +87,7 @@ contract IReputationMiningCycle {
   /// @dev If you know that the disagreement doesn't involve a new reputation being added, the arguments corresponding to the previous new reputation can be zeroed, as they will not be used. You must be sure
   /// that this is the case, however, otherwise you risk being found incorrect. Zeroed arguments will result in a cheaper call to this function.
   function respondToChallenge(
-    uint256[9] u, //An array of 9 UINT Params, ordered as given above.
+    uint256[10] u, //An array of 10 UINT Params, ordered as given above.
     bytes _reputationKey,
     bytes32[] reputationSiblings,
     bytes agreeStateReputationValue,

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -458,7 +458,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
       reputationUpdateLog.push(ReputationLogEntry(
         stakers[i],
         int256(reward),
-        0, //TODO: Work out what skill this should be. This should be a special 'mining' skill.
+        miningSkillId, //This should be the special 'mining' skill.
         commonColonyAddress, // They earn this reputation in the common colony.
         4, // Updates the user's skill, and the colony's skill, both globally and for the special 'mining' skill
         i*4 //We're zero indexed, so this is the number of updates that came before in the reputation log.

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -325,9 +325,10 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   uint constant U_DISAGREE_STATE_BRANCH_MASK = 6;
   uint constant U_PREVIOUS_NEW_REPUTATION_BRANCH_MASK = 7;
   uint constant U_REQUIRE_REPUTATION_CHECK = 8;
+  uint constant U_LOG_ENTRY_NUMBER = 9;
 
   function respondToChallenge(
-    uint256[9] u, //An array of 9 UINT Params, ordered as given above.
+    uint256[10] u, //An array of 10 UINT Params, ordered as given above.
     bytes _reputationKey,
     bytes32[] reputationSiblings,
     bytes agreeStateReputationValue,
@@ -356,7 +357,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     //    that it's a decay calculation - not yet implemented.)
 
     // Check the supplied key is appropriate.
-    checkKey(u[U_ROUND], u[U_IDX], _reputationKey);
+    checkKey(u[U_ROUND], u[U_IDX], u[U_LOG_ENTRY_NUMBER], _reputationKey);
 
     // Prove the reputation's starting value is in some state, and that state is in the appropriate index in our JRH
     proveBeforeReputationValue(u, _reputationKey, reputationSiblings, agreeStateReputationValue, agreeStateSiblings);
@@ -449,7 +450,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     return (x.user, x.amount, x.skillId, x.colony, x.nUpdates, x.nPreviousUpdates);
   }
 
-  function rewardStakersWithReputation(address[] stakers, address commonColonyAddress, uint reward) public {
+  function rewardStakersWithReputation(address[] stakers, address commonColonyAddress, uint reward, uint miningSkillId) public {
     require(reputationUpdateLog.length==0);
     require(msg.sender == colonyNetworkAddress);
     for (uint256 i = 0; i < stakers.length; i++) {
@@ -519,10 +520,19 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     disputeRounds[round][opponentIdx].lastResponseTimestamp = now;
   }
 
-  function checkKey( uint256 round, uint256 idx, bytes memory _reputationKey) internal {
+  function checkKey( uint256 round, uint256 idx, uint256 logEntryNumber, bytes memory _reputationKey) internal {
     // If the state transition we're checking is less than the number of nodes in the currently accepted state, it's a decay transition (TODO: not implemented)
     // Otherwise, look up the corresponding entry in the reputation log.
     uint256 updateNumber = disputeRounds[round][idx].lowerBound - 1;
+    ReputationLogEntry storage logEntry = reputationUpdateLog[logEntryNumber];
+
+    // Check that the supplied log entry corresponds to this update number
+    require(updateNumber >= logEntry.nPreviousUpdates);
+    require(updateNumber < logEntry.nUpdates + logEntry.nPreviousUpdates);
+    uint expectedSkillId;
+    address expectedAddress;
+    (expectedSkillId, expectedAddress) = getExpectedSkillIdAndAddress(logEntry, updateNumber);
+
     bytes memory reputationKey = new bytes(20+32+20);
     reputationKey = _reputationKey;
     address colonyAddress;
@@ -539,13 +549,46 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     bool decayCalculation = false;
     if (decayCalculation) {
     } else {
-      require(reputationUpdateLog[updateNumber].user == userAddress);
-      require(reputationUpdateLog[updateNumber].colony == colonyAddress);
-      require(reputationUpdateLog[updateNumber].skillId == skillId);
+      require(expectedAddress == userAddress);
+      require(logEntry.colony == colonyAddress);
+      require(expectedSkillId == skillId);
     }
   }
 
-  function proveBeforeReputationValue(uint256[9] u, bytes _reputationKey, bytes32[] reputationSiblings, bytes agreeStateReputationValue, bytes32[] agreeStateSiblings) internal {
+  function getExpectedSkillIdAndAddress( ReputationLogEntry storage logEntry, uint updateNumber ) internal returns (uint256 expectedSkillId, address expectedAddress) {
+    // Work out the expected userAddress and skillId for this updateNumber in this logEntry.
+    if ((updateNumber - logEntry.nPreviousUpdates + 1) <= logEntry.nUpdates / 2 ) {
+      // Then we're updating a colony-wide total, so we expect an address of 0x0
+      expectedAddress = 0x0;
+    } else {
+      // We're updating a user-specific total
+      expectedAddress = logEntry.user;
+    }
+
+    // Expected skill Id
+    // We update skills in the order children, then parents, then the skill listed in the log itself.
+    // If the amount in the log is positive, then no children are being updated.
+    uint nParents;
+    (nParents, ) = IColonyNetwork(colonyNetworkAddress).getSkill(logEntry.skillId);
+    uint nChildUpdates;
+    if (logEntry.amount >= 0) {
+      // Then we have no child updates to consider
+    } else {
+      nChildUpdates = logEntry.nUpdates/2 - 1 - nParents;
+      // NB This is not necessarily the same as nChildren. However, this is the number of child updates
+      // that this entry in the log was expecting at the time it was created.
+    }
+    uint256 relativeUpdateNumber = (updateNumber - logEntry.nPreviousUpdates) % (logEntry.nUpdates/2);
+    if (relativeUpdateNumber < nChildUpdates) {
+      expectedSkillId = IColonyNetwork(colonyNetworkAddress).getChildSkillId(logEntry.skillId, relativeUpdateNumber);
+    } else if (relativeUpdateNumber < (nChildUpdates+nParents)) {
+      expectedSkillId = IColonyNetwork(colonyNetworkAddress).getParentSkillId(logEntry.skillId, relativeUpdateNumber - nChildUpdates);
+    } else {
+      expectedSkillId = logEntry.skillId;
+    }
+  }
+
+  function proveBeforeReputationValue(uint256[10] u, bytes _reputationKey, bytes32[] reputationSiblings, bytes agreeStateReputationValue, bytes32[] agreeStateSiblings) internal {
     bytes32 jrh = disputeRounds[u[U_ROUND]][u[U_IDX]].jrh;
     uint256 lastAgreeIdx = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1; // We binary searched to the first disagreement, so the last agreement is the one before.
     uint256 reputationValue;
@@ -581,7 +624,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     // where we don't prove anything with merkle proofs in this whole dance is here.
   }
 
-  function proveAfterReputationValue(uint256[9] u, bytes _reputationKey, bytes32[] reputationSiblings, bytes disagreeStateReputationValue, bytes32[] disagreeStateSiblings) internal {
+  function proveAfterReputationValue(uint256[10] u, bytes _reputationKey, bytes32[] reputationSiblings, bytes disagreeStateReputationValue, bytes32[] disagreeStateSiblings) internal {
     bytes32 jrh = disputeRounds[u[U_ROUND]][u[U_IDX]].jrh;
     uint256 firstDisagreeIdx = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound;
     bytes32 reputationRootHash = getImpliedRoot(_reputationKey, disagreeStateReputationValue, u[U_REPUTATION_BRANCH_MASK], reputationSiblings);
@@ -601,9 +644,10 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     require(jrh==impliedRoot, "colony-invalid-after-reputation-proof");
   }
 
-  function performReputationCalculation(uint256[9] u, bytes agreeStateReputationValueBytes, bytes disagreeStateReputationValueBytes, bytes previousNewReputationValueBytes) internal {
+  function performReputationCalculation(uint256[10] u, bytes agreeStateReputationValueBytes, bytes disagreeStateReputationValueBytes, bytes previousNewReputationValueBytes) internal {
     // TODO: Possibility of decay calculation
-    uint reputationTransitionIdx = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1;
+    // TODO: Possibility of reputation loss - child reputations do not lose the whole of logEntry.amount, but the same fraction logEntry amount is of the user's reputation in skill given by logEntry.skillId
+    ReputationLogEntry storage logEntry = reputationUpdateLog[u[U_LOG_ENTRY_NUMBER]];
     int256 amount;
     uint256 agreeStateReputationValue;
     uint256 disagreeStateReputationValue;
@@ -635,20 +679,20 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
 
     // We don't care about underflows for the purposes of comparison, but for the calculation we deem 'correct'.
     // i.e. a reputation can't be negative.
-    if (reputationUpdateLog[reputationTransitionIdx].amount < 0 && uint(reputationUpdateLog[reputationTransitionIdx].amount * -1) > agreeStateReputationValue ) {
+    if (logEntry.amount < 0 && uint(logEntry.amount * -1) > agreeStateReputationValue ) {
       require(disagreeStateReputationValue == 0);
-    } else if (uint(reputationUpdateLog[reputationTransitionIdx].amount) + agreeStateReputationValue < agreeStateReputationValue) {
+    } else if (uint(logEntry.amount) + agreeStateReputationValue < agreeStateReputationValue) {
       // We also don't allow reputation to overflow
       require(disagreeStateReputationValue == 2**256 - 1);
     } else {
       // TODO: Is this safe? I think so, because even if there's over/underflows, they should
       // still be the same number.
-      require(int(agreeStateReputationValue)+reputationUpdateLog[reputationTransitionIdx].amount == int(disagreeStateReputationValue));
+      require(int(agreeStateReputationValue)+logEntry.amount == int(disagreeStateReputationValue));
     }
   }
 
   function checkPreviousReputationInState(
-    uint256[9] u,
+    uint256[10] u,
     bytes _reputationKey,
     bytes32[] reputationSiblings,
     bytes agreeStateReputationValue,
@@ -674,7 +718,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     require(impliedRoot == disputeRounds[u[U_ROUND]][u[U_IDX]].jrh);
   }
 
-  function saveProvedReputation(uint256[9] u, bytes previousNewReputationValue) internal {
+  function saveProvedReputation(uint256[10] u, bytes previousNewReputationValue) internal {
     uint256 previousReputationUID;
     assembly {
       previousReputationUID := mload(add(previousNewReputationValue,0x40))
@@ -699,10 +743,13 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
 
   function checkJRHProof2(uint round, uint index, bytes32 jrh, uint branchMask2, bytes32[] siblings2) internal {
     // Proof 2 needs to prove that they finished with the reputation root hash they submitted, and the
-    // key is the number of updates in the reputation update log (implemented)
+    // key is the number of updates implied by the contents of the reputation update log (implemented)
     // plus the number of nodes in the last accepted update, each of which will have decayed once (not implemented)
     // TODO: Account for decay calculations
-    uint256 nUpdates = reputationUpdateLog.length;
+    uint256 nLogEntries = reputationUpdateLog.length;
+    // The total number of updates we expect is the nPreviousUpdates in the last entry of the log plus the number
+    // of updates that log entry implies by itself.
+    uint256 nUpdates = reputationUpdateLog[nLogEntries-1].nUpdates + reputationUpdateLog[nLogEntries-1].nPreviousUpdates;
     bytes memory nUpdatesBytes = new bytes(32);
     disputeRounds[round][index].jrhNnodes = nUpdates + 1;
     bytes32 submittedHash = disputeRounds[round][index].proposedNewRootHash;

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -86,7 +86,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
 
   /// @notice A modifier that checks that the supplied `roundNumber` is the final round
   /// @param roundNumber The `roundNumber` to check if it is the final round
-  modifier finalDisputeRoundCompleted(uint roundNumber) {
+  modifier finalDisputeRoundCompleted(uint256 roundNumber) {
     require (nSubmittedHashes - nInvalidatedHashes == 1);
     require (disputeRounds[roundNumber].length == 1); //i.e. this is the final round
     // Note that even if we are passed the penultimate round, which had a length of two, and had one eliminated,
@@ -296,7 +296,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     //TODO: Can we do some deleting to make calling this as cheap as possible for people?
   }
 
-  function respondToBinarySearchForChallenge(uint256 round, uint256 idx, bytes jhIntermediateValue, uint branchMask, bytes32[] siblings) public {
+  function respondToBinarySearchForChallenge(uint256 round, uint256 idx, bytes jhIntermediateValue, uint256 branchMask, bytes32[] siblings) public {
     // TODO: Check this challenge is active.
     // This require is necessary, but not a sufficient check (need to check we have an opponent, at least).
     require(disputeRounds[round][idx].lowerBound!=disputeRounds[round][idx].upperBound);
@@ -398,9 +398,9 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     uint256 round,
     uint256 index,
     bytes32 jrh,
-    uint branchMask1,
+    uint256 branchMask1,
     bytes32[] siblings1,
-    uint branchMask2,
+    uint256 branchMask2,
     bytes32[] siblings2
   ) public
   {
@@ -420,7 +420,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     disputeRounds[round][index].upperBound = disputeRounds[round][index].jrhNnodes;
   }
 
-  function appendReputationUpdateLog(address _user, int _amount, uint _skillId, address _colonyAddress, uint _nParents, uint _nChildren) public {
+  function appendReputationUpdateLog(address _user, int _amount, uint256 _skillId, address _colonyAddress, uint256 _nParents, uint256 _nChildren) public {
     require(colonyNetworkAddress == msg.sender);
     uint reputationUpdateLogLength = reputationUpdateLog.length;
     uint nPreviousUpdates = 0;
@@ -450,7 +450,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     return (x.user, x.amount, x.skillId, x.colony, x.nUpdates, x.nPreviousUpdates);
   }
 
-  function rewardStakersWithReputation(address[] stakers, address commonColonyAddress, uint reward, uint miningSkillId) public {
+  function rewardStakersWithReputation(address[] stakers, address commonColonyAddress, uint256 reward, uint256 miningSkillId) public {
     require(reputationUpdateLog.length==0);
     require(msg.sender == colonyNetworkAddress);
     for (uint256 i = 0; i < stakers.length; i++) {
@@ -555,7 +555,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     }
   }
 
-  function getExpectedSkillIdAndAddress( ReputationLogEntry storage logEntry, uint updateNumber ) internal returns (uint256 expectedSkillId, address expectedAddress) {
+  function getExpectedSkillIdAndAddress( ReputationLogEntry storage logEntry, uint256 updateNumber ) internal returns (uint256 expectedSkillId, address expectedAddress) {
     // Work out the expected userAddress and skillId for this updateNumber in this logEntry.
     if ((updateNumber - logEntry.nPreviousUpdates + 1) <= logEntry.nUpdates / 2 ) {
       // Then we're updating a colony-wide total, so we expect an address of 0x0
@@ -727,7 +727,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     disputeRounds[u[U_ROUND]][u[U_IDX]].provedPreviousReputationUID = previousReputationUID;
   }
 
-  function checkJRHProof1(bytes32 jrh, uint branchMask1, bytes32[] siblings1) internal {
+  function checkJRHProof1(bytes32 jrh, uint256 branchMask1, bytes32[] siblings1) internal {
     // Proof 1 needs to prove that they started with the current reputation root hash
     bytes32 reputationRootHash = IColonyNetwork(colonyNetworkAddress).getReputationRootHash();
     uint256 reputationRootHashNNodes = IColonyNetwork(colonyNetworkAddress).getReputationRootHashNNodes();
@@ -741,7 +741,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     require(jrh==impliedRoot, "colony-invalid-jrh-proof-1");
   }
 
-  function checkJRHProof2(uint round, uint index, bytes32 jrh, uint branchMask2, bytes32[] siblings2) internal {
+  function checkJRHProof2(uint256 round, uint256 index, bytes32 jrh, uint256 branchMask2, bytes32[] siblings2) internal {
     // Proof 2 needs to prove that they finished with the reputation root hash they submitted, and the
     // key is the number of updates implied by the contents of the reputation update log (implemented)
     // plus the number of nodes in the last accepted update, each of which will have decayed once (not implemented)

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -99,9 +99,9 @@ contract("All", accounts => {
 
     it("when working with the Meta Colony", async () => {
       await metaColony.addGlobalSkill(1);
-      await metaColony.addGlobalSkill(5);
       await metaColony.addGlobalSkill(6);
       await metaColony.addGlobalSkill(7);
+      await metaColony.addGlobalSkill(8);
     });
 
     it("when working with a Colony", async () => {
@@ -283,12 +283,18 @@ contract("All", accounts => {
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
 
+      await goodClient.respondToBinarySearchForChallenge();
+      await badClient.respondToBinarySearchForChallenge();
+
       // We now know where they disagree
       await goodClient.respondToChallenge();
       // badClient will fail this if we try
       // await badClient.respondToChallenge();
       await oneHourLater();
       await repCycle.invalidateHash(0, 1);
+
+      await goodClient.respondToBinarySearchForChallenge();
+      await badClient2.respondToBinarySearchForChallenge();
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient2.respondToBinarySearchForChallenge();

--- a/migrations/5_setup_meta_colony.js
+++ b/migrations/5_setup_meta_colony.js
@@ -30,7 +30,7 @@ module.exports = deployer => {
     .then(() => colonyNetwork.startNextCycle())
     .then(() => colonyNetwork.getSkillCount.call())
     .then(skillCount => {
-      assert.equal(skillCount.toNumber(), 2);
+      assert.equal(skillCount.toNumber(), 3);
       return colonyNetwork.getMetaColony.call();
     })
     .then(metaColonyAddress => {

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -180,7 +180,7 @@ class ReputationMiner {
    */
   async addSingleLogEntry(i) {
     const addr = await this.colonyNetwork.getReputationMiningCycle(true);
-    const repCycle = new ethers.Contract(addr, ReputationMiningCycleJSON.abi, this.realWallet);
+    const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
     const logEntry = await repCycle.getReputationUpdateLogEntry(i.toString()); // eslint-disable-line no-await-in-loop
 
     const nUpdates = new BN(logEntry[4].toString());
@@ -319,7 +319,7 @@ class ReputationMiner {
   async getLogEntryNumberForUpdateNumber(_i) {
     const updateNumber = new BN(_i.toString());
     const addr = await this.colonyNetwork.getReputationMiningCycle(true);
-    const repCycle = new ethers.Contract(addr, ReputationMiningCycleJSON.abi, this.realWallet);
+    const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
     const nLogEntries = await repCycle.getReputationUpdateLogLength();
     let lower = new BN("0");
     let upper = new BN(nLogEntries.toString()).subn(1);
@@ -347,7 +347,7 @@ class ReputationMiner {
     const updateNumber = new BN(_i.toString());
     const logEntryNumber = await this.getLogEntryNumberForUpdateNumber(updateNumber);
     const addr = await this.colonyNetwork.getReputationMiningCycle(true);
-    const repCycle = new ethers.Contract(addr, ReputationMiningCycleJSON.abi, this.realWallet);
+    const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
 
     const logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber.toString());
 
@@ -510,7 +510,7 @@ class ReputationMiner {
     const [branchMask1, siblings1] = await this.justificationTree.getProof(`0x${new BN("0").toString(16, 64)}`);
 
     const addr = await this.colonyNetwork.getReputationMiningCycle(true);
-    const repCycle = new ethers.Contract(addr, repCycleContractDef.abi, this.realWallet);
+    const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
     let nLogEntries = await repCycle.getReputationUpdateLogLength();
     nLogEntries = new BN(nLogEntries.toString());
     const lastLogEntry = await repCycle.getReputationUpdateLogEntry(nLogEntries.subn(1).toString());

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -145,9 +145,30 @@ class ReputationMiner {
 
     let nLogEntries = await repCycle.getReputationUpdateLogLength();
     nLogEntries = new BN(nLogEntries.toString());
-    for (let i = new BN("0"); i.lte(nLogEntries); i.iadd(new BN("1"))) {
-      await this.addSingleLogEntry(i, i.eq(nLogEntries)); // eslint-disable-line no-await-in-loop
+    for (let i = new BN("0"); i.lt(nLogEntries); i.iadd(new BN("1"))) {
+      await this.addSingleLogEntry(i); // eslint-disable-line no-await-in-loop
     }
+
+    const lastLogEntry = await repCycle.getReputationUpdateLogEntry(nLogEntries.subn(1).toString());
+    const nUpdates = new BN(lastLogEntry[4].add(lastLogEntry[5]).toString());
+    const prevKey = await this.getKeyForUpdateNumber(nUpdates.subn(1));
+    const justUpdatedProof = await this.getReputationProofObject(prevKey);
+    const newestReputationProof = await this.getNewestReputationProofObject(nUpdates);
+    const interimHash = await this.reputationTree.getRootHash(); // eslint-disable-line no-await-in-loop
+    const jhLeafValue = this.getJRHEntryValueAsBytes(interimHash, this.nReputations);
+    const nextUpdateProof = {};
+    await this.justificationTree.insert(`0x${nUpdates.toString(16, 64)}`, jhLeafValue, { gasLimit: 4000000 }); // eslint-disable-line no-await-in-loop
+
+    this.justificationHashes[`0x${nUpdates.toString(16, 64)}`] = JSON.parse(
+      JSON.stringify({
+        interimHash,
+        nNodes: this.nReputations,
+        jhLeafValue,
+        justUpdatedProof,
+        nextUpdateProof,
+        newestReputationProof
+      })
+    );
   }
 
   /**
@@ -155,47 +176,52 @@ class ReputationMiner {
    * as it does so.
    * @param  {Number}  i    The index of the log entry to process. Note that the final time this function is called, it is equal to the number of logs entries
    *                        present, which could cause out-of-bounds errors if unchecke. In this case, `last` will be set to true to avoid errors.
-   * @param  {Boolean}  last Set to `true` if `i` is out of bounds of the log.
    * @return {Promise}
    */
-  async addSingleLogEntry(i, last) {
+  async addSingleLogEntry(i) {
+    const addr = await this.colonyNetwork.getReputationMiningCycle(true);
+    const repCycle = new ethers.Contract(addr, ReputationMiningCycleJSON.abi, this.realWallet);
+    const logEntry = await repCycle.getReputationUpdateLogEntry(i.toString()); // eslint-disable-line no-await-in-loop
+
+    const nUpdates = new BN(logEntry[4].toString());
+    for (let j = new BN("0"); j.lt(nUpdates); j.iadd(new BN("1"))) {
+      await this.addSingleReputationUpdate(j, logEntry); // eslint-disable-line no-await-in-loop
+    }
+  }
+
+  /**
+   * Process the `j`th update that the log entry logEntry implies, and add to the current reputation state and the
+   * justificationtree.
+   * @param  {BigNumber}  j     The number of the update that the the log entry implies that should be considered.
+   * @param  {[type]}  logEntry The log entry describing the reputation change to be applied
+   * @return {Promise}
+   */
+  async addSingleReputationUpdate(j, logEntry) {
     let interimHash;
     let jhLeafValue;
     let justUpdatedProof;
     let newestReputationProof;
     interimHash = await this.reputationTree.getRootHash(); // eslint-disable-line no-await-in-loop
-    // console.log(interimHash);
     jhLeafValue = this.getJRHEntryValueAsBytes(interimHash, this.nReputations);
-    // console.log(jhLeafValue);
-    let logEntry;
-    if (!last) {
-      const addr = await this.colonyNetwork.getReputationMiningCycle(true);
-      const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
-      logEntry = await repCycle.getReputationUpdateLogEntry(i.toString()); // eslint-disable-line no-await-in-loop
-    } else {
-      logEntry = ["0x", 0, 0, "0x", 0];
-    }
-    const score = this.getScore(i, logEntry);
-    if (i.toString() === "0") {
+    const updateNumber = new BN(logEntry[5].add(j).toString());
+    const score = this.getScore(updateNumber, logEntry);
+
+    if (updateNumber.toString() === "0") {
       // TODO If it's not already this value, then something has gone wrong, and we're working with the wrong state.
       // This 'if' statement is only in for now to make tests easier to write.
       interimHash = await this.colonyNetwork.getReputationRootHash(); // eslint-disable-line no-await-in-loop
       jhLeafValue = this.getJRHEntryValueAsBytes(interimHash, this.nReputations);
     } else {
-      const prevKey = await this.getKeyForLogEntry(i.subn(1));
+      const prevKey = await this.getKeyForUpdateNumber(updateNumber.subn(1));
       justUpdatedProof = await this.getReputationProofObject(prevKey);
-      newestReputationProof = await this.getNewestReputationProofObject(i);
+      newestReputationProof = await this.getNewestReputationProofObject(updateNumber);
     }
-    await this.justificationTree.insert(`0x${i.toString(16, 64)}`, jhLeafValue, { gasLimit: 4000000 }); // eslint-disable-line no-await-in-loop
+    await this.justificationTree.insert(`0x${updateNumber.toString(16, 64)}`, jhLeafValue, { gasLimit: 4000000 }); // eslint-disable-line no-await-in-loop
 
-    let key;
-    let nextUpdateProof = {};
-    if (!last) {
-      key = await this.getKeyForLogEntry(i);
-      nextUpdateProof = await this.getReputationProofObject(key);
-    }
+    const key = await this.getKeyForUpdateNumber(updateNumber);
+    const nextUpdateProof = await this.getReputationProofObject(key);
 
-    this.justificationHashes[`0x${i.toString(16, 64)}`] = JSON.parse(
+    this.justificationHashes[`0x${updateNumber.toString(16, 64)}`] = JSON.parse(
       JSON.stringify({
         interimHash,
         nNodes: this.nReputations,
@@ -206,12 +232,12 @@ class ReputationMiner {
       })
     );
 
-    // We have to process these sequentially - if two updates affected the
-    // same entry, we would have a potential race condition.
-    // Hence, we are awaiting inside these loops.
-    // TODO: Include updates for all parent skills (and child, if x.amount is negative)
-    // TODO: Include updates for colony-wide sums of skills.
-    await this.insert(logEntry[3], logEntry[2], logEntry[0], score, i); // eslint-disable-line no-await-in-loop
+    const [skillId, skillAddress] = await this.getSkillIdAndAddressForUpdateInLogEntry(j, logEntry); // eslint-disable-line no-await-in-loop
+
+    // TODO: Include updates for all child skills if x.amount is negative
+    // We update colonywide sums first (children, parents, skill)
+    // Then the user-specifc sums in the order children, parents, skill.
+    await this.insert(logEntry[3], skillId, skillAddress, score, updateNumber); // eslint-disable-line no-await-in-loop
   }
 
   /**
@@ -282,6 +308,116 @@ class ReputationMiner {
       40
     )}`;
     return key;
+  }
+
+  /**
+   * For update `_i` in the reputationUpdateLog currently under consideration, return the log entry that contains that update. Note that these
+   * are not the same number because each entry in the log implies multiple reputation updates.
+   * @param  {Number}  _i The update number we wish to determine which log entry in the reputationUpdateLog creates
+   * @return {Promise}   A promise that resolves to the number of the corresponding log entry.
+   */
+  async getLogEntryNumberForUpdateNumber(_i) {
+    const updateNumber = new BN(_i.toString());
+    const addr = await this.colonyNetwork.getReputationMiningCycle(true);
+    const repCycle = new ethers.Contract(addr, ReputationMiningCycleJSON.abi, this.realWallet);
+    const nLogEntries = await repCycle.getReputationUpdateLogLength();
+    let lower = new BN("0");
+    let upper = new BN(nLogEntries.toString()).subn(1);
+
+    while (!upper.eq(lower)) {
+      const testIdx = lower.add(upper.sub(lower).divn(2));
+      const testLogEntry = await repCycle.getReputationUpdateLogEntry(testIdx); // eslint-disable-line no-await-in-loop
+      if (new BN(testLogEntry[5].toString()).gt(updateNumber)) {
+        upper = testIdx.subn(1);
+      } else if (
+        new BN(testLogEntry[5].toString()).lte(updateNumber) &&
+        new BN(testLogEntry[5].toString()).add(new BN(testLogEntry[4].toString())).gt(updateNumber)
+      ) {
+        upper = testIdx;
+        lower = testIdx;
+      } else {
+        lower = testIdx.addn(1);
+      }
+    }
+
+    return lower;
+  }
+
+  async getKeyForUpdateNumber(_i) {
+    const updateNumber = new BN(_i.toString());
+    const logEntryNumber = await this.getLogEntryNumberForUpdateNumber(updateNumber);
+    const addr = await this.colonyNetwork.getReputationMiningCycle(true);
+    const repCycle = new ethers.Contract(addr, ReputationMiningCycleJSON.abi, this.realWallet);
+
+    const logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber.toString());
+
+    const [skillId, userAddress] = await this.getSkillIdAndAddressForUpdateInLogEntry(updateNumber.sub(new BN(logEntry[5].toString())), logEntry);
+    const key = `0x${new BN(logEntry[3].slice(2), 16).toString(16, 40)}${new BN(skillId.toString()).toString(16, 64)}${new BN(
+      userAddress.slice(2),
+      16
+    ).toString(16, 40)}`;
+    return key;
+  }
+
+  /**
+   * Gets the skillId and 'user' address appropriate for the nth reputation update that logEntry implies.
+   * If updateNumber is in the first half of the number of updates logEntry implies, `skillAddress` is 0x0, as
+   * this corresponds to a colony-wide total amount of reputation being update. Otherwise, `skillAddress` is the
+   * address of the user in the log entry.
+   * The skillId depends on whether it is a child, parent or the skill listed in the log entry itself being updated.
+   * @param  {BigNumber}  _updateNumber The number of the update the log entry implies we want the information for. Must be less than logEntry[4].
+   * @param  {LogEntry}  logEntry An array six long, containing the log entry in question [userAddress, amount, skillId, colony, nUpdates, nPreviousUpdates ]
+   * @return {Promise}              Promise that resolves to [skillId, address]
+   */
+  async getSkillIdAndAddressForUpdateInLogEntry(_updateNumber, logEntry) {
+    const updateNumber = new BN(_updateNumber.toString());
+    let skillAddress;
+    // We need to work out the skillId and user address to use.
+    // If we are in the first half of 'j's, then we are dealing with global update, so
+    // the skilladdress will be 0x0, rather than the user address
+    if (updateNumber.lt(new BN(logEntry[4].toString()).divn(2))) {
+      skillAddress = "0x0000000000000000000000000000000000000000";
+    } else {
+      skillAddress = logEntry[0]; // eslint-disable-line prefer-destructuring
+      // Following the destructuring rule, this line would be [skillAddress] = logEntry, which I think is very misleading
+    }
+    const nUpdates = new BN(logEntry[4].toString());
+    const score = this.getScore(updateNumber, logEntry);
+
+    let [nParents] = await this.colonyNetwork.getSkill(logEntry[2]);
+    nParents = new BN(nParents.toString());
+    let skillId;
+    // NB This is not necessarily the same as nChildren. However, this is the number of child updates
+    // that this entry in the log was expecting at the time it was created.
+    let nChildUpdates;
+    if (score.gte(new BN("0"))) {
+      nChildUpdates = new BN("0");
+    } else {
+      nChildUpdates = nUpdates
+        .divn(2)
+        .subn(1)
+        .sub(new BN(nParents.toString()));
+    }
+    // The list of skill ids to be updated is the same for the first half and the second half of the list of updates this
+    // log entry implies, it's just the skillAddress that is different, which we've already established. So
+    let skillIndex;
+    if (updateNumber.gte(nUpdates.divn(2))) {
+      skillIndex = updateNumber.sub(nUpdates.divn(2));
+    } else {
+      skillIndex = updateNumber;
+    }
+
+    if (skillIndex.lt(nChildUpdates)) {
+      // Then the skill being updated is the skillIndex-th child skill
+      skillId = await this.colonyNetwork.getChildSkillId(logEntry[2].toString(), skillIndex.toString());
+    } else if (skillIndex.lt(nChildUpdates.add(nParents))) {
+      // Then the skill being updated is the skillIndex-nChildUpdates-th parent skill
+      skillId = await this.colonyNetwork.getParentSkillId(logEntry[2].toString(), skillIndex.sub(nChildUpdates).toString());
+    } else {
+      // Then the skill being update is the skill itself - not a parent or child
+      skillId = logEntry[2]; // eslint-disable-line prefer-destructuring
+    }
+    return [skillId, skillAddress];
   }
 
   /**
@@ -374,14 +510,17 @@ class ReputationMiner {
     const [branchMask1, siblings1] = await this.justificationTree.getProof(`0x${new BN("0").toString(16, 64)}`);
 
     const addr = await this.colonyNetwork.getReputationMiningCycle(true);
-    const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
-    const nLogEntries = await repCycle.getReputationUpdateLogLength();
-
-    const [branchMask2, siblings2] = await this.justificationTree.getProof(`0x${new BN(nLogEntries.toString()).toString(16, 64)}`);
+    const repCycle = new ethers.Contract(addr, repCycleContractDef.abi, this.realWallet);
+    let nLogEntries = await repCycle.getReputationUpdateLogLength();
+    nLogEntries = new BN(nLogEntries.toString());
+    const lastLogEntry = await repCycle.getReputationUpdateLogEntry(nLogEntries.subn(1).toString());
+    const nUpdates = new BN(lastLogEntry[4].toString()).add(new BN(lastLogEntry[5].toString()));
+    const [branchMask2, siblings2] = await this.justificationTree.getProof(`0x${nUpdates.toString(16, 64)}`);
     const [round, index] = await this.getMySubmissionRoundAndIndex();
-    return repCycle.submitJustificationRootHash(round.toString(), index.toString(), jrh, branchMask1, siblings1, branchMask2, siblings2, {
+    const res = repCycle.submitJustificationRootHash(round.toString(), index.toString(), jrh, branchMask1, siblings1, branchMask2, siblings2, {
       gasLimit: 6000000
     });
+    return res;
   }
 
   /**
@@ -454,17 +593,14 @@ class ReputationMiner {
     // console.log(submission);
     const firstDisagreeIdx = new BN(submission[8].toString());
     const lastAgreeIdx = firstDisagreeIdx.subn(1);
-    const logEntry = await repCycle.getReputationUpdateLogEntry(lastAgreeIdx.toString());
-    const colonyAddress = logEntry[3];
-    const skillId = logEntry[2];
-    const userAddress = logEntry[0];
-    const reputationKey = `0x${new BN(colonyAddress.slice(2), 16).toString(16, 40)}${new BN(skillId.toString()).toString(16, 64)}${new BN(
-      userAddress.slice(2),
-      16
-    ).toString(16, 40)}`;
+    // console.log('getReputationUPdateLogEntry', lastAgreeIdx);
+    // const logEntry = await repCycle.getReputationUpdateLogEntry(lastAgreeIdx.toString());
+    // console.log('getReputationUPdateLogEntry done');
+    const reputationKey = await this.getKeyForUpdateNumber(lastAgreeIdx.toString());
     // console.log('get justification tree');
     const [agreeStateBranchMask, agreeStateSiblings] = await this.justificationTree.getProof(`0x${lastAgreeIdx.toString(16, 64)}`);
     const [disagreeStateBranchMask, disagreeStateSiblings] = await this.justificationTree.getProof(`0x${firstDisagreeIdx.toString(16, 64)}`);
+    const logEntryNumber = await this.getLogEntryNumberForUpdateNumber(lastAgreeIdx.toString());
     // console.log('get justification tree done');
 
     // These comments can help with debugging. This implied root is the intermediate root hash that is implied
@@ -511,7 +647,8 @@ class ReputationMiner {
         this.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.nNodes,
         toHexString(disagreeStateBranchMask),
         this.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.branchMask,
-        0
+        0,
+        logEntryNumber.toString()
       ],
       reputationKey,
       this.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.siblings,

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongNewestReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongNewestReputation.js
@@ -1,0 +1,22 @@
+import BN from "bn.js";
+import ReputationMiningClient from "../ReputationMiner";
+
+class MaliciousReputationMiningWrongNewestReputation extends ReputationMiningClient {
+  // This client will supply the wrong newest reputation as part of its proof
+  constructor(opts, amountToFalsify) {
+    super(opts);
+    this.amountToFalsify = new BN(amountToFalsify.toString());
+  }
+
+  async getNewestReputationProofObject() {
+    let key;
+    if (this.nReputations - this.amountToFalsify < 0) {
+      [key] = Object.keys(this.reputations);
+    } else {
+      key = Object.keys(this.reputations)[this.nReputations - this.amountToFalsify];
+    }
+    return this.getReputationProofObject(key);
+  }
+}
+
+export default MaliciousReputationMiningWrongNewestReputation;

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -1,0 +1,55 @@
+import BN from "bn.js";
+import ReputationMiningClient from "../ReputationMiner";
+
+const ethers = require("ethers");
+const ReputationMiningCycleJSON = require("../../../build/contracts/IReputationMiningCycle.json"); // eslint-disable-line import/no-unresolved
+
+class MaliciousReputationMiningWrongProofLogEntry extends ReputationMiningClient {
+  // This client will supply the wrong log entry as part of its proof
+  constructor(opts, amountToFalsify) {
+    super(opts);
+    this.amountToFalsify = new BN(amountToFalsify.toString());
+  }
+
+  async respondToChallenge() {
+    const [round, index] = await this.getMySubmissionRoundAndIndex();
+    const addr = await this.colonyNetwork.getReputationMiningCycle(true);
+    const repCycle = new ethers.Contract(addr, ReputationMiningCycleJSON.abi, this.realWallet);
+    const submission = await repCycle.disputeRounds(round.toString(), index.toString());
+    const firstDisagreeIdx = new BN(submission[8].toString());
+    const lastAgreeIdx = firstDisagreeIdx.subn(1);
+    const reputationKey = await this.getKeyForUpdateNumber(lastAgreeIdx.toString());
+    // console.log('get justification tree');
+    const [agreeStateBranchMask, agreeStateSiblings] = await this.justificationTree.getProof(`0x${lastAgreeIdx.toString(16, 64)}`);
+    const [disagreeStateBranchMask, disagreeStateSiblings] = await this.justificationTree.getProof(`0x${firstDisagreeIdx.toString(16, 64)}`);
+    const logEntryNumber = await this.getLogEntryNumberForUpdateNumber(lastAgreeIdx.toString());
+    logEntryNumber.iadd(this.amountToFalsify);
+    const tx = await repCycle.respondToChallenge(
+      [
+        round.toString(),
+        index.toString(),
+        this.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.branchMask,
+        this.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].nextUpdateProof.nNodes,
+        agreeStateBranchMask.toHexString(),
+        this.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.nNodes,
+        disagreeStateBranchMask.toHexString(),
+        this.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.branchMask,
+        0,
+        logEntryNumber.toString()
+      ],
+      reputationKey,
+      this.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.siblings,
+      this.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].nextUpdateProof.value,
+      agreeStateSiblings,
+      this.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.value,
+      disagreeStateSiblings,
+      this.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.key,
+      this.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.value,
+      this.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.siblings,
+      { gasLimit: 4000000 }
+    );
+    return tx;
+  }
+}
+
+export default MaliciousReputationMiningWrongProofLogEntry;

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -30,9 +30,9 @@ class MaliciousReputationMiningWrongProofLogEntry extends ReputationMiningClient
         index.toString(),
         this.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.branchMask,
         this.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].nextUpdateProof.nNodes,
-        agreeStateBranchMask.toHexString(),
+        `0x${agreeStateBranchMask.toString(16)}`,
         this.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.nNodes,
-        disagreeStateBranchMask.toHexString(),
+        `0x${disagreeStateBranchMask.toString(16)}`,
         this.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.branchMask,
         0,
         logEntryNumber.toString()

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -1288,10 +1288,7 @@ contract("ColonyNetworkStaking", accounts => {
       await goodClient.respondToBinarySearchForChallenge();
 
       // Get the log entry we're arguing over.
-      const submission = await repCycle.disputeRounds(0, 0);
-      const firstDisagreeIdx = submission[8];
-
-      const logEntry = await repCycle.getReputationUpdateLogEntry.call(firstDisagreeIdx - 1);
+      const logEntry = await repCycle.getReputationUpdateLogEntry.call(0);
       const colonyAddress = logEntry[3].slice(2);
       const userAddress = logEntry[0].slice(2);
       const skillId = logEntry[2];
@@ -1309,9 +1306,9 @@ contract("ColonyNetworkStaking", accounts => {
         40
       )}`;
 
-      await checkErrorRevert(repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0], wrongColonyKey, [], 0x0, [], 0x0, [], 0, 0, []));
-      await checkErrorRevert(repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0], wrongReputationKey, [], 0x0, [], 0x0, [], 0, 0, []));
-      await checkErrorRevert(repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0], wrongUserKey, [], 0x0, [], 0x0, [], 0, 0, []));
+      await checkErrorRevert(repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], wrongColonyKey, [], 0x0, [], 0x0, [], 0, 0, []));
+      await checkErrorRevert(repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], wrongReputationKey, [], 0x0, [], 0x0, [], 0, 0, []));
+      await checkErrorRevert(repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], wrongUserKey, [], 0x0, [], 0x0, [], 0, 0, []));
 
       await forwardTime(600, this);
       await goodClient.respondToChallenge();

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -1462,6 +1462,7 @@ contract("ColonyNetworkStaking", accounts => {
         // churning away at once, I *think* it's slower.
         await clients[i].addLogContentsToReputationTree(); // eslint-disable-line no-await-in-loop
         await clients[i].submitRootHash(); // eslint-disable-line no-await-in-loop
+        console.log(`Client ${i} submitted JRH`); // eslint-disable-line no-console
       }
 
       const nSubmittedHashes = await repCycle.nSubmittedHashes.call();

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -831,6 +831,49 @@ contract("ColonyNetworkStaking", accounts => {
       await repCycle.confirmNewHash(1);
     });
 
+    // These tests are useful for checking that every type of parent / child / user / colony-wide-sum skills are accounted for
+    // correctly. Unsure if I should force them to be run every time.
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].forEach(async badIndex => {
+      it.skip(`should cope if wrong reputation transition is transition ${badIndex}`, async function advancingTest() {
+        await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+        await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
+
+        let addr = await colonyNetwork.getReputationMiningCycle.call();
+        let repCycle = ReputationMiningCycle.at(addr);
+        await forwardTime(3600, this);
+        await repCycle.submitRootHash("0x12345678", 10, 10);
+        await repCycle.confirmNewHash(0);
+
+        await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+        addr = await colonyNetwork.getReputationMiningCycle.call();
+        repCycle = ReputationMiningCycle.at(addr);
+        await forwardTime(3600, this);
+        await repCycle.submitRootHash("0x0", 0, 10);
+        await repCycle.confirmNewHash(0);
+        addr = await colonyNetwork.getReputationMiningCycle.call();
+        repCycle = ReputationMiningCycle.at(addr);
+
+        await goodClient.addLogContentsToReputationTree();
+
+        badClient = new MaliciousReputationMiningClient(OTHER_ACCOUNT, realProviderPort, badIndex, "0xfffffffff");
+        await badClient.initialise(colonyNetwork.address);
+        await badClient.addLogContentsToReputationTree();
+
+        let righthash = await goodClient.getRootHash();
+        let wronghash = await badClient.getRootHash();
+        righthash = await goodClient.getRootHash();
+        wronghash = await badClient.getRootHash();
+        assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
+        await forwardTime(3600, this);
+        await goodClient.submitRootHash();
+        await badClient.submitRootHash();
+
+        await forwardTime(3600, this);
+        await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
+        await repCycle.confirmNewHash(1);
+      });
+    });
+
     it("In the event of a disagreement, allows a binary search between opponents to take place to find their first disagreement", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
@@ -861,8 +904,8 @@ contract("ColonyNetworkStaking", accounts => {
       await goodClient.addLogContentsToReputationTree();
 
       badClient = new MaliciousReputationMinerExtraRep(
-        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
-        5,
+        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJSTree },
+        13,
         "0xfffffffff"
       );
       await badClient.initialise(colonyNetwork.address);
@@ -895,55 +938,64 @@ contract("ColonyNetworkStaking", accounts => {
       let badSubmission = await repCycle.disputeRounds(0, 1);
       assert.equal(goodSubmission[3].toNumber(), 1); // Challenge steps completed
       assert.equal(goodSubmission[8].toNumber(), 0); // Lower bound for binary search
-      assert.equal(goodSubmission[9].toNumber(), 14); // Upper bound for binary search
+      assert.equal(goodSubmission[9].toNumber(), 29); // Upper bound for binary search
       assert.equal(badSubmission[3].toNumber(), 1);
       assert.equal(badSubmission[8].toNumber(), 0);
-      assert.equal(badSubmission[9].toNumber(), 14);
+      assert.equal(badSubmission[9].toNumber(), 29);
       await goodClient.respondToBinarySearchForChallenge();
 
       goodSubmission = await repCycle.disputeRounds(0, 0);
       badSubmission = await repCycle.disputeRounds(0, 1);
       assert.equal(goodSubmission[3].toNumber(), 2);
       assert.equal(goodSubmission[8].toNumber(), 0);
-      assert.equal(goodSubmission[9].toNumber(), 14);
+      assert.equal(goodSubmission[9].toNumber(), 29);
       assert.equal(badSubmission[3].toNumber(), 1);
       assert.equal(badSubmission[8].toNumber(), 0);
-      assert.equal(badSubmission[9].toNumber(), 14);
+      assert.equal(badSubmission[9].toNumber(), 29);
 
       await badClient.respondToBinarySearchForChallenge();
       goodSubmission = await repCycle.disputeRounds(0, 0);
       badSubmission = await repCycle.disputeRounds(0, 1);
       assert.equal(goodSubmission[8].toNumber(), 0);
-      assert.equal(goodSubmission[9].toNumber(), 7);
+      assert.equal(goodSubmission[9].toNumber(), 14);
       assert.equal(badSubmission[8].toNumber(), 0);
-      assert.equal(badSubmission[9].toNumber(), 7);
+      assert.equal(badSubmission[9].toNumber(), 14);
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
       goodSubmission = await repCycle.disputeRounds(0, 0);
       badSubmission = await repCycle.disputeRounds(0, 1);
-      assert.equal(goodSubmission[8].toNumber(), 4);
-      assert.equal(goodSubmission[9].toNumber(), 7);
-      assert.equal(badSubmission[8].toNumber(), 4);
-      assert.equal(badSubmission[9].toNumber(), 7);
+      assert.equal(goodSubmission[8].toNumber(), 8);
+      assert.equal(goodSubmission[9].toNumber(), 14);
+      assert.equal(badSubmission[8].toNumber(), 8);
+      assert.equal(badSubmission[9].toNumber(), 14);
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
       goodSubmission = await repCycle.disputeRounds(0, 0);
       badSubmission = await repCycle.disputeRounds(0, 1);
-      assert.equal(goodSubmission[8].toNumber(), 6);
-      assert.equal(goodSubmission[9].toNumber(), 7);
-      assert.equal(badSubmission[8].toNumber(), 6);
-      assert.equal(badSubmission[9].toNumber(), 7);
+      assert.equal(goodSubmission[8].toNumber(), 12);
+      assert.equal(goodSubmission[9].toNumber(), 14);
+      assert.equal(badSubmission[8].toNumber(), 12);
+      assert.equal(badSubmission[9].toNumber(), 14);
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
       goodSubmission = await repCycle.disputeRounds(0, 0);
       badSubmission = await repCycle.disputeRounds(0, 1);
-      assert.equal(goodSubmission[8].toNumber(), 6);
-      assert.equal(goodSubmission[9].toNumber(), 6);
-      assert.equal(badSubmission[8].toNumber(), 6);
-      assert.equal(badSubmission[9].toNumber(), 6);
+      assert.equal(goodSubmission[8].toNumber(), 12);
+      assert.equal(goodSubmission[9].toNumber(), 13);
+      assert.equal(badSubmission[8].toNumber(), 12);
+      assert.equal(badSubmission[9].toNumber(), 13);
+
+      await goodClient.respondToBinarySearchForChallenge();
+      await badClient.respondToBinarySearchForChallenge();
+      goodSubmission = await repCycle.disputeRounds(0, 0);
+      badSubmission = await repCycle.disputeRounds(0, 1);
+      assert.equal(goodSubmission[8].toNumber(), 13);
+      assert.equal(goodSubmission[9].toNumber(), 13);
+      assert.equal(badSubmission[8].toNumber(), 13);
+      assert.equal(badSubmission[9].toNumber(), 13);
 
       // TODO: Split off in to  another test here, but can't be bothered to refactor right now.
       await goodClient.respondToChallenge();

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -863,7 +863,7 @@ contract("ColonyNetworkStaking", accounts => {
         await goodClient.addLogContentsToReputationTree();
 
         badClient = new MaliciousReputationMinerExtraRep(
-          { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+          { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
           badIndex,
           "0xfffffffff"
         );
@@ -914,7 +914,7 @@ contract("ColonyNetworkStaking", accounts => {
       await goodClient.addLogContentsToReputationTree();
 
       badClient = new MaliciousReputationMinerExtraRep(
-        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJSTree },
+        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         12,
         "0xfffffffff"
       );
@@ -1214,7 +1214,7 @@ contract("ColonyNetworkStaking", accounts => {
       repCycle = ReputationMiningCycle.at(addr);
 
       badClient = new MaliciousReputationMinerExtraRep(
-        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         27,
         0xfffffffff
       );
@@ -1223,7 +1223,7 @@ contract("ColonyNetworkStaking", accounts => {
       // This client gets the same root hash as goodCleint, but will submit the wrong newest reputation hash when
       // it calls respondToChallenge.
       badClient2 = new MaliciousReputationMinerWrongNewestReputation(
-        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         27,
         0xfffffffff
       );
@@ -1330,7 +1330,7 @@ contract("ColonyNetworkStaking", accounts => {
       repCycle = ReputationMiningCycle.at(addr);
 
       badClient = new MaliciousReputationMinerExtraRep(
-        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         27,
         0xfffffffff
       );
@@ -1371,9 +1371,9 @@ contract("ColonyNetworkStaking", accounts => {
             index.toString(),
             goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.branchMask.toString(),
             goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].nextUpdateProof.nNodes.toString(),
-            agreeStateBranchMask.toHexString(),
+            `0x${agreeStateBranchMask.toString(16)}`,
             goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.nNodes.toString(),
-            disagreeStateBranchMask.toHexString(),
+            `0x${disagreeStateBranchMask.toString(16)}`,
             // This is the wrong line
             0,
             // This is the correct line, for future reference
@@ -1425,7 +1425,7 @@ contract("ColonyNetworkStaking", accounts => {
       repCycle = ReputationMiningCycle.at(addr);
 
       badClient = new MaliciousReputationMinerExtraRep(
-        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         24,
         0xfffffffff
       );
@@ -1467,11 +1467,11 @@ contract("ColonyNetworkStaking", accounts => {
             goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.branchMask.toString(),
             goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].nextUpdateProof.nNodes.toString(),
             // This is the right line
-            // agreeStateBranchMask.toHexString(),
+            // `0x${agreeStateBranchMask.toString(16)}`,
             // This is the wrong line
             0,
             goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.nNodes.toString(),
-            disagreeStateBranchMask.toHexString(),
+            `0x${disagreeStateBranchMask.toString(16)}`,
             // This is the correct line, for future reference
             goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.branchMask,
             0,
@@ -1497,12 +1497,12 @@ contract("ColonyNetworkStaking", accounts => {
             index.toString(),
             goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.branchMask.toString(),
             goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].nextUpdateProof.nNodes.toString(),
-            agreeStateBranchMask.toHexString(),
+            `0x${agreeStateBranchMask.toString(16)}`,
             goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.nNodes.toString(),
             // This is the wrong line
             0,
             // This is the right line
-            // disagreeStateBranchMask.toHexString(),
+            // `0x${disagreeStateBranchMask.toString(16)}`,
             // This is the correct line, for future reference
             goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.branchMask,
             0,
@@ -1634,7 +1634,7 @@ contract("ColonyNetworkStaking", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
       badClient = new MaliciousReputationMinerExtraRep(
-        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         3,
         0xffffffffffff
       );
@@ -1739,13 +1739,13 @@ contract("ColonyNetworkStaking", accounts => {
           const repCycle = ReputationMiningCycle.at(addr);
 
           badClient = new MaliciousReputationMinerExtraRep(
-            { loader: contractLoader, minerAddress: MAIN_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+            { loader: contractLoader, minerAddress: MAIN_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
             args.badClient1Argument,
             10
           );
 
           badClient2 = new MaliciousReputationMinerWrongProofLogEntry(
-            { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+            { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
             args.badClient2Argument
           );
 

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -1220,6 +1220,7 @@ contract("ColonyNetworkStaking", accounts => {
         await clients[i].addLogContentsToReputationTree(); // eslint-disable-line no-await-in-loop
         await clients[i].submitRootHash(); // eslint-disable-line no-await-in-loop
         await clients[i].submitJustificationRootHash(); // eslint-disable-line no-await-in-loop
+        console.log(`Client ${i} submitted JRH`);
       }
 
       await forwardTime(3600, this);

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -612,7 +612,7 @@ contract("ColonyNetworkStaking", accounts => {
       let repLogEntryMiner = await repCycle.getReputationUpdateLogEntry.call(0);
       assert.equal(repLogEntryMiner[0], MAIN_ACCOUNT);
       assert.equal(repLogEntryMiner[1].toString(), new BN("1").mul(new BN("10").pow(new BN("18"))).toString());
-      assert.equal(repLogEntryMiner[2].toString(), "0");
+      assert.equal(repLogEntryMiner[2].toString(), "3");
       assert.equal(repLogEntryMiner[3], metaColony.address);
       assert.equal(repLogEntryMiner[4].toString(), "4");
       assert.equal(repLogEntryMiner[5].toString(), "0");
@@ -620,7 +620,7 @@ contract("ColonyNetworkStaking", accounts => {
       repLogEntryMiner = await repCycle.getReputationUpdateLogEntry.call(1);
       assert.equal(repLogEntryMiner[0], MAIN_ACCOUNT);
       assert.equal(repLogEntryMiner[1].toString(), new BN("1").mul(new BN("10").pow(new BN("18"))).toString());
-      assert.equal(repLogEntryMiner[2].toString(), "0");
+      assert.equal(repLogEntryMiner[2].toString(), "3");
       assert.equal(repLogEntryMiner[3], metaColony.address);
       assert.equal(repLogEntryMiner[4].toString(), "4");
       assert.equal(repLogEntryMiner[5].toString(), "4");
@@ -731,7 +731,7 @@ contract("ColonyNetworkStaking", accounts => {
       let repLogEntryMiner = await repCycle.getReputationUpdateLogEntry.call(0);
       assert.equal(repLogEntryMiner[0], MAIN_ACCOUNT);
       assert.equal(repLogEntryMiner[1].toString(), new BN("1").mul(new BN("10").pow(new BN("18"))).toString());
-      assert.equal(repLogEntryMiner[2].toString(), "0");
+      assert.equal(repLogEntryMiner[2].toString(), "3");
       assert.equal(repLogEntryMiner[3], metaColony.address);
       assert.equal(repLogEntryMiner[4].toString(), "4");
       assert.equal(repLogEntryMiner[5].toString(), "0");
@@ -739,7 +739,7 @@ contract("ColonyNetworkStaking", accounts => {
       repLogEntryMiner = await repCycle.getReputationUpdateLogEntry.call(1);
       assert.equal(repLogEntryMiner[0], OTHER_ACCOUNT);
       assert.equal(repLogEntryMiner[1].toString(), new BN("1").mul(new BN("10").pow(new BN("18"))).toString());
-      assert.equal(repLogEntryMiner[2].toString(), "0");
+      assert.equal(repLogEntryMiner[2].toString(), "3");
       assert.equal(repLogEntryMiner[3], metaColony.address);
       assert.equal(repLogEntryMiner[4].toString(), "4");
       assert.equal(repLogEntryMiner[5].toString(), "4");
@@ -905,7 +905,7 @@ contract("ColonyNetworkStaking", accounts => {
 
       badClient = new MaliciousReputationMinerExtraRep(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJSTree },
-        13,
+        12,
         "0xfffffffff"
       );
       await badClient.initialise(colonyNetwork.address);
@@ -1044,7 +1044,7 @@ contract("ColonyNetworkStaking", accounts => {
 
       badClient = new MaliciousReputationMinerWrongUID(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
-        5,
+        12,
         "0xfffffffff"
       );
       await badClient.initialise(colonyNetwork.address);
@@ -1062,6 +1062,9 @@ contract("ColonyNetworkStaking", accounts => {
 
       await goodClient.submitJustificationRootHash();
       await badClient.submitJustificationRootHash();
+
+      await goodClient.respondToBinarySearchForChallenge();
+      await badClient.respondToBinarySearchForChallenge();
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
@@ -1139,6 +1142,9 @@ contract("ColonyNetworkStaking", accounts => {
 
       await goodClient.submitJustificationRootHash();
       await badClient.submitJustificationRootHash();
+
+      await goodClient.respondToBinarySearchForChallenge();
+      await badClient.respondToBinarySearchForChallenge();
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
@@ -1274,6 +1280,8 @@ contract("ColonyNetworkStaking", accounts => {
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
       await goodClient.respondToBinarySearchForChallenge();
+      await badClient.respondToBinarySearchForChallenge();
+      await goodClient.respondToBinarySearchForChallenge();
 
       // Get the log entry we're arguing over.
       const submission = await repCycle.disputeRounds(0, 0);
@@ -1326,6 +1334,8 @@ contract("ColonyNetworkStaking", accounts => {
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
+      await badClient.respondToBinarySearchForChallenge();
+      await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
       await goodClient.respondToBinarySearchForChallenge();
 
@@ -1461,6 +1471,8 @@ contract("ColonyNetworkStaking", accounts => {
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
+      await badClient.respondToBinarySearchForChallenge();
+      await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -839,27 +839,29 @@ contract("ColonyNetworkStaking", accounts => {
         await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
         await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
-        let addr = await colonyNetwork.getReputationMiningCycle.call();
+        let addr = await colonyNetwork.getReputationMiningCycle(true);
         let repCycle = ReputationMiningCycle.at(addr);
         await forwardTime(3600, this);
         await repCycle.submitRootHash("0x12345678", 10, 10);
         await repCycle.confirmNewHash(0);
-
         await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
-        addr = await colonyNetwork.getReputationMiningCycle.call();
+        addr = await colonyNetwork.getReputationMiningCycle(true);
         repCycle = ReputationMiningCycle.at(addr);
         await forwardTime(3600, this);
         await repCycle.submitRootHash("0x0", 0, 10);
         await repCycle.confirmNewHash(0);
-        addr = await colonyNetwork.getReputationMiningCycle.call();
+        addr = await colonyNetwork.getReputationMiningCycle(true);
         repCycle = ReputationMiningCycle.at(addr);
 
         await goodClient.addLogContentsToReputationTree();
 
-        badClient = new MaliciousReputationMiningClient(OTHER_ACCOUNT, realProviderPort, badIndex, "0xfffffffff");
+        badClient = new MaliciousReputationMinerExtraRep(
+          { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+          badIndex,
+          "0xfffffffff"
+        );
         await badClient.initialise(colonyNetwork.address);
         await badClient.addLogContentsToReputationTree();
-
         let righthash = await goodClient.getRootHash();
         let wronghash = await badClient.getRootHash();
         righthash = await goodClient.getRootHash();

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -1681,44 +1681,94 @@ contract("ColonyNetworkStaking", accounts => {
       const client = new ReputationMiner({ loader: contractLoader, minerAddress: MAIN_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree });
       await client.initialise(colonyNetwork.address);
       await client.addLogContentsToReputationTree();
+      // Check the client's tree has eight entries. In order these were added (and therefore in order of reputation UID),
+      // these are:
+      // 1. Colony-wide total reputation for metaColony's root skill
+      // 2. Colony-wide total reputation for mining skill
+      // 3. Miner's reputation for metaColony's root skill
+      // 4. Miner's reputation for mining skill
+      // x. Colony-wide total reputation for metacolony's root skill (same as 1)
+      // x. Manager reputation for metaColony's root skill (same as 3, by virtue of Manage and miner being MAIN_ACCOUNT)
+      // x. Colony-wide total reputation for metacolony's root skill (same as 1)
+      // 5. Evaluator reputation for metaColony's root skill
+      // x. Colony-wide total reputation for metacolony's root skill (same as 1)
+      // 6. Worker reputation for metacolony's root skill
+      // 7. Colony-wide total reputation for global skill task was in
+      // 8. Worker reputation for global skill task was in
+      //
 
-      // Check the client's tree has four entries.
-      // manager, worker (domain skill and task skill), evalutator + last log used for disputes
-      assert.equal(Object.keys(client.reputations).length, 5);
+      assert.equal(Object.keys(client.reputations).length, 8);
       // These should be:
-      // 1. Reputation reward for MAIN_ACCOUNT for submitting the previous reputaiton hash
+      // 1. Colony-wide total reputation for metacolony's root skill
+      let key = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`;
+      key += `${new BN("2").toString(16, 64)}`;
+      key += `${new BN(0, 16).toString(16, 40)}`;
+      assert.equal(
+        client.reputations[key],
+        `0x`+`0000000000000000000000000000000000000000000000006124fee993bc0000`+`0000000000000000000000000000000000000000000000000000000000000001` // eslint-disable-line
+      );
+
+      // 2. Colony-wide total reputation for mining skill
+      key = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`;
+      key += `${new BN("3").toString(16, 64)}`;
+      key += `${new BN(0, 16).toString(16, 40)}`;
+      assert.equal(
+        client.reputations[key],
+        `0x`+`0000000000000000000000000000000000000000000000000de0b6b3a7640000`+`0000000000000000000000000000000000000000000000000000000000000002` // eslint-disable-line
+      );
+
+      // 3. Reputation reward for MAIN_ACCOUNT for being the manager for the tasks created by giveUserCLNYTokens
+      key = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`;
+      key += `${new BN("2").toString(16, 64)}`;
+      key += `${new BN(MAIN_ACCOUNT.slice(2), 16).toString(16, 40)}`;
+      assert.equal(
+        client.reputations[key],
+        `0x`+`0000000000000000000000000000000000000000000000006124fee993bc0000`+`0000000000000000000000000000000000000000000000000000000000000003` // eslint-disable-line
+      );
+
+      // 4. Reputation reward for MAIN_ACCOUNT for submitting the previous reputaiton hash
       //   (currently skill 0, needs to change to indicate a special mining skill)
-      let key1 = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`; // Colony address as bytes
-      key1 += `${new BN("0").toString(16, 64)}`; // SkillId as uint256
-      key1 += `${new BN(MAIN_ACCOUNT.slice(2), 16).toString(16, 40)}`; // User address as bytes
+      key = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`; // Colony address as bytes
+      key += `${new BN("3").toString(16, 64)}`; // SkillId as uint256
+      key += `${new BN(MAIN_ACCOUNT.slice(2), 16).toString(16, 40)}`; // User address as bytes
       assert.equal(
-        client.reputations[key1],
-        `0x`+`0000000000000000000000000000000000000000000000000de0b6b3a7640000`+`0000000000000000000000000000000000000000000000000000000000000001` // eslint-disable-line
+        client.reputations[key],
+        `0x`+`0000000000000000000000000000000000000000000000000de0b6b3a7640000`+`0000000000000000000000000000000000000000000000000000000000000004` // eslint-disable-line
       );
-      // 2. Reputation reward for MAIN_ACCOUNT for being the manager for the tasks created by giveUserCLNYTokens
-      let key2 = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`;
-      key2 += `${new BN("2").toString(16, 64)}`;
-      key2 += `${new BN(MAIN_ACCOUNT.slice(2), 16).toString(16, 40)}`;
+      // 5. Reputation reward for OTHER_ACCOUNT for being the evaluator for the tasks created by giveUserCLNYTokens
+      key = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`;
+      key += `${new BN("2").toString(16, 64)}`;
+      key += `${new BN(OTHER_ACCOUNT.slice(2), 16).toString(16, 40)}`;
       assert.equal(
-        client.reputations[key2],
-        `0x`+`00000000000000000000000000000000000000000000000053444835ec580000`+`0000000000000000000000000000000000000000000000000000000000000002` // eslint-disable-line
+        client.reputations[key],
+        `0x`+`0000000000000000000000000000000000000000000000000000000000000000`+`0000000000000000000000000000000000000000000000000000000000000005` // eslint-disable-line
       );
-      // 3. Reputation reward for OTHER_ACCOUNT for being the evaluator for the tasks created by giveUserCLNYTokens
-      let key3 = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`;
-      key3 += `${new BN("2").toString(16, 64)}`;
-      key3 += `${new BN(OTHER_ACCOUNT.slice(2), 16).toString(16, 40)}`;
-      assert.equal(
-        client.reputations[key3],
-        `0x`+`0000000000000000000000000000000000000000000000000000000000000000`+`0000000000000000000000000000000000000000000000000000000000000003` // eslint-disable-line
-      );
-      // 4. Reputation reward for accounts[2] for being the worker for the tasks created by giveUserCLNYTokens
+      // 6. Reputation reward for accounts[2] for being the worker for the tasks created by giveUserCLNYTokens
       // NB at the moment, the reputation reward for the worker is 0.
-      let key4 = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`;
-      key4 += `${new BN("2").toString(16, 64)}`;
-      key4 += `${new BN(accounts[2].slice(2), 16).toString(16, 40)}`;
+      key = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`;
+      key += `${new BN("2").toString(16, 64)}`;
+      key += `${new BN(accounts[2].slice(2), 16).toString(16, 40)}`;
       assert.equal(
-        client.reputations[key4],
-        `0x`+`0000000000000000000000000000000000000000000000000000000000000000`+`0000000000000000000000000000000000000000000000000000000000000004` // eslint-disable-line
+        client.reputations[key],
+        `0x`+`0000000000000000000000000000000000000000000000000000000000000000`+`0000000000000000000000000000000000000000000000000000000000000006` // eslint-disable-line
+      );
+
+      // 7. Colony-wide total reputation for global skill task was in
+      key = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`;
+      key += `${new BN("1").toString(16, 64)}`;
+      key += `${new BN(0, 16).toString(16, 40)}`;
+      assert.equal(
+        client.reputations[key],
+        `0x`+`0000000000000000000000000000000000000000000000000000000000000000`+`0000000000000000000000000000000000000000000000000000000000000007` // eslint-disable-line
+      );
+
+      // 8. Worker reputation for global skill task was in
+      key = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`;
+      key += `${new BN("1").toString(16, 64)}`;
+      key += `${new BN(accounts[2].slice(2), 16).toString(16, 40)}`;
+      assert.equal(
+        client.reputations[key],
+        `0x`+`0000000000000000000000000000000000000000000000000000000000000000`+`0000000000000000000000000000000000000000000000000000000000000008` // eslint-disable-line
       );
     });
 

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -1278,8 +1278,8 @@ contract("ColonyNetworkStaking", accounts => {
       let nLogEntries = await repCycle.getReputationUpdateLogLength();
       nLogEntries = new BN(nLogEntries.toString());
       const lastLogEntry = await repCycle.getReputationUpdateLogEntry(nLogEntries.subn(1).toString());
-      const nUpdates = new BN(lastLogEntry[4].toString()).add(new BN(lastLogEntry[5].toString()));
-      const [branchMask2, siblings2] = await goodClient.justificationTree.getProof(`0x${nUpdates.toString(16, 64)}`);
+      const totalnUpdates = new BN(lastLogEntry[4].toString()).add(new BN(lastLogEntry[5].toString()));
+      const [branchMask2, siblings2] = await goodClient.justificationTree.getProof(`0x${totalnUpdates.toString(16, 64)}`);
       const [round, index] = await goodClient.getMySubmissionRoundAndIndex();
       await checkErrorRevert(
         repCycle.submitJustificationRootHash(round.toString(), index.toString(), jrh, "0", siblings1, branchMask2.toString(), siblings2, {

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -103,11 +103,11 @@ contract("ColonyNetwork", accounts => {
       assert.equal(colonyCount.toNumber(), 7);
     });
 
-    it("when meta colony is created, should have the root global and local skills initialised", async () => {
+    it("when meta colony is created, should have the root global and local skills initialised, plus the local mining skill", async () => {
       const token = await Token.new(...TOKEN_ARGS);
       await colonyNetwork.createMetaColony(token.address);
       const skillCount = await colonyNetwork.getSkillCount.call();
-      assert.equal(skillCount.toNumber(), 2);
+      assert.equal(skillCount.toNumber(), 3);
       const rootGlobalSkill = await colonyNetwork.getSkill.call(1);
       assert.equal(rootGlobalSkill[0].toNumber(), 0);
       assert.equal(rootGlobalSkill[1].toNumber(), 0);
@@ -117,6 +117,9 @@ contract("ColonyNetwork", accounts => {
 
       const globalSkill2 = await colonyNetwork.isGlobalSkill.call(2);
       assert.isFalse(globalSkill2);
+
+      const localSkill1 = await colonyNetwork.isGlobalSkill.call(3);
+      assert.isFalse(localSkill1);
 
       const rootGlobalSkillId = await colonyNetwork.getRootGlobalSkillId.call();
       assert.equal(rootGlobalSkillId, 1);

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -68,7 +68,7 @@ contract("Meta Colony", accounts => {
       await metaColony.addGlobalSkill(1);
 
       const skillCount = await colonyNetwork.getSkillCount.call();
-      assert.equal(skillCount.toNumber(), 3);
+      assert.equal(skillCount.toNumber(), 4);
 
       const newSkill = await colonyNetwork.getSkill.call(skillCount);
       assert.equal(newSkill[0].toNumber(), 1);
@@ -80,7 +80,7 @@ contract("Meta Colony", accounts => {
 
       // Check rootSkill.children first element is the id of the new skill
       const rootSkillChild = await colonyNetwork.getChildSkillId.call(1, 0);
-      assert.equal(rootSkillChild.toNumber(), 3);
+      assert.equal(rootSkillChild.toNumber(), 4);
     });
 
     it("should not allow a non-owner role in the metacolony to add a global skill", async () => {
@@ -93,17 +93,17 @@ contract("Meta Colony", accounts => {
       await metaColony.addGlobalSkill(1);
 
       const skillCount = await colonyNetwork.getSkillCount.call();
-      assert.equal(skillCount.toNumber(), 5);
+      assert.equal(skillCount.toNumber(), 6);
 
-      const newSkill1 = await colonyNetwork.getSkill.call(3);
+      const newSkill1 = await colonyNetwork.getSkill.call(4);
       assert.equal(newSkill1[0].toNumber(), 1);
       assert.equal(newSkill1[1].toNumber(), 0);
 
-      const newSkill2 = await colonyNetwork.getSkill.call(4);
+      const newSkill2 = await colonyNetwork.getSkill.call(5);
       assert.equal(newSkill2[0].toNumber(), 1);
       assert.equal(newSkill2[1].toNumber(), 0);
 
-      const newSkill3 = await colonyNetwork.getSkill.call(5);
+      const newSkill3 = await colonyNetwork.getSkill.call(6);
       assert.equal(newSkill3[0].toNumber(), 1);
       assert.equal(newSkill3[1].toNumber(), 0);
 
@@ -113,28 +113,28 @@ contract("Meta Colony", accounts => {
 
       // Check rootSkill.children contains the ids of the new skills
       const rootSkillChild1 = await colonyNetwork.getChildSkillId.call(1, 0);
-      assert.equal(rootSkillChild1.toNumber(), 3);
+      assert.equal(rootSkillChild1.toNumber(), 4);
       const rootSkillChild2 = await colonyNetwork.getChildSkillId.call(1, 1);
-      assert.equal(rootSkillChild2.toNumber(), 4);
+      assert.equal(rootSkillChild2.toNumber(), 5);
       const rootSkillChild3 = await colonyNetwork.getChildSkillId.call(1, 2);
-      assert.equal(rootSkillChild3.toNumber(), 5);
+      assert.equal(rootSkillChild3.toNumber(), 6);
     });
 
     it("should be able to add child skills a few levels down the skills tree", async () => {
       // Add 2 skill nodes to root skill
       await metaColony.addGlobalSkill(1);
       await metaColony.addGlobalSkill(1);
-      // Add a child skill to skill id 3
-      await metaColony.addGlobalSkill(3);
+      // Add a child skill to skill id 4
+      await metaColony.addGlobalSkill(4);
 
-      const newDeepSkill = await colonyNetwork.getSkill.call(5);
+      const newDeepSkill = await colonyNetwork.getSkill.call(6);
       assert.equal(newDeepSkill[0].toNumber(), 2);
       assert.equal(newDeepSkill[1].toNumber(), 0);
 
-      const parentSkill1 = await colonyNetwork.getParentSkillId.call(5, 0);
-      assert.equal(parentSkill1.toNumber(), 3);
+      const parentSkill1 = await colonyNetwork.getParentSkillId.call(6, 0);
+      assert.equal(parentSkill1.toNumber(), 4);
 
-      const parentSkill2 = await colonyNetwork.getParentSkillId.call(5, 1);
+      const parentSkill2 = await colonyNetwork.getParentSkillId.call(6, 1);
       assert.equal(parentSkill2.toNumber(), 1);
     });
 
@@ -143,93 +143,92 @@ contract("Meta Colony", accounts => {
       await metaColony.addGlobalSkill(1);
       await metaColony.addGlobalSkill(1);
 
-      await checkErrorRevert(metaColony.addGlobalSkill(5));
+      await checkErrorRevert(metaColony.addGlobalSkill(6));
       const skillCount = await colonyNetwork.getSkillCount.call();
-      assert.equal(skillCount.toNumber(), 4);
+      assert.equal(skillCount.toNumber(), 5);
     });
 
     it("should NOT be able to add a child skill to a local skill parent", async () => {
       await checkErrorRevert(metaColony.addGlobalSkill(2));
       const skillCount = await colonyNetwork.getSkillCount.call();
-      assert.equal(skillCount.toNumber(), 2);
+      assert.equal(skillCount.toNumber(), 3);
     });
 
     it("should be able to add skills in the middle of the skills tree", async () => {
       await metaColony.addGlobalSkill(1);
       await metaColony.addGlobalSkill(1);
-      await metaColony.addGlobalSkill(4);
+      await metaColony.addGlobalSkill(5);
       await metaColony.addGlobalSkill(1);
-      await metaColony.addGlobalSkill(3);
       await metaColony.addGlobalSkill(4);
+      await metaColony.addGlobalSkill(5);
 
       const rootSkill = await colonyNetwork.getSkill.call(1);
       assert.equal(rootSkill[0].toNumber(), 0);
       assert.equal(rootSkill[1].toNumber(), 6);
       const rootSkillChildSkillId1 = await colonyNetwork.getChildSkillId.call(1, 0);
-      assert.equal(rootSkillChildSkillId1.toNumber(), 3);
+      assert.equal(rootSkillChildSkillId1.toNumber(), 4);
       const rootSkillChildSkillId2 = await colonyNetwork.getChildSkillId.call(1, 1);
-      assert.equal(rootSkillChildSkillId2.toNumber(), 4);
+      assert.equal(rootSkillChildSkillId2.toNumber(), 5);
       const rootSkillChildSkillId3 = await colonyNetwork.getChildSkillId.call(1, 2);
-      assert.equal(rootSkillChildSkillId3.toNumber(), 5);
+      assert.equal(rootSkillChildSkillId3.toNumber(), 6);
       const rootSkillChildSkillId4 = await colonyNetwork.getChildSkillId.call(1, 3);
-      assert.equal(rootSkillChildSkillId4.toNumber(), 6);
+      assert.equal(rootSkillChildSkillId4.toNumber(), 7);
       const rootSkillChildSkillId5 = await colonyNetwork.getChildSkillId.call(1, 4);
-      assert.equal(rootSkillChildSkillId5.toNumber(), 7);
+      assert.equal(rootSkillChildSkillId5.toNumber(), 8);
       const rootSkillChildSkillId6 = await colonyNetwork.getChildSkillId.call(1, 5);
-      assert.equal(rootSkillChildSkillId6.toNumber(), 8);
+      assert.equal(rootSkillChildSkillId6.toNumber(), 9);
 
-      const skill1 = await colonyNetwork.getSkill.call(3);
+      const skill1 = await colonyNetwork.getSkill.call(4);
       assert.equal(skill1[0].toNumber(), 1);
       assert.equal(skill1[1].toNumber(), 1);
-      const skill1ParentSkillId1 = await colonyNetwork.getParentSkillId.call(3, 0);
+      const skill1ParentSkillId1 = await colonyNetwork.getParentSkillId.call(4, 0);
       assert.equal(skill1ParentSkillId1.toNumber(), 1);
-      const skill1ChildSkillId1 = await colonyNetwork.getChildSkillId.call(3, 0);
-      assert.equal(skill1ChildSkillId1.toNumber(), 7);
+      const skill1ChildSkillId1 = await colonyNetwork.getChildSkillId.call(4, 0);
+      assert.equal(skill1ChildSkillId1.toNumber(), 8);
 
-      const skill2 = await colonyNetwork.getSkill.call(4);
+      const skill2 = await colonyNetwork.getSkill.call(5);
       assert.equal(skill2[0].toNumber(), 1);
       assert.equal(skill2[1].toNumber(), 2);
-      const skill2ParentSkillId1 = await colonyNetwork.getParentSkillId.call(4, 0);
+      const skill2ParentSkillId1 = await colonyNetwork.getParentSkillId.call(5, 0);
       assert.equal(skill2ParentSkillId1.toNumber(), 1);
-      const skill2ChildSkillId1 = await colonyNetwork.getChildSkillId.call(4, 0);
-      assert.equal(skill2ChildSkillId1.toNumber(), 5);
-      const skill2ChildSkillId2 = await colonyNetwork.getChildSkillId.call(4, 1);
-      assert.equal(skill2ChildSkillId2.toNumber(), 8);
+      const skill2ChildSkillId1 = await colonyNetwork.getChildSkillId.call(5, 0);
+      assert.equal(skill2ChildSkillId1.toNumber(), 6);
+      const skill2ChildSkillId2 = await colonyNetwork.getChildSkillId.call(5, 1);
+      assert.equal(skill2ChildSkillId2.toNumber(), 9);
 
-      const skill3 = await colonyNetwork.getSkill.call(5);
+      const skill3 = await colonyNetwork.getSkill.call(6);
       assert.equal(skill3[0].toNumber(), 2);
       assert.equal(skill3[1].toNumber(), 0);
-      const skill3ParentSkillId1 = await colonyNetwork.getParentSkillId.call(5, 0);
-      assert.equal(skill3ParentSkillId1.toNumber(), 4);
-      const skill3ParentSkillId2 = await colonyNetwork.getParentSkillId.call(5, 1);
+      const skill3ParentSkillId1 = await colonyNetwork.getParentSkillId.call(6, 0);
+      assert.equal(skill3ParentSkillId1.toNumber(), 5);
+      const skill3ParentSkillId2 = await colonyNetwork.getParentSkillId.call(6, 1);
       assert.equal(skill3ParentSkillId2.toNumber(), 1);
 
-      const skill4 = await colonyNetwork.getSkill.call(6);
+      const skill4 = await colonyNetwork.getSkill.call(7);
       assert.equal(skill4[0].toNumber(), 1);
       assert.equal(skill4[1].toNumber(), 0);
-      const skill4ParentSkillId1 = await colonyNetwork.getParentSkillId.call(6, 0);
+      const skill4ParentSkillId1 = await colonyNetwork.getParentSkillId.call(7, 0);
       assert.equal(skill4ParentSkillId1.toNumber(), 1);
 
-      const skill5 = await colonyNetwork.getSkill.call(7);
+      const skill5 = await colonyNetwork.getSkill.call(8);
       assert.equal(skill5[0].toNumber(), 2);
       assert.equal(skill5[1].toNumber(), 0);
-      const skill5ParentSkillId1 = await colonyNetwork.getParentSkillId.call(7, 0);
-      assert.equal(skill5ParentSkillId1.toNumber(), 3);
-      const skill5ParentSkillId2 = await colonyNetwork.getParentSkillId.call(7, 1);
+      const skill5ParentSkillId1 = await colonyNetwork.getParentSkillId.call(8, 0);
+      assert.equal(skill5ParentSkillId1.toNumber(), 4);
+      const skill5ParentSkillId2 = await colonyNetwork.getParentSkillId.call(8, 1);
       assert.equal(skill5ParentSkillId2.toNumber(), 1);
 
-      const skill6 = await colonyNetwork.getSkill.call(8);
+      const skill6 = await colonyNetwork.getSkill.call(9);
       assert.equal(skill6[0].toNumber(), 2);
       assert.equal(skill6[1].toNumber(), 0);
-      const skill6ParentSkillId1 = await colonyNetwork.getParentSkillId.call(8, 0);
-      assert.equal(skill6ParentSkillId1.toNumber(), 4);
-      const skill6ParentSkillId2 = await colonyNetwork.getParentSkillId.call(8, 1);
+      const skill6ParentSkillId1 = await colonyNetwork.getParentSkillId.call(9, 0);
+      assert.equal(skill6ParentSkillId1.toNumber(), 5);
+      const skill6ParentSkillId2 = await colonyNetwork.getParentSkillId.call(9, 1);
       assert.equal(skill6ParentSkillId2.toNumber(), 1);
     });
 
     it("when N parents are there, should record parent skill ids for N = integer powers of 2", async () => {
       await metaColony.addGlobalSkill(1);
-      await metaColony.addGlobalSkill(3);
       await metaColony.addGlobalSkill(4);
       await metaColony.addGlobalSkill(5);
       await metaColony.addGlobalSkill(6);
@@ -237,35 +236,35 @@ contract("Meta Colony", accounts => {
       await metaColony.addGlobalSkill(8);
       await metaColony.addGlobalSkill(9);
       await metaColony.addGlobalSkill(10);
+      await metaColony.addGlobalSkill(11);
 
-      const skill11 = await colonyNetwork.getSkill.call(11);
-      assert.equal(skill11[0].toNumber(), 9);
-      assert.equal(skill11[1].toNumber(), 0);
+      const skill12 = await colonyNetwork.getSkill.call(12);
+      assert.equal(skill12[0].toNumber(), 9);
+      assert.equal(skill12[1].toNumber(), 0);
 
-      const skill11ParentSkillId1 = await colonyNetwork.getParentSkillId.call(11, 0);
-      assert.equal(skill11ParentSkillId1.toNumber(), 10);
-      const skill11ParentSkillId2 = await colonyNetwork.getParentSkillId.call(11, 1);
-      assert.equal(skill11ParentSkillId2.toNumber(), 9);
-      const skill11ParentSkillId3 = await colonyNetwork.getParentSkillId.call(11, 2);
-      assert.equal(skill11ParentSkillId3.toNumber(), 7);
-      const skill11ParentSkillId4 = await colonyNetwork.getParentSkillId.call(11, 3);
-      assert.equal(skill11ParentSkillId4.toNumber(), 3);
+      const skill12ParentSkillId1 = await colonyNetwork.getParentSkillId.call(12, 0);
+      assert.equal(skill12ParentSkillId1.toNumber(), 11);
+      const skill12ParentSkillId2 = await colonyNetwork.getParentSkillId.call(12, 1);
+      assert.equal(skill12ParentSkillId2.toNumber(), 10);
+      const skill12ParentSkillId3 = await colonyNetwork.getParentSkillId.call(12, 2);
+      assert.equal(skill12ParentSkillId3.toNumber(), 8);
+      const skill12ParentSkillId4 = await colonyNetwork.getParentSkillId.call(12, 3);
+      assert.equal(skill12ParentSkillId4.toNumber(), 4);
     });
 
     it("should NOT be able to add a new root global skill", async () => {
       await checkErrorRevert(metaColony.addGlobalSkill(0));
 
       const skillCount = await colonyNetwork.getSkillCount.call();
-      assert.equal(skillCount.toNumber(), 2);
+      assert.equal(skillCount.toNumber(), 3);
     });
   });
 
   describe("when adding domains in the meta colony", () => {
     it("should be able to add new domains as children to the root domain", async () => {
       await metaColony.addDomain(2);
-
       const skillCount = await colonyNetwork.getSkillCount.call();
-      assert.equal(skillCount.toNumber(), 3);
+      assert.equal(skillCount.toNumber(), 4);
       const domainCount = await metaColony.getDomainCount.call();
       assert.equal(domainCount.toNumber(), 2);
 
@@ -273,21 +272,22 @@ contract("Meta Colony", accounts => {
       assert.equal(newDomain[0].toNumber(), 2);
       assert.equal(newDomain[1].toNumber(), 1);
 
-      // Check root local skill.nChildren is now 1
+      // Check root local skill.nChildren is now 2
+      // One special mining skill, and the skill associated with the domain we just added
       const rootLocalSkill = await colonyNetwork.getSkill.call(2);
-      assert.equal(rootLocalSkill[1].toNumber(), 1);
+      assert.equal(rootLocalSkill[1].toNumber(), 2);
 
-      // Check root local skill.children first element is the id of the new skill
-      const rootSkillChild = await colonyNetwork.getChildSkillId.call(2, 0);
-      assert.equal(rootSkillChild.toNumber(), 3);
+      // Check root local skill.children second element is the id of the new skill
+      const rootSkillChild = await colonyNetwork.getChildSkillId.call(2, 1);
+      assert.equal(rootSkillChild.toNumber(), 4);
     });
 
     it("should NOT be able to add a child local skill more than one level from the root local skill", async () => {
       await metaColony.addDomain(2);
-      await checkErrorRevert(metaColony.addDomain(3));
+      await checkErrorRevert(metaColony.addDomain(4));
 
       const skillCount = await colonyNetwork.getSkillCount.call();
-      assert.equal(skillCount.toNumber(), 3);
+      assert.equal(skillCount.toNumber(), 4);
       const domainCount = await metaColony.getDomainCount.call();
       assert.equal(domainCount.toNumber(), 2);
     });
@@ -309,46 +309,45 @@ contract("Meta Colony", accounts => {
     });
 
     it("should be able to add new domains as children to the root domain", async () => {
-      await colony.addDomain(3);
-      await colony.addDomain(3);
-      await colony.addDomain(3);
+      await colony.addDomain(4);
+      await colony.addDomain(4);
+      await colony.addDomain(4);
 
       const skillCount = await colonyNetwork.getSkillCount.call();
-      assert.equal(skillCount.toNumber(), 6);
+      assert.equal(skillCount.toNumber(), 7);
       const domainCount = await colony.getDomainCount.call();
       assert.equal(domainCount.toNumber(), 4);
 
+      // TODO: I think newDomain1 is the root domain of the colony?
       const newDomain1 = await colony.getDomain.call(1);
-      assert.equal(newDomain1[0].toNumber(), 3);
+      assert.equal(newDomain1[0].toNumber(), 4);
       assert.equal(newDomain1[1].toNumber(), 1);
 
       const newDomain2 = await colony.getDomain.call(2);
-      assert.equal(newDomain2[0].toNumber(), 4);
+      assert.equal(newDomain2[0].toNumber(), 5);
       assert.equal(newDomain2[1].toNumber(), 2);
 
       const newDomain3 = await colony.getDomain.call(3);
-      assert.equal(newDomain3[0].toNumber(), 5);
+      assert.equal(newDomain3[0].toNumber(), 6);
       assert.equal(newDomain3[1].toNumber(), 3);
-
       // Check root local skill.nChildren is now 3
-      const rootLocalSkill = await colonyNetwork.getSkill.call(3);
+      const rootLocalSkill = await colonyNetwork.getSkill.call(4);
       assert.equal(rootLocalSkill[1].toNumber(), 3);
-
       // Check root local skill.children are the ids of the new skills
-      const rootSkillChild1 = await colonyNetwork.getChildSkillId.call(3, 0);
-      assert.equal(rootSkillChild1.toNumber(), 4);
-      const rootSkillChild2 = await colonyNetwork.getChildSkillId.call(3, 1);
-      assert.equal(rootSkillChild2.toNumber(), 5);
-      const rootSkillChild3 = await colonyNetwork.getChildSkillId.call(3, 2);
-      assert.equal(rootSkillChild3.toNumber(), 6);
+      const rootSkillChild1 = await colonyNetwork.getChildSkillId.call(4, 0);
+      assert.equal(rootSkillChild1.toNumber(), 5);
+      const rootSkillChild2 = await colonyNetwork.getChildSkillId.call(4, 1);
+      assert.equal(rootSkillChild2.toNumber(), 6);
+      const rootSkillChild3 = await colonyNetwork.getChildSkillId.call(4, 2);
+      assert.equal(rootSkillChild3.toNumber(), 7);
     });
 
     it("should NOT be able to add a child local skill more than one level from the root local skill", async () => {
-      await colony.addDomain(3);
-      await checkErrorRevert(colony.addDomain(4));
+      await colony.addDomain(4);
+      await checkErrorRevert(colony.addDomain(5));
 
       const skillCount = await colonyNetwork.getSkillCount.call();
-      assert.equal(skillCount.toNumber(), 4);
+      assert.equal(skillCount.toNumber(), 5);
       const domainCount = await colony.getDomainCount.call();
       assert.equal(domainCount.toNumber(), 2);
     });
@@ -357,7 +356,7 @@ contract("Meta Colony", accounts => {
       await checkErrorRevert(colony.addDomain(1));
 
       const skillCount = await colonyNetwork.getSkillCount.call();
-      assert.equal(skillCount.toNumber(), 3);
+      assert.equal(skillCount.toNumber(), 4);
       const domainCount = await colony.getDomainCount.call();
       assert.equal(domainCount.toNumber(), 1);
     });
@@ -366,14 +365,14 @@ contract("Meta Colony", accounts => {
       await checkErrorRevert(colonyNetwork.addSkill(2, false));
 
       const skillCount = await colonyNetwork.getSkillCount.call();
-      assert.equal(skillCount.toNumber(), 3);
+      assert.equal(skillCount.toNumber(), 4);
     });
 
     it("should NOT be able to add a new root local skill", async () => {
       await checkErrorRevert(colonyNetwork.addSkill(0, false));
 
       const skillCount = await colonyNetwork.getSkillCount.call();
-      assert.equal(skillCount.toNumber(), 3);
+      assert.equal(skillCount.toNumber(), 4);
     });
   });
 
@@ -388,7 +387,8 @@ contract("Meta Colony", accounts => {
     });
 
     it("should be able to set domain on task", async () => {
-      await colony.addDomain(3);
+      const colonyRootDomain = await colony.getDomain(1);
+      await colony.addDomain(colonyRootDomain[0].toString());
       const taskId = await makeTask({ colony });
 
       await colony.setTaskDomain(taskId, 2);
@@ -426,7 +426,7 @@ contract("Meta Colony", accounts => {
 
     it("should be able to set global skill on task", async () => {
       await metaColony.addGlobalSkill(1);
-      await metaColony.addGlobalSkill(4);
+      await metaColony.addGlobalSkill(5);
 
       const taskId = await makeTask({ colony });
 
@@ -436,11 +436,11 @@ contract("Meta Colony", accounts => {
         taskId,
         signers: [MANAGER],
         sigTypes: [0],
-        args: [taskId, 5]
+        args: [taskId, 6]
       });
 
       const task = await colony.getTask.call(taskId);
-      assert.equal(task[9][0].toNumber(), 5);
+      assert.equal(task[9][0].toNumber(), 6);
     });
 
     it("should not allow a non-manager to set global skill on task", async () => {
@@ -459,11 +459,11 @@ contract("Meta Colony", accounts => {
 
     it("should NOT be able to set global skill on finalized task", async () => {
       await metaColony.addGlobalSkill(1);
-      await metaColony.addGlobalSkill(4);
+      await metaColony.addGlobalSkill(5);
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony });
       await colony.finalizeTask(taskId);
-      await checkErrorRevert(colony.setTaskSkill(taskId, 5));
+      await checkErrorRevert(colony.setTaskSkill(taskId, 6));
 
       const task = await colony.getTask.call(taskId);
       assert.equal(task[9][0].toNumber(), 1);

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -447,10 +447,10 @@ contract("Meta Colony", accounts => {
 
     it("should not allow a non-manager to set global skill on task", async () => {
       await metaColony.addGlobalSkill(1);
-      await metaColony.addGlobalSkill(4);
+      await metaColony.addGlobalSkill(5);
 
       await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskSkill(1, 6, { from: OTHER_ACCOUNT }));
+      await checkErrorRevert(colony.setTaskSkill(1, 5, { from: OTHER_ACCOUNT }));
       const task = await colony.getTask.call(1);
       assert.equal(task[9][0].toNumber(), 0);
     });

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -398,7 +398,9 @@ contract("Meta Colony", accounts => {
     });
 
     it("should NOT allow a non-manager to set domain on task", async () => {
-      await colony.addDomain(3);
+      const colonyRootDomain = await colony.getDomain(1);
+      await colony.addDomain(colonyRootDomain[0].toString());
+
       await makeTask({ colony });
       await checkErrorRevert(colony.setTaskDomain(1, 2, { from: OTHER_ACCOUNT }));
       const task = await colony.getTask.call(1);
@@ -448,7 +450,7 @@ contract("Meta Colony", accounts => {
       await metaColony.addGlobalSkill(4);
 
       await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskSkill(1, 5, { from: OTHER_ACCOUNT }));
+      await checkErrorRevert(colony.setTaskSkill(1, 6, { from: OTHER_ACCOUNT }));
       const task = await colony.getTask.call(1);
       assert.equal(task[9][0].toNumber(), 0);
     });

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -120,7 +120,11 @@ contract("Colony Reputation Updates", () => {
         assert.equal(repLogEntryManager[1].toString(), rating.reputationChangeManager.toString());
         assert.equal(repLogEntryManager[2].toNumber(), 2);
         assert.equal(repLogEntryManager[3], metaColony.address);
-        assert.equal(repLogEntryManager[4].toNumber(), 2);
+        if (rating.manager >= 25) {
+          assert.equal(repLogEntryManager[4].toNumber(), 2);
+        } else {
+          assert.equal(repLogEntryManager[4].toNumber(), 4);
+        }
         assert.equal(repLogEntryManager[5].toNumber(), 0);
 
         const repLogEntryWorker = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(2);
@@ -128,8 +132,16 @@ contract("Colony Reputation Updates", () => {
         assert.equal(repLogEntryWorker[1].toString(), rating.reputationChangeWorker.toString());
         assert.equal(repLogEntryWorker[2].toNumber(), 2);
         assert.equal(repLogEntryWorker[3], metaColony.address);
-        assert.equal(repLogEntryWorker[4].toNumber(), 2);
-        assert.equal(repLogEntryWorker[5].toNumber(), 4);
+        if (rating.worker >= 25) {
+          assert.equal(repLogEntryWorker[4].toNumber(), 2);
+        } else {
+          assert.equal(repLogEntryWorker[4].toNumber(), 4);
+        }
+        if (rating.manager >= 25) {
+          assert.equal(repLogEntryWorker[5].toNumber(), 4);
+        } else {
+          assert.equal(repLogEntryWorker[5].toNumber(), 6);
+        }
       });
     });
 

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -120,6 +120,10 @@ contract("Colony Reputation Updates", () => {
         assert.equal(repLogEntryManager[1].toString(), rating.reputationChangeManager.toString());
         assert.equal(repLogEntryManager[2].toNumber(), 2);
         assert.equal(repLogEntryManager[3], metaColony.address);
+        // If the rating is less than 25, then we also subtract reputation from all child skills. In the case
+        // of the metaColony here, the task was created in the root domain of the metaColony, and a child of the
+        // root skill is the mining skill. So the number we expect here differs depending on whether it's a reputation
+        // gain or loss that we're logging.
         if (rating.manager >= 25) {
           assert.equal(repLogEntryManager[4].toNumber(), 2);
         } else {
@@ -137,6 +141,8 @@ contract("Colony Reputation Updates", () => {
         } else {
           assert.equal(repLogEntryWorker[4].toNumber(), 4);
         }
+        // This last entry in the log entry is nPreviousUpdates, which depends on whether the manager was given a reputation
+        // gain or loss.
         if (rating.manager >= 25) {
           assert.equal(repLogEntryWorker[5].toNumber(), 4);
         } else {

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -120,11 +120,11 @@ contract("Colony Reputation Updates", () => {
         assert.equal(repLogEntryManager[1].toString(), rating.reputationChangeManager.toString());
         assert.equal(repLogEntryManager[2].toNumber(), 2);
         assert.equal(repLogEntryManager[3], metaColony.address);
-        // If the rating is less than 25, then we also subtract reputation from all child skills. In the case
+        // If the rating is less than 2, then we also subtract reputation from all child skills. In the case
         // of the metaColony here, the task was created in the root domain of the metaColony, and a child of the
         // root skill is the mining skill. So the number we expect here differs depending on whether it's a reputation
         // gain or loss that we're logging.
-        if (rating.manager >= 25) {
+        if (rating.manager >= 2) {
           assert.equal(repLogEntryManager[4].toNumber(), 2);
         } else {
           assert.equal(repLogEntryManager[4].toNumber(), 4);
@@ -136,14 +136,14 @@ contract("Colony Reputation Updates", () => {
         assert.equal(repLogEntryWorker[1].toString(), rating.reputationChangeWorker.toString());
         assert.equal(repLogEntryWorker[2].toNumber(), 2);
         assert.equal(repLogEntryWorker[3], metaColony.address);
-        if (rating.worker >= 25) {
+        if (rating.worker >= 2) {
           assert.equal(repLogEntryWorker[4].toNumber(), 2);
         } else {
           assert.equal(repLogEntryWorker[4].toNumber(), 4);
         }
         // This last entry in the log entry is nPreviousUpdates, which depends on whether the manager was given a reputation
         // gain or loss.
-        if (rating.manager >= 25) {
+        if (rating.manager >= 2) {
           assert.equal(repLogEntryWorker[5].toNumber(), 4);
         } else {
           assert.equal(repLogEntryWorker[5].toNumber(), 6);

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -158,13 +158,13 @@ contract("Colony Reputation Updates", () => {
 
     it("should calculate nUpdates correctly when making a log", async () => {
       await metaColony.addGlobalSkill(1);
-      await metaColony.addGlobalSkill(3);
       await metaColony.addGlobalSkill(4);
       await metaColony.addGlobalSkill(5);
+      await metaColony.addGlobalSkill(6);
       const taskId1 = await setupRatedTask({
         colonyNetwork,
         colony: metaColony,
-        skill: 4
+        skill: 5
       });
       await metaColony.finalizeTask(taskId1);
       let repLogEntryWorker = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(3);
@@ -178,7 +178,7 @@ contract("Colony Reputation Updates", () => {
       const taskId2 = await setupRatedTask({
         colonyNetwork,
         colony: metaColony,
-        skill: 5
+        skill: 6
       });
       await metaColony.finalizeTask(taskId2);
       repLogEntryWorker = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(7);


### PR DESCRIPTION
I guess this is part of #51, though the description there is woefully out of date (Patricia/Merkle)

This PR adds colony-wide reputation totals to the reputation state tree, as well as updating all parent reputations (both colony-wide totals of the parent reputations, and for the user's reputation) as appropriate. It also tests that disputes in these reputations are resolved successfully.

It also adds a special 'mining skill' to the metacolony. This is a little unusual for a skill, as it is a local skill that is not associated with a domain, but... I think that's most appropriate? Open to discussion on that. Otherwise, my implementation to date meant that this was pretty straightforward to add!

The same will not be true for child reputation updates...