### PR TITLE
Token Locking

### DIFF
--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -57,6 +57,10 @@ contract ColonyNetwork is ColonyNetworkStorage {
     _;
   }
 
+  function isColony(address _colony) public view returns (bool) {
+    return _isColony[_colony];
+  }
+
   function getCurrentColonyVersion() public view returns (uint256) {
     return currentColonyVersion;
   }
@@ -97,7 +101,17 @@ contract ColonyNetwork is ColonyNetworkStorage {
     return reputationRootHashNNodes;
   }
 
-  function createMetaColony(address _tokenAddress) public 
+  function setTokenLocking(address _tokenLocking) public
+  auth
+  {
+    tokenLocking = _tokenLocking;
+  }
+
+  function getTokenLocking() public view returns (address) {
+    return tokenLocking;
+  }
+
+  function createMetaColony(address _tokenAddress) public
   auth
   {
     require(metaColony == 0);
@@ -108,10 +122,10 @@ contract ColonyNetwork is ColonyNetworkStorage {
     skills[skillCount] = rootGlobalSkill;
     rootGlobalSkillId = skillCount;
     // TODO: add the special 'mining' skill, which is local to the meta Colony.
-    
+
     metaColony = createColony(_tokenAddress);
   }
-  
+
   function createColony(address _tokenAddress) public returns (address) {
     EtherRouter etherRouter = new EtherRouter();
     address resolverForLatestColonyVersion = colonyVersionResolver[currentColonyVersion];

--- a/contracts/ColonyNetworkStorage.sol
+++ b/contracts/ColonyNetworkStorage.sol
@@ -35,6 +35,8 @@ contract ColonyNetworkStorage is DSAuth {
   uint256 currentColonyVersion;
   // Address of the Meta Colony
   address metaColony;
+  // Address of token locking contract
+  address tokenLocking;
   // Maps index to colony address
   mapping (uint256 => address) colonies;
   mapping (address => bool) _isColony;

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -21,6 +21,7 @@ pragma experimental "v0.5.0";
 import "../lib/dappsys/auth.sol";
 import "./ERC20Extended.sol";
 import "./IColonyNetwork.sol";
+import "./ITokenLocking.sol";
 
 
 contract ColonyStorage is DSAuth {
@@ -61,13 +62,13 @@ contract ColonyStorage is DSAuth {
   mapping (uint256 => RewardPayoutCycle) rewardPayoutCycles;
   // Active payouts for particular token address. Assures that one token is used for only one active payout
   mapping (address => bool) activeRewardPayouts;
-  // Incremented every time a reward payout is created. Used for comparing with `userRewardPayoutCount`
-  // to ensure that rewards are claimed in the right order.
+  // Incremented every time a reward payout is created. Used for indexing the reward payout
   // Can be used for iterating over all reward payouts (excluding index 0)
   uint256 globalRewardPayoutCount;
-  // Keeps track of how many payouts are claimed by the particular user.
-  // Can be incremented either by waiving or claiming the reward.
-  mapping (address => uint256) userRewardPayoutCount;
+
+  // Keeps track if user claimed or waived specific reward payout.
+  // Used for ensuring that user cannot claim or waive the reward twice
+  mapping (address => mapping(uint256 => bool)) userRewardPayouts;
 
   // This keeps track of how much of the colony's funds that it owns have been moved into pots other than pot 0,
   // which (by definition) have also had the reward amount siphoned off and put in to pot 0.

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -339,10 +339,9 @@ contract IColony {
   /// @param _token Addess of the token used for reward payout
   function startNextRewardPayout(address _token) public returns (uint256);
 
-  /// @notice Claim the reward payout at `_payoutId`. User needs to provide their reputation and colony-wide reputation
+  /// @notice Claim payout with id of `_payoutId`. User needs to provide their reputation and colony-wide reputation
   /// which will be proven via Merkle proof inside this function.
   /// Can only be called if payout is active, i.e if 60 days have not passed from its creation.
-  /// Can only be called if next in queue
   /// @param _payoutId Id of the reward payout
   /// @param _squareRoots Square roots of values used in equation
   /// _squareRoots[0] - square root of user reputation
@@ -356,20 +355,18 @@ contract IColony {
   /// @param _totalReputation Total reputation at the point of creation of reward payout cycle
   function claimRewardPayout(uint256 _payoutId, uint256[7] _squareRoots, uint256 _userReputation, uint256 _totalReputation) public;
 
-  /// @notice Waive reward payouts. This will unlock the sender's tokens and increment users reward payout counter,
-  /// allowing them to claim next reward payout
-  /// @param _numPayouts Number of payouts you want to waive
-  function waiveRewardPayouts(uint256 _numPayouts) public;
+  /// @notice Waive reward payout. Unlocks users tokens once
+  /// @param _payoutId Id of the payout
+  function waiveRewardPayout(uint256 _payoutId) public;
 
   /// @notice Get useful information about specific reward payout
   /// @param _payoutId Id of the reward payout
   /// @return Reputation root hash at the time of creation
   /// @return Total colony tokens at the time of creation
   /// @return Total amount of tokens taken aside for reward payout
-  /// @return Remaining (unclaimed) amount of tokens
   /// @return Token address
   /// @return Block number at the time of creation
-  function getRewardPayoutInfo(uint256 _payoutId) public view returns (bytes32, uint256, uint256, uint256, address, uint256);
+  function getRewardPayoutInfo(uint256 _payoutId) public view returns (bytes32, uint256, uint256, address, uint256);
 
   /// @notice Finalises the reward payout. Allows creation of next reward payouts for token that has been used in `_payoutId`
   /// Can only be called when reward payout cycle is finished i.e when 60 days have passed from its creation
@@ -379,10 +376,6 @@ contract IColony {
   /// @notice Get number of reward payout cycles
   /// @return Number of reward payout cycles
   function getGlobalRewardPayoutCount() public returns (uint256);
-
-  /// @notice Get number of claimed and waived reward payouts for `_user`
-  /// @return Number of claimed and waived reward payouts
-  function getUserRewardPayoutCount(address _user) public returns (uint256);
 
   /// @notice Get the `_token` balance of pot with id `_potId`
   /// @param _potId Id of the funding pot

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -50,7 +50,7 @@ contract IColonyNetwork {
   /// @return The colony count
   function getColonyCount() public view returns (uint256);
 
-  /// @notice Check if specific address is colony created on colony network
+  /// @notice Check if specific address is a colony created on colony network
   /// @param _colony Address of the colony
   /// @return true if specified address is a colony, otherwise false
   function isColony(address _colony) public view returns (bool);

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -50,6 +50,11 @@ contract IColonyNetwork {
   /// @return The colony count
   function getColonyCount() public view returns (uint256);
 
+  /// @notice Check if specific address is colony created on colony network
+  /// @param _colony Address of the colony
+  /// @return true if specified address is a colony, otherwise false
+  function isColony(address _colony) public view returns (bool);
+
   /// @notice Adds a new skill to the global or local skills tree, under skill `_parentSkillId`
   /// Only the Meta Colony is allowed to add a global skill, called via `IColony.addGlobalSkill`
   /// Any colony is allowed to add a local skill and which is associated with a new domain via `IColony.addDomain`
@@ -85,6 +90,14 @@ contract IColonyNetwork {
   /// @dev This is set once when the Meta Colony is created
   /// @return The root global skill id
   function getRootGlobalSkillId() public view returns (uint256);
+
+  /// @notice Sets the token locking address
+  /// @param _tokenLockingAddress Address of the locking contract
+  function setTokenLocking(address _tokenLockingAddress) public;
+
+  /// @notice Get token locking contract address
+  /// @return Token locking contract address
+  function getTokenLocking() public view returns (address);
 
   /// @notice Create the Meta Colony, same as a normal colony plus the root skill
   /// @param _tokenAddress Address of the CLNY token

--- a/contracts/ITokenLocking.sol
+++ b/contracts/ITokenLocking.sol
@@ -1,0 +1,54 @@
+pragma solidity ^0.4.23;
+
+
+contract ITokenLocking {
+
+  /// @notice Set the ColonyNetwork contract address
+  /// @dev ColonyNetwork is used for checking if sender is a colony created on colony network
+  /// @param _colonyNetwork Address of the ColonyNetwork
+  function setColonyNetwork(address _colonyNetwork) public;
+
+  /// @notice Get ColonyNetwork address
+  /// @return ColonyNetwork address
+  function getColonyNetwork() public view returns (address);
+
+  /// @notice Locks everyones' tokens on `_token` address
+  /// @param _token Address of the token we want to lock
+  function lockToken(address _token) public;
+
+  /// @notice Increments the lock counter for the `_user`. Can only be called by a colony
+  /// @param _token Address of the token we want to unlock
+  /// @param _user Address of the user
+  function unlockTokenForUser(address _token, address _user) public;
+
+  /// @notice Deposit `_amount` of colony tokens. Can only be called if user tokens are not locked
+  /// Before calling this function user has to allow that their tokens can be transferred by token locking contract
+  /// @param _amount Amount to deposit
+  function deposit(address _token, uint256 _amount) public;
+
+  /// @notice Withdraw `_amount` of deposited tokens. Can only be called if user tokens are not locked
+  /// @param _amount Amount to withdraw
+  function withdraw(address _token, uint256 _amount) public;
+
+  /// @notice Get deposited balance by `_user`
+  /// @param _user Address of the user
+  /// @return Users deposited amount
+  function getUserDepositedBalance(address _token, address _user) public view returns(uint256);
+
+  /// @notice Check if users tokens are locked
+  /// @param _token Address of the token
+  /// @param _user Address of the user
+  /// @return true if users tokens are locked, false otherwise
+  function usersTokensLocked(address _token, address _user) public view returns (bool);
+
+  /// @notice Get global token lock count
+  /// @param _token Address of the token
+  /// @return Global token lock count
+  function getTotalTokenLockCount(address _token) public view returns (uint256);
+
+  /// @notice Get user token lock count
+  /// @param _token Address of the token
+  /// @param _user Address of the user
+  /// @return User token lock count
+  function getUserTokenLockCount(address _token, address _user) public view returns (uint256);
+}

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -47,7 +47,7 @@ contract Token is DSTokenBase(0), DSAuth, ERC20Extended {
   function burn(uint wad) public {
     _balances[msg.sender] = sub(_balances[msg.sender], wad);
     _supply = sub(_supply, wad);
-    
+
     emit Burn(msg.sender, wad);
   }
 }

--- a/contracts/TokenLocking.sol
+++ b/contracts/TokenLocking.sol
@@ -1,0 +1,71 @@
+pragma solidity ^0.4.23;
+
+import "./ERC20Extended.sol";
+import "./IColonyNetwork.sol";
+import "./TokenLockingStorage.sol";
+import "../lib/dappsys/math.sol";
+
+contract TokenLocking is TokenLockingStorage, DSMath {
+  modifier tokenNotLocked(address _token) {
+    require(userTokenLocks[_token][msg.sender].count == totalTokenLockCount[_token]);
+    _;
+  }
+
+  modifier onlyColony() {
+    require(IColonyNetwork(colonyNetwork).isColony(msg.sender), "token-locking-sender-not-colony");
+    _;
+  }
+
+
+  function setColonyNetwork(address _colonyNetwork) public auth {
+    colonyNetwork = _colonyNetwork;
+  }
+
+  // Used for testing purposes
+  function getColonyNetwork() public view returns (address) {
+    return colonyNetwork;
+  }
+
+  function lockToken(address _token) public onlyColony {
+    totalTokenLockCount[_token] += 1;
+  }
+
+  function unlockTokenForUser(address _token, address _user) public onlyColony {
+    // This should never throw if you are using it right, so it can't be tested
+    assert(userTokenLocks[_token][_user].count < totalTokenLockCount[_token]);
+    userTokenLocks[_token][_user].count += 1;
+  }
+
+  function deposit(address _token, uint256 _amount) public
+  tokenNotLocked(_token)
+  {
+    // If we transfer before we increment `depositedBalances`, user won't be able to take advantage of re-entrance
+    require(ERC20Extended(_token).transferFrom(msg.sender, address(this), _amount));
+
+    userTokenLocks[_token][msg.sender].amount = add(userTokenLocks[_token][msg.sender].amount, _amount);
+  }
+
+  function withdraw(address _token, uint256 _amount) public
+  tokenNotLocked(_token)
+  {
+    userTokenLocks[_token][msg.sender].amount = sub(userTokenLocks[_token][msg.sender].amount, _amount);
+
+    require(ERC20Extended(_token).transfer(msg.sender, _amount));
+  }
+
+  function getUserDepositedBalance(address _token, address _user) public view returns (uint256) {
+    return userTokenLocks[_token][_user].amount;
+  }
+
+  function usersTokensLocked(address _token, address _user) public view returns (bool) {
+    return userTokenLocks[_token][_user].count < totalTokenLockCount[_token];
+  }
+
+  function getTotalTokenLockCount(address _token) public view returns (uint256) {
+    return totalTokenLockCount[_token];
+  }
+
+  function getUserTokenLockCount(address _token, address _user) public view returns (uint256) {
+    return userTokenLocks[_token][_user].count;
+  }
+}

--- a/contracts/TokenLockingStorage.sol
+++ b/contracts/TokenLockingStorage.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.4.23;
+
+import "../lib/dappsys/auth.sol";
+
+
+contract TokenLockingStorage is DSAuth {
+  address resolver;
+
+  // Address of ColonyNetwork contract
+  address colonyNetwork;
+
+  struct TokenLock {
+    // Amount of deposited tokens
+    uint256 amount;
+    // user token lock counter
+    uint256 count;
+  }
+
+  // Maps token to user to TokenLock struct
+  mapping (address => mapping (address => TokenLock)) userTokenLocks;
+
+  // Maps token to total token lock count. If user token lock count is the same as global, that means that their tokens are unlocked.
+  // If user token lock count is less than global, that means that their tokens are locked.
+  // It must not happend that user lock count is greater than global lock count
+  mapping (address => uint256) totalTokenLockCount;
+}

--- a/helpers/upgradable-contracts.js
+++ b/helpers/upgradable-contracts.js
@@ -95,3 +95,13 @@ export async function setupUpgradableColonyNetwork(etherRouter, resolver, colony
 
   await etherRouter.setResolver(resolver.address);
 }
+
+export async function setupUpgradableTokenLocking(etherRouter, resolver, tokenLocking) {
+  const deployedImplementations = {};
+  deployedImplementations.TokenLocking = tokenLocking.address;
+  await setupEtherRouter("ITokenLocking", deployedImplementations, resolver);
+
+  await etherRouter.setResolver(resolver.address);
+  const registeredResolver = await etherRouter.resolver.call();
+  assert.equal(registeredResolver, resolver.address);
+}

--- a/migrations/6_setup_token_locking.js
+++ b/migrations/6_setup_token_locking.js
@@ -1,0 +1,38 @@
+/* globals artifacts */
+/* eslint-disable no-console */
+
+const { setupUpgradableTokenLocking } = require("../helpers/upgradable-contracts");
+
+const TokenLocking = artifacts.require("./TokenLocking");
+const IColonyNetwork = artifacts.require("./IColonyNetwork");
+const EtherRouter = artifacts.require("./EtherRouter");
+const Resolver = artifacts.require("./Resolver");
+
+module.exports = deployer => {
+  let resolver;
+  let etherRouter;
+  let colonyNetworkEtherRouter;
+  deployer
+    .then(() => Resolver.new())
+    .then(instance => {
+      resolver = instance;
+      return EtherRouter.new();
+    })
+    .then(instance => {
+      etherRouter = instance;
+      return TokenLocking.new();
+    })
+    .then(instance => setupUpgradableTokenLocking(etherRouter, resolver, instance))
+    .then(() => EtherRouter.deployed())
+    .then(_colonyNetworkEtherRouter => {
+      colonyNetworkEtherRouter = _colonyNetworkEtherRouter;
+      return IColonyNetwork.at(_colonyNetworkEtherRouter.address).setTokenLocking(etherRouter.address);
+    })
+    .then(() => TokenLocking.at(etherRouter.address).setColonyNetwork(colonyNetworkEtherRouter.address))
+    .then(() => {
+      console.log("### Token locking setup at ", etherRouter.address, "with Resolver", resolver.address);
+    })
+    .catch(err => {
+      console.log("### Error occurred ", err);
+    });
+};

--- a/scripts/check-storage.js
+++ b/scripts/check-storage.js
@@ -23,6 +23,7 @@ walkSync("./contracts/").forEach(contractName => {
       "contracts/Resolver.sol",
       "contracts/ReputationMiningCycle.sol", // Does not use EtherRouter
       "contracts/Token.sol", // Not directly used by any colony contracts
+      "contracts/TokenLockingStorage.sol",
       "contracts/PatriciaTree/PatriciaTree.sol", // Used by ReputationMiningCycle, which does not use EtherRouter
       "contracts/gnosis/MultiSigWallet.sol" // Not directly used by any colony contracts
     ].indexOf(contractName) > -1

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -3,7 +3,7 @@ import { SPECIFICATION_HASH, INITIAL_FUNDING } from "../helpers/constants";
 import { checkErrorRevert, getTokenArgs } from "../helpers/test-helper";
 import { fundColonyWithTokens, setupRatedTask } from "../helpers/test-data-generator";
 
-const upgradableContracts = require("../helpers/upgradable-contracts");
+import { setupColonyVersionResolver } from "../helpers/upgradable-contracts";
 
 const EtherRouter = artifacts.require("EtherRouter");
 const Resolver = artifacts.require("Resolver");
@@ -37,7 +37,7 @@ contract("Meta Colony", accounts => {
     const etherRouter = await EtherRouter.new();
     await etherRouter.setResolver(resolverColonyNetworkDeployed.address);
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
-    await upgradableContracts.setupColonyVersionResolver(colonyTemplate, colonyTask, colonyFunding, resolver, colonyNetwork);
+    await setupColonyVersionResolver(colonyTemplate, colonyTask, colonyFunding, resolver, colonyNetwork);
     await colonyNetwork.startNextCycle();
 
     metaColonyToken = await Token.new("Colony Network Token", "CLNY", 18);

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -1,0 +1,265 @@
+/* globals artifacts */
+
+import { getTokenArgs, checkErrorRevert } from "../helpers/test-helper";
+
+const EtherRouter = artifacts.require("EtherRouter");
+const IColonyNetwork = artifacts.require("IColonyNetwork");
+const IColony = artifacts.require("IColony");
+const ITokenLocking = artifacts.require("ITokenLocking");
+const Token = artifacts.require("Token");
+
+contract("TokenLocking", addresses => {
+  const usersTokens = 6;
+  const userAddress = addresses[1];
+  let token;
+  let tokenLocking;
+  let otherToken;
+  let colonyNetwork;
+  let colony;
+
+  before(async () => {
+    const etherRouter = await EtherRouter.deployed();
+    colonyNetwork = IColonyNetwork.at(etherRouter.address);
+    const tokenLockingAddress = await colonyNetwork.getTokenLocking.call();
+    tokenLocking = ITokenLocking.at(tokenLockingAddress);
+  });
+
+  beforeEach(async () => {
+    let tokenArgs = getTokenArgs();
+    token = await Token.new(...tokenArgs);
+    await token.mint(usersTokens);
+    await token.transfer(userAddress, usersTokens);
+
+    tokenArgs = getTokenArgs();
+    otherToken = await Token.new(...tokenArgs);
+
+    const { logs } = await colonyNetwork.createColony(token.address);
+    const { colonyAddress } = logs[0].args;
+    colony = IColony.at(colonyAddress);
+  });
+
+  describe("when locking tokens", async () => {
+    it("should correctly set colony network address", async () => {
+      await tokenLocking.setColonyNetwork(0x0);
+      let colonyNetworkAddress = await tokenLocking.getColonyNetwork.call();
+      assert.equal(colonyNetworkAddress, 0x0);
+
+      await tokenLocking.setColonyNetwork(colonyNetwork.address);
+      colonyNetworkAddress = await tokenLocking.getColonyNetwork.call();
+      assert.equal(colonyNetworkAddress, colonyNetwork.address);
+    });
+
+    it("should correctly deposit tokens", async () => {
+      await token.approve(tokenLocking.address, usersTokens, {
+        from: userAddress
+      });
+      await tokenLocking.deposit(token.address, usersTokens, {
+        from: userAddress
+      });
+      const userDepositedBalance = await tokenLocking.getUserDepositedBalance.call(token.address, userAddress);
+      assert.equal(userDepositedBalance.toNumber(), usersTokens);
+    });
+
+    it("should not be able todo deposit tokens if they are not approved", async () => {
+      await checkErrorRevert(
+        tokenLocking.deposit(token.address, usersTokens, {
+          from: userAddress
+        })
+      );
+      const userDepositedBalance = await tokenLocking.getUserDepositedBalance.call(token.address, userAddress);
+      assert.equal(userDepositedBalance.toNumber(), 0);
+    });
+
+    it("should not be able to withdraw if specified amount is greated than deposited", async () => {
+      await token.approve(tokenLocking.address, usersTokens, {
+        from: userAddress
+      });
+      await tokenLocking.deposit(token.address, usersTokens, {
+        from: userAddress
+      });
+      await checkErrorRevert(
+        tokenLocking.withdraw(token.address, 10, {
+          from: userAddress
+        })
+      );
+      const userDepositedBalance = await tokenLocking.getUserDepositedBalance.call(token.address, userAddress);
+      assert.equal(userDepositedBalance.toNumber(), usersTokens);
+    });
+
+    it("should correctly withdraw tokens", async () => {
+      await token.approve(tokenLocking.address, usersTokens, {
+        from: userAddress
+      });
+      await tokenLocking.deposit(token.address, usersTokens, {
+        from: userAddress
+      });
+
+      await tokenLocking.withdraw(token.address, usersTokens, {
+        from: userAddress
+      });
+      const userDepositedBalance = await tokenLocking.getUserDepositedBalance.call(token.address, userAddress);
+      assert.equal(userDepositedBalance.toNumber(), 0);
+    });
+
+    it("should correctly increment total lock count", async () => {
+      await token.approve(tokenLocking.address, usersTokens, {
+        from: userAddress
+      });
+      await tokenLocking.deposit(token.address, usersTokens, {
+        from: userAddress
+      });
+      await colony.startNextRewardPayout(otherToken.address);
+      const totalLockCount = await tokenLocking.getTotalTokenLockCount.call(token.address);
+      assert.equal(totalLockCount.toNumber(), 1);
+    });
+
+    it("should correctly users lock count", async () => {
+      await token.approve(tokenLocking.address, usersTokens, {
+        from: userAddress
+      });
+      await tokenLocking.deposit(token.address, usersTokens, {
+        from: userAddress
+      });
+      const { logs } = await colony.startNextRewardPayout(otherToken.address);
+      const payoutId = logs[0].args.id;
+
+      await colony.waiveRewardPayout(payoutId, {
+        from: userAddress
+      });
+      const lockCount = await tokenLocking.getUserTokenLockCount.call(token.address, userAddress);
+      assert.equal(lockCount.toNumber(), 1);
+    });
+
+    it("should correctly lock tokens", async () => {
+      await token.approve(tokenLocking.address, usersTokens, {
+        from: userAddress
+      });
+      await tokenLocking.deposit(token.address, usersTokens, {
+        from: userAddress
+      });
+      await colony.startNextRewardPayout(otherToken.address);
+
+      const locked = await tokenLocking.usersTokensLocked.call(token.address, userAddress);
+      assert(locked, "Users tokens are not locked");
+    });
+
+    it("should correctly unlock tokens", async () => {
+      await token.approve(tokenLocking.address, usersTokens, {
+        from: userAddress
+      });
+      await tokenLocking.deposit(token.address, usersTokens, {
+        from: userAddress
+      });
+      const { logs } = await colony.startNextRewardPayout(otherToken.address);
+      const payoutId = logs[0].args.id;
+
+      await colony.waiveRewardPayout(payoutId, {
+        from: userAddress
+      });
+
+      const locked = await tokenLocking.usersTokensLocked.call(token.address, userAddress);
+      assert(!locked, "Users tokens are locked");
+    });
+
+    it("should not be able to lock tokens if sender is not colony", async () => {
+      await token.approve(tokenLocking.address, usersTokens, {
+        from: userAddress
+      });
+      await tokenLocking.deposit(token.address, usersTokens, {
+        from: userAddress
+      });
+      await checkErrorRevert(tokenLocking.lockToken(token.address), "token-locking-sender-not-colony");
+    });
+
+    it("should not be able to unlock users tokens if sender is not colony", async () => {
+      await token.approve(tokenLocking.address, usersTokens, {
+        from: userAddress
+      });
+      await tokenLocking.deposit(token.address, usersTokens, {
+        from: userAddress
+      });
+      await colony.startNextRewardPayout(otherToken.address);
+      await checkErrorRevert(tokenLocking.unlockTokenForUser(token.address, userAddress), "token-locking-sender-not-colony");
+    });
+
+    it("should be able to deposit tokens multiple times before if they are unlocked", async () => {
+      await token.approve(tokenLocking.address, usersTokens, {
+        from: userAddress
+      });
+      await tokenLocking.deposit(token.address, usersTokens / 2, {
+        from: userAddress
+      });
+      await tokenLocking.deposit(token.address, usersTokens / 2, {
+        from: userAddress
+      });
+      const userDepositedBalance = await tokenLocking.getUserDepositedBalance.call(token.address, userAddress);
+      assert.equal(userDepositedBalance.toNumber(), usersTokens);
+    });
+
+    it("should not be able to deposit tokens while they are locked", async () => {
+      await token.approve(tokenLocking.address, usersTokens, {
+        from: userAddress
+      });
+      await tokenLocking.deposit(token.address, usersTokens, {
+        from: userAddress
+      });
+      await colony.startNextRewardPayout(otherToken.address);
+      await checkErrorRevert(
+        tokenLocking.deposit(token.address, usersTokens, {
+          from: userAddress
+        })
+      );
+    });
+
+    it("should not be able to withdraw tokens while they are locked", async () => {
+      await token.approve(tokenLocking.address, usersTokens, {
+        from: userAddress
+      });
+      await tokenLocking.deposit(token.address, usersTokens, {
+        from: userAddress
+      });
+      await colony.startNextRewardPayout(otherToken.address);
+      await checkErrorRevert(
+        tokenLocking.withdraw(token.address, usersTokens, {
+          from: userAddress
+        })
+      );
+    });
+
+    it("should be able to withdraw tokens after they are unlocked", async () => {
+      await token.approve(tokenLocking.address, usersTokens, {
+        from: userAddress
+      });
+      await tokenLocking.deposit(token.address, usersTokens, {
+        from: userAddress
+      });
+      const { logs } = await colony.startNextRewardPayout(otherToken.address);
+      const payoutId = logs[0].args.id;
+      await colony.waiveRewardPayout(payoutId, {
+        from: userAddress
+      });
+      await tokenLocking.withdraw(token.address, usersTokens, {
+        from: userAddress
+      });
+      const userDepositedBalance = await tokenLocking.getUserDepositedBalance.call(token.address, userAddress);
+      assert.equal(userDepositedBalance, 0);
+    });
+
+    it("should be able to lock tokens twice", async () => {
+      await token.approve(tokenLocking.address, usersTokens, {
+        from: userAddress
+      });
+      await tokenLocking.deposit(token.address, usersTokens, {
+        from: userAddress
+      });
+      await colony.startNextRewardPayout(otherToken.address);
+
+      const tokenArgs = getTokenArgs();
+      const newToken = await Token.new(...tokenArgs);
+      await colony.startNextRewardPayout(newToken.address);
+
+      const totalLockCount = await tokenLocking.getTotalTokenLockCount.call(token.address);
+      assert.equal(totalLockCount.toNumber(), 2);
+    });
+  });
+});


### PR DESCRIPTION
Closes #217 

Forth version. Same as the first one, except its modified so it can be used for by multiple colonies.
Works like this:
We have total and users lock count. Counters are separate for every token. If total count is greater than the users, then the users tokens are locked, otherwise, if they are equal, users token are unlocked. When colony increments total lock count, everyones tokens are locked, even if they don't have any deposited tokens. This is the simplest and cheapest way to avoid double spending by user.
If by any chance happens that users lock count is greater than total lock count, then this implementation is not used the way its meant to.