### PR TITLE
Add events for more granularity during task changes

### DIFF
--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -28,6 +28,7 @@ import "./ColonyStorage.sol";
 contract ColonyFunding is ColonyStorage, DSMath {
   event RewardPayoutCycleStarted(uint256 indexed id);
   event RewardPayoutCycleEnded(uint256 indexed id);
+  event TaskWorkerPayoutChanged(uint256 indexed id, address token, uint256 amount);
 
   function getFeeInverse() public pure returns (uint256) {
     // TODO: refer to ColonyNetwork
@@ -49,6 +50,8 @@ contract ColonyFunding is ColonyStorage, DSMath {
 
   function setTaskWorkerPayout(uint256 _id, address _token, uint256 _amount) public self {
     setTaskPayout(_id, WORKER, _token, _amount);
+
+    emit TaskWorkerPayoutChanged(_id, _token, _amount);
   }
 
   // To get all payouts for a task iterate over roles.length

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -30,6 +30,13 @@ contract ColonyTask is ColonyStorage, DSMath {
   uint256 constant RATING_REVEAL_TIMEOUT = 432000;
 
   event TaskAdded(uint256 indexed id);
+  event TaskBriefChanged(uint256 indexed id, bytes32 specificationHash);
+  event TaskDueDateChanged(uint256 indexed id, uint256 dueDate);
+  event TaskDomainChanged(uint256 indexed id, uint256 domainId);
+  event TaskSkillChanged(uint256 indexed id, uint256 skillId);
+  event TaskRoleUserChanged(uint256 indexed id, uint8 role, address user);
+  event TaskFinalized(uint256 indexed id);
+  event TaskCanceled(uint256 indexed id);
 
   modifier confirmTaskRoleIdentity(uint256 _id, uint8 _role) {
     Role storage role = tasks[_id].roles[_role];
@@ -257,6 +264,8 @@ contract ColonyTask is ColonyStorage, DSMath {
       rated: false,
       rating: 0
     });
+
+    emit TaskRoleUserChanged(_id, _role, _user);
   }
 
   function setTaskDomain(uint256 _id, uint256 _domainId) public
@@ -266,6 +275,8 @@ contract ColonyTask is ColonyStorage, DSMath {
   {
     require(tasks[_id].roles[MANAGER].user == msg.sender);
     tasks[_id].domainId = _domainId;
+
+    emit TaskDomainChanged(_id, _domainId);
   }
 
   // TODO: Restrict function visibility to whoever submits the approved Transaction from Client
@@ -279,6 +290,8 @@ contract ColonyTask is ColonyStorage, DSMath {
     require(tasks[_id].roles[MANAGER].user == msg.sender);
 
     tasks[_id].skills[0] = _skillId;
+
+    emit TaskSkillChanged(_id, _skillId);
   }
 
   function setTaskBrief(uint256 _id, bytes32 _specificationHash) public
@@ -287,6 +300,8 @@ contract ColonyTask is ColonyStorage, DSMath {
   taskNotFinalized(_id)
   {
     tasks[_id].specificationHash = _specificationHash;
+
+    emit TaskBriefChanged(_id, _specificationHash);
   }
 
   function setTaskDueDate(uint256 _id, uint256 _dueDate) public
@@ -295,6 +310,8 @@ contract ColonyTask is ColonyStorage, DSMath {
   taskNotFinalized(_id)
   {
     tasks[_id].dueDate = _dueDate;
+
+    emit TaskDueDateChanged(_id, _dueDate);
   }
 
   function submitTaskDeliverable(uint256 _id, bytes32 _deliverableHash) public
@@ -337,6 +354,8 @@ contract ColonyTask is ColonyStorage, DSMath {
         }
       }
     }
+
+    emit TaskFinalized(_id);
   }
 
   function cancelTask(uint256 _id) public
@@ -345,6 +364,8 @@ contract ColonyTask is ColonyStorage, DSMath {
   taskNotFinalized(_id)
   {
     tasks[_id].cancelled = true;
+
+    emit TaskCanceled(_id);
   }
 
   function getTask(uint256 _id) public view returns (bytes32, bytes32, bool, bool, uint256, uint256, uint256, uint256, uint256, uint256[]) {

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -27,6 +27,40 @@ contract IColony {
   /// @param id The newly added task id
   event TaskAdded(uint256 indexed id);
 
+  /// @notice Event logged when a task's specification hash changes
+  /// @param id Id of the task
+  /// @param specificationHash New specification hash of the task
+  event TaskBriefChanged(uint256 indexed id, bytes32 specificationHash);
+
+  /// @notice Event logged when a task's due date changes
+  /// @param id Id of the task
+  /// @param dueDate New due date of the task
+  event TaskDueDateChanged(uint256 indexed id, uint256 dueDate);
+
+  /// @notice Event logged when a task's domain changes
+  /// @param id Id of the task
+  /// @param domainId New domain id of the task
+  event TaskDomainChanged(uint256 indexed id, uint256 domainId);
+
+  /// @notice Event logged when a task's skill changes
+  /// @param id Id of the task
+  /// @param skillId New skill id of the task
+  event TaskSkillChanged(uint256 indexed id, uint256 skillId);
+
+  /// @notice Event logged when a task's role user changes
+  /// @param id Id of the task
+  /// @param role Role of the user
+  /// @param user User that fulfills the designated role
+  event TaskRoleUserChanged(uint256 indexed id, uint8 role, address user);
+
+  /// @notice Event logged when a task has been finalized
+  /// @param id Id of the finalized task
+  event TaskFinalized(uint256 indexed id);
+
+  /// @notice Event logged when a task has been canceled
+  /// @param id Id of the canceled task
+  event TaskCanceled(uint256 indexed id);
+
   /// @notice Event logged when a new reward payout cycle has started
   /// @param id Payout id
   event RewardPayoutCycleStarted(uint256 indexed id);

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -53,6 +53,12 @@ contract IColony {
   /// @param user User that fulfills the designated role
   event TaskRoleUserChanged(uint256 indexed id, uint8 role, address user);
 
+  /// @notice Event logged when a task's worker funding changes
+  /// @param id Id of the task
+  /// @param token Token of the payout funding
+  /// @param amount Amount of the payout funding
+  event TaskWorkerPayoutChanged(uint256 indexed id, address token, uint256 amount);
+
   /// @notice Event logged when a task has been finalized
   /// @param id Id of the finalized task
   event TaskFinalized(uint256 indexed id);

--- a/test/colony.js
+++ b/test/colony.js
@@ -459,6 +459,62 @@ contract("Colony", addresses => {
 
       await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData));
     });
+
+    it("should log a TaskBriefChanged event, if the task brief gets changed", async () => {
+      await colony.makeTask(SPECIFICATION_HASH, 1);
+      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
+
+      // Change the task brief
+      const signers = [MANAGER, WORKER];
+      const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
+      const sigs = await createSignatures(colony, signers, 0, txData);
+
+      await expectEvent(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData), "TaskBriefChanged");
+    });
+
+    it("should log a TaskDueDateChanged event, if the task due date gets changed", async () => {
+      await colony.makeTask(SPECIFICATION_HASH, 1);
+      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
+
+      // Change the due date
+      const dueDate = await currentBlockTime();
+      const signers = [MANAGER, WORKER];
+      const txData = await colony.contract.setTaskDueDate.getData(1, dueDate);
+      const sigs = await createSignatures(colony, signers, 0, txData);
+
+      await expectEvent(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData), "TaskDueDateChanged");
+    });
+
+    it("should log a TaskSkillChanged event, if the task skill gets changed", async () => {
+      await colony.makeTask(SPECIFICATION_HASH, 1);
+      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
+
+      // Acquire meta colony, create new global skill, assign new task's skill
+      const metaColonyAddress = await colonyNetwork.getMetaColony.call();
+      const metaColony = await IColony.at(metaColonyAddress);
+      await metaColony.addGlobalSkill(1);
+
+      const skillCount = await colonyNetwork.getSkillCount.call();
+      await expectEvent(colony.setTaskSkill(1, skillCount.toNumber()), "TaskSkillChanged");
+    });
+
+    it("should log a TaskDomainChanged event, if the task domain gets changed", async () => {
+      await colony.makeTask(SPECIFICATION_HASH, 1);
+      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
+
+      // Create a domain, change task's domain
+      const skillCount = await colonyNetwork.getSkillCount.call();
+      await colony.addDomain(skillCount.toNumber());
+
+      await expectEvent(colony.setTaskDomain(1, 2), "TaskDomainChanged");
+    });
+
+    it("should log a TaskRoleUserChanged event, if a task role's user gets changed", async () => {
+      await colony.makeTask(SPECIFICATION_HASH, 1);
+
+      // Change the task role's user
+      await expectEvent(colony.setTaskRoleUser(1, WORKER_ROLE, WORKER), "TaskRoleUserChanged");
+    });
   });
 
   describe("when submitting task deliverable", () => {
@@ -550,6 +606,12 @@ contract("Colony", addresses => {
       await setupRatedTask({ colonyNetwork, colony, token });
       await checkErrorRevert(colony.finalizeTask(10));
     });
+
+    it("should log a TaskFinalized event", async () => {
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      const taskId = await setupRatedTask({ colonyNetwork, colony, token });
+      await expectEvent(colony.finalizeTask(taskId), "TaskFinalized");
+    });
   });
 
   describe("when cancelling a task", () => {
@@ -628,6 +690,12 @@ contract("Colony", addresses => {
 
     it("should fail if manager tries to cancel a task with invalid id", async () => {
       await checkErrorRevert(colony.cancelTask(10));
+    });
+
+    it("should log a TaskCanceled event", async () => {
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      const taskId = await setupRatedTask({ colonyNetwork, colony, token });
+      await expectEvent(colony.cancelTask(taskId), "TaskCanceled");
     });
   });
 

--- a/test/colony.js
+++ b/test/colony.js
@@ -743,6 +743,18 @@ contract("Colony", addresses => {
       const taskPayoutWorker2 = await colony.getTaskPayout.call(1, WORKER_ROLE, token.address);
       assert.equal(taskPayoutWorker2.toNumber(), 200);
     });
+
+    it("should log a TaskWorkerPayoutChanged event, if the task's worker's payout changed", async () => {
+      await colony.makeTask(SPECIFICATION_HASH, 1);
+      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
+      await colony.mintTokens(100);
+
+      // Set the evaluator payout as 1000 ethers
+      const txData = await colony.contract.setTaskWorkerPayout.getData(1, 0x0, 98000);
+      const sigs = await createSignatures(colony, [MANAGER, WORKER], 0, txData);
+
+      await expectEvent(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData), "TaskWorkerPayoutChanged");
+    });
   });
 
   describe("when claiming payout for a task", () => {


### PR DESCRIPTION
This PR relates to #188. Increasing the amounts of events emitted during the task workflow allows for increased granularity of the whole process and enables further integrations with the contracts, especially in regard to the following use cases:

* Live updates of changes on tasks in the Colony dApp, e.g., if the worker's payout changed.
* Further integrations when using the JavaScript client, [`colonyJS`](https://github.com/JoinColony/colonyJS). This comes in handy when having the upcoming [Colony hackathon](https://colony.io/hackathon/) in mind. Participants could easily integrate third-party services and have data synchronized in real-time.

I added 8 events to `ColonyTask` and `ColonyFunding` that give updates within a worker's perspective:
  * `TaskBriefChanged(uint256 indexed id, bytes32 specificationHash)`
  * `TaskDueDateChanged(uint256 indexed id, uint256 dueDate)`
  * `TaskDomainChanged(uint256 id, uint256 domainId)`
  * `TaskSkillChanged(uint256 id, uint256 skillId)`
  * `TaskRoleUserChanged(uint256 id, uint8 role, address user)`
  * `TaskWorkerPayoutChanged(uint256 id, address token, uint256 amount)`
  * `TaskFinalized(uint256 indexed id)`
  * `TaskCanceled(uint256 indexed id)`

The events' args contain the respective task's ID as well as the new attribute value. I didn't op for events of changes in the evaluator's and manager's payout. In the respective tests, events are checked for their occurrence with `expectEvent`, but I didn't add tests for the events' arguments, since web3 `^0.20` doesn't provide proper typing for events and returns just an object with string values.