### PR TITLE
Roles and permissions

### DIFF
--- a/contracts/Authority.sol
+++ b/contracts/Authority.sol
@@ -33,6 +33,7 @@ contract Authority is DSRoles {
     bytes4 addGlobalSkillSig = bytes4(keccak256("addGlobalSkill(uint256)"));
     bytes4 setOwnerRoleSig = bytes4(keccak256("setOwnerRole(address)"));
     bytes4 removeAdminRoleSig = bytes4(keccak256("removeAdminRole(address)"));
+    bytes4 upgradeSig = bytes4(keccak256("upgrade(uint256)"));
 
     // functions for admin + owner role
     bytes4 moveFundsBetweenPotsSig = bytes4(keccak256("moveFundsBetweenPots(uint256,uint256,uint256,address)"));
@@ -54,6 +55,8 @@ contract Authority is DSRoles {
     setRoleCapability(ownerRole, colony, setOwnerRoleSig, true);
     // Remove admin role
     setRoleCapability(ownerRole, colony, removeAdminRoleSig, true);
+    // Upgrade colony
+    setRoleCapability(ownerRole, colony, upgradeSig, true);
 
     // Allocate funds
     setRoleCapability(adminRole, colony, moveFundsBetweenPotsSig, true);

--- a/contracts/Authority.sol
+++ b/contracts/Authority.sol
@@ -22,28 +22,28 @@ import "../lib/dappsys/roles.sol";
 
 
 contract Authority is DSRoles {
-  uint8 ownerRole = 0;
   uint8 adminRole = 1;
 
   constructor(address colony) public {
-    bytes4 makeTaskSig = bytes4(keccak256("makeTask(bytes32,uint256)"));
-    setRoleCapability(ownerRole, colony, makeTaskSig, true);
-    setRoleCapability(adminRole, colony, makeTaskSig, true);
-
-    bytes4 acceptTaskSig = bytes4(keccak256("finalizeTask(uint256)"));
-    setRoleCapability(ownerRole, colony, acceptTaskSig, true);
-    setRoleCapability(adminRole, colony, acceptTaskSig, true);
-
-    bytes4 setTaskDueDateSig = bytes4(keccak256("setTaskDueDate(uint256,uint256)"));
-    setRoleCapability(ownerRole, colony, setTaskDueDateSig, true);
-    setRoleCapability(adminRole, colony, setTaskDueDateSig, true);
-
-    bytes4 setTaskPayoutSig = bytes4(keccak256("setTaskPayout(uint256,uint256,address,uint256)"));
-    setRoleCapability(ownerRole, colony, setTaskPayoutSig, true);
-    setRoleCapability(adminRole, colony, setTaskPayoutSig, true);
-
     bytes4 moveFundsBetweenPotsSig = bytes4(keccak256("moveFundsBetweenPots(uint256,uint256,uint256,address)"));
-    setRoleCapability(ownerRole, colony, moveFundsBetweenPotsSig, true);
+    bytes4 addDomainSig = bytes4(keccak256("addDomain(uint256)"));
+    bytes4 makeTaskSig = bytes4(keccak256("makeTask(bytes32,uint256)"));
+    bytes4 startNextRewardPayoutSig = bytes4(keccak256("startNextRewardPayout(address)"));
+    bytes4 cancelTaskSig = bytes4(keccak256("cancelTask(uint256)"));
+    bytes4 setAdminSig = bytes4(keccak256("setAdmin(address)"));
+
+    // Admin
+    // Allocate funds
     setRoleCapability(adminRole, colony, moveFundsBetweenPotsSig, true);
+    // Add domain
+    setRoleCapability(adminRole, colony, addDomainSig, true);
+    // Add task
+    setRoleCapability(adminRole, colony, makeTaskSig, true);
+    // Start next reward payout
+    setRoleCapability(adminRole, colony, startNextRewardPayoutSig, true);
+    // Cancel task
+    setRoleCapability(adminRole, colony, cancelTaskSig, true);
+    // Set admin
+    setRoleCapability(adminRole, colony, setAdminSig, true);
   }
 }

--- a/contracts/Authority.sol
+++ b/contracts/Authority.sol
@@ -22,28 +22,53 @@ import "../lib/dappsys/roles.sol";
 
 
 contract Authority is DSRoles {
+  uint8 ownerRole = 0;
   uint8 adminRole = 1;
 
   constructor(address colony) public {
+    // functions for owner role
+    bytes4 setTokenSig = bytes4(keccak256("setToken(address)"));
+    bytes4 bootstrapColonySig = bytes4(keccak256("bootstrapColony(address[],int256[])"));
+    bytes4 mintTokensSig = bytes4(keccak256("mintTokens(uint256)"));
+    bytes4 addGlobalSkillSig = bytes4(keccak256("addGlobalSkill(uint256)"));
+    bytes4 removeAdminRoleSig = bytes4(keccak256("removeAdminRole(address)"));
+
+    // functions for admin + owner role
     bytes4 moveFundsBetweenPotsSig = bytes4(keccak256("moveFundsBetweenPots(uint256,uint256,uint256,address)"));
     bytes4 addDomainSig = bytes4(keccak256("addDomain(uint256)"));
     bytes4 makeTaskSig = bytes4(keccak256("makeTask(bytes32,uint256)"));
     bytes4 startNextRewardPayoutSig = bytes4(keccak256("startNextRewardPayout(address)"));
     bytes4 cancelTaskSig = bytes4(keccak256("cancelTask(uint256)"));
-    bytes4 setAdminSig = bytes4(keccak256("setAdmin(address)"));
+    bytes4 setAdminRoleSig = bytes4(keccak256("setAdminRole(address)"));
 
-    // Admin
+    // Set token
+    setRoleCapability(ownerRole, colony, setTokenSig, true);
+    // Bootstrap colony
+    setRoleCapability(ownerRole, colony, bootstrapColonySig, true);
+    // Mint tokens
+    setRoleCapability(ownerRole, colony, mintTokensSig, true);
+    // Add global skill
+    setRoleCapability(ownerRole, colony, addGlobalSkillSig, true);
+    // Remove admin role
+    setRoleCapability(ownerRole, colony, removeAdminRoleSig, true);
+
     // Allocate funds
     setRoleCapability(adminRole, colony, moveFundsBetweenPotsSig, true);
+    setRoleCapability(ownerRole, colony, moveFundsBetweenPotsSig, true);
     // Add domain
     setRoleCapability(adminRole, colony, addDomainSig, true);
+    setRoleCapability(ownerRole, colony, addDomainSig, true);
     // Add task
     setRoleCapability(adminRole, colony, makeTaskSig, true);
+    setRoleCapability(ownerRole, colony, makeTaskSig, true);
     // Start next reward payout
     setRoleCapability(adminRole, colony, startNextRewardPayoutSig, true);
+    setRoleCapability(ownerRole, colony, startNextRewardPayoutSig, true);
     // Cancel task
     setRoleCapability(adminRole, colony, cancelTaskSig, true);
+    setRoleCapability(ownerRole, colony, cancelTaskSig, true);
     // Set admin
-    setRoleCapability(adminRole, colony, setAdminSig, true);
+    setRoleCapability(adminRole, colony, setAdminRoleSig, true);
+    setRoleCapability(ownerRole, colony, setAdminRoleSig, true);
   }
 }

--- a/contracts/Authority.sol
+++ b/contracts/Authority.sol
@@ -31,6 +31,7 @@ contract Authority is DSRoles {
     bytes4 bootstrapColonySig = bytes4(keccak256("bootstrapColony(address[],int256[])"));
     bytes4 mintTokensSig = bytes4(keccak256("mintTokens(uint256)"));
     bytes4 addGlobalSkillSig = bytes4(keccak256("addGlobalSkill(uint256)"));
+    bytes4 setOwnerRoleSig = bytes4(keccak256("setOwnerRole(address)"));
     bytes4 removeAdminRoleSig = bytes4(keccak256("removeAdminRole(address)"));
 
     // functions for admin + owner role
@@ -49,6 +50,8 @@ contract Authority is DSRoles {
     setRoleCapability(ownerRole, colony, mintTokensSig, true);
     // Add global skill
     setRoleCapability(ownerRole, colony, addGlobalSkillSig, true);
+    // Transfer ownership
+    setRoleCapability(ownerRole, colony, setOwnerRoleSig, true);
     // Remove admin role
     setRoleCapability(ownerRole, colony, removeAdminRoleSig, true);
 

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -23,6 +23,7 @@ import "./IColonyNetwork.sol";
 import "./IColony.sol";
 import "./ColonyStorage.sol";
 import "./PatriciaTree/PatriciaTreeProofs.sol";
+import "./Authority.sol";
 
 
 contract Colony is ColonyStorage, PatriciaTreeProofs {
@@ -30,6 +31,15 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   // This function, exactly as defined, is used in build scripts. Take care when updating.
   // Version number should be upped with every change in Colony or its dependency contracts or libraries.
   function version() public pure returns (uint256) { return 1; }
+
+  function setAdmin(address _user) public auth {
+    Authority(authority).setUserRole(_user, ADMIN_ROLE, true);
+  }
+
+  // Can only be called by the owner.
+  function removeAdmin(address _user) public auth {
+    Authority(authority).setUserRole(_user, ADMIN_ROLE, false);
+  }
 
   function setToken(address _token) public
   auth
@@ -84,7 +94,6 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     token.transfer(colonyNetworkAddress, _wad);
   }
 
-  //TODO: Secure this function 'properly'
   function addGlobalSkill(uint _parentSkillId) public
   auth
   returns (uint256)

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -56,10 +56,17 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     colonyNetworkAddress = _address;
 
     // Initialise the task update reviewers
-    setFunctionReviewers(0xda4db249, 0, 2); // setTaskBrief => manager, worker
-    setFunctionReviewers(0xcae960fe, 0, 2); // setTaskDueDate => manager, worker
-    setFunctionReviewers(0x6fb0794f, 0, 1); // setTaskEvaluatorPayout => manager, evaluator
-    setFunctionReviewers(0x2cf62b39, 0, 2); // setTaskWorkerPayout => manager, worker
+    setFunctionReviewers(bytes4(keccak256("setTaskBrief(uint256,bytes32)")), MANAGER, WORKER);
+    setFunctionReviewers(bytes4(keccak256("setTaskDueDate(uint256,uint256)")), MANAGER, WORKER);
+    setFunctionReviewers(bytes4(keccak256("setTaskSkill(uint256,uint256)")), MANAGER, WORKER);
+    setFunctionReviewers(bytes4(keccak256("setTaskEvaluatorPayout(uint256,address,uint256)")), MANAGER, EVALUATOR);
+    setFunctionReviewers(bytes4(keccak256("setTaskWorkerPayout(uint256,address,uint256)")), MANAGER, WORKER);
+    setFunctionReviewers(bytes4(keccak256("removeTaskEvaluatorRole(uint256)")), MANAGER, EVALUATOR);
+    setFunctionReviewers(bytes4(keccak256("removeTaskWorkerRole(uint256)")), MANAGER, WORKER);
+
+    setRoleAssignmentFunction(bytes4(keccak256("setTaskManagerRole(uint256,address)")));
+    setRoleAssignmentFunction(bytes4(keccak256("setTaskEvaluatorRole(uint256,address)")));
+    setRoleAssignmentFunction(bytes4(keccak256("setTaskWorkerRole(uint256,address)")));
 
     // Initialise the root domain
     IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
@@ -133,6 +140,10 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   {
     uint8[2] memory _reviewers = [_firstReviewer, _secondReviewer];
     reviewers[_sig] = _reviewers;
+  }
+
+  function setRoleAssignmentFunction(bytes4 _sig) private {
+    roleAssignmentSigs[_sig] = true;
   }
 
   modifier verifyKey(bytes key) {

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -34,8 +34,9 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
   function setOwnerRole(address _user) public auth {
     // To allow only one owner at a time we have to remove current owner from their role
-    Authority(authority).setUserRole(msg.sender, OWNER_ROLE, false);
-    Authority(authority).setUserRole(_user, OWNER_ROLE, true);
+    Authority colonyAuthority = Authority(authority);
+    colonyAuthority.setUserRole(msg.sender, OWNER_ROLE, false);
+    colonyAuthority.setUserRole(_user, OWNER_ROLE, true);
   }
 
   function setAdminRole(address _user) public auth {
@@ -65,6 +66,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     setFunctionReviewers(bytes4(keccak256("setTaskBrief(uint256,bytes32)")), MANAGER, WORKER);
     setFunctionReviewers(bytes4(keccak256("setTaskDueDate(uint256,uint256)")), MANAGER, WORKER);
     setFunctionReviewers(bytes4(keccak256("setTaskSkill(uint256,uint256)")), MANAGER, WORKER);
+    setFunctionReviewers(bytes4(keccak256("setTaskManagerPayout(uint256,address,uint256)")), MANAGER, MANAGER);
     setFunctionReviewers(bytes4(keccak256("setTaskEvaluatorPayout(uint256,address,uint256)")), MANAGER, EVALUATOR);
     setFunctionReviewers(bytes4(keccak256("setTaskWorkerPayout(uint256,address,uint256)")), MANAGER, WORKER);
     setFunctionReviewers(bytes4(keccak256("removeTaskEvaluatorRole(uint256)")), MANAGER, EVALUATOR);

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -33,6 +33,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   function version() public pure returns (uint256) { return 1; }
 
   function setOwnerRole(address _user) public auth {
+    // To allow only one owner at a time we have to remove current owner from their role
+    Authority(authority).setUserRole(msg.sender, OWNER_ROLE, false);
     Authority(authority).setUserRole(_user, OWNER_ROLE, true);
   }
 

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -32,12 +32,16 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   // Version number should be upped with every change in Colony or its dependency contracts or libraries.
   function version() public pure returns (uint256) { return 1; }
 
-  function setAdmin(address _user) public auth {
+  function setOwnerRole(address _user) public auth {
+    Authority(authority).setUserRole(_user, OWNER_ROLE, true);
+  }
+
+  function setAdminRole(address _user) public auth {
     Authority(authority).setUserRole(_user, ADMIN_ROLE, true);
   }
 
   // Can only be called by the owner.
-  function removeAdmin(address _user) public auth {
+  function removeAdminRole(address _user) public auth {
     Authority(authority).setUserRole(_user, ADMIN_ROLE, false);
   }
 

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -39,7 +39,9 @@ contract ColonyFunding is ColonyStorage, DSMath {
     return 100;
   }
 
-  function setTaskManagerPayout(uint256 _id, address _token, uint256 _amount) public isManager(_id) {
+  function setTaskManagerPayout(uint256 _id, address _token, uint256 _amount) public
+  confirmTaskRoleIdentity(_id, MANAGER)
+  {
     setTaskPayout(_id, MANAGER, _token, _amount);
   }
 

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -39,9 +39,7 @@ contract ColonyFunding is ColonyStorage, DSMath {
     return 100;
   }
 
-  function setTaskManagerPayout(uint256 _id, address _token, uint256 _amount) public
-  confirmTaskRoleIdentity(_id, MANAGER)
-  {
+  function setTaskManagerPayout(uint256 _id, address _token, uint256 _amount) public self {
     setTaskPayout(_id, MANAGER, _token, _amount);
   }
 

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -126,9 +126,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
     DSAuth dsauth = DSAuth(etherRouter);
     dsauth.setAuthority(authority);
 
-    authority.setRootUser(address(this), true);
     authority.setOwner(etherRouter);
-
     colony.setOwnerRole(msg.sender);
 
     // Initialise the root (domain) local skill with defaults by just incrementing the skillCount

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -129,6 +129,9 @@ contract ColonyNetwork is ColonyNetworkStorage {
     authority.setOwner(etherRouter);
     colony.setOwnerRole(msg.sender);
 
+    // Colony will not have owner
+    dsauth.setOwner(0x0);
+
     // Initialise the root (domain) local skill with defaults by just incrementing the skillCount
     skillCount += 1;
     colonyCount += 1;
@@ -152,23 +155,6 @@ contract ColonyNetwork is ColonyNetworkStorage {
 
   function getColony(uint256 _id) public view returns (address) {
     return colonies[_id];
-  }
-
-  function upgradeColony(uint256 _id, uint _newVersion) public {
-    address etherRouter = colonies[_id];
-    // Check the calling user is authorised
-    DSAuth auth = DSAuth(etherRouter);
-    address authority = auth.authority();
-    require(Authority(authority).hasUserRole(msg.sender, 0));
-    // Upgrades can only go up in version
-    IColony colony = IColony(etherRouter);
-    uint currentVersion = colony.version();
-    require(_newVersion > currentVersion);
-    // Requested version has to be registered
-    address newResolver = colonyVersionResolver[_newVersion];
-    require(newResolver != 0x0);
-    EtherRouter e = EtherRouter(etherRouter);
-    e.setResolver(newResolver);
   }
 
   function addSkill(uint _parentSkillId, bool _globalSkill) public

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -125,10 +125,11 @@ contract ColonyNetwork is ColonyNetworkStorage {
 
     DSAuth dsauth = DSAuth(etherRouter);
     dsauth.setAuthority(authority);
-    dsauth.setOwner(msg.sender);
 
     authority.setRootUser(address(this), true);
     authority.setOwner(etherRouter);
+
+    colony.setOwnerRole(msg.sender);
 
     // Initialise the root (domain) local skill with defaults by just incrementing the skillCount
     skillCount += 1;
@@ -159,7 +160,8 @@ contract ColonyNetwork is ColonyNetworkStorage {
     address etherRouter = colonies[_id];
     // Check the calling user is authorised
     DSAuth auth = DSAuth(etherRouter);
-    require(msg.sender == auth.owner());
+    address authority = auth.authority();
+    require(Authority(authority).hasUserRole(msg.sender, 0));
     // Upgrades can only go up in version
     IColony colony = IColony(etherRouter);
     uint currentVersion = colony.version();

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -21,6 +21,7 @@ pragma experimental "v0.5.0";
 import "../lib/dappsys/auth.sol";
 import "./ERC20Extended.sol";
 import "./IColonyNetwork.sol";
+import "./Authority.sol";
 
 
 contract ColonyStorage is DSAuth {
@@ -85,6 +86,7 @@ contract ColonyStorage is DSAuth {
   uint256 potCount;
   uint256 domainCount;
 
+  uint8 constant ADMIN_ROLE = 1;
   uint8 constant MANAGER = 0;
   uint8 constant EVALUATOR = 1;
   uint8 constant WORKER = 2;
@@ -183,6 +185,11 @@ contract ColonyStorage is DSAuth {
 
   modifier isInBootstrapPhase() {
     require(taskCount == 0);
+    _;
+  }
+
+  modifier isAdmin(address _user) {
+    require(Authority(authority).hasUserRole(_user, ADMIN_ROLE));
     _;
   }
 

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -39,6 +39,9 @@ contract ColonyStorage is DSAuth {
   // Mapping function signature to 2 task roles whose approval is needed to execute
   mapping (bytes4 => uint8[2]) reviewers;
   uint256 taskChangeNonce; // Made obsolete in #203
+  // Role assignment functions require special type of sign-off.
+  // This keeps track of which functions are related to role assignment
+  mapping (bytes4 => bool) roleAssignmentSigs;
 
   mapping (uint256 => Task) tasks;
 
@@ -139,9 +142,9 @@ contract ColonyStorage is DSAuth {
     uint256 potId;
   }
 
-  modifier isManager(uint256 _id) {
-    Task storage task = tasks[_id];
-    require(task.roles[0].user == msg.sender);
+  modifier confirmTaskRoleIdentity(uint256 _id, uint8 _role) {
+    Role storage role = tasks[_id].roles[_role];
+    require(msg.sender == role.user);
     _;
   }
 

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -89,6 +89,7 @@ contract ColonyStorage is DSAuth {
   uint256 potCount;
   uint256 domainCount;
 
+  uint8 constant OWNER_ROLE = 0;
   uint8 constant ADMIN_ROLE = 1;
   uint8 constant MANAGER = 0;
   uint8 constant EVALUATOR = 1;

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -235,7 +235,10 @@ contract ColonyTask is ColonyStorage, DSMath {
       require(reviewerAddresses[0] == tasks[taskId].roles[MANAGER].user || reviewerAddresses[1] == tasks[taskId].roles[MANAGER].user);
       // One of the signers must be an address we want to set here
       require(userAddress == reviewerAddresses[0] || userAddress == reviewerAddresses[1]);
-      // require that signatures are not from the same address
+      // Require that signatures are not from the same address
+      // This will never throw, because we require that manager is one of the signers,
+      // and if manager is both signers, then `userAddress` must also be a manager, and if
+      // `userAddress` is a manager, then we require 1 signature (will be kept for possible future changes)
       require(reviewerAddresses[0] != reviewerAddresses[1]);
     }
 

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -38,12 +38,6 @@ contract ColonyTask is ColonyStorage, DSMath {
   event TaskFinalized(uint256 indexed id);
   event TaskCanceled(uint256 indexed id);
 
-  modifier confirmTaskRoleIdentity(uint256 _id, uint8 _role) {
-    Role storage role = tasks[_id].roles[_role];
-    require(msg.sender == role.user);
-    _;
-  }
-
   modifier userCanRateRole(uint256 _id, uint8 _role) {
     // Manager rated by worker
     // Worker rated by evaluator
@@ -162,6 +156,7 @@ contract ColonyTask is ColonyStorage, DSMath {
     uint256 taskId;
     (sig, taskId) = deconstructCall(_data);
     require(!tasks[taskId].finalized);
+    require(!roleAssignmentSigs[sig]);
 
     uint8 nSignaturesRequired;
     if (tasks[taskId].roles[reviewers[sig][0]].user == address(0) || tasks[taskId].roles[reviewers[sig][1]].user == address(0)) {
@@ -177,26 +172,73 @@ contract ColonyTask is ColonyStorage, DSMath {
     require(_sigR.length == nSignaturesRequired);
 
     bytes32 msgHash = keccak256(abi.encodePacked(address(this), address(this), _value, _data, taskChangeNonces[taskId]));
-    address[] memory reviewerAddresses = new address[](nSignaturesRequired);
-    for (uint i = 0; i < nSignaturesRequired; i++) {
-      // 0 'Normal' mode - geth, etc.
-      // >0 'Trezor' mode
-      // Correct incantation helpfully cribbed from https://github.com/trezor/trezor-mcu/issues/163#issuecomment-368435292
-      bytes32 txHash;
-      if (_mode[i] == 0) {
-        txHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", msgHash));
-      } else {
-        txHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n\x20", msgHash));
-      }
-
-      reviewerAddresses[i] = ecrecover(txHash, _sigV[i], _sigR[i], _sigS[i]);
-    }
+    address[] memory reviewerAddresses = getReviewerAddresses(
+      _sigV,
+      _sigR,
+      _sigS,
+      _mode,
+      msgHash,
+      nSignaturesRequired
+    );
 
     require(reviewerAddresses[0] == tasks[taskId].roles[reviewers[sig][0]].user || reviewerAddresses[0] == tasks[taskId].roles[reviewers[sig][1]].user);
 
     if (nSignaturesRequired == 2) {
       require(reviewerAddresses[0] != reviewerAddresses[1]);
       require(reviewerAddresses[1] == tasks[taskId].roles[reviewers[sig][0]].user || reviewerAddresses[1] == tasks[taskId].roles[reviewers[sig][1]].user);
+    }
+
+    taskChangeNonces[taskId]++;
+    require(executeCall(address(this), _value, _data));
+  }
+
+  function executeTaskRoleAssignment(
+    uint8[] _sigV,
+    bytes32[] _sigR,
+    bytes32[] _sigS,
+    uint8[] _mode,
+    uint256 _value,
+    bytes _data) public
+  {
+    require(_value == 0);
+    require(_sigR.length == _sigS.length && _sigR.length == _sigV.length);
+
+    bytes4 sig;
+    uint256 taskId;
+    address userAddress;
+    (sig, taskId, userAddress) = deconstructRoleChangeCall(_data);
+
+    require(roleAssignmentSigs[sig]);
+
+    uint8 nSignaturesRequired;
+    // If manager wants to set himself to a role
+    if (userAddress == tasks[taskId].roles[MANAGER].user) {
+      nSignaturesRequired = 1;
+    } else {
+      nSignaturesRequired = 2;
+    }
+    require(_sigR.length == nSignaturesRequired);
+
+    bytes32 msgHash = keccak256(abi.encodePacked(address(this), address(this), _value, _data, taskChangeNonces[taskId]));
+    address[] memory reviewerAddresses = getReviewerAddresses(
+      _sigV,
+      _sigR,
+      _sigS,
+      _mode,
+      msgHash,
+      nSignaturesRequired
+    );
+
+    if (nSignaturesRequired == 1) {
+      // Since we want to set a manager as an evaluator, require just manager's signature
+      require(reviewerAddresses[0] == tasks[taskId].roles[MANAGER].user);
+    } else {
+      // One of signers must be a manager
+      require(reviewerAddresses[0] == tasks[taskId].roles[MANAGER].user || reviewerAddresses[1] == tasks[taskId].roles[MANAGER].user);
+      // One of the signers must be an address we want to set here
+      require(userAddress == reviewerAddresses[0] || userAddress == reviewerAddresses[1]);
+      // require that signatures are not from the same address
+      require(reviewerAddresses[0] != reviewerAddresses[1]);
     }
 
     taskChangeNonces[taskId]++;
@@ -267,43 +309,51 @@ contract ColonyTask is ColonyStorage, DSMath {
     return taskWorkRatings[_id].secret[_role];
   }
 
-  // TODO: Restrict function visibility to whoever submits the approved Transaction from Client
-  // Note task assignment is agreed off-chain
-  function setTaskRoleUser(uint256 _id, uint8 _role, address _user) public
-  taskExists(_id)
-  taskNotFinalized(_id)
+  function setTaskManagerRole(uint256 _id, address _user) public
+  self()
+  isAdmin(_user)
   {
-    require(tasks[_id].roles[MANAGER].user == msg.sender);
-    tasks[_id].roles[_role] = Role({
-      user: _user,
-      rateFail: false,
-      rating: TaskRatings.None
-    });
+    setTaskRoleUser(_id, MANAGER, _user);
+  }
 
-    emit TaskRoleUserChanged(_id, _role, _user);
+  function setTaskEvaluatorRole(uint256 _id, address _user) public self {
+    // Can only assign role if no one is currently assigned to it
+    require(tasks[_id].roles[EVALUATOR].user == 0x0);
+    setTaskRoleUser(_id, EVALUATOR, _user);
+  }
+
+  function setTaskWorkerRole(uint256 _id, address _user) public self {
+    // Can only assign role if no one is currently assigned to it
+    require(tasks[_id].roles[WORKER].user == 0x0);
+    setTaskRoleUser(_id, WORKER, _user);
+  }
+
+  function removeTaskEvaluatorRole(uint256 _id) public self {
+    setTaskRoleUser(_id, EVALUATOR, 0x0);
+  }
+
+  function removeTaskWorkerRole(uint256 _id) public self {
+    setTaskRoleUser(_id, WORKER, 0x0);
   }
 
   function setTaskDomain(uint256 _id, uint256 _domainId) public
+  confirmTaskRoleIdentity(_id, MANAGER)
   taskExists(_id)
   taskNotFinalized(_id)
   domainExists(_domainId)
   {
-    require(tasks[_id].roles[MANAGER].user == msg.sender);
     tasks[_id].domainId = _domainId;
 
     emit TaskDomainChanged(_id, _domainId);
   }
 
-  // TODO: Restrict function visibility to whoever submits the approved Transaction from Client
-  // Maybe just the administrator is adequate for the skill?
   function setTaskSkill(uint256 _id, uint256 _skillId) public
+  self()
   taskExists(_id)
   taskNotFinalized(_id)
   skillExists(_skillId)
   globalSkill(_skillId)
   {
-    require(tasks[_id].roles[MANAGER].user == msg.sender);
-
     tasks[_id].skills[0] = _skillId;
 
     emit TaskSkillChanged(_id, _skillId);
@@ -341,29 +391,15 @@ contract ColonyTask is ColonyStorage, DSMath {
   }
 
   function finalizeTask(uint256 _id) public
-  auth
+  confirmTaskRoleIdentity(_id, MANAGER)
   taskWorkRatingsAssigned(_id)
   taskNotFinalized(_id)
   {
     Task storage task = tasks[_id];
-    IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
-
     task.finalized = true;
 
     for (uint8 roleId = 0; roleId <= 2; roleId++) {
-      Role storage role = task.roles[roleId];
-
-      if (roleId == EVALUATOR) { // They had one job!
-        role.rating = role.rateFail ? TaskRatings.Unsatisfactory : TaskRatings.Satisfactory;
-      }
-
-      uint payout = task.payouts[roleId][token];
-      int reputation = getReputation(int(payout), uint8(role.rating), role.rateFail);
-
-      colonyNetworkContract.appendReputationUpdateLog(role.user, reputation, domains[task.domainId].skillId);
-      if (roleId == WORKER) {
-        colonyNetworkContract.appendReputationUpdateLog(role.user, reputation, task.skills[0]);
-      }
+      updateReputation(roleId, task);
     }
 
     emit TaskFinalized(_id);
@@ -389,6 +425,23 @@ contract ColonyTask is ColonyStorage, DSMath {
     return (role.user, role.rateFail, uint8(role.rating));
   }
 
+  function updateReputation(uint8 roleId, Task storage task) internal {
+    IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
+    Role storage role = task.roles[roleId];
+
+    if (roleId == EVALUATOR) { // They had one job!
+      role.rating = role.rateFail ? TaskRatings.Unsatisfactory : TaskRatings.Satisfactory;
+    }
+
+    uint payout = task.payouts[roleId][token];
+    int reputation = getReputation(int(payout), uint8(role.rating), role.rateFail);
+
+    colonyNetworkContract.appendReputationUpdateLog(role.user, reputation, domains[task.domainId].skillId);
+    if (roleId == WORKER) {
+      colonyNetworkContract.appendReputationUpdateLog(role.user, reputation, task.skills[0]);
+    }
+  }
+
   function getReputation(int payout, uint8 rating, bool rateFail) internal pure returns(int reputation) {
     require(rating > 0 && rating <= 3, "Invalid rating");
 
@@ -401,12 +454,59 @@ contract ColonyTask is ColonyStorage, DSMath {
     reputation /= ratingDivisor; // We may lose one atom of reputation here :sad:
   }
 
+  function getReviewerAddresses(
+    uint8[] _sigV,
+    bytes32[] _sigR,
+    bytes32[] _sigS,
+    uint8[] _mode,
+    bytes32 msgHash,
+    uint8 nSignaturesRequired
+  ) internal pure returns (address[])
+  {
+    address[] memory reviewerAddresses = new address[](nSignaturesRequired);
+    for (uint i = 0; i < nSignaturesRequired; i++) {
+      // 0 'Normal' mode - geth, etc.
+      // >0 'Trezor' mode
+      // Correct incantation helpfully cribbed from https://github.com/trezor/trezor-mcu/issues/163#issuecomment-368435292
+      bytes32 txHash;
+      if (_mode[i] == 0) {
+        txHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", msgHash));
+      } else {
+        txHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n\x20", msgHash));
+      }
+
+      reviewerAddresses[i] = ecrecover(txHash, _sigV[i], _sigR[i], _sigS[i]);
+    }
+    return reviewerAddresses;
+  }
+
   // Get the function signature and task id from the transaction bytes data
   // Note: Relies on the encoded function's first parameter to be the uint256 taskId
   function deconstructCall(bytes _data) internal pure returns (bytes4 sig, uint256 taskId) {
     assembly {
       sig := mload(add(_data, 0x20))
-      taskId := mload(add(_data, add(0x20, 4))) // same as calldataload(72)
+      taskId := mload(add(_data, 0x24)) // same as calldataload(72)
     }
+  }
+
+  function deconstructRoleChangeCall(bytes _data) internal pure returns (bytes4 sig, uint256 taskId, address userAddress) {
+    assembly {
+      sig := mload(add(_data, 0x20))
+      taskId := mload(add(_data, 0x24)) // same as calldataload(72)
+      userAddress := mload(add(_data, 0x44))
+    }
+  }
+
+  function setTaskRoleUser(uint256 _id, uint8 _role, address _user) private
+  taskExists(_id)
+  taskNotFinalized(_id)
+  {
+    tasks[_id].roles[_role] = Role({
+      user: _user,
+      rateFail: false,
+      rating: TaskRatings.None
+    });
+
+    emit TaskRoleUserChanged(_id, _role, _user);
   }
 }

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -177,8 +177,7 @@ contract ColonyTask is ColonyStorage, DSMath {
       _sigR,
       _sigS,
       _mode,
-      msgHash,
-      nSignaturesRequired
+      msgHash
     );
 
     require(reviewerAddresses[0] == tasks[taskId].roles[reviewers[sig][0]].user || reviewerAddresses[0] == tasks[taskId].roles[reviewers[sig][1]].user);
@@ -225,8 +224,7 @@ contract ColonyTask is ColonyStorage, DSMath {
       _sigR,
       _sigS,
       _mode,
-      msgHash,
-      nSignaturesRequired
+      msgHash
     );
 
     if (nSignaturesRequired == 1) {
@@ -391,7 +389,6 @@ contract ColonyTask is ColonyStorage, DSMath {
   }
 
   function finalizeTask(uint256 _id) public
-  confirmTaskRoleIdentity(_id, MANAGER)
   taskWorkRatingsAssigned(_id)
   taskNotFinalized(_id)
   {
@@ -459,12 +456,11 @@ contract ColonyTask is ColonyStorage, DSMath {
     bytes32[] _sigR,
     bytes32[] _sigS,
     uint8[] _mode,
-    bytes32 msgHash,
-    uint8 nSignaturesRequired
+    bytes32 msgHash
   ) internal pure returns (address[])
   {
-    address[] memory reviewerAddresses = new address[](nSignaturesRequired);
-    for (uint i = 0; i < nSignaturesRequired; i++) {
+    address[] memory reviewerAddresses = new address[](_sigR.length);
+    for (uint i = 0; i < _sigR.length; i++) {
       // 0 'Normal' mode - geth, etc.
       // >0 'Trezor' mode
       // Correct incantation helpfully cribbed from https://github.com/trezor/trezor-mcu/issues/163#issuecomment-368435292
@@ -497,6 +493,7 @@ contract ColonyTask is ColonyStorage, DSMath {
     }
   }
 
+  // TODO: Check if we are changing a role before due date and before work has been submitted
   function setTaskRoleUser(uint256 _id, uint8 _role, address _user) private
   taskExists(_id)
   taskNotFinalized(_id)

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -100,13 +100,13 @@ contract IColony {
   /// that control has to be transferred to the colony after this call
   function setToken(address _token) public;
 
-  /// @notice Set new colony owner.
-  /// Can be called by colony network.
+  /// @notice Set new colony owner role.
+  /// Can be called by owner and owner role.
   /// @param _user User we want to give an owner role to
   function setOwnerRole(address _user) public;
 
-  /// @notice Set new colony admin.
-  /// Can be called by owner or admin.
+  /// @notice Set new colony admin role.
+  /// Can be called by owner, owner role or admin role.
   /// @param _user User we want to give an admin role to
   function setAdminRole(address _user) public;
 
@@ -259,6 +259,7 @@ contract IColony {
   /// @notice Assigning manager role
   /// Current manager and user we want to assign role to both need to agree
   /// User we want to set here also needs to be an admin
+  /// @dev This function can only be called through `executeTaskRoleAssignment`
   /// @param _id Id of the task
   /// @param _user Address of the user we want to give a manager role to
   function setTaskManagerRole(uint256 _id, address _user) public;
@@ -267,6 +268,7 @@ contract IColony {
   /// Can only be set if there is no one currently assigned to be an evaluator
   /// Manager of the task and user we want to assign role to both need to agree
   /// Managers can assign themselves to this role, if there is no one currently assigned to it
+  /// @dev This function can only be called through `executeTaskRoleAssignment`
   /// @param _id Id of the task
   /// @param _user Address of the user we want to give a evaluator role to
   function setTaskEvaluatorRole(uint256 _id, address _user) public;
@@ -274,6 +276,7 @@ contract IColony {
   /// @notice Assigning worker role
   /// Can only be set if there is no one currently assigned to be a worker
   /// Manager of the task and user we want to assign role to both need to agree
+  /// @dev This function can only be called through `executeTaskRoleAssignment`
   /// @param _id Id of the task
   /// @param _user Address of the user we want to give a worker role to
   function setTaskWorkerRole(uint256 _id, address _user) public;

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -100,6 +100,16 @@ contract IColony {
   /// that control has to be transferred to the colony after this call
   function setToken(address _token) public;
 
+  /// @notice Set new colony admin.
+  /// Can be called by owner or admin.
+  /// @param _user User we want to give an admin role to
+  function setAdmin(address _user) public;
+
+  /// @notice Remove colony admin.
+  /// Can only be called by owner.
+  /// @param _user User we want to remove admin role from
+  function removeAdmin(address _user) public;
+
   /// @notice Get the colony token
   /// @return Address of the token contract
   function getToken() public view returns (address);

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -84,7 +84,8 @@ contract IColony {
   /// @return The `Authority` contract address
   function authority() public view returns (address);
 
-  /// @notice Get the colony `owner` address. Inherited from the DSAuth contract
+  /// @notice Get the colony `owner` address. This should be 0x0 at all times
+  /// @dev Used for testing.
   /// @return Address of the colony owner
   function owner() public view returns (address);
 
@@ -94,6 +95,11 @@ contract IColony {
   /// @return Version number
   function version() public pure returns (uint256);
 
+  /// @notice Upgrades a colony to a new Colony contract version `_newVersion`
+  /// @dev Downgrades are not allowed, i.e. `_newVersion` should be higher than the currect colony version
+  /// @param _newVersion The target version for the upgrade
+  function upgrade(uint _newVersion) public;
+
   /// @notice Set the colony token. Secured function to authorised members
   /// @param _token Address of the token contract to use.
   /// Note that if the `mint` functionality is to be controlled through the colony,
@@ -101,17 +107,17 @@ contract IColony {
   function setToken(address _token) public;
 
   /// @notice Set new colony owner role.
-  /// Can be called by owner and owner role.
+  /// Can be called by owner role.
   /// @param _user User we want to give an owner role to
   function setOwnerRole(address _user) public;
 
   /// @notice Set new colony admin role.
-  /// Can be called by owner, owner role or admin role.
+  /// Can be called by owner role or admin role.
   /// @param _user User we want to give an admin role to
   function setAdminRole(address _user) public;
 
   /// @notice Remove colony admin.
-  /// Can only be called by owner.
+  /// Can only be called by owner role.
   /// @param _user User we want to remove admin role from
   function removeAdminRole(address _user) public;
 

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -196,6 +196,18 @@ contract IColony {
   /// @param _data The transaction data
   function executeTaskChange(uint8[] _sigV, bytes32[] _sigR, bytes32[] _sigS, uint8[] _mode, uint256 _value, bytes _data) public;
 
+  /// @notice Executes a task role update transaction `_data` which is approved and signed by two of addresses
+  /// depending of which function we are calling. Allowed functions are `setTaskManagerRole`, `setTaskEvaluatorRole` and `setTaskWorkerRole`.
+  /// Upon successful execution the `taskChangeNonces` entry for the task is incremented
+  /// @param _sigV recovery id
+  /// @param _sigR r output of the ECDSA signature of the transaction
+  /// @param _sigS s output of the ECDSA signature of the transaction
+  /// @param _mode How the signature was generated - 0 for Geth-style (usual), 1 for Trezor-style (only Trezor does this)
+  /// @param _value The transaction value, i.e. number of wei to be sent when the transaction is executed
+  /// Currently we only accept 0 value transactions but this is kept as a future option
+  /// @param _data The transaction data
+  function executeTaskRoleAssignment(uint8[] _sigV, bytes32[] _sigR, bytes32[] _sigS, uint8[] _mode, uint256 _value, bytes _data) public;
+
   /// @notice Submit a hashed secret of the rating for work in task `_id` which was performed by user with task role id `_role`
   /// Allowed within 5 days period starting which whichever is first from either the deliverable being submitted or the dueDate been reached
   /// Allowed only for evaluator to rate worker and for worker to rate manager performance
@@ -239,12 +251,37 @@ contract IColony {
   /// @return Rating secret `bytes32` value
   function getTaskWorkRatingSecret(uint256 _id, uint8 _role) public view returns (bytes32);
 
-  /// @notice Set the user for role `_role` in task `_id`. Only allowed before the task is `finalized`, as in
-  // you cannot change the task contributors after the work is complete. Allowed before a task is finalized.
+  /// @notice Assigning manager role
+  /// Current manager and user we want to assign role to both need to agree
+  /// User we want to set here also needs to be an admin
   /// @param _id Id of the task
-  /// @param _role Id of the role, as defined in `ColonyStorage` `MANAGER`, `EVALUATOR` and `WORKER` constants
-  /// @param _user Address of the user to assume role `_role`
-  function setTaskRoleUser(uint256 _id, uint8 _role, address _user) public;
+  /// @param _user Address of the user we want to give a manager role to
+  function setTaskManagerRole(uint256 _id, address _user) public;
+
+  /// @notice Assigning evaluator role
+  /// Can only be set if there is no one currently assigned to be an evaluator
+  /// Manager of the task and user we want to assign role to both need to agree
+  /// Managers can assign themselves to this role, if there is no one currently assigned to it
+  /// @param _id Id of the task
+  /// @param _user Address of the user we want to give a evaluator role to
+  function setTaskEvaluatorRole(uint256 _id, address _user) public;
+
+  /// @notice Assigning worker role
+  /// Can only be set if there is no one currently assigned to be a worker
+  /// Manager of the task and user we want to assign role to both need to agree
+  /// @param _id Id of the task
+  /// @param _user Address of the user we want to give a worker role to
+  function setTaskWorkerRole(uint256 _id, address _user) public;
+
+  /// @notice Removing evaluator role
+  /// Agreed between manager and currently assigned evaluator
+  /// @param _id Id of the task
+  function removeTaskEvaluatorRole(uint256 _id) public;
+
+  /// @notice Removing worker role
+  /// Agreed between manager and currently assigned worker
+  /// @param _id Id of the task
+  function removeTaskWorkerRole(uint256 _id) public;
 
   /// @notice Set the skill for task `_id`
   /// @dev Currently we only allow one skill per task although we have provisioned for an array of skills in `Task` struct

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -107,6 +107,8 @@ contract IColony {
   function setToken(address _token) public;
 
   /// @notice Set new colony owner role.
+  /// @dev There can only be one address assigned to owner role at a time.
+  /// Whoever calls this function will lose their owner role
   /// Can be called by owner role.
   /// @param _user User we want to give an owner role to
   function setOwnerRole(address _user) public;

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -100,15 +100,20 @@ contract IColony {
   /// that control has to be transferred to the colony after this call
   function setToken(address _token) public;
 
+  /// @notice Set new colony owner.
+  /// Can be called by colony network.
+  /// @param _user User we want to give an owner role to
+  function setOwnerRole(address _user) public;
+
   /// @notice Set new colony admin.
   /// Can be called by owner or admin.
   /// @param _user User we want to give an admin role to
-  function setAdmin(address _user) public;
+  function setAdminRole(address _user) public;
 
   /// @notice Remove colony admin.
   /// Can only be called by owner.
   /// @param _user User we want to remove admin role from
-  function removeAdmin(address _user) public;
+  function removeAdminRole(address _user) public;
 
   /// @notice Get the colony token
   /// @return Address of the token contract

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -112,12 +112,6 @@ contract IColonyNetwork {
   /// @return The current / latest Colony contract version
   function getCurrentColonyVersion() public view returns (uint256);
 
-  /// @notice Upgrades a colony with identifier: `_id` to a new Colony contract version `_newVersion`
-  /// @dev Downgrades are not allowed, i.e. `_newVersion` should be higher than the currect colony version
-  /// @param _id The colony identifier in the network
-  /// @param _newVersion The target version for the upgrade
-  function upgradeColony(uint256 _id, uint _newVersion) public;
-
   /// @notice Get the id of the parent skill at index `_parentSkillIndex` for skill with Id `_skillId`
   /// @param _skillId Id of the skill
   /// @param _parentSkillIndex Index of the `skill.parents` array to get

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -106,7 +106,7 @@ contract("All", accounts => {
     it("when working with a Colony", async () => {
       await colony.mintTokens(200);
       await colony.claimColonyFunds(tokenAddress);
-      await colony.setAdmin(EVALUATOR);
+      await colony.setAdminRole(EVALUATOR);
     });
 
     it("when working with a Task", async () => {

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -28,7 +28,8 @@ import {
   giveUserCLNYTokensAndStake,
   fundColonyWithTokens,
   executeSignedTaskChange,
-  executeSignedRoleAssignment
+  executeSignedRoleAssignment,
+  makeTask
 } from "../helpers/test-data-generator";
 
 import ReputationMiner from "../packages/reputation-miner/ReputationMiner";
@@ -110,8 +111,7 @@ contract("All", accounts => {
     });
 
     it("when working with a Task", async () => {
-      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
-      const taskId = logs[0].args.id.toNumber();
+      const taskId = await makeTask({ colony });
 
       // setTaskDomain
       await colony.setTaskDomain(taskId, 1);

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -153,7 +153,14 @@ contract("All", accounts => {
       await colony.moveFundsBetweenPots(1, 2, 150, tokenAddress);
 
       // setTaskManagerPayout
-      await colony.setTaskManagerPayout(taskId, tokenAddress, 50);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, tokenAddress, 50]
+      });
 
       // setTaskEvaluatorPayout
       await executeSignedTaskChange({

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -38,7 +38,6 @@ const ColonyTask = artifacts.require("ColonyTask");
 const ColonyFunding = artifacts.require("ColonyFunding");
 const Resolver = artifacts.require("Resolver");
 const EtherRouter = artifacts.require("EtherRouter");
-const Authority = artifacts.require("Authority");
 const ReputationMiningCycle = artifacts.require("ReputationMiningCycle");
 
 const oneHourLater = async () => forwardTime(3600, this);
@@ -58,7 +57,6 @@ contract("All", accounts => {
   let colonyTask;
   let colonyFunding;
   let metaColony;
-  let authority;
   let colonyNetwork;
 
   before(async () => {
@@ -77,8 +75,6 @@ contract("All", accounts => {
     await token.setOwner(colonyAddress);
     colony = await IColony.at(colonyAddress);
     tokenAddress = await colony.getToken.call();
-    const authorityAddress = await colony.authority.call();
-    authority = await Authority.at(authorityAddress);
     await IColony.defaults({ gasPrice });
 
     const metaColonyAddress = await colonyNetwork.getMetaColony.call();
@@ -106,7 +102,7 @@ contract("All", accounts => {
     it("when working with a Colony", async () => {
       await colony.mintTokens(200);
       await colony.claimColonyFunds(tokenAddress);
-      await authority.setUserRole(EVALUATOR, 1, true);
+      await colony.setAdmin(EVALUATOR);
     });
 
     it("when working with a Task", async () => {

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -148,7 +148,14 @@ export async function setupFundedTask({
   const totalPayouts = managerPayoutBN.add(workerPayoutBN).add(evaluatorPayoutBN);
   await colony.moveFundsBetweenPots(1, potId, totalPayouts.toString(), tokenAddress);
 
-  await colony.setTaskManagerPayout(taskId, tokenAddress, managerPayout.toString());
+  await executeSignedTaskChange({
+    colony,
+    functionName: "setTaskManagerPayout",
+    taskId,
+    signers: [MANAGER],
+    sigTypes: [0],
+    args: [taskId, tokenAddress, managerPayout.toString()]
+  });
 
   let signers = MANAGER === evaluator ? [MANAGER] : [MANAGER, evaluator];
   let sigTypes = Array.from({ length: signers.length }, () => 0);

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -14,14 +14,38 @@ import {
   RATING_1_SALT,
   RATING_2_SALT,
   MANAGER_ROLE,
-  EVALUATOR_ROLE,
   WORKER_ROLE,
   SPECIFICATION_HASH
 } from "./constants";
-import { currentBlockTime, createSignatures } from "./test-helper";
+import { currentBlockTime, createSignatures, createSignaturesTrezor } from "./test-helper";
 
 const IColony = artifacts.require("IColony");
 const Token = artifacts.require("Token");
+
+async function getSigsAndTransactionData({ colony, functionName, taskId, signers, sigTypes, args }) {
+  const txData = await colony.contract[functionName].getData(...args);
+  const sigsPromises = sigTypes.map((type, i) => {
+    if (type === 0) {
+      return createSignatures(colony, taskId, [signers[i]], 0, txData);
+    }
+    return createSignaturesTrezor(colony, taskId, [signers[i]], 0, txData);
+  });
+  const sigs = await Promise.all(sigsPromises);
+  const sigV = sigs.map(sig => sig.sigV[0]);
+  const sigR = sigs.map(sig => sig.sigR[0]);
+  const sigS = sigs.map(sig => sig.sigS[0]);
+  return { sigV, sigR, sigS, txData };
+}
+
+export async function executeSignedTaskChange({ colony, functionName, taskId, signers, sigTypes, args }) {
+  const { sigV, sigR, sigS, txData } = await getSigsAndTransactionData({ colony, functionName, taskId, signers, sigTypes, args });
+  return colony.executeTaskChange(sigV, sigR, sigS, sigTypes, 0, txData);
+}
+
+export async function executeSignedRoleAssignment({ colony, functionName, taskId, signers, sigTypes, args }) {
+  const { sigV, sigR, sigS, txData } = await getSigsAndTransactionData({ colony, functionName, taskId, signers, sigTypes, args });
+  return colony.executeTaskRoleAssignment(sigV, sigR, sigS, sigTypes, 0, txData);
+}
 
 export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain = 1, skill = 0, evaluator = EVALUATOR, worker = WORKER }) {
   const specificationHash = SPECIFICATION_HASH;
@@ -32,22 +56,63 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
   if (skill === 0) {
     const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId.call();
     if (rootGlobalSkill.toNumber() === 0) throw new Error("Meta Colony is not setup and therefore the root global skill does not exist");
-    await colony.setTaskSkill(taskId, rootGlobalSkill);
+
+    await executeSignedTaskChange({
+      colony,
+      functionName: "setTaskSkill",
+      taskId,
+      signers: [MANAGER],
+      sigTypes: [0],
+      args: [taskId, rootGlobalSkill.toNumber()]
+    });
   } else {
-    await colony.setTaskSkill(taskId, skill);
+    await executeSignedTaskChange({
+      colony,
+      functionName: "setTaskSkill",
+      taskId,
+      signers: [MANAGER],
+      sigTypes: [0],
+      args: [taskId, skill]
+    });
   }
-  await colony.setTaskRoleUser(taskId, EVALUATOR_ROLE, evaluator);
-  await colony.setTaskRoleUser(taskId, WORKER_ROLE, worker);
+
+  let signers = MANAGER === evaluator ? [MANAGER] : [MANAGER, evaluator];
+  let sigTypes = Array.from({ length: signers.length }, () => 0);
+
+  await executeSignedRoleAssignment({
+    colony,
+    taskId,
+    functionName: "setTaskEvaluatorRole",
+    signers,
+    sigTypes,
+    args: [taskId, evaluator]
+  });
+
+  signers = MANAGER === worker ? [MANAGER] : [MANAGER, worker];
+  sigTypes = Array.from({ length: signers.length }, () => 0);
+
+  await executeSignedRoleAssignment({
+    colony,
+    taskId,
+    functionName: "setTaskWorkerRole",
+    signers,
+    sigTypes,
+    args: [taskId, worker]
+  });
 
   let dueDateTimestamp = dueDate;
   if (!dueDateTimestamp) {
     dueDateTimestamp = await currentBlockTime();
   }
-  const txData = await colony.contract.setTaskDueDate.getData(taskId, dueDateTimestamp);
-  const signers = MANAGER === worker ? [MANAGER] : [MANAGER, worker];
-  const sigs = await createSignatures(colony, taskId, signers, 0, txData);
-  const signatureTypes = Array.from({ length: signers.length }, () => 0);
-  await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, signatureTypes, 0, txData);
+
+  await executeSignedTaskChange({
+    colony,
+    functionName: "setTaskDueDate",
+    taskId,
+    signers,
+    sigTypes,
+    args: [taskId, dueDateTimestamp]
+  });
   return taskId;
 }
 
@@ -65,8 +130,6 @@ export async function setupFundedTask({
   workerPayout = WORKER_PAYOUT
 }) {
   let tokenAddress;
-  let txData;
-  let sigs;
 
   if (token === undefined) {
     tokenAddress = await colony.getToken.call();
@@ -84,17 +147,29 @@ export async function setupFundedTask({
 
   await colony.setTaskManagerPayout(taskId, tokenAddress, managerPayout.toString());
 
-  txData = await colony.contract.setTaskEvaluatorPayout.getData(taskId, tokenAddress, evaluatorPayout.toString());
   let signers = MANAGER === evaluator ? [MANAGER] : [MANAGER, evaluator];
-  sigs = await createSignatures(colony, taskId, signers, 0, txData);
-  let signatureTypes = Array.from({ length: signers.length }, () => 0);
-  await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, signatureTypes, 0, txData);
+  let sigTypes = Array.from({ length: signers.length }, () => 0);
 
-  txData = await colony.contract.setTaskWorkerPayout.getData(taskId, tokenAddress, workerPayout.toString());
+  await executeSignedTaskChange({
+    colony,
+    functionName: "setTaskEvaluatorPayout",
+    taskId,
+    signers,
+    sigTypes,
+    args: [taskId, tokenAddress, evaluatorPayout.toString()]
+  });
+
   signers = MANAGER === worker ? [MANAGER] : [MANAGER, worker];
-  sigs = await createSignatures(colony, taskId, signers, 0, txData);
-  signatureTypes = Array.from({ length: signers.length }, () => 0);
-  await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, signatureTypes, 0, txData);
+  sigTypes = Array.from({ length: signers.length }, () => 0);
+
+  await executeSignedTaskChange({
+    colony,
+    functionName: "setTaskWorkerPayout",
+    taskId,
+    signers,
+    sigTypes,
+    args: [taskId, tokenAddress, workerPayout.toString()]
+  });
   return taskId;
 }
 

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -186,6 +186,10 @@ export async function forwardTime(seconds, test) {
   return p;
 }
 
+export function getFunctionSignature(sig) {
+  return web3Utils.sha3(sig).slice(0, 10);
+}
+
 export async function createSignatures(colony, taskId, signers, value, data) {
   const sourceAddress = colony.address;
   const destinationAddress = colony.address;

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -4,7 +4,7 @@ import { toBN } from "web3-utils";
 
 import { MANAGER, EVALUATOR, WORKER, MANAGER_ROLE, EVALUATOR_ROLE, WORKER_ROLE, WORKER_PAYOUT, INITIAL_FUNDING } from "../helpers/constants";
 import { getTokenArgs, checkErrorRevert, web3GetBalance, forwardTime, bnSqrt } from "../helpers/test-helper";
-import { fundColonyWithTokens, setupRatedTask, executeSignedRoleAssignment, makeTask } from "../helpers/test-data-generator";
+import { fundColonyWithTokens, setupRatedTask, executeSignedTaskChange, executeSignedRoleAssignment, makeTask } from "../helpers/test-data-generator";
 
 const EtherRouter = artifacts.require("EtherRouter");
 const IColony = artifacts.require("IColony");
@@ -152,50 +152,78 @@ contract("Colony Funding", addresses => {
       });
       // Pot 0, Payout 0
       // Pot was equal to payout, transition to pot being equal by changing payout (18)
-      await colony.setTaskManagerPayout(1, otherToken.address, 0);
-      let task = await colony.getTask.call(1);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, otherToken.address, 0]
+      });
+      let task = await colony.getTask.call(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 0, Payout 0
       // Pot was equal to payout, transition to pot being equal by changing pot (17)
       await colony.moveFundsBetweenPots(1, 2, 0, otherToken.address);
-      task = await colony.getTask.call(1);
+      task = await colony.getTask.call(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 0, Payout 0
       // Pot was equal to payout, transition to pot being lower by increasing payout (8)
-      await colony.setTaskManagerPayout(1, otherToken.address, 40);
-      task = await colony.getTask.call(1);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, otherToken.address, 40]
+      });
+      task = await colony.getTask.call(taskId);
       assert.equal(task[5].toNumber(), 1);
 
       // Pot 0, Payout 40
       // Pot was below payout, transition to being equal by increasing pot (1)
       await colony.moveFundsBetweenPots(1, 2, 40, otherToken.address);
-      task = await colony.getTask.call(1);
+      task = await colony.getTask.call(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 40, Payout 40
       // Pot was equal to payout, transition to being above by increasing pot (5)
       await colony.moveFundsBetweenPots(1, 2, 40, otherToken.address);
-      task = await colony.getTask.call(1);
+      task = await colony.getTask.call(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 80, Payout 40
       // Pot was above payout, transition to being equal by increasing payout (12)
-      await colony.setTaskManagerPayout(1, otherToken.address, 80);
-      task = await colony.getTask.call(1);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, otherToken.address, 80]
+      });
+      task = await colony.getTask.call(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 80, Payout 80
       // Pot was equal to payout, transition to being above by decreasing payout (6)
-      await colony.setTaskManagerPayout(1, otherToken.address, 40);
-      task = await colony.getTask.call(1);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, otherToken.address, 40]
+      });
+      task = await colony.getTask.call(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 80, Payout 40
       // Pot was above payout, transition to being equal by decreasing pot (11)
       await colony.moveFundsBetweenPots(2, 1, 40, otherToken.address);
-      task = await colony.getTask.call(1);
+      task = await colony.getTask.call(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 40, Payout 40
@@ -203,14 +231,28 @@ contract("Colony Funding", addresses => {
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 20, otherToken.address), "colony-funding-task-bad-state");
 
       // Remove 20 from pot
-      await colony.setTaskManagerPayout(1, otherToken.address, 20);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, otherToken.address, 20]
+      });
       await colony.moveFundsBetweenPots(2, 1, 20, otherToken.address);
-      await colony.setTaskManagerPayout(1, otherToken.address, 40);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, otherToken.address, 40]
+      });
 
       // Pot 20, Payout 40
       // Pot was below payout, change to being above by changing pot (3)
       await colony.moveFundsBetweenPots(1, 2, 60, otherToken.address);
-      task = await colony.getTask.call(1);
+      task = await colony.getTask.call(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 80, Payout 40
@@ -218,38 +260,80 @@ contract("Colony Funding", addresses => {
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 60, otherToken.address), "colony-funding-task-bad-state");
 
       // Remove 60 from pot
-      await colony.setTaskManagerPayout(1, otherToken.address, 20);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, otherToken.address, 20]
+      });
       await colony.moveFundsBetweenPots(2, 1, 60, otherToken.address);
-      await colony.setTaskManagerPayout(1, otherToken.address, 40);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, otherToken.address, 40]
+      });
 
       // Pot 20, Payout 40
       // Pot was below payout, change to being above by changing payout (4)
-      await colony.setTaskManagerPayout(1, otherToken.address, 10);
-      task = await colony.getTask.call(1);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, otherToken.address, 10]
+      });
+      task = await colony.getTask.call(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 20, Payout 10
       // Pot was above, change to being above by changing payout (16)
-      await colony.setTaskManagerPayout(1, otherToken.address, 5);
-      task = await colony.getTask.call(1);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, otherToken.address, 5]
+      });
+      task = await colony.getTask.call(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 20, Payout 5
       // Pot was above, change to being above by changing pot (15)
       await colony.moveFundsBetweenPots(2, 1, 10, otherToken.address);
-      task = await colony.getTask.call(1);
+      task = await colony.getTask.call(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 10, Payout 5
       // Pot was above payout, change to being below by changing payout (10)
-      await colony.setTaskManagerPayout(1, otherToken.address, 40);
-      task = await colony.getTask.call(1);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, otherToken.address, 40]
+      });
+      task = await colony.getTask.call(taskId);
       assert.equal(task[5].toNumber(), 1);
 
       // Pot 10, Payout 40
       // Pot was below payout, change to being below by changing payout (14)
-      await colony.setTaskManagerPayout(1, otherToken.address, 30);
-      task = await colony.getTask.call(1);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, otherToken.address, 30]
+      });
+      task = await colony.getTask.call(taskId);
       assert.equal(task[5].toNumber(), 1);
 
       // Pot 10, Payout 30
@@ -257,14 +341,35 @@ contract("Colony Funding", addresses => {
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 5, otherToken.address), "colony-funding-task-bad-state");
 
       // Remove 5 from pot
-      await colony.setTaskManagerPayout(1, otherToken.address, 5);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, otherToken.address, 5]
+      });
       await colony.moveFundsBetweenPots(2, 1, 5, otherToken.address);
-      await colony.setTaskManagerPayout(1, otherToken.address, 30);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, otherToken.address, 30]
+      });
 
       // Pot 5, Payout 30
       // Pot was below payout, change to being equal by changing payout (2)
-      await colony.setTaskManagerPayout(1, otherToken.address, 5);
-      task = await colony.getTask.call(1);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, otherToken.address, 5]
+      });
+      task = await colony.getTask.call(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 5, Payout 5
@@ -399,26 +504,40 @@ contract("Colony Funding", addresses => {
       });
 
       // Set manager payout above pot value 40 > 0
-      await colony.setTaskManagerPayout(1, 0x0, 40);
-      let task = await colony.getTask(1);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, 0x0, 40]
+      });
+      let task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 1);
 
       // Fund the pot equal to manager payout 40 = 40
       await colony.moveFundsBetweenPots(1, 2, 40, 0x0);
-      task = await colony.getTask(1);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Cannot bring pot balance below current payout
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 30, 0x0), "colony-funding-task-bad-state");
 
       // Set manager payout above pot value 50 > 40
-      await colony.setTaskManagerPayout(1, 0x0, 50);
-      task = await colony.getTask(1);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskManagerPayout",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, 0x0, 50]
+      });
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 1);
 
       // Fund the pot equal to manager payout, plus 10, 50 < 60
       await colony.moveFundsBetweenPots(1, 2, 20, 0x0);
-      task = await colony.getTask(1);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Cannot bring pot balance below current payout
@@ -426,7 +545,7 @@ contract("Colony Funding", addresses => {
 
       // Can remove surplus 50 = 50
       await colony.moveFundsBetweenPots(2, 1, 10, 0x0);
-      task = await colony.getTask(1);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 0);
     });
 

--- a/test/colony.js
+++ b/test/colony.js
@@ -34,10 +34,16 @@ import {
   forwardTime,
   currentBlockTime,
   createSignatures,
-  createSignaturesTrezor,
   getFunctionSignature
 } from "../helpers/test-helper";
-import { fundColonyWithTokens, setupRatedTask, setupAssignedTask, setupFundedTask } from "../helpers/test-data-generator";
+import {
+  fundColonyWithTokens,
+  setupRatedTask,
+  setupAssignedTask,
+  setupFundedTask,
+  executeSignedTaskChange,
+  executeSignedRoleAssignment
+} from "../helpers/test-data-generator";
 
 import { setupColonyVersionResolver } from "../helpers/upgradable-contracts";
 
@@ -353,166 +359,677 @@ contract("Colony", addresses => {
   });
 
   describe("when updating tasks", () => {
-    it("should allow the worker and evaluator roles to be assigned", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(1, EVALUATOR_ROLE, EVALUATOR);
-      const evaluator = await colony.getTaskRole.call(1, EVALUATOR_ROLE);
-      assert.equal(evaluator[0], EVALUATOR);
+    it("should not be able to pass unallowed function signature to `executeTaskRoleAssignment`", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
 
-      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
-      const worker = await colony.getTaskRole.call(1, WORKER_ROLE);
-      assert.equal(worker[0], WORKER);
+      await checkErrorRevert(
+        executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskDueDate",
+          signers: [MANAGER, WORKER],
+          sigTypes: [0, 0],
+          args: [taskId, WORKER]
+        })
+      );
     });
 
-    it("should not allow the worker or evaluator roles to be assigned by an address that is not the manager", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      await checkErrorRevert(colony.setTaskRoleUser(1, EVALUATOR_ROLE, EVALUATOR, { from: OTHER }));
-      const evaluator = await colony.getTaskRole.call(1, EVALUATOR_ROLE);
+    it("should not be able to send any ether while assigning a role", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      const sigTypes = [0, 0];
+      const signers = [MANAGER, WORKER];
+      const txData = await colony.contract.setTaskWorkerRole.getData(taskId, WORKER);
+      const sigsPromises = sigTypes.map((type, i) => createSignatures(colony, taskId, [signers[i]], 0, txData));
+      const sigs = await Promise.all(sigsPromises);
+      const sigV = sigs.map(sig => sig.sigV[0]);
+      const sigR = sigs.map(sig => sig.sigR[0]);
+      const sigS = sigs.map(sig => sig.sigS[0]);
+
+      await checkErrorRevert(colony.executeTaskRoleAssignment(sigV, sigR, sigS, sigTypes, 10, txData));
+    });
+
+    it("should allow the worker and evaluator roles to be assigned", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskWorkerRole",
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, WORKER]
+      });
+
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskEvaluatorRole",
+        signers: [MANAGER, EVALUATOR],
+        sigTypes: [0, 0],
+        args: [taskId, EVALUATOR]
+      });
+
+      const worker = await colony.getTaskRole(taskId, WORKER_ROLE);
+      assert.equal(worker[0], WORKER);
+
+      const evaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
+      assert.equal(evaluator[0], EVALUATOR);
+    });
+
+    it("should not allow the worker or evaluator roles to be assigned only by manager", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await checkErrorRevert(
+        executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskEvaluatorRole",
+          signers: [MANAGER],
+          sigTypes: [0],
+          args: [taskId, EVALUATOR]
+        })
+      );
+
+      const evaluator = await colony.getTaskRole.call(taskId, EVALUATOR_ROLE);
       assert.equal(evaluator[0], "0x0000000000000000000000000000000000000000");
 
-      await checkErrorRevert(colony.setTaskRoleUser(1, WORKER_ROLE, WORKER, { from: OTHER }));
-      const worker = await colony.getTaskRole.call(1, WORKER_ROLE);
+      await checkErrorRevert(
+        executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskWorkerRole",
+          signers: [MANAGER],
+          sigTypes: [0],
+          args: [taskId, WORKER]
+        })
+      );
+
+      await checkErrorRevert(
+        executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskWorkerRole",
+          signers: [MANAGER, MANAGER],
+          sigTypes: [0, 0],
+          args: [taskId, MANAGER]
+        })
+      );
+
+      const worker = await colony.getTaskRole.call(taskId, WORKER_ROLE);
       assert.equal(worker[0], "0x0000000000000000000000000000000000000000");
     });
 
+    it("should not allow role to be assigned if it is already assigned to somebody", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskWorkerRole",
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, WORKER]
+      });
+
+      await checkErrorRevert(
+        executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskWorkerRole",
+          signers: [MANAGER, OTHER],
+          sigTypes: [0, 0],
+          args: [taskId, OTHER]
+        })
+      );
+
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskEvaluatorRole",
+        signers: [MANAGER, EVALUATOR],
+        sigTypes: [0, 0],
+        args: [taskId, EVALUATOR]
+      });
+
+      await checkErrorRevert(
+        executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskEvaluatorRole",
+          signers: [MANAGER, OTHER],
+          sigTypes: [0, 0],
+          args: [taskId, OTHER]
+        })
+      );
+    });
+
+    it("should allow role to be unassigned, as long as the current assigned address agrees", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskWorkerRole",
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, WORKER]
+      });
+
+      let workerInfo = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      assert.equal(workerInfo[0], WORKER);
+
+      await executeSignedTaskChange({
+        colony,
+        taskId,
+        functionName: "removeTaskWorkerRole",
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId]
+      });
+
+      workerInfo = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      assert.equal(workerInfo[0], "0x0000000000000000000000000000000000000000");
+    });
+
+    it("should not allow role to be unassigned, if current assigned address does not agree", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskWorkerRole",
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, WORKER]
+      });
+
+      await checkErrorRevert(
+        executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskWorkerRole",
+          signers: [MANAGER, OTHER],
+          sigTypes: [0, 0],
+          args: [taskId, 0x0]
+        })
+      );
+
+      const workerInfo = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      assert.equal(workerInfo[0], WORKER);
+    });
+
+    it("should not allow role to be assigned if passed address is not equal to one of the signers", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await checkErrorRevert(
+        executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskWorkerRole",
+          signers: [MANAGER, WORKER],
+          sigTypes: [0, 0],
+          args: [taskId, EVALUATOR]
+        })
+      );
+
+      const workerInfo = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      assert.equal(workerInfo[0], "0x0000000000000000000000000000000000000000");
+    });
+
+    it("should allow manager to assign himself as an evaluator", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskEvaluatorRole",
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, MANAGER]
+      });
+
+      const evaluatorInfo = await colony.getTaskRole.call(taskId, EVALUATOR_ROLE);
+      assert.equal(evaluatorInfo[0], MANAGER);
+    });
+
+    it("should not allow anyone to assign himself as an evaluator with one signature except manager", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await checkErrorRevert(
+        executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskEvaluatorRole",
+          signers: [WORKER],
+          sigTypes: [0],
+          args: [taskId, MANAGER]
+        })
+      );
+
+      const evaluatorInfo = await colony.getTaskRole.call(taskId, EVALUATOR_ROLE);
+      assert.equal(evaluatorInfo[0], "0x0000000000000000000000000000000000000000");
+    });
+
+    it("should be able to remove evaluator role", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskEvaluatorRole",
+        signers: [MANAGER, EVALUATOR],
+        sigTypes: [0, 0],
+        args: [taskId, EVALUATOR]
+      });
+
+      let evaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
+      assert.equal(evaluator[0], EVALUATOR);
+
+      await executeSignedTaskChange({
+        colony,
+        taskId,
+        functionName: "removeTaskEvaluatorRole",
+        signers: [MANAGER, EVALUATOR],
+        sigTypes: [0, 0],
+        args: [taskId]
+      });
+
+      evaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
+      assert.equal(evaluator[0], "0x0000000000000000000000000000000000000000");
+    });
+
+    it("should allow different modes of signing when assigning roles", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskWorkerRole",
+        signers: [WORKER, MANAGER],
+        sigTypes: [0, 1],
+        args: [taskId, WORKER]
+      });
+
+      const worker = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      assert.equal(worker[0], WORKER);
+    });
+
+    it("should not allow role assignment if non of the signers is manager", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await checkErrorRevert(
+        executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskWorkerRole",
+          signers: [WORKER, OTHER],
+          sigTypes: [0, 0],
+          args: [taskId, WORKER]
+        })
+      );
+
+      const worker = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      assert.equal(worker[0], "0x0000000000000000000000000000000000000000");
+    });
+
+    it("should allow to change manager role if the user agrees", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await colony.setAdmin(OTHER);
+
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskManagerRole",
+        signers: [MANAGER, OTHER],
+        sigTypes: [0, 0],
+        args: [taskId, OTHER]
+      });
+
+      const managerInfo = await colony.getTaskRole(taskId, MANAGER_ROLE);
+      assert.equal(managerInfo[0], OTHER);
+    });
+
+    it("should not allow assignment of manager role if the user does not agree", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await colony.setAdmin(OTHER);
+
+      await checkErrorRevert(
+        executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskManagerRole",
+          signers: [MANAGER, EVALUATOR],
+          sigTypes: [0, 0],
+          args: [taskId, OTHER]
+        })
+      );
+
+      const managerInfo = await colony.getTaskRole(taskId, MANAGER_ROLE);
+      assert.equal(managerInfo[0], MANAGER);
+    });
+
+    it("should not allow assignment of manager role if user is not an admin", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await checkErrorRevert(
+        executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskManagerRole",
+          signers: [MANAGER, OTHER],
+          sigTypes: [0, 0],
+          args: [taskId, OTHER]
+        })
+      );
+
+      const managerInfo = await colony.getTaskRole(taskId, MANAGER_ROLE);
+      assert.equal(managerInfo[0], MANAGER);
+    });
+
+    it("should not allow removal of manager role", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await colony.setAdmin(OTHER);
+
+      await checkErrorRevert(
+        executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskManagerRole",
+          signers: [MANAGER, OTHER],
+          sigTypes: [0, 0],
+          args: [taskId, 0x0]
+        })
+      );
+
+      const managerInfo = await colony.getTaskRole(taskId, MANAGER_ROLE);
+      assert.equal(managerInfo[0], MANAGER);
+    });
+
+    it("should not allow assignment of manager role if current manager is not one of the signers", async () => {
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
+
+      await colony.setAdmin(WORKER);
+
+      // Setting the worker
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskWorkerRole",
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, WORKER]
+      });
+
+      // Setting the manager
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskEvaluatorRole",
+        signers: [MANAGER, EVALUATOR],
+        sigTypes: [0, 0],
+        args: [taskId, EVALUATOR]
+      });
+
+      await checkErrorRevert(
+        // Evaluator and worker trying to set a manager
+        executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskManagerRole",
+          signers: [EVALUATOR, WORKER],
+          sigTypes: [0, 0],
+          args: [taskId, WORKER]
+        })
+      );
+
+      const managerInfo = await colony.getTaskRole(taskId, MANAGER_ROLE);
+      assert.equal(managerInfo[0], MANAGER);
+    });
+
     it("should correctly increment `taskChangeNonce` for multiple updates on a single task", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id;
 
       // Change the task brief
-      let txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
-      const signers = [MANAGER, WORKER];
-      let sigs = await createSignatures(colony, 1, signers, 0, txData);
-      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskBrief",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, SPECIFICATION_HASH_UPDATED]
+      });
 
-      let taskChangeNonce = await colony.getTaskChangeNonce.call(1);
+      let taskChangeNonce = await colony.getTaskChangeNonce.call(taskId);
       assert.equal(taskChangeNonce, 1);
 
       // Change the due date
       const dueDate = await currentBlockTime();
-      txData = await colony.contract.setTaskDueDate.getData(1, dueDate);
-      sigs = await createSignatures(colony, 1, signers, 0, txData);
-      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
-      taskChangeNonce = await colony.getTaskChangeNonce.call(1);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskDueDate",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, dueDate]
+      });
+
+      taskChangeNonce = await colony.getTaskChangeNonce.call(taskId);
       assert.equal(taskChangeNonce, 2);
     });
 
     it("should correctly increment `taskChangeNonce` for multiple updates on multiple tasks", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
+      let { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId1 = logs[0].args.id;
 
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(2, WORKER_ROLE, WORKER);
-
-      const signers = [MANAGER, WORKER];
+      ({ logs } = await colony.makeTask(SPECIFICATION_HASH, 1));
+      const taskId2 = logs[0].args.id;
 
       // Change the task1 brief
-      const txData1 = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
-      const sigs1 = await createSignatures(colony, 1, signers, 0, txData1);
-
-      // Change the task2 brief
-      const txData2 = await colony.contract.setTaskBrief.getData(2, SPECIFICATION_HASH_UPDATED);
-      const sigs2 = await createSignatures(colony, 2, signers, 0, txData2);
-
-      // Execute the above 2 changes
-      await colony.executeTaskChange(sigs1.sigV, sigs1.sigR, sigs1.sigS, [0, 0], 0, txData1);
-      let taskChangeNonce = await colony.getTaskChangeNonce.call(1);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskBrief",
+        taskId: taskId1,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId1, SPECIFICATION_HASH_UPDATED]
+      });
+      let taskChangeNonce = await colony.getTaskChangeNonce.call(taskId1);
       assert.equal(taskChangeNonce, 1);
-      await colony.executeTaskChange(sigs2.sigV, sigs2.sigR, sigs2.sigS, [0, 0], 0, txData2);
-      taskChangeNonce = await colony.getTaskChangeNonce.call(2);
+
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskBrief",
+        taskId: taskId2,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId2, SPECIFICATION_HASH_UPDATED]
+      });
+
+      taskChangeNonce = await colony.getTaskChangeNonce.call(taskId2);
       assert.equal(taskChangeNonce, 1);
 
       // Change the task2 due date
       const dueDate = await currentBlockTime();
-      const txData3 = await colony.contract.setTaskDueDate.getData(2, dueDate);
-      const sigs3 = await createSignatures(colony, 2, signers, 0, txData3);
 
-      await colony.executeTaskChange(sigs3.sigV, sigs3.sigR, sigs3.sigS, [0, 0], 0, txData3);
-      taskChangeNonce = await colony.getTaskChangeNonce.call(2);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskDueDate",
+        taskId: taskId2,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId2, dueDate]
+      });
+
+      taskChangeNonce = await colony.getTaskChangeNonce.call(taskId2);
       assert.equal(taskChangeNonce, 2);
     });
 
     it("should allow update of task brief signed by manager only when worker has not been assigned", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
-      const sigs = await createSignatures(colony, 1, [MANAGER], 0, txData);
-      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0], 0, txData);
-      const task = await colony.getTask.call(1);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id;
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskBrief",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, SPECIFICATION_HASH_UPDATED]
+      });
+      const task = await colony.getTask.call(taskId);
       assert.equal(task[0], SPECIFICATION_HASH_UPDATED);
     });
 
     it("should allow update of task brief signed by manager and worker", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
-      const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
-      const signers = [MANAGER, WORKER];
-      const sigs = await createSignatures(colony, 1, signers, 0, txData);
-      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
-      const task = await colony.getTask.call(1);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id;
+
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskWorkerRole",
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, WORKER]
+      });
+
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskBrief",
+        taskId,
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, SPECIFICATION_HASH_UPDATED]
+      });
+      const task = await colony.getTask.call(taskId);
       assert.equal(task[0], SPECIFICATION_HASH_UPDATED);
     });
 
     it("should allow update of task brief signed by manager and worker using Trezor-style signatures", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
-      const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
-      const signers = [MANAGER, WORKER];
-      const sigs = await createSignaturesTrezor(colony, 1, signers, 0, txData);
-      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [1, 1], 0, txData);
-      const task = await colony.getTask.call(1);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id;
+
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskWorkerRole",
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, WORKER]
+      });
+
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskBrief",
+        taskId,
+        signers: [MANAGER, WORKER],
+        sigTypes: [1, 1],
+        args: [taskId, SPECIFICATION_HASH_UPDATED]
+      });
+      const task = await colony.getTask.call(taskId);
       assert.equal(task[0], SPECIFICATION_HASH_UPDATED);
     });
 
     it("should allow update of task brief signed by manager and worker if one uses Trezor-style signatures and the other does not", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
-      const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
-      const sigs = await createSignatures(colony, 1, [MANAGER], 0, txData);
-      const trezorSigs = await createSignaturesTrezor(colony, 1, [WORKER], 0, txData);
-      await colony.executeTaskChange(
-        [sigs.sigV[0], trezorSigs.sigV[0]],
-        [sigs.sigR[0], trezorSigs.sigR[0]],
-        [sigs.sigS[0], trezorSigs.sigS[0]],
-        [0, 1],
-        0,
-        txData
-      );
-      const task = await colony.getTask.call(1);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id;
+
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskWorkerRole",
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, WORKER]
+      });
+
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskBrief",
+        taskId,
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 1],
+        args: [taskId, SPECIFICATION_HASH_UPDATED]
+      });
+      const task = await colony.getTask.call(taskId);
       assert.equal(task[0], SPECIFICATION_HASH_UPDATED);
     });
 
     it("should not allow update of task brief signed by manager twice, with two different signature styles", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
-      const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
-      const sigs = await createSignatures(colony, 1, [MANAGER], 0, txData);
-      const trezorSigs = await createSignaturesTrezor(colony, 1, [MANAGER], 0, txData);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id;
+
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskWorkerRole",
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, WORKER]
+      });
+
       await checkErrorRevert(
-        colony.executeTaskChange(
-          [sigs.sigV[0], trezorSigs.sigV[0]],
-          [sigs.sigR[0], trezorSigs.sigR[0]],
-          [sigs.sigS[0], trezorSigs.sigS[0]],
-          [0, 1],
-          0,
-          txData
-        )
+        executeSignedTaskChange({
+          colony,
+          functionName: "setTaskBrief",
+          taskId,
+          signers: [MANAGER, MANAGER],
+          sigTypes: [0, 1],
+          args: [taskId, SPECIFICATION_HASH_UPDATED]
+        })
       );
-      const task = await colony.getTask.call(1);
+      const task = await colony.getTask.call(taskId);
       assert.equal(task[0], SPECIFICATION_HASH);
     });
 
     it("should allow update of task due date signed by manager and worker", async () => {
       const dueDate = await currentBlockTime();
 
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
-      const txData = await colony.contract.setTaskDueDate.getData(1, dueDate);
-      const signers = [MANAGER, WORKER];
-      const sigs = await createSignatures(colony, 1, signers, 0, txData);
-      await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id;
 
-      const task = await colony.getTask.call(1);
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskWorkerRole",
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, WORKER]
+      });
+
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskDueDate",
+        taskId,
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, dueDate]
+      });
+
+      const task = await colony.getTask.call(taskId);
       assert.equal(task[4], dueDate);
     });
 
@@ -522,44 +1039,94 @@ contract("Colony", addresses => {
     });
 
     it("should fail update of task brief signed by a non-registered role", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(1, EVALUATOR_ROLE, EVALUATOR);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id;
 
-      const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
-      const signers = [MANAGER, OTHER];
-      const sigs = await createSignatures(colony, 1, signers, 0, txData);
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskEvaluatorRole",
+        signers: [MANAGER, EVALUATOR],
+        sigTypes: [0, 0],
+        args: [taskId, EVALUATOR]
+      });
 
-      await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData));
+      await checkErrorRevert(
+        executeSignedTaskChange({
+          colony,
+          functionName: "setTaskBrief",
+          taskId,
+          signers: [MANAGER, OTHER],
+          sigTypes: [0, 0],
+          args: [taskId, SPECIFICATION_HASH_UPDATED]
+        })
+      );
     });
 
     it("should fail update of task brief signed by manager and evaluator", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(1, EVALUATOR_ROLE, EVALUATOR);
-      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id;
 
-      const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
-      const signers = [MANAGER, EVALUATOR];
-      const sigs = await createSignatures(colony, 1, signers, 0, txData);
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskEvaluatorRole",
+        signers: [MANAGER, EVALUATOR],
+        sigTypes: [0, 0],
+        args: [taskId, EVALUATOR]
+      });
 
-      await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData));
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskWorkerRole",
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, WORKER]
+      });
+
+      await checkErrorRevert(
+        executeSignedTaskChange({
+          colony,
+          functionName: "setTaskBrief",
+          taskId,
+          signers: [MANAGER, EVALUATOR],
+          sigTypes: [0, 0],
+          args: [taskId, SPECIFICATION_HASH_UPDATED]
+        })
+      );
     });
 
     it("should fail to execute task change for a non-registered function signature", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      const txData = await colony.contract.getTaskRole.getData(1, 0);
-      const signers = [MANAGER, EVALUATOR];
-      const sigs = await createSignatures(colony, 1, signers, 0, txData);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id;
 
-      await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData));
+      await checkErrorRevert(
+        executeSignedTaskChange({
+          colony,
+          functionName: "getTaskRole",
+          taskId,
+          signers: [MANAGER, EVALUATOR],
+          sigTypes: [0, 0],
+          args: [taskId, 0]
+        })
+      );
     });
 
     it("should fail to execute change of task brief, using an invalid task id", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      const txData = await colony.contract.setTaskBrief.getData(10, SPECIFICATION_HASH_UPDATED);
-      const signers = [MANAGER, EVALUATOR];
-      const sigs = await createSignatures(colony, 1, signers, 0, txData);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id;
 
-      await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData));
+      await checkErrorRevert(
+        executeSignedTaskChange({
+          colony,
+          functionName: "setTaskBrief",
+          taskId,
+          signers: [MANAGER, EVALUATOR],
+          sigTypes: [0, 0],
+          args: [10, 0]
+        })
+      );
     });
 
     it("should fail to execute task change, if the task is already finalized", async () => {
@@ -567,53 +1134,100 @@ contract("Colony", addresses => {
       const taskId = await setupRatedTask({ colonyNetwork, colony, token });
       await colony.finalizeTask(taskId);
 
-      const txData = await colony.contract.setTaskBrief.getData(taskId, SPECIFICATION_HASH_UPDATED);
-      const signers = [MANAGER, EVALUATOR];
-      const sigs = await createSignatures(colony, 1, signers, 0, txData);
-
-      await checkErrorRevert(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData));
+      await checkErrorRevert(
+        executeSignedTaskChange({
+          colony,
+          functionName: "setTaskBrief",
+          taskId,
+          signers: [MANAGER, EVALUATOR],
+          sigTypes: [0, 0],
+          args: [taskId, SPECIFICATION_HASH_UPDATED]
+        })
+      );
     });
 
     it("should log a TaskBriefChanged event, if the task brief gets changed", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      const txData = await colony.contract.setTaskBrief.getData(1, SPECIFICATION_HASH_UPDATED);
-      const sigs = await createSignatures(colony, 1, [MANAGER], 0, txData);
-      await expectEvent(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0], 0, txData), "TaskBriefChanged");
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id;
+      await expectEvent(
+        executeSignedTaskChange({
+          colony,
+          functionName: "setTaskBrief",
+          taskId,
+          signers: [MANAGER],
+          sigTypes: [0],
+          args: [taskId, SPECIFICATION_HASH_UPDATED]
+        }),
+        "TaskBriefChanged"
+      );
     });
 
     it("should log a TaskDueDateChanged event, if the task due date gets changed", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id;
       const dueDate = await currentBlockTime();
-      const txData = await colony.contract.setTaskDueDate.getData(1, dueDate);
-      const sigs = await createSignatures(colony, 1, [MANAGER], 0, txData);
-      await expectEvent(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData), "TaskDueDateChanged");
+      await expectEvent(
+        executeSignedTaskChange({
+          colony,
+          functionName: "setTaskDueDate",
+          taskId,
+          signers: [MANAGER],
+          sigTypes: [0],
+          args: [taskId, dueDate]
+        }),
+        "TaskDueDateChanged"
+      );
     });
 
     it("should log a TaskSkillChanged event, if the task skill gets changed", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
       // Acquire meta colony, create new global skill, assign new task's skill
       const metaColonyAddress = await colonyNetwork.getMetaColony.call();
       const metaColony = await IColony.at(metaColonyAddress);
       await metaColony.addGlobalSkill(1);
 
       const skillCount = await colonyNetwork.getSkillCount.call();
-      await expectEvent(colony.setTaskSkill(1, skillCount.toNumber()), "TaskSkillChanged");
+
+      await expectEvent(
+        executeSignedTaskChange({
+          colony,
+          functionName: "setTaskSkill",
+          taskId,
+          signers: [MANAGER],
+          sigTypes: [0],
+          args: [taskId, skillCount.toNumber()]
+        }),
+        "TaskSkillChanged"
+      );
     });
 
     it("should log a TaskDomainChanged event, if the task domain gets changed", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
       // Create a domain, change task's domain
       const skillCount = await colonyNetwork.getSkillCount.call();
       await colony.addDomain(skillCount.toNumber());
 
-      await expectEvent(colony.setTaskDomain(1, 2), "TaskDomainChanged");
+      await expectEvent(colony.setTaskDomain(taskId, 2), "TaskDomainChanged");
     });
 
     it("should log a TaskRoleUserChanged event, if a task role's user gets changed", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id.toNumber();
 
       // Change the task role's user
-      await expectEvent(colony.setTaskRoleUser(1, WORKER_ROLE, WORKER), "TaskRoleUserChanged");
+      await expectEvent(
+        await executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskWorkerRole",
+          signers: [MANAGER, WORKER],
+          sigTypes: [0, 0],
+          args: [taskId, WORKER]
+        }),
+        "TaskRoleUserChanged"
+      );
     });
   });
 
@@ -801,75 +1415,131 @@ contract("Colony", addresses => {
 
   describe("when funding tasks", () => {
     it("should be able to set the task payouts for different roles", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id;
 
       let dueDate = await currentBlockTime();
       dueDate += SECONDS_PER_DAY * 7;
-      const txData0 = await colony.contract.setTaskDueDate.getData(1, dueDate);
-      const sigs0 = await createSignatures(colony, 1, [MANAGER], 0, txData0);
-      await colony.executeTaskChange(sigs0.sigV, sigs0.sigR, sigs0.sigS, [0], 0, txData0);
 
-      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
-      await colony.setTaskRoleUser(1, EVALUATOR_ROLE, EVALUATOR);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskDueDate",
+        taskId,
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, dueDate]
+      });
+
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskWorkerRole",
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, WORKER]
+      });
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskEvaluatorRole",
+        signers: [MANAGER, EVALUATOR],
+        sigTypes: [0, 0],
+        args: [taskId, EVALUATOR]
+      });
       await colony.mintTokens(100);
 
       // Set the manager payout as 5000 wei and 100 colony tokens
-      await colony.setTaskManagerPayout(1, 0x0, 5000);
-      await colony.setTaskManagerPayout(1, token.address, 100);
+      await colony.setTaskManagerPayout(taskId, 0x0, 5000);
+      await colony.setTaskManagerPayout(taskId, token.address, 100);
 
       // Set the evaluator payout as 1000 ethers
-      const txData1 = await colony.contract.setTaskEvaluatorPayout.getData(1, 0x0, 1000);
-      const sigs1 = await createSignatures(colony, 1, [MANAGER, EVALUATOR], 0, txData1);
-      await colony.executeTaskChange(sigs1.sigV, sigs1.sigR, sigs1.sigS, [0, 0], 0, txData1);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskEvaluatorPayout",
+        taskId,
+        signers: [MANAGER, EVALUATOR],
+        sigTypes: [0, 0],
+        args: [taskId, 0x0, 1000]
+      });
 
       // Set the evaluator payout as 40 colony tokens
-      const txData2 = await colony.contract.setTaskEvaluatorPayout.getData(1, token.address, 40);
-      const sigs2 = await createSignatures(colony, 1, [MANAGER, EVALUATOR], 0, txData2);
-      await colony.executeTaskChange(sigs2.sigV, sigs2.sigR, sigs2.sigS, [0, 0], 0, txData2);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskEvaluatorPayout",
+        taskId,
+        signers: [MANAGER, EVALUATOR],
+        sigTypes: [0, 0],
+        args: [taskId, token.address, 40]
+      });
 
       // Set the worker payout as 98000 wei and 200 colony tokens
-      const txData3 = await colony.contract.setTaskWorkerPayout.getData(1, 0x0, 98000);
-      const sigs3 = await createSignatures(colony, 1, [MANAGER, WORKER], 0, txData3);
-      await colony.executeTaskChange(sigs3.sigV, sigs3.sigR, sigs3.sigS, [0, 0], 0, txData3);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskWorkerPayout",
+        taskId,
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, 0x0, 98000]
+      });
 
-      const txData4 = await colony.contract.setTaskWorkerPayout.getData(1, token.address, 200);
-      const sigs4 = await createSignatures(colony, 1, [MANAGER, WORKER], 0, txData4);
-      await colony.executeTaskChange(sigs4.sigV, sigs4.sigR, sigs4.sigS, [0, 0], 0, txData4);
+      await executeSignedTaskChange({
+        colony,
+        functionName: "setTaskWorkerPayout",
+        taskId,
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, token.address, 200]
+      });
 
       // Run through the task flow
-      await colony.submitTaskDeliverable(1, DELIVERABLE_HASH, { from: WORKER });
-      await colony.submitTaskWorkRating(1, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
-      await colony.submitTaskWorkRating(1, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
-      await colony.revealTaskWorkRating(1, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR });
-      await colony.revealTaskWorkRating(1, MANAGER_ROLE, MANAGER_RATING, RATING_1_SALT, { from: WORKER });
-      await colony.finalizeTask(1);
+      await colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH, { from: WORKER });
+      await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
+      await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
+      await colony.revealTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR });
+      await colony.revealTaskWorkRating(taskId, MANAGER_ROLE, MANAGER_RATING, RATING_1_SALT, { from: WORKER });
+      await colony.finalizeTask(taskId);
 
-      const taskPayoutManager1 = await colony.getTaskPayout.call(1, MANAGER_ROLE, 0x0);
+      const taskPayoutManager1 = await colony.getTaskPayout.call(taskId, MANAGER_ROLE, 0x0);
       assert.equal(taskPayoutManager1.toNumber(), 5000);
-      const taskPayoutManager2 = await colony.getTaskPayout.call(1, MANAGER_ROLE, token.address);
+      const taskPayoutManager2 = await colony.getTaskPayout.call(taskId, MANAGER_ROLE, token.address);
       assert.equal(taskPayoutManager2.toNumber(), 100);
 
-      const taskPayoutEvaluator1 = await colony.getTaskPayout.call(1, EVALUATOR_ROLE, 0x0);
+      const taskPayoutEvaluator1 = await colony.getTaskPayout.call(taskId, EVALUATOR_ROLE, 0x0);
       assert.equal(taskPayoutEvaluator1.toNumber(), 1000);
-      const taskPayoutEvaluator2 = await colony.getTaskPayout.call(1, EVALUATOR_ROLE, token.address);
+      const taskPayoutEvaluator2 = await colony.getTaskPayout.call(taskId, EVALUATOR_ROLE, token.address);
       assert.equal(taskPayoutEvaluator2.toNumber(), 40);
 
-      const taskPayoutWorker1 = await colony.getTaskPayout.call(1, WORKER_ROLE, 0x0);
+      const taskPayoutWorker1 = await colony.getTaskPayout.call(taskId, WORKER_ROLE, 0x0);
       assert.equal(taskPayoutWorker1.toNumber(), 98000);
-      const taskPayoutWorker2 = await colony.getTaskPayout.call(1, WORKER_ROLE, token.address);
+      const taskPayoutWorker2 = await colony.getTaskPayout.call(taskId, WORKER_ROLE, token.address);
       assert.equal(taskPayoutWorker2.toNumber(), 200);
     });
 
     it("should log a TaskWorkerPayoutChanged event, if the task's worker's payout changed", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
-      await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
+      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
+      const taskId = logs[0].args.id;
+      await executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskWorkerRole",
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, WORKER]
+      });
       await colony.mintTokens(100);
 
-      // Set the evaluator payout as 1000 ethers
-      const txData = await colony.contract.setTaskWorkerPayout.getData(1, 0x0, 98000);
-      const sigs = await createSignatures(colony, 1, [MANAGER, WORKER], 0, txData);
-
-      await expectEvent(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData), "TaskWorkerPayoutChanged");
+      // Set the worker payout as 98000 wei
+      await expectEvent(
+        executeSignedTaskChange({
+          colony,
+          functionName: "setTaskWorkerPayout",
+          taskId,
+          signers: [MANAGER, WORKER],
+          sigTypes: [0, 0],
+          args: [taskId, 0x0, 98000]
+        }),
+        "TaskWorkerPayoutChanged"
+      );
     });
 
     it("should correctly return the current total payout", async () => {

--- a/test/colony.js
+++ b/test/colony.js
@@ -103,9 +103,9 @@ contract("Colony", addresses => {
       assert.equal(colonyBalance.toNumber(), 1);
     });
 
-    it("should set colony network to be owner", async () => {
+    it("should not have owner", async () => {
       const owner = await colony.owner.call();
-      assert.equal(owner, colonyNetwork.address);
+      assert.equal(owner, "0x0000000000000000000000000000000000000000");
     });
 
     it("should return zero task count", async () => {
@@ -156,7 +156,7 @@ contract("Colony", addresses => {
       const futureOwner = addresses[2];
 
       let hasRole = await authority.hasUserRole(currentOwner, ownerRole);
-      assert(hasRole, `${currentOwner} is not current owner`);
+      assert(hasRole, `${currentOwner} does not have owner role`);
 
       await colony.setOwnerRole(futureOwner);
 

--- a/test/colony.js
+++ b/test/colony.js
@@ -102,9 +102,9 @@ contract("Colony", addresses => {
       assert.equal(colonyBalance.toNumber(), 1);
     });
 
-    it("should set creator of the colony to be owner", async () => {
+    it("should set colony network to be owner", async () => {
       const owner = await colony.owner.call();
-      assert.equal(owner, addresses[0]);
+      assert.equal(owner, colonyNetwork.address);
     });
 
     it("should return zero task count", async () => {
@@ -155,13 +155,13 @@ contract("Colony", addresses => {
       const user1 = addresses[1];
       const user5 = addresses[5];
 
-      await colony.setAdmin(user1);
+      await colony.setAdminRole(user1);
 
-      const functionSig = getFunctionSignature("setAdmin(address)");
+      const functionSig = getFunctionSignature("setAdminRole(address)");
       const canCall = await authority.canCall(user1, colony.address, functionSig);
-      assert(canCall, `Address ${user1} can't call 'setAdmin' function`);
+      assert(canCall, `Address ${user1} can't call 'setAdminRole' function`);
 
-      await colony.setAdmin(user5, {
+      await colony.setAdminRole(user5, {
         from: user1
       });
 
@@ -174,12 +174,12 @@ contract("Colony", addresses => {
 
       const user1 = addresses[1];
 
-      await colony.setAdmin(user1);
+      await colony.setAdminRole(user1);
 
       let hasRole = await authority.hasUserRole(user1, adminRole);
       assert(hasRole, `Admin role not assigned to ${user1}`);
 
-      await colony.removeAdmin(user1);
+      await colony.removeAdminRole(user1);
 
       hasRole = await authority.hasUserRole(user1, adminRole);
       assert(!hasRole, `Admin role not removed from ${user1}`);
@@ -188,7 +188,7 @@ contract("Colony", addresses => {
     it("should allow admin to call predetermined functions", async () => {
       const user3 = addresses[3];
 
-      await colony.setAdmin(user3);
+      await colony.setAdminRole(user3);
 
       let functionSig = getFunctionSignature("moveFundsBetweenPots(uint256,uint256,uint256,address)");
       let canCall = await authority.canCall(user3, colony.address, functionSig);
@@ -690,7 +690,7 @@ contract("Colony", addresses => {
       const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
       const taskId = logs[0].args.id.toNumber();
 
-      await colony.setAdmin(OTHER);
+      await colony.setAdminRole(OTHER);
 
       await executeSignedRoleAssignment({
         colony,
@@ -709,7 +709,7 @@ contract("Colony", addresses => {
       const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
       const taskId = logs[0].args.id.toNumber();
 
-      await colony.setAdmin(OTHER);
+      await colony.setAdminRole(OTHER);
 
       await checkErrorRevert(
         executeSignedRoleAssignment({
@@ -749,7 +749,7 @@ contract("Colony", addresses => {
       const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
       const taskId = logs[0].args.id.toNumber();
 
-      await colony.setAdmin(OTHER);
+      await colony.setAdminRole(OTHER);
 
       await checkErrorRevert(
         executeSignedRoleAssignment({
@@ -770,7 +770,7 @@ contract("Colony", addresses => {
       const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
       const taskId = logs[0].args.id.toNumber();
 
-      await colony.setAdmin(WORKER);
+      await colony.setAdminRole(WORKER);
 
       // Setting the worker
       await executeSignedRoleAssignment({

--- a/test/colony.js
+++ b/test/colony.js
@@ -150,6 +150,20 @@ contract("Colony", addresses => {
   });
 
   describe("when working with permissions", () => {
+    it("should allow current owner role to transfer role to another address", async () => {
+      const ownerRole = 0;
+      const currentOwner = addresses[0];
+      const futureOwner = addresses[2];
+
+      let hasRole = await authority.hasUserRole(currentOwner, ownerRole);
+      assert(hasRole, `${currentOwner} is not current owner`);
+
+      await colony.setOwnerRole(futureOwner);
+
+      hasRole = await authority.hasUserRole(futureOwner, ownerRole);
+      assert(hasRole, `Ownership not transfered to ${futureOwner}`);
+    });
+
     it("should allow admin to assign colony admin role", async () => {
       const adminRole = 1;
 

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -83,7 +83,7 @@ contract("Meta Colony", accounts => {
       assert.equal(rootSkillChild.toNumber(), 3);
     });
 
-    it("should not allow a non-owner of the metacolony to add a global skill", async () => {
+    it("should not allow a non-owner role in the metacolony to add a global skill", async () => {
       await checkErrorRevert(metaColony.addGlobalSkill(1, { from: OTHER_ACCOUNT }));
     });
 
@@ -304,7 +304,7 @@ contract("Meta Colony", accounts => {
       token = await Token.at(tokenAddress);
     });
 
-    it("someone who is not the colony owner should not be able to add domains", async () => {
+    it("someone who does not have owner role should not be able to add domains", async () => {
       await checkErrorRevert(colony.addDomain(3, { from: OTHER_ACCOUNT }));
     });
 

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -1,7 +1,7 @@
 /* globals artifacts */
-import { SPECIFICATION_HASH, INITIAL_FUNDING, MANAGER } from "../helpers/constants";
+import { INITIAL_FUNDING, MANAGER } from "../helpers/constants";
 import { checkErrorRevert, getTokenArgs } from "../helpers/test-helper";
-import { fundColonyWithTokens, setupRatedTask, executeSignedTaskChange } from "../helpers/test-data-generator";
+import { fundColonyWithTokens, setupRatedTask, executeSignedTaskChange, makeTask } from "../helpers/test-data-generator";
 
 const upgradableContracts = require("../helpers/upgradable-contracts");
 
@@ -389,8 +389,7 @@ contract("Meta Colony", accounts => {
 
     it("should be able to set domain on task", async () => {
       await colony.addDomain(3);
-      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
-      const taskId = logs[0].args.id.toNumber();
+      const taskId = await makeTask({ colony });
 
       await colony.setTaskDomain(taskId, 2);
 
@@ -400,7 +399,7 @@ contract("Meta Colony", accounts => {
 
     it("should NOT allow a non-manager to set domain on task", async () => {
       await colony.addDomain(3);
-      await colony.makeTask(SPECIFICATION_HASH, 1);
+      await makeTask({ colony });
       await checkErrorRevert(colony.setTaskDomain(1, 2, { from: OTHER_ACCOUNT }));
       const task = await colony.getTask.call(1);
       assert.equal(task[8].toNumber(), 1);
@@ -411,7 +410,7 @@ contract("Meta Colony", accounts => {
     });
 
     it("should NOT be able to set a nonexistent domain on task", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
+      await makeTask({ colony });
       await checkErrorRevert(colony.setTaskDomain(1, 20));
 
       const task = await colony.getTask.call(1);
@@ -429,8 +428,7 @@ contract("Meta Colony", accounts => {
       await metaColony.addGlobalSkill(1);
       await metaColony.addGlobalSkill(4);
 
-      const { logs } = await colony.makeTask(SPECIFICATION_HASH, 1);
-      const taskId = logs[0].args.id.toNumber();
+      const taskId = await makeTask({ colony });
 
       await executeSignedTaskChange({
         colony,
@@ -449,7 +447,7 @@ contract("Meta Colony", accounts => {
       await metaColony.addGlobalSkill(1);
       await metaColony.addGlobalSkill(4);
 
-      await colony.makeTask(SPECIFICATION_HASH, 1);
+      await makeTask({ colony });
       await checkErrorRevert(colony.setTaskSkill(1, 5, { from: OTHER_ACCOUNT }));
       const task = await colony.getTask.call(1);
       assert.equal(task[9][0].toNumber(), 0);
@@ -472,12 +470,12 @@ contract("Meta Colony", accounts => {
     });
 
     it("should NOT be able to set nonexistent skill on task", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
+      await makeTask({ colony });
       await checkErrorRevert(colony.setTaskSkill(1, 5));
     });
 
     it("should NOT be able to set local skill on task", async () => {
-      await colony.makeTask(SPECIFICATION_HASH, 1);
+      await makeTask({ colony });
       await checkErrorRevert(colony.setTaskSkill(1, 3));
     });
   });

--- a/upgrade-test/colony-upgrade.js
+++ b/upgrade-test/colony-upgrade.js
@@ -34,7 +34,7 @@ contract("Colony contract upgrade", accounts => {
     const tokenArgs = getTokenArgs();
     const colonyToken = await Token.new(...tokenArgs);
     const { logs } = await colonyNetwork.createColony(colonyToken.address);
-    const { colonyId, colonyAddress } = logs[0].args;
+    const { colonyAddress } = logs[0].args;
     colony = await IColony.at(colonyAddress);
     colonyTask = await ColonyTask.new();
     colonyFunding = await ColonyFunding.new();
@@ -54,7 +54,7 @@ contract("Colony contract upgrade", accounts => {
     updatedColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
 
     // Upgrade our existing colony
-    await colonyNetwork.upgradeColony(colonyId, updatedColonyVersion.toNumber());
+    await colony.upgrade(updatedColonyVersion.toNumber());
     updatedColony = await IUpdatedColony.at(colonyAddress);
   });
 

--- a/upgrade-test/colony-upgrade.js
+++ b/upgrade-test/colony-upgrade.js
@@ -2,6 +2,7 @@
 import { getTokenArgs } from "../helpers/test-helper";
 import { setupColonyVersionResolver } from "../helpers/upgradable-contracts";
 import { SPECIFICATION_HASH, SPECIFICATION_HASH_UPDATED } from "../helpers/constants";
+import { makeTask } from "../helpers/test-data-generator";
 
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const EtherRouter = artifacts.require("EtherRouter");
@@ -42,9 +43,8 @@ contract("Colony contract upgrade", accounts => {
     const tokenAddress = await colony.getToken.call();
     token = await Token.at(tokenAddress);
 
-    await authority.setUserRole(ACCOUNT_TWO, 0, true);
-    await colony.makeTask(SPECIFICATION_HASH, 1);
-    await colony.makeTask(SPECIFICATION_HASH_UPDATED, 1);
+    await makeTask({ colony });
+    await makeTask({ colony, hash: SPECIFICATION_HASH_UPDATED });
     // Setup new Colony contract version on the Network
     const updatedColonyContract = await UpdatedColony.new();
     const resolver = await Resolver.new();

--- a/upgrade-test/colony-upgrade.js
+++ b/upgrade-test/colony-upgrade.js
@@ -16,7 +16,7 @@ const Authority = artifacts.require("Authority");
 const Token = artifacts.require("Token");
 
 contract("Colony contract upgrade", accounts => {
-  const ACCOUNT_TWO = accounts[1];
+  const ACCOUNT_ONE = accounts[0];
 
   let colony;
   let colonyTask;
@@ -91,7 +91,7 @@ contract("Colony contract upgrade", accounts => {
     });
 
     it("should return correct permissions", async () => {
-      const owner = await authority.hasUserRole.call(ACCOUNT_TWO, 0);
+      const owner = await authority.hasUserRole.call(ACCOUNT_ONE, 0);
       assert.isTrue(owner);
     });
 


### PR DESCRIPTION
- `ownerRole` - One person. Creator of the colony. Can call `setToken`, `bootstrapColony`, `mintTokens`, `addGlobalSkill`, `removeAdminRole`, plus all functions that admin can call.
- `adminRole` - has permission to call `setAdmin`, `moveFundsBetweenPots`, `addDomain`, `makeTask`, `cancelTask`, `startNextRewardPayout`.
- Member - can only call public functions that don't require auth.


Task level permission (as discussed with Pat, we should be the one to decide what those should be):

- `setTaskSkill` - Since worker is going to receive the reputation in this skill, should be agreed with manager and worker.
- `setTaskDomain` - Manager.
- `setTaskBrief` - Agreed between manager and worker.
- `setTaskDueDate` - Agreed between manager and worker.
- `finalizeTask` - Can only be called by a manager.
- `setTaskManagerPayout` - Can only be called by manager.
- `setTaskEvaluatorPayout` - Agreed between manager and evaluator.
- `setTaskWorkerPayout` - Agreed between manager and worker.

Assigning roles for the first time:

- Manager role - set automatically to whoever created a task
- Evaluator role - Signed by manager and address we want to assign role to
- Worker role - Signed by manager and address we want to assign role to

Unassigning roles:

- Manager role - Can’t be unassigned
- Evaluator role - Signed by manager and currently assigned evaluator
- Worker role - Signed by manager and currently assigned worker

Changing roles:

- Evaluator and worker - We would have 2 transactions: Unassigning a role (Signed by manager and currently assigned role) ===> Assigning new role (Signed by manager and address we want to assign role to)

- Manager - Signed by current manager and address we want to assign manager role to. Other address must also be an admin

Changes not in scope of the task:
- Refactored tests that include signed task changes to avoid code duplication.
- Refactored `finalizeTask` function to fix "stack too deep" error.
- Added helper function `makeTask`.