### PR TITLE
Prevent reputation overflows or underflows

### DIFF
--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -633,9 +633,15 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
       u[U_REQUIRE_REPUTATION_CHECK] = 1;
     }
 
-    // TODO: Is this safe? I think so, because even if there's over/underflows, they should
-    // still be the same number.
-    require(int(agreeStateReputationValue)+reputationUpdateLog[reputationTransitionIdx].amount == int(disagreeStateReputationValue));
+    // We don't care about underflows for the purposes of comparison, but for the calculation we deem 'correct'.
+    // i.e. a reputation can't be negative.
+    if (reputationUpdateLog[reputationTransitionIdx].amount < 0 && uint(reputationUpdateLog[reputationTransitionIdx].amount * -1) > agreeStateReputationValue ) {
+      require(disagreeStateReputationValue == 0);
+    } else {
+      // TODO: Is this safe? I think so, because even if there's over/underflows, they should
+      // still be the same number.
+      require(int(agreeStateReputationValue)+reputationUpdateLog[reputationTransitionIdx].amount == int(disagreeStateReputationValue));
+    }
   }
 
   function checkPreviousReputationInState(

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -637,6 +637,9 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     // i.e. a reputation can't be negative.
     if (reputationUpdateLog[reputationTransitionIdx].amount < 0 && uint(reputationUpdateLog[reputationTransitionIdx].amount * -1) > agreeStateReputationValue ) {
       require(disagreeStateReputationValue == 0);
+    } else if (uint(reputationUpdateLog[reputationTransitionIdx].amount) + agreeStateReputationValue < agreeStateReputationValue) {
+      // We also don't allow reputation to overflow
+      require(disagreeStateReputationValue == 2**256 - 1);
     } else {
       // TODO: Is this safe? I think so, because even if there's over/underflows, they should
       // still be the same number.

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -44,10 +44,9 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
     dueDateTimestamp = await currentBlockTime();
   }
   const txData = await colony.contract.setTaskDueDate.getData(taskId, dueDateTimestamp);
-  const signers = [MANAGER, WORKER];
+  const signers = [MANAGER, worker];
   const sigs = await createSignatures(colony, signers, 0, txData);
   await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
-
   return taskId;
 }
 
@@ -89,7 +88,7 @@ export async function setupFundedTask({
   await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
 
   txData = await colony.contract.setTaskWorkerPayout.getData(taskId, tokenAddress, workerPayout.toString());
-  sigs = await createSignatures(colony, [MANAGER, WORKER], 0, txData);
+  sigs = await createSignatures(colony, [MANAGER, worker], 0, txData);
   await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
   return taskId;
 }

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -553,12 +553,16 @@ class ReputationMiner {
       if (newValue.lt(new BN("0"))) {
         newValue = new BN("0");
       }
+      if (newValue.gt(new BN("2").pow(new BN("256")).subn(1))) {
+        newValue = new BN("2").pow(new BN("256")).subn(1);
+      }
       value = this.getValueAsBytes(newValue, uid, index);
     } else {
       newValue = _reputationScore;
       if (newValue.lt(new BN("0"))) {
         newValue = new BN("0");
       }
+      // A new value can never overflow, so we don't need a 'capping' check here
       value = this.getValueAsBytes(newValue, this.nReputations + 1, index);
       this.nReputations += 1;
     }


### PR DESCRIPTION
If a user fails a task, the reputation they lose could exceed the reputation they have. Their reputation is not meant to become negative, but instead become zero and no lower. This PR introduces this behaviour, where previously the client would attempt to mine a negative reputation and fail.

Similarly, if a user had a lot of reputation (or received a very large payout), their reputation could overflow. This caps their reputation at `2**256 - 1`, which is the largest value able to be represented in `uint256`.