### PR TITLE
Upgrade truffle to 0.4.11

### DIFF
--- a/contracts/ColonyNetworkStaking.sol
+++ b/contracts/ColonyNetworkStaking.sol
@@ -52,7 +52,7 @@ contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
     uint256 balance = stakedBalances[msg.sender];
     require(balance >= _amount);
     bytes32 submittedHash;
-    (submittedHash, ) = ReputationMiningCycle(activeReputationMiningCycle).reputationHashSubmissions(msg.sender);
+    (submittedHash, , , , , , , , , , ) = ReputationMiningCycle(activeReputationMiningCycle).reputationHashSubmissions(msg.sender);
     bool hasRequesterSubmitted = submittedHash == 0x0 ? false : true;
     require(hasRequesterSubmitted==false);
     stakedBalances[msg.sender] -= _amount;

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -140,20 +140,14 @@ contract ColonyTask is ColonyStorage, DSMath {
   }
 
   function getSignedMessageHash(uint256 _value, bytes _data, uint8 _mode) private returns (bytes32 txHash) {
-    bytes32 msgHash = keccak256(
-      address(this),
-      address(this),
-      _value,
-      _data,
-      taskChangeNonce
-    );
+    bytes32 msgHash = keccak256(abi.encodePacked(address(this), address(this), _value, _data, taskChangeNonce));
     if (_mode==0) {
       // 'Normal' mode - geth, etc.
-      return keccak256("\x19Ethereum Signed Message:\n32", msgHash);
+      return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", msgHash));
     } else {
       // Trezor mode
       // Correct incantation helpfully cribbed from https://github.com/trezor/trezor-mcu/issues/163#issuecomment-368435292
-      return keccak256("\x19Ethereum Signed Message:\n\x20", msgHash);
+      return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n\x20", msgHash));
     }
   }
 
@@ -240,7 +234,7 @@ contract ColonyTask is ColonyStorage, DSMath {
   }
 
   function generateSecret(bytes32 _salt, uint256 _value) public pure returns (bytes32) {
-    return keccak256(_salt, _value);
+    return keccak256(abi.encodePacked(_salt, _value));
   }
 
   function getTaskWorkRatings(uint256 _id) public view returns (uint256, uint256) {

--- a/contracts/PatriciaTree/Data.sol
+++ b/contracts/PatriciaTree/Data.sol
@@ -62,7 +62,7 @@ library Data {
   }
 
   function edgeHash(Edge memory self) internal pure returns (bytes32) {
-    return keccak256(self.node, self.label.length, self.label.data);
+    return keccak256(abi.encodePacked(self.node, self.label.length, self.label.data));
   }
 
   function insert(Tree storage self, bytes key, bytes value) internal {
@@ -120,7 +120,7 @@ library Data {
 
   // Returns the hash of the encoding of a node.
   function nodeEncodingHash(Node memory self) private pure returns (bytes32) {
-    return keccak256(edgeHash(self.children[0]), edgeHash(self.children[1]));
+    return keccak256(abi.encodePacked(edgeHash(self.children[0]), edgeHash(self.children[1])));
   }
 
   // Returns the result of removing a prefix of length `prefix` bits from the

--- a/contracts/PatriciaTree/PatriciaTreeProofs.sol
+++ b/contracts/PatriciaTree/PatriciaTreeProofs.sol
@@ -25,7 +25,7 @@ contract PatriciaTreeProofs {
       bytes32[2] memory edgeHashes;
       edgeHashes[bit] = e.edgeHash();
       edgeHashes[1 - bit] = siblings[siblings.length - i - 1];
-      e.node = keccak256(edgeHashes);
+      e.node = keccak256(abi.encodePacked(edgeHashes));
     }
     e.label = k;
     return e.edgeHash();

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -144,7 +144,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   }
 
   function getEntryHash(address submitter, uint256 entryIndex, bytes32 newHash) public pure returns (bytes32) {
-    return keccak256(submitter, entryIndex, newHash);
+    return keccak256(abi.encodePacked(submitter, entryIndex, newHash));
   }
 
   /// @notice Constructor for this contract.

--- a/contracts/Resolver.sol
+++ b/contracts/Resolver.sol
@@ -35,6 +35,6 @@ contract Resolver is DSAuth {
   }
 
   function stringToSig(string signature) public pure returns(bytes4) {
-    return bytes4(keccak256(signature));
+    return bytes4(keccak256(abi.encodePacked(signature)));
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ganache-core": "^2.0.2",
     "istanbul": "^0.4.5",
     "jsonfile": "^4.0.0",
-    "mocha": "^5.1.1",
+    "mocha": "^5.2.0",
     "mocha-circleci-reporter": "^0.0.3",
     "pre-commit": "^1.2.2",
     "prettier": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "solidity-coverage": "0.5.4",
     "solidity-parser-antlr": "^0.2.10",
     "solium": "^1.1.7",
-    "truffle": "^4.1.7",
+    "truffle": "^4.1.11",
     "web3-utils": "^1.0.0-beta.34"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "rimraf": "^2.6.2",
     "shortid": "^2.2.8",
     "solidity-coverage": "0.5.4",
-    "solidity-parser-antlr": "^0.2.10",
+    "solidity-parser-antlr": "^0.2.11",
     "solium": "^1.1.7",
     "truffle": "^4.1.11",
     "web3-utils": "^1.0.0-beta.34"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6705,9 +6705,9 @@ solidity-coverage@0.5.4:
     tree-kill "^1.2.0"
     web3 "^0.18.4"
 
-solidity-parser-antlr@^0.2.10:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/solidity-parser-antlr/-/solidity-parser-antlr-0.2.10.tgz#6bc9e48faf49c1bf7bb49562cc1900f25153171c"
+solidity-parser-antlr@^0.2.11:
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/solidity-parser-antlr/-/solidity-parser-antlr-0.2.11.tgz#b3e4d0aca0d15796e9b59da53a49137aab51c298"
 
 solidity-parser-sc@0.4.10:
   version "0.4.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,15 +1833,15 @@ commander@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
+commander@2.15.1, commander@^2.11.0, commander@^2.8.1, commander@^2.9.0:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+
 commander@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
-
-commander@^2.11.0, commander@^2.8.1, commander@^2.9.0:
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
 commander@~2.8.1:
   version "2.8.1"
@@ -3546,6 +3546,10 @@ growl@1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
 
+growl@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+
 growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
@@ -5096,6 +5100,22 @@ mocha@^5.1.1:
     minimatch "3.0.4"
     mkdirp "0.5.1"
     supports-color "4.4.0"
+
+mocha@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
+  dependencies:
+    browser-stdout "1.3.1"
+    commander "2.15.1"
+    debug "3.1.0"
+    diff "3.5.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.2"
+    growl "1.10.5"
+    he "1.1.1"
+    minimatch "3.0.4"
+    mkdirp "0.5.1"
+    supports-color "5.4.0"
 
 mocha@~3.3.0:
   version "3.3.0"
@@ -6994,6 +7014,12 @@ supports-color@4.4.0:
   dependencies:
     has-flag "^2.0.0"
 
+supports-color@5.4.0, supports-color@^5.3.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -7003,12 +7029,6 @@ supports-color@^3.1.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
-
-supports-color@^5.3.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
-  dependencies:
-    has-flag "^3.0.0"
 
 swarm-js@0.1.37:
   version "0.1.37"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5049,7 +5049,7 @@ mocha-junit-reporter@^1.17.0:
     strip-ansi "^4.0.0"
     xml "^1.0.0"
 
-mocha@^3.4.2, mocha@^3.5.3:
+mocha@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
   dependencies:
@@ -6650,7 +6650,17 @@ solc@0.4.18:
     semver "^5.3.0"
     yargs "^4.7.1"
 
-solc@0.4.23, solc@^0.4.2:
+solc@0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.24.tgz#354f14b269b38cbaa82a47d1ff151723502b954e"
+  dependencies:
+    fs-extra "^0.30.0"
+    memorystream "^0.3.1"
+    require-from-string "^1.1.0"
+    semver "^5.3.0"
+    yargs "^4.7.1"
+
+solc@^0.4.2:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.23.tgz#54a0ff4015827b32fddb62c0a418b5247310a58e"
   dependencies:
@@ -7255,13 +7265,13 @@ trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
 
-truffle@^4.1.7:
-  version "4.1.7"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-4.1.7.tgz#b2d66d26eafd92da868d67765953e12c8160aedb"
+truffle@^4.1.11:
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-4.1.11.tgz#a4df812ebf4a564892900c4a1dac1131104a0799"
   dependencies:
-    mocha "^3.4.2"
+    mocha "^4.1.0"
     original-require "^1.0.1"
-    solc "0.4.23"
+    solc "0.4.24"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
As well as preparing us further for solidity 0.5.0, I believe this fixes the issues with Truffle being not very talkative when tests fail.