### PR TITLE
Add a few permissions and fix oracle server errors

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -89,8 +89,9 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     token.transfer(colonyNetworkAddress, _wad);
   }
 
-  //TODO: Secure this function
+  //TODO: Secure this function 'properly'
   function addGlobalSkill(uint _parentSkillId) public
+  auth
   returns (uint256)
   {
     IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
@@ -98,6 +99,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   }
 
   function addDomain(uint256 _parentSkillId) public
+  auth
   localSkill(_parentSkillId)
   {
     // Note: remove that when we start allowing more domain hierarchy levels

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -251,6 +251,7 @@ contract ColonyTask is ColonyStorage, DSMath {
   taskExists(_id)
   taskNotFinalized(_id)
   {
+    require(tasks[_id].roles[MANAGER].user == msg.sender);
     tasks[_id].roles[_role] = Role({
       user: _user,
       rated: false,
@@ -263,6 +264,7 @@ contract ColonyTask is ColonyStorage, DSMath {
   taskNotFinalized(_id)
   domainExists(_domainId)
   {
+    require(tasks[_id].roles[MANAGER].user == msg.sender);
     tasks[_id].domainId = _domainId;
   }
 
@@ -274,6 +276,8 @@ contract ColonyTask is ColonyStorage, DSMath {
   skillExists(_skillId)
   globalSkill(_skillId)
   {
+    require(tasks[_id].roles[MANAGER].user == msg.sender);
+
     tasks[_id].skills[0] = _skillId;
   }
 

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -2,6 +2,7 @@ const path = require("path");
 const jsonfile = require("jsonfile");
 const ethers = require("ethers");
 const express = require("express");
+const BN = require("bn.js");
 
 const ReputationMiner = require("./ReputationMiner");
 
@@ -20,7 +21,7 @@ class ReputationMinerClient {
     this._app = express();
     this._app.get("/:colonyAddress/:skillId/:userAddress", async (req, res) => {
       const key = await ReputationMiner.getKey(req.params.colonyAddress, req.params.skillId, req.params.userAddress);
-      if (key) {
+      if (this._miner.reputations[key]) {
         const proof = await this._miner.getReputationProofObject(key);
         delete proof.nNodes;
         proof.reputationAmount = ethers.utils.bigNumberify(`0x${proof.value.slice(2, 66)}`).toString();
@@ -64,13 +65,13 @@ class ReputationMinerClient {
       const ADDRESS3 = "0x2b183746bd1403cdec8e4fe45139339da20bcf3d";
       const ADDRESS4 = "0xcd0751d4181acda4f8edb2f3b33b915f91abeef0";
       const ADDRESS0 = "0x0000000000000000000000000000000000000000";
-      await this.insert(ADDRESS1, 1, ADDRESS2, "999999999");
-      await this.insert(ADDRESS1, 1, ADDRESS0, "999999999");
-      await this.insert(ADDRESS1, 2, ADDRESS2, "888888888888888");
-      await this.insert(ADDRESS1, 2, ADDRESS0, "888888888888888");
-      await this.insert(ADDRESS3, 1, ADDRESS2, "100000000");
-      await this.insert(ADDRESS3, 1, ADDRESS4, "100000000");
-      await this.insert(ADDRESS3, 1, ADDRESS0, "200000000");
+      await this._miner.insert(ADDRESS1, 1, ADDRESS2, new BN("999999999"));
+      await this._miner.insert(ADDRESS1, 1, ADDRESS0, new BN("999999999"));
+      await this._miner.insert(ADDRESS1, 2, ADDRESS2, new BN("888888888888888"));
+      await this._miner.insert(ADDRESS1, 2, ADDRESS0, new BN("888888888888888"));
+      await this._miner.insert(ADDRESS3, 1, ADDRESS2, new BN("100000000"));
+      await this._miner.insert(ADDRESS3, 1, ADDRESS4, new BN("100000000"));
+      await this._miner.insert(ADDRESS3, 1, ADDRESS0, new BN("200000000"));
       console.log("💾 Writing initialised state with dummy data to JSON file");
 
       jsonfile.writeFileSync(this._file, this._miner.reputations);

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -5,7 +5,7 @@ const ethers = require("ethers");
 
 const ReputationMinerClient = require("../ReputationMinerClient");
 
-const { file, minerAddress, colonyNetworkAddress, rinkeby, privateKey } = argv;
+const { file, minerAddress, colonyNetworkAddress, rinkeby, privateKey, seed } = argv;
 
 if ((!minerAddress && !privateKey) || !colonyNetworkAddress || !file) {
   console.log("❗️ You have to specify all of ( --minerAddress or --privateKey ), --colonyNetworkAddress and --file on the command line!");
@@ -21,5 +21,5 @@ if (rinkeby) {
   provider = new ethers.providers.InfuraProvider("rinkeby");
 }
 
-const client = new ReputationMinerClient({ file, loader, minerAddress, privateKey, provider });
+const client = new ReputationMinerClient({ file, loader, minerAddress, privateKey, provider, seed });
 client.initialise(colonyNetworkAddress);

--- a/test/colony.js
+++ b/test/colony.js
@@ -292,6 +292,17 @@ contract("Colony", addresses => {
       assert.equal(worker[0], WORKER);
     });
 
+    it("should not allow the worker or evaluator roles to be assigned by an address that is not the manager", async () => {
+      await colony.makeTask(SPECIFICATION_HASH, 1);
+      await checkErrorRevert(colony.setTaskRoleUser(1, EVALUATOR_ROLE, EVALUATOR, { from: OTHER }));
+      const evaluator = await colony.getTaskRole.call(1, EVALUATOR_ROLE);
+      assert.equal(evaluator[0], "0x0000000000000000000000000000000000000000");
+
+      await checkErrorRevert(colony.setTaskRoleUser(1, WORKER_ROLE, WORKER, { from: OTHER }));
+      const worker = await colony.getTaskRole.call(1, WORKER_ROLE);
+      assert.equal(worker[0], "0x0000000000000000000000000000000000000000");
+    });
+
     it("should correctly increment `taskChangeNonce`", async () => {
       await colony.makeTask(SPECIFICATION_HASH, 1);
       await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);


### PR DESCRIPTION
If there's going to be a public instance of the network anywhere, we need to make sure that people can't mess it up. This adds permissions to 

* `addGlobalSkill` (colony owner only, and only works from metaColony, so effectively only the metaColony's owner)
* `addDomain` (colony owner only)
* `setTaskRoleUser`, `setTaskDomain`, `setTaskSkill` are now restricted to the manager of the task.

I also took the opportunity to fix a couple of issues floating around in the reputation miner that I needed fixed.