### PR TITLE
Implement three-point ratings

### DIFF
--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -35,7 +35,7 @@ contract ColonyStorage is DSAuth {
   // Mapping function signature to 2 task roles whose approval is needed to execute
   mapping (bytes4 => uint8[2]) reviewers;
   uint256 taskChangeNonce; // Made obsolete in #203
-  
+
   mapping (uint256 => Task) tasks;
 
   // Pots can be tied to tasks or domains, so giving them their own mapping.
@@ -109,13 +109,15 @@ contract ColonyStorage is DSAuth {
     mapping (uint256 => mapping (address => uint256)) payouts;
   }
 
+  enum TaskRatings { None, Unsatisfactory, Satisfactory, Excellent }
+
   struct Role {
     // Address of the user for the given role
     address user;
-    // Has the user work been rated
-    bool rated;
+    // Whether the user failed to submit their rating
+    bool rateFail;
     // Rating the user received
-    uint8 rating;
+    TaskRatings rating;
   }
 
   struct RatingSecrets {

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -288,7 +288,7 @@ contract IColony {
   /// @param _id Id of the task
   /// @param _role Id of the role, as defined in `ColonyStorage` `MANAGER`, `EVALUATOR` and `WORKER` constants
   /// @return Address of the user for the given role
-  /// @return Has the user work been rated
+  /// @return Whether the user failed to rate their counterpart
   /// @return Rating the user received
   function getTaskRole(uint256 _id, uint8 _role) public view returns (address, bool, uint8);
 

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -18,8 +18,9 @@ const INITIAL_FUNDING = 360 * 1e18;
 const MANAGER_PAYOUT = web3Utils.toBN(100 * 1e18);
 const EVALUATOR_PAYOUT = web3Utils.toBN(50 * 1e18);
 const WORKER_PAYOUT = web3Utils.toBN(200 * 1e18);
-const MANAGER_RATING = 30;
-const WORKER_RATING = 40;
+const MANAGER_RATING = 2;
+const WORKER_RATING = 3;
+const RATING_MULTIPLIER = { 1: -1, 2: 1, 3: 1.5 };
 const SECONDS_PER_DAY = 86400;
 const RATING_1_SALT = web3Utils.soliditySha3(getRandomString(10));
 const RATING_2_SALT = web3Utils.soliditySha3(getRandomString(10));
@@ -44,6 +45,7 @@ module.exports = {
   WORKER_PAYOUT,
   MANAGER_RATING,
   WORKER_RATING,
+  RATING_MULTIPLIER,
   RATING_1_SALT,
   RATING_2_SALT,
   RATING_1_SECRET,

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -286,13 +286,13 @@ contract("Colony Funding", addresses => {
       assert.equal(colonyPotBalance.toNumber(), 0);
     });
 
-    it("should not allow user to claim payout if rating is less or equal than 2", async () => {
+    it("should not allow user to claim payout if rating is 1", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({
         colonyNetwork,
         colony,
         token,
-        workerRating: 20
+        workerRating: 1
       });
       await colony.finalizeTask(taskId);
       const payout = await colony.getTaskPayout.call(taskId, WORKER_ROLE, token.address);

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -1364,7 +1364,7 @@ contract("ColonyNetworkStaking", accounts => {
             colonyNetwork,
             colony: metaColony,
             colonyToken: clny,
-            workerRating: 20,
+            workerRating: 1,
             managerPayout: 1,
             evaluatorPayout: 1,
             workerPayout: 1
@@ -1437,8 +1437,8 @@ contract("ColonyNetworkStaking", accounts => {
         managerPayout: 1000000000000,
         evaluatorPayout: 1000000000000,
         workerPayout: 1000000000000,
-        managerRating: 10,
-        workerRating: 10
+        managerRating: 1,
+        workerRating: 1
       });
       await metaColony.finalizeTask(taskId);
       await repCycle.submitRootHash("0x0", 0, 10);
@@ -1481,8 +1481,8 @@ contract("ColonyNetworkStaking", accounts => {
         managerPayout: 1000000000000,
         evaluatorPayout: 1000000000000,
         workerPayout: 1000000000000,
-        managerRating: 10,
-        workerRating: 10
+        managerRating: 1,
+        workerRating: 1
       });
       await metaColony.finalizeTask(taskId);
 
@@ -1530,8 +1530,8 @@ contract("ColonyNetworkStaking", accounts => {
         managerPayout: 1000000000000,
         evaluatorPayout: 1000000000000,
         workerPayout: 1000000000000,
-        managerRating: 50,
-        workerRating: 50
+        managerRating: 3,
+        workerRating: 3
       });
       await metaColony.finalizeTask(taskId);
 

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -1603,7 +1603,7 @@ contract("ColonyNetworkStaking", accounts => {
       await repCycle.confirmNewHash(0);
 
       // The update log should contain the person being rewarded for the previous
-      // update cycle, and reputation updates for three task completions (manager, worker (domain and skill), evalutator);
+      // update cycle, and reputation updates for three task completions (manager, worker (domain and skill), evaluator);
       // That's thirteen in total.
       addr = await colonyNetwork.getReputationMiningCycle.call(true);
       repCycle = ReputationMiningCycle.at(addr);
@@ -1625,7 +1625,7 @@ contract("ColonyNetworkStaking", accounts => {
       key1 += `${new BN(MAIN_ACCOUNT.slice(2), 16).toString(16, 40)}`; // User address as bytes
       assert.equal(
         client.reputations[key1],
-        "0x0000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000000000000000001"
+        `0x`+`0000000000000000000000000000000000000000000000000de0b6b3a7640000`+`0000000000000000000000000000000000000000000000000000000000000001` // eslint-disable-line
       );
       // 2. Reputation reward for MAIN_ACCOUNT for being the manager for the tasks created by giveUserCLNYTokens
       let key2 = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`;
@@ -1633,7 +1633,7 @@ contract("ColonyNetworkStaking", accounts => {
       key2 += `${new BN(MAIN_ACCOUNT.slice(2), 16).toString(16, 40)}`;
       assert.equal(
         client.reputations[key2],
-        "0x00000000000000000000000000000000000000000000000010a741a4627800000000000000000000000000000000000000000000000000000000000000000002"
+        `0x`+`00000000000000000000000000000000000000000000000053444835ec580000`+`0000000000000000000000000000000000000000000000000000000000000002` // eslint-disable-line
       );
       // 3. Reputation reward for OTHER_ACCOUNT for being the evaluator for the tasks created by giveUserCLNYTokens
       let key3 = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`;
@@ -1641,7 +1641,7 @@ contract("ColonyNetworkStaking", accounts => {
       key3 += `${new BN(OTHER_ACCOUNT.slice(2), 16).toString(16, 40)}`;
       assert.equal(
         client.reputations[key3],
-        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003"
+        `0x`+`0000000000000000000000000000000000000000000000000000000000000000`+`0000000000000000000000000000000000000000000000000000000000000003` // eslint-disable-line
       );
       // 4. Reputation reward for accounts[2] for being the worker for the tasks created by giveUserCLNYTokens
       // NB at the moment, the reputation reward for the worker is 0.
@@ -1650,7 +1650,7 @@ contract("ColonyNetworkStaking", accounts => {
       key4 += `${new BN(accounts[2].slice(2), 16).toString(16, 40)}`;
       assert.equal(
         client.reputations[key4],
-        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004"
+        `0x`+`0000000000000000000000000000000000000000000000000000000000000000`+`0000000000000000000000000000000000000000000000000000000000000004` // eslint-disable-line
       );
     });
 

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -61,7 +61,7 @@ contract("Colony Reputation Updates", () => {
 
       const repLogEntryManager = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(0);
       assert.equal(repLogEntryManager[0], MANAGER);
-      assert.equal(repLogEntryManager[1].toNumber(), 1000 * 1e18 / 50);
+      assert.equal(repLogEntryManager[1].toNumber(), 100 * 1e18);
       assert.equal(repLogEntryManager[2].toNumber(), 2);
       assert.equal(repLogEntryManager[3], metaColony.address);
       assert.equal(repLogEntryManager[4].toNumber(), 2);
@@ -77,7 +77,7 @@ contract("Colony Reputation Updates", () => {
 
       const repLogEntryWorker = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(2);
       assert.equal(repLogEntryWorker[0], WORKER);
-      assert.equal(repLogEntryWorker[1].toNumber(), 200 * 1e18);
+      assert.equal(repLogEntryWorker[1].toNumber(), 300 * 1e18);
       assert.equal(repLogEntryWorker[2].toNumber(), 2);
       assert.equal(repLogEntryWorker[3], metaColony.address);
       assert.equal(repLogEntryWorker[4].toNumber(), 2);
@@ -168,7 +168,10 @@ contract("Colony Reputation Updates", () => {
       });
       await metaColony.finalizeTask(taskId1);
       let repLogEntryWorker = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(3);
-      const result = web3Utils.toBN("1").mul(WORKER_PAYOUT);
+      const result = web3Utils
+        .toBN(WORKER_PAYOUT)
+        .muln(3)
+        .divn(2);
       assert.equal(repLogEntryWorker[1].toString(), result.toString());
       assert.equal(repLogEntryWorker[4].toNumber(), 6);
 

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -86,58 +86,22 @@ contract("Colony Reputation Updates", () => {
 
     const ratings = [
       {
-        manager: 0,
-        reputationChangeManager: MANAGER_PAYOUT.muln(50)
-          .neg()
-          .divn(50),
-        worker: 0,
-        reputationChangeWorker: WORKER_PAYOUT.muln(50)
-          .neg()
-          .divn(30)
+        manager: 1,
+        reputationChangeManager: MANAGER_PAYOUT.neg(),
+        worker: 1,
+        reputationChangeWorker: WORKER_PAYOUT.neg()
       },
       {
-        manager: 10,
-        reputationChangeManager: MANAGER_PAYOUT.muln(30)
-          .neg()
-          .divn(50),
-        worker: 10,
-        reputationChangeWorker: WORKER_PAYOUT.muln(30)
-          .neg()
-          .divn(30)
+        manager: 2,
+        reputationChangeManager: MANAGER_PAYOUT,
+        worker: 2,
+        reputationChangeWorker: WORKER_PAYOUT
       },
       {
-        manager: 20,
-        reputationChangeManager: MANAGER_PAYOUT.muln(10)
-          .neg()
-          .divn(50),
-        worker: 20,
-        reputationChangeWorker: WORKER_PAYOUT.muln(10)
-          .neg()
-          .divn(30)
-      },
-      {
-        manager: 25,
-        reputationChangeManager: MANAGER_PAYOUT.muln(0).divn(50),
-        worker: 25,
-        reputationChangeWorker: WORKER_PAYOUT.muln(0).divn(30)
-      },
-      {
-        manager: 30,
-        reputationChangeManager: MANAGER_PAYOUT.muln(10).divn(50),
-        worker: 30,
-        reputationChangeWorker: WORKER_PAYOUT.muln(10).divn(30)
-      },
-      {
-        manager: 40,
-        reputationChangeManager: MANAGER_PAYOUT.muln(30).divn(50),
-        worker: 40,
-        reputationChangeWorker: WORKER_PAYOUT.muln(30).divn(30)
-      },
-      {
-        manager: 50,
-        reputationChangeManager: MANAGER_PAYOUT.muln(50).divn(50),
-        worker: 50,
-        reputationChangeWorker: WORKER_PAYOUT.muln(50).divn(30)
+        manager: 3,
+        reputationChangeManager: MANAGER_PAYOUT.muln(3).divn(2),
+        worker: 3,
+        reputationChangeWorker: WORKER_PAYOUT.muln(3).divn(2)
       }
     ];
 
@@ -237,7 +201,7 @@ contract("Colony Reputation Updates", () => {
         managerPayout,
         evaluatorPayout,
         workerPayout,
-        workerRating: 20
+        workerRating: 1
       });
 
       // Check the task pot is correctly funded with the max amount


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #154 

<!--- Summary of changes including design decisions -->

- Switch to 3-point scale with corresponding [-1, 1, 1.5] reputation boost.
- Evaluator receives Satisfactory rating by default.
- Scale implemented as enum, meaning `role.rated` boolean is no longer needed.
- **However, we repurpose the storage slot to `role.rateFail`**, set to `true` if the user does not rate their counterpart (set in `assignWorkRating`).
- Reputation calculation moved into a separate (internal, pure) function of `(payout, rating, rateFail)`.
- Update tests to specify ratings on the 1-3 point scale.
- Update tests to conform to usage of `TaskRatings` enum and `rateFail` boolean.
- Update tests with new rating and reputation values.