### PR TITLE
Minor miner changes because the world is imperfect

### DIFF
--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -319,7 +319,7 @@ class ReputationMiner {
     const hash = await this.getRootHash();
     // TODO: Work out what entry we should use when we submit
     const gas = await repCycle.estimate.submitRootHash(hash, this.nReputations, 1);
-    await repCycle.submitRootHash(hash, this.nReputations, 1, { gasLimit: `0x${gas.mul(2).toString()}` });
+    return repCycle.submitRootHash(hash, this.nReputations, 1, { gasLimit: `0x${gas.mul(2).toString()}` });
   }
 
   /**


### PR DESCRIPTION
Not sure anyone cares about these changes other than me... everything works as before, we're just a bit more accommodating of the real world.

Context for the one meaningful change: sometimes, when using Infura, the 'confirm' tx would error with 'replacement transaction too cheap' or similar error message. That suggests that it's using the same nonce for both the 'confirm' and the previous 'submit' transaction, which in turn I hypothesize is because the relevant block hasn't broadcast to all of infura's nodes yet, and we happen to query a node that hasn't seen the block with the 'submit' transaction in yet.

Not really something we can test, but my best guess for now. I will continue to keep an eye on the reputation miner.