### PR TITLE
Add content for running the usable reputation mining client.

### DIFF
--- a/docs/_Docs_GetStarted.md
+++ b/docs/_Docs_GetStarted.md
@@ -52,7 +52,7 @@ Start the mining client with:
 node packages/reputation-miner/bin/index.js --file ./reputations.json --colonyNetworkAddress 0x76d508fa65654654ffdb334a3023353587112e09 --minerAddress 0xb77d57f4959eafa0339424b83fcfaf9c15407461
 ```
 
-This will use the first account in `ganache-accounts.json` as the Reputation miner.
+The `minerAddress` in the execution above is the first account in `ganache-accounts.json`
 
 ### Force Reputation Updates
 The client is set to provide a reputation update once per hour. For testing, you'll likely want to 'fast-forward' your network through a few submissions to see usable reputation.
@@ -74,7 +74,7 @@ The mining client will answer queries for Reputation scores locally over HTTP:
 http://127.0.0.1:3000/{colonyAddress}/{skillId}/{userAddress}
 ```
 
-For example, you can get the reputation score of the miner using the address of the Meta Colony, the skill tag of `0`, and the address of the miner:
+For example, you can get the reputation score of the miner using the address of the Meta Colony (`0xdb8fe93a3a9c97f04f5c862f52a84f992bd331df`), the skill tag of `0`, and the address of the miner (0xb77d57f4959eafa0339424b83fcfaf9c15407461):
 ```
 http://127.0.0.1:3000/0xdb8fe93a3a9c97f04f5c862f52a84f992bd331df/0/0xb77d57f4959eafa0339424b83fcfaf9c15407461
 ```

--- a/docs/_Docs_GetStarted.md
+++ b/docs/_Docs_GetStarted.md
@@ -35,7 +35,51 @@ Alternatively, you can start a local test node and deploy the contracts yourself
 ```
 ~$ yarn run start:blockchain:client
 
-~$ ./node_modules/.bin/truffle migrate
+~$ ./node_modules/.bin/truffle migrate --reset --compile-all
 ```
 
 For more detailed instructions, and additional steps required to set up an environment for use with colonyJS, refer to the [colonyJS get started doc](/colonyjs/docs-get-started/).
+
+## Set Up Reputation Mining for Local Testing
+
+The Reputation Mining client is usable for testing, but has a limited functionality. There is currently no challenge-response process to accommodate multiple submitted Reputation Root Hashes. Still, it is possible to run a single miner instance for usable reputation scores on a testnet.
+
+### Start the Mining Client
+
+Start the mining client with:
+
+```
+node packages/reputation-miner/bin/index.js --file ./reputations.json --colonyNetworkAddress 0x76d508fa65654654ffdb334a3023353587112e09 --minerAddress 0xb77d57f4959eafa0339424b83fcfaf9c15407461
+```
+
+This will use the first account in `ganache-accounts.json` as the Reputation miner.
+
+### Force Reputation Updates
+The client is set to provide a reputation update once per hour. For testing, you'll likely want to 'fast-forward' your network through a few submissions to see usable reputation.
+
+Move the network forward by an hour with:
+```
+$ curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"evm_increaseTime","params":[3600],"id": 1}' localhost:8545
+```
+And mine a new block:
+```
+$ curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"evm_mine","params":[]}' localhost:8545
+```
+
+Note that because reputation is awarded for the *previous* submission window, you will need to use the 'fast-forward' commands above to speed through at least 3 reputation updates before noticing a change in the miner's reputation.
+
+### Get Reputation from the Reputation Oracle
+The mining client will answer queries for Reputation scores locally over HTTP:
+```
+http://127.0.0.1:3000/{colonyAddress}/{skillId}/{userAddress}
+```
+
+For example, you can get the reputation score of the miner using the address of the Meta Colony, the skill tag of `0`, and the address of the miner:
+```
+http://127.0.0.1:3000/0xdb8fe93a3a9c97f04f5c862f52a84f992bd331df/0/0xb77d57f4959eafa0339424b83fcfaf9c15407461
+```
+
+The oracle should return something like this:
+```
+{"branchMask":"0x00","siblings":[],"key":"0xdb8fe93a3a9c97f04f5c862f52a84f992bd331df0000000000000000000000000000000000000000000000000000000000000000b77d57f4959eafa0339424b83fcfaf9c15407461","value":"0x0000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000000000000000001","reputationAmount":"1000000000000000000"}
+```

--- a/docs/_Docs_GetStarted.md
+++ b/docs/_Docs_GetStarted.md
@@ -42,7 +42,7 @@ For more detailed instructions, and additional steps required to set up an envir
 
 ## Set Up Reputation Mining for Local Testing
 
-The Reputation Mining client is usable for testing, but has a limited functionality. There is currently no challenge-response process to accommodate multiple submitted Reputation Root Hashes. Still, it is possible to run a single miner instance for usable reputation scores on a testnet.
+The Reputation Mining client is usable for testing, but has a limited functionality. It currently has no support for the challenge-response process to accommodate multiple submitted Reputation Root Hashes. Still, it is possible to run a single miner instance for usable reputation scores on a testnet.
 
 ### Start the Mining Client
 
@@ -52,7 +52,10 @@ Start the mining client with:
 node packages/reputation-miner/bin/index.js --file ./reputations.json --colonyNetworkAddress 0x76d508fa65654654ffdb334a3023353587112e09 --minerAddress 0xb77d57f4959eafa0339424b83fcfaf9c15407461
 ```
 
-The `minerAddress` in the execution above is the first account in `ganache-accounts.json`
+The `minerAddress` in the execution above is the first account in `ganache-accounts.json`.
+
+The `colonyNetwork` address in the execution above is not the address outputted at contract deployment, but is the address of the Colony Network `EtherRouter`. See [Upgrades to the Colony Network](/colonynetwork/docs-upgrades-to-the-colony-network/) for more information about the EtherRouter design pattern.
+
 
 ### Force Reputation Updates
 The client is set to provide a reputation update once per hour. For testing, you'll likely want to 'fast-forward' your network through a few submissions to see usable reputation.


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
This adds the colonyNetwork-relevant instructions for running the usable mining client for local development to the 'Get Started' doc page. 

Needed for colonyJS#177 
<!--- Summary of changes including design decisions -->

