### PR TITLE
Use actual bytes32 hex encoded ipfs hash in tests

### DIFF
--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -8,10 +8,12 @@ let OTHER;
 const MANAGER_ROLE = 0;
 const EVALUATOR_ROLE = 1;
 const WORKER_ROLE = 2;
-// The base58 decoded, bytes32 converted value of the task ipfsHash
-const SPECIFICATION_HASH = "9bb76d8e6c89b524d34a454b3140df28";
-const SPECIFICATION_HASH_UPDATED = "9bb76d8e6c89b524d34a454b3140df29";
-const DELIVERABLE_HASH = "9cc89e3e3d12a672d67a424b3640ce34";
+// The base58 decoded, bytes32 converted hex value of a test task ipfsHash "QmNSUYVKDSvPUnRLKmuxk9diJ6yS96r1TrAXzjTiBcCLAL"
+const SPECIFICATION_HASH = "0x017dfd85d4f6cb4dcd715a88101f7b1f06cd1e009b2327a0809d01eb9c91f231";
+// The above bytes32 hash where the last raw byte was changed from 1 -> 2
+const SPECIFICATION_HASH_UPDATED = "0x017dfd85d4f6cb4dcd715a88101f7b1f06cd1e009b2327a0809d01eb9c91f232";
+// The base58 decoded, bytes32 converted hex value of a test task ipfsHash "qmv8ndh7ageh9b24zngaextmuhj7aiuw3scc8hkczvjkww"
+const DELIVERABLE_HASH = "0xfb027a4d64f29d83e27769cb05d945e67ef7396fa1bd73ef53f065311fd3313e";
 const INITIAL_FUNDING = 360 * 1e18;
 const MANAGER_PAYOUT = web3Utils.toBN(100 * 1e18);
 const EVALUATOR_PAYOUT = web3Utils.toBN(50 * 1e18);

--- a/test/colony.js
+++ b/test/colony.js
@@ -1,6 +1,6 @@
 /* globals artifacts */
 
-import { hexToUtf8, toBN } from "web3-utils";
+import { toBN } from "web3-utils";
 
 import {
   MANAGER,
@@ -153,8 +153,8 @@ contract("Colony", addresses => {
     it("should allow admins to make task", async () => {
       await colony.makeTask(SPECIFICATION_HASH, 1);
       const task = await colony.getTask.call(1);
-      assert.equal(hexToUtf8(task[0]), SPECIFICATION_HASH);
-      assert.equal(hexToUtf8(task[1]), "");
+      assert.equal(task[0], SPECIFICATION_HASH);
+      assert.equal(task[1], "0x0000000000000000000000000000000000000000000000000000000000000000");
       assert.isFalse(task[2]);
       assert.isFalse(task[3]);
       assert.equal(task[4].toNumber(), 0);
@@ -367,7 +367,7 @@ contract("Colony", addresses => {
       const sigs = await createSignatures(colony, 1, [MANAGER], 0, txData);
       await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0], 0, txData);
       const task = await colony.getTask.call(1);
-      assert.equal(hexToUtf8(task[0]), SPECIFICATION_HASH_UPDATED);
+      assert.equal(task[0], SPECIFICATION_HASH_UPDATED);
     });
 
     it("should allow update of task brief signed by manager and worker", async () => {
@@ -378,7 +378,7 @@ contract("Colony", addresses => {
       const sigs = await createSignatures(colony, 1, signers, 0, txData);
       await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData);
       const task = await colony.getTask.call(1);
-      assert.equal(hexToUtf8(task[0]), SPECIFICATION_HASH_UPDATED);
+      assert.equal(task[0], SPECIFICATION_HASH_UPDATED);
     });
 
     it("should allow update of task brief signed by manager and worker using Trezor-style signatures", async () => {
@@ -389,7 +389,7 @@ contract("Colony", addresses => {
       const sigs = await createSignaturesTrezor(colony, 1, signers, 0, txData);
       await colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [1, 1], 0, txData);
       const task = await colony.getTask.call(1);
-      assert.equal(hexToUtf8(task[0]), SPECIFICATION_HASH_UPDATED);
+      assert.equal(task[0], SPECIFICATION_HASH_UPDATED);
     });
 
     it("should allow update of task brief signed by manager and worker if one uses Trezor-style signatures and the other does not", async () => {
@@ -407,7 +407,7 @@ contract("Colony", addresses => {
         txData
       );
       const task = await colony.getTask.call(1);
-      assert.equal(hexToUtf8(task[0]), SPECIFICATION_HASH_UPDATED);
+      assert.equal(task[0], SPECIFICATION_HASH_UPDATED);
     });
 
     it("should not allow update of task brief signed by manager twice, with two different signature styles", async () => {
@@ -427,7 +427,7 @@ contract("Colony", addresses => {
         )
       );
       const task = await colony.getTask.call(1);
-      assert.equal(hexToUtf8(task[0]), SPECIFICATION_HASH);
+      assert.equal(task[0], SPECIFICATION_HASH);
     });
 
     it("should allow update of task due date signed by manager and worker", async () => {
@@ -552,12 +552,12 @@ contract("Colony", addresses => {
       await setupAssignedTask({ colonyNetwork, colony, dueDate });
 
       let task = await colony.getTask.call(1);
-      assert.equal(hexToUtf8(task[1]), "");
+      assert.equal(task[1], "0x0000000000000000000000000000000000000000000000000000000000000000");
 
       const currentTime = await currentBlockTime();
       await colony.submitTaskDeliverable(1, DELIVERABLE_HASH, { from: WORKER });
       task = await colony.getTask.call(1);
-      assert.equal(hexToUtf8(task[1]), DELIVERABLE_HASH);
+      assert.equal(task[1], DELIVERABLE_HASH);
       assert.closeTo(task[7].toNumber(), currentTime, 2);
     });
 
@@ -587,7 +587,7 @@ contract("Colony", addresses => {
 
       await checkErrorRevert(colony.submitTaskDeliverable(1, SPECIFICATION_HASH, { from: WORKER }));
       const task = await colony.getTask.call(1);
-      assert.equal(hexToUtf8(task[1]), DELIVERABLE_HASH);
+      assert.equal(task[1], DELIVERABLE_HASH);
     });
 
     it("should fail if I try to submit work if I'm not the assigned worker", async () => {
@@ -597,7 +597,7 @@ contract("Colony", addresses => {
 
       await checkErrorRevert(colony.submitTaskDeliverable(1, SPECIFICATION_HASH, { from: OTHER }));
       const task = await colony.getTask.call(1);
-      assert.notEqual(hexToUtf8(task[1]), DELIVERABLE_HASH);
+      assert.notEqual(task[1], DELIVERABLE_HASH);
     });
   });
 

--- a/upgrade-test/colony-upgrade.js
+++ b/upgrade-test/colony-upgrade.js
@@ -1,7 +1,7 @@
 /* globals artifacts */
-import { hexToUtf8 } from "web3-utils";
 import { getTokenArgs } from "../helpers/test-helper";
 import { setupColonyVersionResolver } from "../helpers/upgradable-contracts";
+import { SPECIFICATION_HASH, SPECIFICATION_HASH_UPDATED } from "../helpers/constants";
 
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const EtherRouter = artifacts.require("EtherRouter");
@@ -16,9 +16,6 @@ const Token = artifacts.require("Token");
 
 contract("Colony contract upgrade", accounts => {
   const ACCOUNT_TWO = accounts[1];
-  // The base58 decoded, bytes32 converted value of the task ipfsHash
-  const specificationHash = "9bb76d8e6c89b524d34a454b3140df28";
-  const newSpecificationHash = "9bb76d8e6c89b524d34a454b3140df29";
 
   let colony;
   let colonyTask;
@@ -46,8 +43,8 @@ contract("Colony contract upgrade", accounts => {
     token = await Token.at(tokenAddress);
 
     await authority.setUserRole(ACCOUNT_TWO, 0, true);
-    await colony.makeTask(specificationHash, 1);
-    await colony.makeTask(newSpecificationHash, 1);
+    await colony.makeTask(SPECIFICATION_HASH, 1);
+    await colony.makeTask(SPECIFICATION_HASH_UPDATED, 1);
     // Setup new Colony contract version on the Network
     const updatedColonyContract = await UpdatedColony.new();
     const resolver = await Resolver.new();
@@ -79,14 +76,14 @@ contract("Colony contract upgrade", accounts => {
 
     it("should return correct tasks", async () => {
       const task1 = await updatedColony.getTask.call(1);
-      assert.equal(hexToUtf8(task1[0]), specificationHash);
+      assert.equal(task1[0], SPECIFICATION_HASH);
       assert.isFalse(task1[2]);
       assert.isFalse(task1[3]);
       assert.equal(task1[4].toNumber(), 0);
       assert.equal(task1[5].toNumber(), 0);
 
       const task2 = await updatedColony.getTask.call(2);
-      assert.equal(hexToUtf8(task2[0]), newSpecificationHash);
+      assert.equal(task2[0], SPECIFICATION_HASH_UPDATED);
       assert.isFalse(task2[2]);
       assert.isFalse(task2[3]);
       assert.equal(task2[4].toNumber(), 0);


### PR DESCRIPTION
Replaces sample IPFS hashes with examples matching the expected format.
e.g. the `base58` decoded, `bytes32` converted `hex` value of a sample ipfs hash `QmNSUYVKDSvPUnRLKmuxk9diJ6yS96r1TrAXzjTiBcCLAL` is `0x017dfd85d4f6cb4dcd715a88101f7b1f06cd1e009b2327a0809d01eb9c91f231`