### PR TITLE
Supply the selected network ID to the loader (`colony-network-contract-loader` package)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,5 +5,4 @@ contracts/*
 coverage/*
 keys/*
 lib/*
-packages/reputation-miner/node_modules/*
-packages/colony-contract-loader-network/node_modules/*
+packages/**/node_modules

--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ coverage/*
 keys/*
 lib/*
 packages/reputation-miner/node_modules/*
+packages/colony-contract-loader-network/node_modules/*

--- a/packages/colony-js-contract-loader-network/package.json
+++ b/packages/colony-js-contract-loader-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/colony-js-contract-loader-network",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Load the Colony contract ABIs directly from this package",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/colony-js-contract-loader-network/package.json
+++ b/packages/colony-js-contract-loader-network/package.json
@@ -11,7 +11,7 @@
   "author": "Christian Maniewski <chris@colony.io>",
   "license": "GPL-3.0",
   "dependencies": {
-    "@colony/colony-js-contract-loader": "^1.3.0",
+    "@colony/colony-js-contract-loader": "^1.4.1",
     "assert": "^1.4.1",
     "babel-runtime": "^6.26.0"
   },

--- a/packages/colony-js-contract-loader-network/src/NetworkLoader.js
+++ b/packages/colony-js-contract-loader-network/src/NetworkLoader.js
@@ -38,18 +38,19 @@ class NetworkLoader extends ContractLoader {
   }
   async _load(query = {}, requiredProps) {
     const { contractName = "", version = LATEST_VERSION } = query;
+    const networkQuery = Object.assign({}, query, { network: this._network });
 
     assert(!!contractName, "A `contractName` option must be provided");
     assert(!!version, "A valid `version` option must be provided");
 
     if (STATIC_CONTRACTS[contractName]) {
-      return this._transform(STATIC_CONTRACTS[contractName], query, requiredProps);
+      return this._transform(STATIC_CONTRACTS[contractName], networkQuery, requiredProps);
     } else if (
       VERSIONED_CONTRACTS[contractName] &&
       VERSIONED_CONTRACTS[contractName][this._network] &&
       VERSIONED_CONTRACTS[contractName][this._network][version]
     ) {
-      return this._transform(VERSIONED_CONTRACTS[contractName][this._network][version], query, requiredProps);
+      return this._transform(VERSIONED_CONTRACTS[contractName][this._network][version], networkQuery, requiredProps);
     }
     throw new Error(`Contract ${contractName} with version ${version} not found in ${this._network}`);
   }

--- a/packages/colony-js-contract-loader-network/src/__tests__/NetworkLoader.test.js
+++ b/packages/colony-js-contract-loader-network/src/__tests__/NetworkLoader.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 
 import NetworkLoader from "../NetworkLoader";
+import EtherRouter from "../../contracts/static/EtherRouter.json";
 
 describe("colony-contract-loader-network - NetworkLoader", () => {
   const loader = new NetworkLoader({ network: "rinkeby" });
@@ -16,6 +17,28 @@ describe("colony-contract-loader-network - NetworkLoader", () => {
     const contract = await loader.load({ contractName: "IColony", contractAddress, version: "1" });
     expect(contract).toHaveProperty("abi", expect.any(Array));
     expect(contract).toHaveProperty("address", contractAddress);
+  });
+
+  test("It should load a versioned router contract that is defined, without an address or version", async () => {
+    const contract = await loader.load({
+      contractName: "IColonyNetwork",
+      routerName: "EtherRouter"
+    });
+    expect(contract).toHaveProperty("abi", expect.any(Array));
+    expect(contract).toHaveProperty("address", EtherRouter.networks.rinkeby.address);
+  });
+
+  test("It should not load a versioned router contract that is not defined on the selected network", async () => {
+    const mainLoader = new NetworkLoader({ network: "main" });
+    try {
+      await mainLoader.load({
+        contractName: "IColonyNetwork",
+        routerName: "EtherRouter"
+      });
+      expect(false).toBe(true); // should be unreachable
+    } catch (error) {
+      expect(error.toString()).toMatch("Contract IColonyNetwork with version 1 not found in main");
+    }
   });
 
   test("It should fail to load a contract that does not exist", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,6 +106,13 @@
     assert "^1.4.1"
     babel-runtime "^6.26.0"
 
+"@colony/colony-js-contract-loader@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-loader/-/colony-js-contract-loader-1.4.1.tgz#0427b24d1fc06e3482895c4ebbea94832016a719"
+  dependencies:
+    assert "^1.4.1"
+    babel-runtime "^6.26.0"
+
 "@colony/eslint-config-colony@4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@colony/eslint-config-colony/-/eslint-config-colony-4.0.1.tgz#74495655bf461ef196edc262983c471b42cf2d75"
@@ -3473,9 +3480,9 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-ganache-cli@6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.1.0.tgz#486c846497204b644166b5f0f74c9b41d02bdc25"
+ganache-cli@6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.1.3.tgz#40323e56c878b5c7275830cb8a4fa75a32f6d468"
   dependencies:
     source-map-support "^0.5.3"
     webpack-cli "^2.0.9"


### PR DESCRIPTION
This PR makes a small change to the loader so that the selected networkId (set in the loader instance) is supplied to the transform function. This makes it possible to find the address for the selected network automatically when loading the contract.

![Ronseal](https://pbs.twimg.com/media/C2O_QxsWQAAcUMY.jpg)
