### PR TITLE
Improve payout accounting

### DIFF
--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -53,6 +53,7 @@ contract ColonyFunding is ColonyStorage, DSMath {
     emit TaskWorkerPayoutChanged(_id, _token, _amount);
   }
 
+  // To get all payouts for a task iterate over roles.length
   function getTaskPayout(uint256 _id, uint256 _role, address _token) public view returns (uint256) {
     Task storage task = tasks[_id];
     bool unsatisfactory = task.roles[_role].rating == TaskRatings.Unsatisfactory;
@@ -297,6 +298,11 @@ contract ColonyFunding is ColonyStorage, DSMath {
   {
     uint currentTotalAmount = getTotalTaskPayout(_id, _token);
     tasks[_id].payouts[_role][_token] = _amount;
+
+    // This call functions as a guard to make sure the new total payout doesn't overflow
+    // If there is an overflow, the call will revert
+    getTotalTaskPayout(_id, _token);
+
     updateTaskPayoutsWeCannotMakeAfterBudgetChange(_id, _token, currentTotalAmount);
   }
 }

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -104,7 +104,7 @@ contract ColonyStorage is DSAuth {
     // TODO switch this mapping to a uint8 when all role instances are uint8-s specifically ColonyFunding source
     mapping (uint256 => Role) roles;
     // Maps a token to the sum of all payouts of it for this task
-    mapping (address => uint256) totalPayouts;
+    mapping (address => uint256) totalPayouts; // DEPRECATED
     // Maps task role ids (0,1,2..) to a token amount to be paid on task completion
     mapping (uint256 => mapping (address => uint256)) payouts;
   }

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -103,8 +103,6 @@ contract ColonyStorage is DSAuth {
 
     // TODO switch this mapping to a uint8 when all role instances are uint8-s specifically ColonyFunding source
     mapping (uint256 => Role) roles;
-    // Maps a token to the sum of all payouts of it for this task
-    mapping (address => uint256) totalPayouts; // DEPRECATED
     // Maps task role ids (0,1,2..) to a token amount to be paid on task completion
     mapping (uint256 => mapping (address => uint256)) payouts;
   }

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -172,13 +172,13 @@ contract ColonyTask is ColonyStorage, DSMath {
     } else {
       nSignaturesRequired = 2;
     }
-    
+
     require(_sigR.length == nSignaturesRequired);
 
     bytes32 msgHash = keccak256(abi.encodePacked(address(this), address(this), _value, _data, taskChangeNonces[taskId]));
     address[] memory reviewerAddresses = new address[](nSignaturesRequired);
     for (uint i = 0; i < nSignaturesRequired; i++) {
-      // 0 'Normal' mode - geth, etc. 
+      // 0 'Normal' mode - geth, etc.
       // >0 'Trezor' mode
       // Correct incantation helpfully cribbed from https://github.com/trezor/trezor-mcu/issues/163#issuecomment-368435292
       bytes32 txHash;
@@ -187,17 +187,17 @@ contract ColonyTask is ColonyStorage, DSMath {
       } else {
         txHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n\x20", msgHash));
       }
-    
+
       reviewerAddresses[i] = ecrecover(txHash, _sigV[i], _sigR[i], _sigS[i]);
     }
 
     require(reviewerAddresses[0] == tasks[taskId].roles[reviewers[sig][0]].user || reviewerAddresses[0] == tasks[taskId].roles[reviewers[sig][1]].user);
-    
+
     if (nSignaturesRequired == 2) {
       require(reviewerAddresses[0] != reviewerAddresses[1]);
       require(reviewerAddresses[1] == tasks[taskId].roles[reviewers[sig][0]].user || reviewerAddresses[1] == tasks[taskId].roles[reviewers[sig][1]].user);
     }
-    
+
     taskChangeNonces[taskId]++;
     require(executeCall(address(this), _value, _data));
   }
@@ -351,20 +351,17 @@ contract ColonyTask is ColonyStorage, DSMath {
 
     for (uint8 roleId = 0; roleId <= 2; roleId++) {
       Role storage role = task.roles[roleId];
-      TaskRatings rating = (roleId == EVALUATOR) ? TaskRatings.Satisfactory : role.rating;
-      uint payout = task.payouts[roleId][token];
 
-      int reputation = getReputation(int(payout), uint8(rating), role.rateFail);
+      if (roleId == EVALUATOR) { // They had one job!
+        role.rating = role.rateFail ? TaskRatings.Unsatisfactory : TaskRatings.Satisfactory;
+      }
+
+      uint payout = task.payouts[roleId][token];
+      int reputation = getReputation(int(payout), uint8(role.rating), role.rateFail);
 
       colonyNetworkContract.appendReputationUpdateLog(role.user, reputation, domains[task.domainId].skillId);
-
       if (roleId == WORKER) {
         colonyNetworkContract.appendReputationUpdateLog(role.user, reputation, task.skills[0]);
-
-        if (rating == TaskRatings.Unsatisfactory) {
-          task.payouts[roleId][token] = 0;
-          task.totalPayouts[token] = sub(task.totalPayouts[token], payout);
-        }
       }
     }
 

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -308,6 +308,12 @@ contract IColony {
   /// @return Payout amount
   function getTaskPayout(uint256 _id, uint256 _role, address _token) public view returns (uint256);
 
+  /// @notice Get total payout amount in `_token` denomination for task `_id`
+  /// @param _id Id of the task
+  /// @param _token Address of the token, `0x0` value indicates Ether
+  /// @return Payout amount
+  function getTotalTaskPayout(uint256 _id, address _token) public view returns (uint256);
+
   /// @notice Set `_token` payout for manager in task `_id` to `_amount`
   /// @param _id Id of the task
   /// @param _token Address of the token, `0x0` value indicates Ether

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -264,7 +264,7 @@ contract("Colony Funding", addresses => {
       await fundColonyWithTokens(colony, otherToken, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony, token: otherToken });
       await colony.finalizeTask(taskId);
-      await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 40, otherToken.address));
+      await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 40, otherToken.address), "colony-funding-task-bad-state");
       const colonyPotBalance = await colony.getPotBalance.call(2, otherToken.address);
       assert.equal(colonyPotBalance.toNumber(), 350 * 1e18);
     });
@@ -364,18 +364,18 @@ contract("Colony Funding", addresses => {
       await colony.setTaskRoleUser(1, WORKER_ROLE, WORKER);
 
       await colony.setTaskManagerPayout(1, 0x0, 40);
-
       let task = await colony.getTask.call(1);
       assert.equal(task[5].toNumber(), 1);
+
       await colony.moveFundsBetweenPots(1, 2, 40, 0x0);
       task = await colony.getTask.call(1);
       assert.equal(task[5].toNumber(), 0);
+
       await colony.moveFundsBetweenPots(2, 1, 30, 0x0);
       task = await colony.getTask.call(1);
       assert.equal(task[5].toNumber(), 1);
 
       await colony.setTaskManagerPayout(1, 0x0, 10);
-
       task = await colony.getTask.call(1);
       assert.equal(task[5].toNumber(), 0);
     });

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -241,7 +241,7 @@ contract("Colony Task Work Rating", () => {
       assert.isFalse(roleEvaluator[1]);
     });
 
-    it("should assign rating 3 to worker, when evaluator hasn't submitted rating on time", async () => {
+    it("should assign rating 3 to worker and 1 to evaluator if evaluator hasn't submitted rating on time", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
@@ -257,8 +257,10 @@ contract("Colony Task Work Rating", () => {
       assert.isFalse(roleManager[1]);
       assert.equal(roleManager[2].toNumber(), MANAGER_RATING);
 
+      await colony.finalizeTask(taskId);
       const roleEvaluator = await colony.getTaskRole.call(taskId, EVALUATOR_ROLE);
       assert.isTrue(roleEvaluator[1]);
+      assert.equal(roleEvaluator[2].toNumber(), 1);
     });
 
     it("should assign rating 3 to manager and 3 to worker, with penalties, when no one has submitted any ratings", async () => {
@@ -274,8 +276,10 @@ contract("Colony Task Work Rating", () => {
       assert.isFalse(roleManager[1]);
       assert.equal(roleManager[2].toNumber(), 3);
 
+      await colony.finalizeTask(taskId);
       const roleEvaluator = await colony.getTaskRole.call(taskId, EVALUATOR_ROLE);
       assert.isTrue(roleEvaluator[1]);
+      assert.equal(roleEvaluator[2].toNumber(), 1);
     });
 
     it("should revert if I try to assign ratings before the reveal period is over", async () => {

--- a/test/colony.js
+++ b/test/colony.js
@@ -21,6 +21,8 @@ import {
   RATING_2_SALT,
   RATING_1_SECRET,
   RATING_2_SECRET,
+  MANAGER_PAYOUT,
+  WORKER_PAYOUT,
   EVALUATOR_PAYOUT
 } from "../helpers/constants";
 import {
@@ -799,6 +801,15 @@ contract("Colony", addresses => {
       const sigs = await createSignatures(colony, 1, [MANAGER, WORKER], 0, txData);
 
       await expectEvent(colony.executeTaskChange(sigs.sigV, sigs.sigR, sigs.sigS, [0, 0], 0, txData), "TaskWorkerPayoutChanged");
+    });
+
+    it("should correctly return the current total payout", async () => {
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      const taskId = await setupFundedTask({ colonyNetwork, colony, token });
+
+      const totalTokenPayout = await colony.getTotalTaskPayout(taskId, token.address);
+      const totalTokenPayoutExpected = MANAGER_PAYOUT.add(EVALUATOR_PAYOUT).add(WORKER_PAYOUT);
+      assert.equal(totalTokenPayout.toString(), totalTokenPayoutExpected.toString());
     });
   });
 


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->

Closes #232 

<!--- Summary of changes including design decisions -->

- If a user has done Unsatisfactory work, `claimPayout` will be a no-op (instead of raising an exception).
- Ratings for all users are guaranteed to be set after `finalizeTask` has been called. The rating for the evaluator will not be set before then.
- The `task.totalPayouts` field is deprecated and replaced by the `getTotalTaskPayout()` function which calculates the total payout dynamically based on the individual role payouts. This eliminates the need to synchronize two variables (and avoids paying the SSTORE gas cost of setting a redundant variable). Instead, we pay the price for a ~relatively cheap loop.

