### PR TITLE
Add DomainAdded/PotAdded events

### DIFF
--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -28,6 +28,9 @@ contract ColonyStorage is DSAuth {
   // this one will have the getters. Make custom getters in the contract that seems most appropriate,
   // and add it to IColony.sol
 
+  event DomainAdded(uint256 indexed id);
+  event PotAdded(uint256 indexed id);
+
   address resolver;
   address colonyNetworkAddress;
   ERC20Extended token;

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -135,6 +135,7 @@ contract ColonyTask is ColonyStorage, DSMath {
 
     pots[potCount].taskId = taskCount;
 
+    emit PotAdded(potCount);
     emit TaskAdded(taskCount);
   }
 

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -71,6 +71,14 @@ contract IColony {
   /// @param id Payout id
   event RewardPayoutCycleStarted(uint256 indexed id);
 
+  /// @notice Event logged when a new Domain is added
+  /// @param id Id of the newly-created Domain
+  event DomainAdded(uint256 indexed id);
+
+  /// @notice Event logged when a new Pot is added
+  /// @param id Id of the newly-created Pot
+  event PotAdded(uint256 indexed id);
+
   // Implemented in DSAuth.sol
   /// @notice Get the `Authority` for the colony
   /// @return The `Authority` contract address

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -27,7 +27,7 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
   const specificationHash = SPECIFICATION_HASH;
   const tx = await colony.makeTask(specificationHash, domain);
   // Reading the ID out of the event triggered by our transaction will allow us to make multiple tasks in parallel in the future.
-  const taskId = tx.logs[0].args.id.toNumber();
+  const taskId = tx.logs.filter(log => log.event === "TaskAdded")[0].args.id.toNumber();
   // If the skill is not specified, default to the root global skill
   if (skill === 0) {
     const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId.call();

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -141,6 +141,12 @@ export async function expectEvent(tx, eventName) {
   return assert.exists(event);
 }
 
+export async function expectAllEvents(tx, eventNames) {
+  const { logs } = await tx;
+  const events = eventNames.every(eventName => logs.find(e => e.event === eventName));
+  return assert.isTrue(events);
+}
+
 export async function forwardTime(seconds, test) {
   const client = await web3GetClient();
   const p = new Promise((resolve, reject) => {


### PR DESCRIPTION
Closes #243

This PR consolidates the new domain/pot logic into a private function `initialiseColony(skillId)` and adds `DomainAdded` and `PotAdded` events. 

It also adds some test coverage for initialising the root domain for a new Colony, and a new test helper (`expectAllEvents`). 