### PR TITLE
Only allow auctions to be started at most once a month per token

### DIFF
--- a/contracts/ColonyNetworkAuction.sol
+++ b/contracts/ColonyNetworkAuction.sol
@@ -25,10 +25,14 @@ contract ColonyNetworkAuction is ColonyNetworkStorage {
   event AuctionCreated(address auction, address token, uint256 quantity);
 
   function startTokenAuction(address _token) public {
+    uint lastAuctionTimestamp = recentAuctions[_token];
+    require(lastAuctionTimestamp == 0 || now - lastAuctionTimestamp >= 30 days, "colony-auction-start-too-soon");
     address clny = IColony(metaColony).getToken();
     DutchAuction auction = new DutchAuction(clny, _token);
     uint availableTokens = ERC20Extended(_token).balanceOf(this);
     ERC20Extended(_token).transfer(auction, availableTokens);
+    auction.start();
+    recentAuctions[_token] = now;
     emit AuctionCreated(address(auction), _token, availableTokens);
   }
 }

--- a/contracts/ColonyNetworkStorage.sol
+++ b/contracts/ColonyNetworkStorage.sol
@@ -70,4 +70,7 @@ contract ColonyNetworkStorage is DSAuth, DSMath {
   uint256 reputationRootHashNNodes;
   // Mapping containing how much has been staked by each user
   mapping (address => uint) stakedBalances;
+
+  // Mapping containing the last auction start timestamp for a token address
+  mapping (address => uint) recentAuctions;
 }


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #185 

<!--- Summary of changes including design decisions -->
- Make auction start immediately upon creation
- Only allow auctions to be started at most once a month (per token)
