### PR TITLE
Create Solidity-equivalent PatriciaJs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,9 @@ jobs:
           name: "Running gas cost tests"
           command: yarn run test:contracts:gasCosts
       - run:
+          name: "Running patricia tree tests"
+          command: yarn run test:contracts:patricia
+      - run:
           name: "Running colony-contract-loader-network tests"
           command: cd packages/colony-js-contract-loader-network && yarn run test
       - run:

--- a/contracts/PatriciaTree/Data.sol
+++ b/contracts/PatriciaTree/Data.sol
@@ -92,7 +92,7 @@ library Data {
     if (suffix.length == 0) {
       // Full match with the key, update operation
       newNodeHash = value;
-    } else if (prefix.length >= e.label.length) {
+    } else if (prefix.length >= e.label.length) {  // NOTE: how could a common prefix be longer than either label?
       // Partial match, just follow the path
       assert(suffix.length > 1);
       Node memory n = self.nodes[e.node];

--- a/contracts/PatriciaTree/PatriciaTree.sol
+++ b/contracts/PatriciaTree/PatriciaTree.sol
@@ -42,7 +42,7 @@ contract PatriciaTree is IPatriciaTree, PatriciaTreeProofs {
       Data.Label memory prefix;
       Data.Label memory suffix;
       (prefix, suffix) = k.splitCommonPrefix(e.label);
-      assert(prefix.length == e.label.length);
+      assert(prefix.length == e.label.length); // I.e. never an unseen branch
       if (suffix.length == 0) {
         // Found it
         break;

--- a/helpers/patricia.js
+++ b/helpers/patricia.js
@@ -1,0 +1,240 @@
+const BN = require("bn.js");
+const web3Utils = require("web3-utils");
+
+// //////////////
+// Internal utilities
+// ////////////////////////
+function makeLabel(data, length) {
+  return {
+    data, // 256-bit path as BigNumber
+    length // Number of bits in use
+  };
+}
+
+function makeEdge(nodeHash, label) {
+  return {
+    nodeHash, // Hash of node value (this is confusing), used as key in tree.nodes
+    label // Label object containing path to node
+  };
+}
+
+function makeNode(left = {}, right = {}) {
+  return { children: [left, right] }; // Left and right Edges
+}
+
+function sha2bn(hash) {
+  return new BN(hash.slice(2), 16);
+}
+
+function bn2hex64(bn) {
+  const bnStr = bn.toString(16);
+  return `0x${"0".repeat(64 - bnStr.length)}${bnStr}`;
+}
+
+function sha3(value) {
+  const hash = sha2bn(web3Utils.soliditySha3(value));
+  return hash;
+}
+
+function edgeEncodingHash(edge) {
+  const hash = sha2bn(web3Utils.soliditySha3(bn2hex64(edge.nodeHash), bn2hex64(new BN(edge.label.length)), bn2hex64(edge.label.data)));
+  return hash;
+}
+
+function nodeEncodingHash(node) {
+  const hash = sha2bn(web3Utils.soliditySha3(edgeEncodingHash(node.children[0]), edgeEncodingHash(node.children[1])));
+  return hash;
+}
+
+function splitAt(label, pos) {
+  if (!(pos <= label.length && pos <= 256)) throw "AssertFail"; // eslint-disable-line no-throw-literal
+  const prefix = {};
+  const suffix = {};
+  prefix.length = pos;
+  if (pos === 0) {
+    prefix.data = new BN(0, 16);
+  } else {
+    prefix.data = label.data.and(new BN(0, 16).notn(256).shln(256 - pos));
+    // NOTE: Solidity is bytes32(uint(self.data) & ~uint(1) << 255 - pos);
+  }
+  suffix.length = label.length - pos;
+  suffix.data = label.data.shln(pos).maskn(256); // Maskn to limit word to 256 bits
+  return [prefix, suffix];
+}
+
+function commonPrefix(a, b) {
+  const length = a.length < b.length ? a.length : b.length;
+  if (length === 0) {
+    return 0;
+  }
+  // uint diff = uint(a.data ^ b.data) & ~uint(0) << 256 - length; // TODO Mask should not be needed.
+  const diff = a.data.xor(b.data);
+  if (diff.toString(16) === "0") {
+    return length;
+  }
+  // Find highest bit set
+  let ret;
+  for (let i = 255; i >= 0; i -= 1) {
+    if (diff.testn(i)) {
+      ret = 255 - i;
+      break;
+    }
+  }
+  return Math.min(length, ret);
+}
+
+function splitCommonPrefix(a, b) {
+  return splitAt(a, commonPrefix(a, b));
+}
+
+function chopFirstBit(label) {
+  if (!(label.length > 0)) throw "AssertFail"; // eslint-disable-line no-throw-literal
+  const head = label.data.shrn(255).toNumber();
+  const tail = makeLabel(label.data.shln(1).maskn(256), label.length - 1);
+  return [head, tail];
+}
+
+function removePrefix(label, prefix) {
+  if (!(prefix <= label.length)) throw "AssertFail"; // eslint-disable-line no-throw-literal
+  return makeLabel(label.data.shln(prefix).maskn(256), label.length - prefix);
+}
+
+// function printBinary(hexString) {
+//   let out = "";
+//   let char;
+//   console.log(hexString.length, hexString);
+//   for (let i = 0; i < hexString.length; i += 1) {
+//     char = hexString[i];
+//     if (char === "0") out += "0000";
+//     if (char === "1") out += "0001";
+//     if (char === "2") out += "0010";
+//     if (char === "3") out += "0011";
+//     if (char === "4") out += "0100";
+//     if (char === "5") out += "0101";
+//     if (char === "6") out += "0110";
+//     if (char === "7") out += "0111";
+//     if (char === "8") out += "1000";
+//     if (char === "9") out += "1001";
+//     if (char === "a") out += "1010";
+//     if (char === "b") out += "1011";
+//     if (char === "c") out += "1100";
+//     if (char === "d") out += "1101";
+//     if (char === "e") out += "1110";
+//     if (char === "f") out += "1111";
+//   }
+//   console.log(out.length, out);
+// }
+
+// //////
+// Patricia Tree
+// //////////////////
+exports.PatriciaTree = function() {
+  // Label: { data, length } (data is the path, length says how many bits are used)
+  // Edge: { nodeHash, label }
+  // Node: [leftEdge, rightEdge] (no actual node)
+
+  this.tree = {
+    root: new BN(0, 16),
+    rootEdge: {},
+    nodes: new Map()
+  };
+
+  // ////////////
+  // Public functions
+  // //////////////////////
+
+  // Unused _ arg to conform to interace which accepts gas execution options
+
+  // eslint-disable-next-line no-unused-vars
+  this.getRootHash = function getRootHash(_ = undefined) {
+    return bn2hex64(this.tree.root);
+  };
+
+  // eslint-disable-next-line no-unused-vars
+  this.insert = function insert(key, value, _ = undefined) {
+    const label = makeLabel(sha3(key), 256);
+    const valueHash = sha3(value);
+    let edge = {};
+    if (this.tree.root.toString(16) === "0") {
+      edge.label = label;
+      edge.nodeHash = valueHash;
+    } else {
+      edge = this.insertAtEdge(this.tree.rootEdge, label, valueHash);
+    }
+    this.tree.root = edgeEncodingHash(edge);
+    this.tree.rootEdge = edge;
+  };
+
+  // eslint-disable-next-line no-unused-vars
+  this.getProof = function getProof(key, _ = undefined) {
+    if (!(this.tree.root.toString(16) !== "0")) throw "AssertFail"; // eslint-disable-line no-throw-literal
+    const siblings = [];
+
+    let label = makeLabel(sha3(key), 256);
+    let edge = this.tree.rootEdge;
+    let numSiblings = 0;
+    let length = 0;
+    let branchMask = new BN(0, 16);
+
+    while (true) {
+      const [prefix, suffix] = splitCommonPrefix(label, edge.label);
+
+      // I.e. never an unseen branch
+      if (!(prefix.length === edge.label.length)) throw "AssertFail"; // eslint-disable-line no-throw-literal
+      if (suffix.length === 0) {
+        break; // Found it
+      }
+
+      length += prefix.length;
+      // NOTE: Solidity is branchMask | uint(1) << 255 - length;
+      branchMask = branchMask.or(new BN(1, 16).shln(255 - length));
+      length += 1;
+
+      const node = this.tree.nodes[edge.nodeHash.toString(16)];
+      const [head, tail] = chopFirstBit(suffix);
+
+      const sibling = node.children[1 - head];
+      siblings[numSiblings++] = edgeEncodingHash(sibling); // eslint-disable-line no-plusplus
+
+      edge = node.children[head];
+      label = tail;
+    }
+    return [branchMask, siblings.map(s => bn2hex64(s))];
+  };
+
+  // ////////////
+  // Private functions
+  // /////////////////////
+  this.insertAtEdge = function insertAtEdge(edge, label, valueHash) {
+    if (!(label.length >= edge.label.length)) throw "AssertFail"; // eslint-disable-line no-throw-literal
+    const [prefix, suffix] = splitCommonPrefix(label, edge.label);
+    let newNodeHash;
+    if (suffix.length === 0) {
+      // Full match with the key, update operation
+      newNodeHash = valueHash;
+    } else if (prefix.length >= edge.label.length) {
+      // Partial match, just follow the path
+      // NOTE: but how could a common prefix be longer than either label?
+      if (!(suffix.length > 1)) throw "AssertFail"; // eslint-disable-line no-throw-literal
+      const node = this.tree.nodes[edge.nodeHash.toString(16)];
+      const [head, tail] = chopFirstBit(suffix);
+      node.children[head] = this.insertAtEdge(node.children[head], tail, valueHash);
+      delete this.tree.nodes[edge.nodeHash.toString(16)];
+      newNodeHash = this.insertNode(node);
+    } else {
+      // Mismatch, so let us create a new branch node.
+      const [head, tail] = chopFirstBit(suffix);
+      const branchNode = makeNode();
+      branchNode.children[head] = makeEdge(valueHash, tail);
+      branchNode.children[1 - head] = makeEdge(edge.nodeHash, removePrefix(edge.label, prefix.length + 1));
+      newNodeHash = this.insertNode(branchNode);
+    }
+    return makeEdge(newNodeHash, prefix);
+  };
+
+  this.insertNode = function insertNode(node) {
+    const nodeHash = nodeEncodingHash(node);
+    this.tree.nodes[nodeHash.toString(16)] = node;
+    return nodeHash;
+  };
+};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:contracts": "npm run start:blockchain:client & truffle migrate --reset --compile-all && truffle test --network development",
     "test:contracts:upgrade": "npm run start:blockchain:client parity & npm run generate:test:contracts && truffle migrate --reset --compile-all && truffle test ./upgrade-test/* --network integration",
     "test:contracts:gasCosts": "npm run start:blockchain:client & truffle migrate --reset --compile-all && truffle test gasCosts/gasCosts.js --network development",
+    "test:contracts:patricia": "npm run start:blockchain:client & truffle migrate --reset --compile-all && truffle test packages/reputation-miner/patricia-test.js --network development",
     "test:contracts:coverage": "SOLIDITY_COVERAGE=1 solidity-coverage && istanbul check-coverage --statements 94 --branches 88 --functions 92 --lines 94",
     "pretest:contracts": "sed -ie \"s/eth-gas-reporter/mocha-circleci-reporter/g\" ./truffle.js && rimraf ./truffle.jse",
     "pretest:contracts:upgrade": "sed -ie \"s/eth-gas-reporter/mocha-circleci-reporter/g\" ./truffle.js && rimraf ./truffle.jse",
@@ -24,7 +25,8 @@
     "pretest:contracts:coverage": "sed -ie \"s/eth-gas-reporter/mocha-circleci-reporter/g\" ./truffle.js && rimraf ./truffle.jse",
     "posttest:contracts": "npm run stop:blockchain:client",
     "posttest:contracts:upgrade": "npm run clean:test:contracts | npm run stop:blockchain:client",
-    "posttest:contracts:gasCosts": "npm run stop:blockchain:client"
+    "posttest:contracts:gasCosts": "npm run stop:blockchain:client",
+    "posttest:contracts:patricia": "npm run stop:blockchain:client"
   },
   "pre-commit": [
     "eslint-staged",

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -2,7 +2,7 @@ const BN = require("bn.js");
 const web3Utils = require("web3-utils");
 const ganache = require("ganache-core");
 const ethers = require("ethers");
-const patriciaJs = require("../../helpers/patricia");
+const patriciaJs = require("./patricia");
 
 // We don't need the account address right now for this secret key, but I'm leaving it in in case we
 // do in the future.
@@ -67,21 +67,24 @@ class ReputationMiner {
   constructor({ loader, minerAddress, privateKey, provider, realProviderPort = 8545, useJsTree = false }) {
     this.loader = loader;
     this.minerAddress = minerAddress;
-    const ganacheProvider = ganache.provider({
-      network_id: 515,
-      vmErrorsOnRPCResponse: false,
-      locked: false,
-      verbose: true,
-      accounts: [
-        {
-          balance: "0x10000000000000000000000000",
-          secretKey
-        }
-      ]
-    });
-    this.ganacheProvider = new ethers.providers.Web3Provider(ganacheProvider);
-    this.ganacheWallet = new ethers.Wallet(secretKey, this.ganacheProvider);
+
     this.useJsTree = useJsTree;
+    if (!this.useJsTree) {
+      const ganacheProvider = ganache.provider({
+        network_id: 515,
+        vmErrorsOnRPCResponse: false,
+        locked: false,
+        verbose: true,
+        accounts: [
+          {
+            balance: "0x10000000000000000000000000",
+            secretKey
+          }
+        ]
+      });
+      this.ganacheProvider = new ethers.providers.Web3Provider(ganacheProvider);
+      this.ganacheWallet = new ethers.Wallet(secretKey, this.ganacheProvider);
+    }
 
     if (provider) {
       this.realProvider = provider;

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -2,6 +2,7 @@ const BN = require("bn.js");
 const web3Utils = require("web3-utils");
 const ganache = require("ganache-core");
 const ethers = require("ethers");
+const patriciaJs = require("../../helpers/patricia");
 
 // We don't need the account address right now for this secret key, but I'm leaving it in in case we
 // do in the future.
@@ -47,13 +48,23 @@ function RPCSigner(minerAddress, provider) {
 }
 // ===================================
 
+/**
+ * Convert number to 0x Hex encoding
+ * @param  {BN or BigNumber} bnLike
+ * @return {String} hexString
+ * @dev Used to provide standard interface for BN and BigNumber
+ */
+function toHexString(bnLike) {
+  return ethers.utils.bigNumberify(bnLike.toString()).toHexString();
+}
+
 class ReputationMiner {
   /**
    * Constructor for ReputationMiner
    * @param {string} minerAddress            The address that is staking CLNY that will allow the miner to submit reputation hashes
    * @param {Number} [realProviderPort=8545] The port that the RPC node with the ability to sign transactions from `minerAddress` is responding on. The address is assumed to be `localhost`.
    */
-  constructor({ loader, minerAddress, privateKey, provider, realProviderPort = 8545 }) {
+  constructor({ loader, minerAddress, privateKey, provider, realProviderPort = 8545, useJsTree = false }) {
     this.loader = loader;
     this.minerAddress = minerAddress;
     const ganacheProvider = ganache.provider({
@@ -70,6 +81,7 @@ class ReputationMiner {
     });
     this.ganacheProvider = new ethers.providers.Web3Provider(ganacheProvider);
     this.ganacheWallet = new ethers.Wallet(secretKey, this.ganacheProvider);
+    this.useJsTree = useJsTree;
 
     if (provider) {
       this.realProvider = provider;
@@ -92,16 +104,22 @@ class ReputationMiner {
    * @return {Promise}
    */
   async initialise(colonyNetworkAddress) {
-    this.patriciaTreeContractDef = await this.loader.load({ contractName: "PatriciaTree" }, { abi: true, address: false, bytecode: true });
     this.colonyNetworkContractDef = await this.loader.load({ contractName: "IColonyNetwork" }, { abi: true, address: false });
     this.repCycleContractDef = await this.loader.load({ contractName: "IReputationMiningCycle" }, { abi: true, address: false });
 
-    const patriciaTreeDeployTx = ethers.Contract.getDeployTransaction(this.patriciaTreeContractDef.bytecode, this.patriciaTreeContractDef.abi);
-    const tx = await this.ganacheWallet.sendTransaction(patriciaTreeDeployTx);
-    this.reputationTree = new ethers.Contract(ethers.utils.getContractAddress(tx), this.patriciaTreeContractDef.abi, this.ganacheWallet);
+    this.colonyNetwork = new ethers.Contract(colonyNetworkAddress, this.colonyNetworkContractDef.abi, this.realWallet);
+
+    if (this.useJsTree) {
+      this.reputationTree = new patriciaJs.PatriciaTree();
+    } else {
+      this.patriciaTreeContractDef = await this.loader.load({ contractName: "PatriciaTree" }, { abi: true, address: false, bytecode: true });
+      const patriciaTreeDeployTx = ethers.Contract.getDeployTransaction(this.patriciaTreeContractDef.bytecode, this.patriciaTreeContractDef.abi);
+      const tx = await this.ganacheWallet.sendTransaction(patriciaTreeDeployTx);
+      this.reputationTree = new ethers.Contract(ethers.utils.getContractAddress(tx), this.patriciaTreeContractDef.abi, this.ganacheWallet);
+    }
+
     this.nReputations = 0;
     this.reputations = {};
-    this.colonyNetwork = new ethers.Contract(colonyNetworkAddress, this.colonyNetworkContractDef.abi, this.realWallet);
   }
 
   /**
@@ -110,10 +128,13 @@ class ReputationMiner {
    * @return {Promise}
    */
   async addLogContentsToReputationTree() {
-    const patriciaTreeDeployTx = ethers.Contract.getDeployTransaction(this.patriciaTreeContractDef.bytecode, this.patriciaTreeContractDef.abi);
-
-    const tx = await this.ganacheWallet.sendTransaction(patriciaTreeDeployTx);
-    this.justificationTree = new ethers.Contract(ethers.utils.getContractAddress(tx), this.patriciaTreeContractDef.abi, this.ganacheWallet);
+    if (this.useJsTree) {
+      this.justificationTree = new patriciaJs.PatriciaTree();
+    } else {
+      const patriciaTreeDeployTx = ethers.Contract.getDeployTransaction(this.patriciaTreeContractDef.bytecode, this.patriciaTreeContractDef.abi);
+      const tx = await this.ganacheWallet.sendTransaction(patriciaTreeDeployTx);
+      this.justificationTree = new ethers.Contract(ethers.utils.getContractAddress(tx), this.patriciaTreeContractDef.abi, this.ganacheWallet);
+    }
 
     this.justificationHashes = {};
     const addr = await this.colonyNetwork.getReputationMiningCycle(true);
@@ -337,7 +358,7 @@ class ReputationMiner {
    */
   async getProof(key) {
     const [branchMask, siblings] = await this.reputationTree.getProof(key);
-    const retBranchMask = branchMask.toHexString();
+    const retBranchMask = toHexString(branchMask);
     return [retBranchMask, siblings];
   }
 
@@ -483,9 +504,9 @@ class ReputationMiner {
         index.toString(),
         this.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.branchMask,
         this.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].nextUpdateProof.nNodes,
-        agreeStateBranchMask.toHexString(),
+        toHexString(agreeStateBranchMask),
         this.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.nNodes,
-        disagreeStateBranchMask.toHexString(),
+        toHexString(disagreeStateBranchMask),
         this.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.branchMask,
         0
       ],

--- a/packages/reputation-miner/patricia-test.js
+++ b/packages/reputation-miner/patricia-test.js
@@ -1,0 +1,108 @@
+/* globals artifacts */
+
+import path from "path";
+import web3Utils from "web3-utils";
+
+import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
+import ReputationMiner from "./ReputationMiner";
+
+const EtherRouter = artifacts.require("EtherRouter");
+const IColonyNetwork = artifacts.require("IColonyNetwork");
+
+const contractLoader = new TruffleLoader({
+  contractDir: path.resolve(__dirname, "..", "..", "build", "contracts")
+});
+
+contract("Javascript Patricia Tree", accounts => {
+  const MAIN_ACCOUNT = accounts[0];
+  const OTHER_ACCOUNT = accounts[1];
+  const REAL_PROVIDER_PORT = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
+
+  let colonyNetwork;
+  let jsClient;
+  let solClient;
+
+  before(async () => {
+    const etherRouter = await EtherRouter.deployed();
+    colonyNetwork = await IColonyNetwork.at(etherRouter.address);
+  });
+
+  beforeEach(async () => {
+    jsClient = new ReputationMiner({
+      loader: contractLoader,
+      minerAddress: MAIN_ACCOUNT,
+      realProviderPort: REAL_PROVIDER_PORT,
+      useJsTree: true
+    });
+    solClient = new ReputationMiner({
+      loader: contractLoader,
+      minerAddress: OTHER_ACCOUNT,
+      realProviderPort: REAL_PROVIDER_PORT,
+      useJsTree: false
+    });
+
+    await jsClient.initialise(colonyNetwork.address);
+    await solClient.initialise(colonyNetwork.address);
+  });
+
+  describe("Javascript Patricia Tree implementation", () => {
+    it("should have identical root hashes after one insert", async () => {
+      const dog = web3Utils.fromAscii("dog");
+      const fido = web3Utils.fromAscii("fido");
+
+      await jsClient.reputationTree.insert(dog, fido);
+      await solClient.reputationTree.insert(dog, fido);
+
+      const jsRoot = await jsClient.reputationTree.getRootHash();
+      const solRoot = await solClient.reputationTree.getRootHash();
+      assert.equal(jsRoot, solRoot);
+    });
+
+    it("should have identical root hashes after two inserts and one update", async () => {
+      const dog = web3Utils.fromAscii("dog");
+      const fido = web3Utils.fromAscii("fido");
+      const ape = web3Utils.fromAscii("ape");
+      const bubbles = web3Utils.fromAscii("bubbles");
+      const rover = web3Utils.fromAscii("rover");
+
+      await jsClient.reputationTree.insert(dog, fido);
+      await solClient.reputationTree.insert(dog, fido);
+
+      await jsClient.reputationTree.insert(ape, bubbles);
+      await solClient.reputationTree.insert(ape, bubbles);
+
+      await jsClient.reputationTree.insert(dog, rover);
+      await solClient.reputationTree.insert(dog, rover);
+
+      const jsRoot = await jsClient.reputationTree.getRootHash();
+      const solRoot = await solClient.reputationTree.getRootHash();
+      assert.equal(jsRoot, solRoot);
+    });
+
+    it("should give identical proofs after two inserts and one update", async () => {
+      const dog = web3Utils.fromAscii("dog");
+      const fido = web3Utils.fromAscii("fido");
+      const ape = web3Utils.fromAscii("ape");
+      const bubbles = web3Utils.fromAscii("bubbles");
+      const rover = web3Utils.fromAscii("rover");
+
+      await jsClient.reputationTree.insert(dog, fido);
+      await solClient.reputationTree.insert(dog, fido);
+
+      await jsClient.reputationTree.insert(ape, bubbles);
+      await solClient.reputationTree.insert(ape, bubbles);
+
+      await jsClient.reputationTree.insert(dog, rover);
+      await solClient.reputationTree.insert(dog, rover);
+
+      const [jsMask, jsSiblings] = await jsClient.reputationTree.getProof(dog);
+      const [solMask, solSiblings] = await solClient.reputationTree.getProof(dog);
+
+      assert.equal(jsMask.toString(), solMask.toString());
+      assert.equal(jsSiblings.length, solSiblings.length);
+      for (let i = 0; i < jsSiblings.length; i += 1) {
+        assert.equal(jsSiblings[i], solSiblings[i]);
+      }
+    });
+  });
+});

--- a/packages/reputation-miner/patricia.js
+++ b/packages/reputation-miner/patricia.js
@@ -99,32 +99,6 @@ function removePrefix(label, prefix) {
   return makeLabel(label.data.shln(prefix).maskn(256), label.length - prefix);
 }
 
-// function printBinary(hexString) {
-//   let out = "";
-//   let char;
-//   console.log(hexString.length, hexString);
-//   for (let i = 0; i < hexString.length; i += 1) {
-//     char = hexString[i];
-//     if (char === "0") out += "0000";
-//     if (char === "1") out += "0001";
-//     if (char === "2") out += "0010";
-//     if (char === "3") out += "0011";
-//     if (char === "4") out += "0100";
-//     if (char === "5") out += "0101";
-//     if (char === "6") out += "0110";
-//     if (char === "7") out += "0111";
-//     if (char === "8") out += "1000";
-//     if (char === "9") out += "1001";
-//     if (char === "a") out += "1010";
-//     if (char === "b") out += "1011";
-//     if (char === "c") out += "1100";
-//     if (char === "d") out += "1101";
-//     if (char === "e") out += "1110";
-//     if (char === "f") out += "1111";
-//   }
-//   console.log(out.length, out);
-// }
-
 // //////
 // Patricia Tree
 // //////////////////

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -2,6 +2,7 @@
 
 import path from "path";
 import BN from "bn.js";
+import web3Utils from "web3-utils";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
 import { forwardTime, checkErrorRevert, web3GetTransactionReceipt } from "../helpers/test-helper";
@@ -21,6 +22,8 @@ const ReputationMiningCycle = artifacts.require("ReputationMiningCycle");
 const contractLoader = new TruffleLoader({
   contractDir: path.resolve(__dirname, "..", "build", "contracts")
 });
+
+const useJsTree = true;
 
 contract("ColonyNetworkStaking", accounts => {
   const MAIN_ACCOUNT = accounts[0];
@@ -45,16 +48,16 @@ contract("ColonyNetworkStaking", accounts => {
   });
 
   beforeEach(async () => {
-    goodClient = new ReputationMiner({ loader: contractLoader, minerAddress: MAIN_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT });
+    goodClient = new ReputationMiner({ loader: contractLoader, minerAddress: MAIN_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree });
     // Mess up the second calculation. There will always be one if giveUserCLNYTokens has been called.
     badClient = new MaliciousReputationMinerExtraRep(
-      { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+      { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
       1,
       0xfffffffff
     );
     // Mess up the second calculation in a different way
     badClient2 = new MaliciousReputationMinerExtraRep(
-      { loader: contractLoader, minerAddress: accounts[2], realProviderPort: REAL_PROVIDER_PORT },
+      { loader: contractLoader, minerAddress: accounts[2], realProviderPort: REAL_PROVIDER_PORT, useJsTree },
       1,
       0xeeeeeeeee
     );
@@ -683,7 +686,7 @@ contract("ColonyNetworkStaking", accounts => {
 
       // We want badclient2 to submit the same hash as badclient for this test.
       badClient2 = new MaliciousReputationMinerExtraRep(
-        { loader: contractLoader, minerAddress: accounts[2], realProviderPort: REAL_PROVIDER_PORT },
+        { loader: contractLoader, minerAddress: accounts[2], realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         1,
         "0xfffffffff"
       );
@@ -859,7 +862,7 @@ contract("ColonyNetworkStaking", accounts => {
       await goodClient.addLogContentsToReputationTree();
 
       badClient = new MaliciousReputationMinerExtraRep(
-        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         5,
         "0xfffffffff"
       );
@@ -989,7 +992,7 @@ contract("ColonyNetworkStaking", accounts => {
       await goodClient.addLogContentsToReputationTree();
 
       badClient = new MaliciousReputationMinerWrongUID(
-        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         5,
         "0xfffffffff"
       );
@@ -1066,7 +1069,7 @@ contract("ColonyNetworkStaking", accounts => {
       await goodClient.addLogContentsToReputationTree();
 
       badClient = new MaliciousReputationMinerReuseUID(
-        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         3,
         1
       );
@@ -1140,7 +1143,7 @@ contract("ColonyNetworkStaking", accounts => {
       const clients = await Promise.all(
         accountsForTest.map(async (addr, index) => {
           const client = new MaliciousReputationMinerExtraRep(
-            { loader: contractLoader, minerAddress: addr, realProviderPort: REAL_PROVIDER_PORT },
+            { loader: contractLoader, minerAddress: addr, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
             accountsForTest.length - index,
             index
           );
@@ -1308,7 +1311,7 @@ contract("ColonyNetworkStaking", accounts => {
       const clients = await Promise.all(
         accounts.slice(0, nClients).map(async (addr, index) => {
           const client = new MaliciousReputationMinerExtraRep(
-            { loader: contractLoader, minerAddress: addr, realProviderPort: REAL_PROVIDER_PORT },
+            { loader: contractLoader, minerAddress: addr, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
             accounts.length - index,
             index
           );
@@ -1422,7 +1425,7 @@ contract("ColonyNetworkStaking", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
       badClient = new MaliciousReputationMinerExtraRep(
-        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         11,
         0xffffffffffff
       );
@@ -1465,7 +1468,7 @@ contract("ColonyNetworkStaking", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
       badClient = new MaliciousReputationMinerExtraRep(
-        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         11,
         0xffffffffffff
       );
@@ -1510,7 +1513,7 @@ contract("ColonyNetworkStaking", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
       badClient = new MaliciousReputationMinerExtraRep(
-        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT },
+        { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         12,
         new BN("-1000000000000000000000000000000000000000000")
       );
@@ -1611,7 +1614,7 @@ contract("ColonyNetworkStaking", accounts => {
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 13);
 
-      const client = new ReputationMiner({ loader: contractLoader, minerAddress: MAIN_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT });
+      const client = new ReputationMiner({ loader: contractLoader, minerAddress: MAIN_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree });
       await client.initialise(colonyNetwork.address);
       await client.addLogContentsToReputationTree();
 
@@ -1670,7 +1673,7 @@ contract("ColonyNetworkStaking", accounts => {
       await repCycle.submitRootHash("0x123456789", 10, 10);
       await repCycle.confirmNewHash(0);
 
-      const client = new ReputationMiner({ loader: contractLoader, minerAddress: MAIN_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT });
+      const client = new ReputationMiner({ loader: contractLoader, minerAddress: MAIN_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree });
       await client.initialise(colonyNetwork.address);
       await client.addLogContentsToReputationTree();
       const newRootHash = await client.getRootHash();
@@ -1693,5 +1696,114 @@ contract("ColonyNetworkStaking", accounts => {
 
     it.skip("The reputation mining client should calculate reputation decay correctly");
     it.skip("should abort if a deposit did not complete correctly");
+  });
+
+  describe("Javascript Patricia Tree implementation", () => {
+    it("should have identical root hashes after one insert", async () => {
+      const jsClient = new ReputationMiner({
+        loader: contractLoader,
+        minerAddress: MAIN_ACCOUNT,
+        realProviderPort: REAL_PROVIDER_PORT,
+        useJsTree: true
+      });
+      const solClient = new ReputationMiner({
+        loader: contractLoader,
+        minerAddress: MAIN_ACCOUNT,
+        realProviderPort: REAL_PROVIDER_PORT,
+        useJsTree: false
+      });
+
+      await jsClient.initialise(colonyNetwork.address);
+      await solClient.initialise(colonyNetwork.address);
+
+      const dog = web3Utils.fromAscii("dog");
+      const fido = web3Utils.fromAscii("fido");
+
+      await jsClient.reputationTree.insert(dog, fido);
+      await solClient.reputationTree.insert(dog, fido);
+
+      const jsRoot = await jsClient.reputationTree.getRootHash();
+      const solRoot = await solClient.reputationTree.getRootHash();
+      assert.equal(jsRoot, solRoot);
+    });
+
+    it("should have identical root hashes after two inserts and one update", async () => {
+      const jsClient = new ReputationMiner({
+        loader: contractLoader,
+        minerAddress: MAIN_ACCOUNT,
+        realProviderPort: REAL_PROVIDER_PORT,
+        useJsTree: true
+      });
+      const solClient = new ReputationMiner({
+        loader: contractLoader,
+        minerAddress: MAIN_ACCOUNT,
+        realProviderPort: REAL_PROVIDER_PORT,
+        useJsTree: false
+      });
+
+      await jsClient.initialise(colonyNetwork.address);
+      await solClient.initialise(colonyNetwork.address);
+
+      const dog = web3Utils.fromAscii("dog");
+      const fido = web3Utils.fromAscii("fido");
+      const ape = web3Utils.fromAscii("ape");
+      const bubbles = web3Utils.fromAscii("bubbles");
+      const rover = web3Utils.fromAscii("rover");
+
+      await jsClient.reputationTree.insert(dog, fido);
+      await solClient.reputationTree.insert(dog, fido);
+
+      await jsClient.reputationTree.insert(ape, bubbles);
+      await solClient.reputationTree.insert(ape, bubbles);
+
+      await jsClient.reputationTree.insert(dog, rover);
+      await solClient.reputationTree.insert(dog, rover);
+
+      const jsRoot = await jsClient.reputationTree.getRootHash();
+      const solRoot = await solClient.reputationTree.getRootHash();
+      assert.equal(jsRoot, solRoot);
+    });
+
+    it("should give identical proofs after two inserts and one update", async () => {
+      const jsClient = new ReputationMiner({
+        loader: contractLoader,
+        minerAddress: MAIN_ACCOUNT,
+        realProviderPort: REAL_PROVIDER_PORT,
+        useJsTree: true
+      });
+      const solClient = new ReputationMiner({
+        loader: contractLoader,
+        minerAddress: MAIN_ACCOUNT,
+        realProviderPort: REAL_PROVIDER_PORT,
+        useJsTree: false
+      });
+
+      await jsClient.initialise(colonyNetwork.address);
+      await solClient.initialise(colonyNetwork.address);
+
+      const dog = web3Utils.fromAscii("dog");
+      const fido = web3Utils.fromAscii("fido");
+      const ape = web3Utils.fromAscii("ape");
+      const bubbles = web3Utils.fromAscii("bubbles");
+      const rover = web3Utils.fromAscii("rover");
+
+      await jsClient.reputationTree.insert(dog, fido);
+      await solClient.reputationTree.insert(dog, fido);
+
+      await jsClient.reputationTree.insert(ape, bubbles);
+      await solClient.reputationTree.insert(ape, bubbles);
+
+      await jsClient.reputationTree.insert(dog, rover);
+      await solClient.reputationTree.insert(dog, rover);
+
+      const [jsMask, jsSiblings] = await jsClient.reputationTree.getProof(dog);
+      const [solMask, solSiblings] = await solClient.reputationTree.getProof(dog);
+
+      assert.equal(jsMask.toString(), solMask.toString());
+      assert.equal(jsSiblings.length, solSiblings.length);
+      for (let i = 0; i < jsSiblings.length; i += 1) {
+        assert.equal(jsSiblings[i], solSiblings[i]);
+      }
+    });
   });
 });

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -2,7 +2,6 @@
 
 import path from "path";
 import BN from "bn.js";
-import web3Utils from "web3-utils";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
 import { forwardTime, checkErrorRevert, web3GetTransactionReceipt } from "../helpers/test-helper";
@@ -1696,114 +1695,5 @@ contract("ColonyNetworkStaking", accounts => {
 
     it.skip("The reputation mining client should calculate reputation decay correctly");
     it.skip("should abort if a deposit did not complete correctly");
-  });
-
-  describe("Javascript Patricia Tree implementation", () => {
-    it("should have identical root hashes after one insert", async () => {
-      const jsClient = new ReputationMiner({
-        loader: contractLoader,
-        minerAddress: MAIN_ACCOUNT,
-        realProviderPort: REAL_PROVIDER_PORT,
-        useJsTree: true
-      });
-      const solClient = new ReputationMiner({
-        loader: contractLoader,
-        minerAddress: MAIN_ACCOUNT,
-        realProviderPort: REAL_PROVIDER_PORT,
-        useJsTree: false
-      });
-
-      await jsClient.initialise(colonyNetwork.address);
-      await solClient.initialise(colonyNetwork.address);
-
-      const dog = web3Utils.fromAscii("dog");
-      const fido = web3Utils.fromAscii("fido");
-
-      await jsClient.reputationTree.insert(dog, fido);
-      await solClient.reputationTree.insert(dog, fido);
-
-      const jsRoot = await jsClient.reputationTree.getRootHash();
-      const solRoot = await solClient.reputationTree.getRootHash();
-      assert.equal(jsRoot, solRoot);
-    });
-
-    it("should have identical root hashes after two inserts and one update", async () => {
-      const jsClient = new ReputationMiner({
-        loader: contractLoader,
-        minerAddress: MAIN_ACCOUNT,
-        realProviderPort: REAL_PROVIDER_PORT,
-        useJsTree: true
-      });
-      const solClient = new ReputationMiner({
-        loader: contractLoader,
-        minerAddress: MAIN_ACCOUNT,
-        realProviderPort: REAL_PROVIDER_PORT,
-        useJsTree: false
-      });
-
-      await jsClient.initialise(colonyNetwork.address);
-      await solClient.initialise(colonyNetwork.address);
-
-      const dog = web3Utils.fromAscii("dog");
-      const fido = web3Utils.fromAscii("fido");
-      const ape = web3Utils.fromAscii("ape");
-      const bubbles = web3Utils.fromAscii("bubbles");
-      const rover = web3Utils.fromAscii("rover");
-
-      await jsClient.reputationTree.insert(dog, fido);
-      await solClient.reputationTree.insert(dog, fido);
-
-      await jsClient.reputationTree.insert(ape, bubbles);
-      await solClient.reputationTree.insert(ape, bubbles);
-
-      await jsClient.reputationTree.insert(dog, rover);
-      await solClient.reputationTree.insert(dog, rover);
-
-      const jsRoot = await jsClient.reputationTree.getRootHash();
-      const solRoot = await solClient.reputationTree.getRootHash();
-      assert.equal(jsRoot, solRoot);
-    });
-
-    it("should give identical proofs after two inserts and one update", async () => {
-      const jsClient = new ReputationMiner({
-        loader: contractLoader,
-        minerAddress: MAIN_ACCOUNT,
-        realProviderPort: REAL_PROVIDER_PORT,
-        useJsTree: true
-      });
-      const solClient = new ReputationMiner({
-        loader: contractLoader,
-        minerAddress: MAIN_ACCOUNT,
-        realProviderPort: REAL_PROVIDER_PORT,
-        useJsTree: false
-      });
-
-      await jsClient.initialise(colonyNetwork.address);
-      await solClient.initialise(colonyNetwork.address);
-
-      const dog = web3Utils.fromAscii("dog");
-      const fido = web3Utils.fromAscii("fido");
-      const ape = web3Utils.fromAscii("ape");
-      const bubbles = web3Utils.fromAscii("bubbles");
-      const rover = web3Utils.fromAscii("rover");
-
-      await jsClient.reputationTree.insert(dog, fido);
-      await solClient.reputationTree.insert(dog, fido);
-
-      await jsClient.reputationTree.insert(ape, bubbles);
-      await solClient.reputationTree.insert(ape, bubbles);
-
-      await jsClient.reputationTree.insert(dog, rover);
-      await solClient.reputationTree.insert(dog, rover);
-
-      const [jsMask, jsSiblings] = await jsClient.reputationTree.getProof(dog);
-      const [solMask, solSiblings] = await solClient.reputationTree.getProof(dog);
-
-      assert.equal(jsMask.toString(), solMask.toString());
-      assert.equal(jsSiblings.length, solSiblings.length);
-      for (let i = 0; i < jsSiblings.length; i += 1) {
-        assert.equal(jsSiblings[i], solSiblings[i]);
-      }
-    });
   });
 });


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #246 

<!--- Summary of changes including design decisions -->

- Create a Solidity-equivalent Patricia tree in Javascript.
- Add `useJsTree` to ReputationMiner config to decide which implementation to use.
- Set tests to use the Javascript equivalent by default.