### PR TITLE
Add contract events for deliverable submission and rating revelation

### DIFF
--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -36,6 +36,7 @@ contract ColonyTask is ColonyStorage, DSMath {
   event TaskSkillChanged(uint256 indexed id, uint256 skillId);
   event TaskRoleUserChanged(uint256 indexed id, uint8 role, address user);
   event TaskDeliverableSubmitted(uint256 indexed id, bytes32 deliverableHash);
+  event TaskWorkRatingRevealed(uint256 indexed id, uint8 role, uint8 rating);
   event TaskFinalized(uint256 indexed id);
   event TaskCanceled(uint256 indexed id);
 
@@ -276,6 +277,8 @@ contract ColonyTask is ColonyStorage, DSMath {
     TaskRatings rating = TaskRatings(_rating);
     require(rating != TaskRatings.None, "Cannot rate None!");
     tasks[_id].roles[_role].rating = rating;
+
+    emit TaskWorkRatingRevealed(_id, _role, _rating);
   }
 
   // In the event of a user not committing or revealing within the 10 day rating window,

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -35,6 +35,7 @@ contract ColonyTask is ColonyStorage, DSMath {
   event TaskDomainChanged(uint256 indexed id, uint256 domainId);
   event TaskSkillChanged(uint256 indexed id, uint256 skillId);
   event TaskRoleUserChanged(uint256 indexed id, uint8 role, address user);
+  event TaskDeliverableSubmitted(uint256 indexed id, bytes32 deliverableHash);
   event TaskFinalized(uint256 indexed id);
   event TaskCanceled(uint256 indexed id);
 
@@ -389,6 +390,8 @@ contract ColonyTask is ColonyStorage, DSMath {
   {
     tasks[_id].deliverableHash = _deliverableHash;
     tasks[_id].deliverableTimestamp = now;
+
+    emit TaskDeliverableSubmitted(_id, _deliverableHash);
   }
 
   function finalizeTask(uint256 _id) public

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -59,6 +59,11 @@ contract IColony {
   /// @param amount Amount of the payout funding
   event TaskWorkerPayoutChanged(uint256 indexed id, address token, uint256 amount);
 
+  /// @notice Event logged when a deliverable has been submitted for a task
+  /// @param id Id of the task
+  /// @param deliverableHash Hash of the work performed
+  event TaskDeliverableSubmitted(uint256 indexed id, bytes32 deliverableHash);
+
   /// @notice Event logged when a task has been finalized
   /// @param id Id of the finalized task
   event TaskFinalized(uint256 indexed id);

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -64,6 +64,12 @@ contract IColony {
   /// @param deliverableHash Hash of the work performed
   event TaskDeliverableSubmitted(uint256 indexed id, bytes32 deliverableHash);
 
+  /// @notice Event logged when the rating of a role was revealed
+  /// @param id Id of the task
+  /// @param role Role that got rated
+  /// @param rating Rating the role received
+  event TaskWorkRatingRevealed(uint256 indexed id, uint8 role, uint8 rating);
+
   /// @notice Event logged when a task has been finalized
   /// @param id Id of the finalized task
   event TaskFinalized(uint256 indexed id);

--- a/test/colony.js
+++ b/test/colony.js
@@ -1327,6 +1327,19 @@ contract("Colony", addresses => {
       const task = await colony.getTask.call(1);
       assert.notEqual(task[1], DELIVERABLE_HASH);
     });
+
+    it("should log a TaskDeliverableSubmitted event", async () => {
+      let dueDate = await currentBlockTime();
+      dueDate += SECONDS_PER_DAY * 4;
+      await setupAssignedTask({ colonyNetwork, colony, dueDate });
+
+      await expectEvent(
+        colony.submitTaskDeliverable(1, DELIVERABLE_HASH, {
+          from: WORKER
+        }),
+        "TaskDeliverableSubmitted"
+      );
+    });
   });
 
   describe("when finalizing a task", () => {


### PR DESCRIPTION
This PR extends the work done in #216, and addresses the changes discussed in #188.

I propose two new events for tasks: `TaskDeliverableSubmitted` and `TaskWorkRatingRevealed`. Each is covered with tests. Having these events implemented allows for keeping track of the whole task lifecycle, whereas #216 focused more on change in (meta) data and finalization.