### PR TITLE
Compile warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,8 @@
     "max-len": [2, { "code": 150, "ignoreComments": true }],
     "prettier/prettier": ["error", {"printWidth": 150}],
     "flowtype/require-valid-file-annotation": "off",
-    "import/named": "off"
+    "import/named": "off",
+    "no-console": "off"
   },
   "parserOptions": {
     "ecmaVersion": 2017

--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -9,6 +9,7 @@
     "quotes": ["error", "double"],
     "security/no-inline-assembly": 0,
     "security/no-call-value": 0,
-    "security/no-block-members": 0
+    "security/no-block-members": 0,
+    "no-experimental": 0
   }
 }

--- a/contracts/Authority.sol
+++ b/contracts/Authority.sol
@@ -26,55 +26,48 @@ contract Authority is DSRoles {
   uint8 adminRole = 1;
 
   constructor(address colony) public {
-    // functions for owner role
-    bytes4 setTokenSig = bytes4(keccak256("setToken(address)"));
-    bytes4 bootstrapColonySig = bytes4(keccak256("bootstrapColony(address[],int256[])"));
-    bytes4 mintTokensSig = bytes4(keccak256("mintTokens(uint256)"));
-    bytes4 addGlobalSkillSig = bytes4(keccak256("addGlobalSkill(uint256)"));
-    bytes4 setOwnerRoleSig = bytes4(keccak256("setOwnerRole(address)"));
-    bytes4 removeAdminRoleSig = bytes4(keccak256("removeAdminRole(address)"));
-    bytes4 upgradeSig = bytes4(keccak256("upgrade(uint256)"));
-
-    // functions for admin + owner role
-    bytes4 moveFundsBetweenPotsSig = bytes4(keccak256("moveFundsBetweenPots(uint256,uint256,uint256,address)"));
-    bytes4 addDomainSig = bytes4(keccak256("addDomain(uint256)"));
-    bytes4 makeTaskSig = bytes4(keccak256("makeTask(bytes32,uint256)"));
-    bytes4 startNextRewardPayoutSig = bytes4(keccak256("startNextRewardPayout(address)"));
-    bytes4 cancelTaskSig = bytes4(keccak256("cancelTask(uint256)"));
-    bytes4 setAdminRoleSig = bytes4(keccak256("setAdminRole(address)"));
-
     // Set token
-    setRoleCapability(ownerRole, colony, setTokenSig, true);
+    setOwnerRoleCapability(colony, "setToken(address)");
     // Bootstrap colony
-    setRoleCapability(ownerRole, colony, bootstrapColonySig, true);
+    setOwnerRoleCapability(colony, "bootstrapColony(address[],int256[])");
     // Mint tokens
-    setRoleCapability(ownerRole, colony, mintTokensSig, true);
+    setOwnerRoleCapability(colony, "mintTokens(uint256)");
     // Add global skill
-    setRoleCapability(ownerRole, colony, addGlobalSkillSig, true);
+    setOwnerRoleCapability(colony, "addGlobalSkill(uint256)");
     // Transfer ownership
-    setRoleCapability(ownerRole, colony, setOwnerRoleSig, true);
+    setOwnerRoleCapability(colony, "setOwnerRole(address)");
     // Remove admin role
-    setRoleCapability(ownerRole, colony, removeAdminRoleSig, true);
+    setOwnerRoleCapability(colony, "removeAdminRole(address)");
     // Upgrade colony
-    setRoleCapability(ownerRole, colony, upgradeSig, true);
+    setOwnerRoleCapability(colony, "upgrade(uint256)");
 
     // Allocate funds
-    setRoleCapability(adminRole, colony, moveFundsBetweenPotsSig, true);
-    setRoleCapability(ownerRole, colony, moveFundsBetweenPotsSig, true);
+    setAdminRoleCapability(colony, "moveFundsBetweenPots(uint256,uint256,uint256,address)");
+    setOwnerRoleCapability(colony, "moveFundsBetweenPots(uint256,uint256,uint256,address)");
     // Add domain
-    setRoleCapability(adminRole, colony, addDomainSig, true);
-    setRoleCapability(ownerRole, colony, addDomainSig, true);
+    setAdminRoleCapability(colony, "addDomain(uint256)");
+    setOwnerRoleCapability(colony, "addDomain(uint256)");
     // Add task
-    setRoleCapability(adminRole, colony, makeTaskSig, true);
-    setRoleCapability(ownerRole, colony, makeTaskSig, true);
+    setAdminRoleCapability(colony, "makeTask(bytes32,uint256)");
+    setOwnerRoleCapability(colony, "makeTask(bytes32,uint256)");
     // Start next reward payout
-    setRoleCapability(adminRole, colony, startNextRewardPayoutSig, true);
-    setRoleCapability(ownerRole, colony, startNextRewardPayoutSig, true);
+    setAdminRoleCapability(colony, "startNextRewardPayout(address)");
+    setOwnerRoleCapability(colony, "startNextRewardPayout(address)");
     // Cancel task
-    setRoleCapability(adminRole, colony, cancelTaskSig, true);
-    setRoleCapability(ownerRole, colony, cancelTaskSig, true);
+    setAdminRoleCapability(colony, "cancelTask(uint256)");
+    setOwnerRoleCapability(colony, "cancelTask(uint256)");
     // Set admin
-    setRoleCapability(adminRole, colony, setAdminRoleSig, true);
-    setRoleCapability(ownerRole, colony, setAdminRoleSig, true);
+    setAdminRoleCapability(colony, "setAdminRole(address)");
+    setOwnerRoleCapability(colony, "setAdminRole(address)");
+  }
+
+  function setOwnerRoleCapability(address colony, bytes sig) private {
+    bytes4 functionSig = bytes4(keccak256(sig));
+    setRoleCapability(ownerRole, colony, functionSig, true);
+  }
+
+  function setAdminRoleCapability(address colony, bytes sig) private {
+    bytes4 functionSig = bytes4(keccak256(sig));
+    setRoleCapability(adminRole, colony, functionSig, true);
   }
 }

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -18,12 +18,8 @@
 pragma solidity ^0.4.23;
 pragma experimental "v0.5.0";
 
-import "./ERC20Extended.sol";
-import "./IColonyNetwork.sol";
-import "./IColony.sol";
 import "./ColonyStorage.sol";
 import "./PatriciaTree/PatriciaTreeProofs.sol";
-import "./Authority.sol";
 import "./EtherRouter.sol";
 
 

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -105,8 +105,10 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   }
 
   function mintTokensForColonyNetwork(uint _wad) public {
-    require(msg.sender == colonyNetworkAddress, "colony-access-denied-only-network-allowed"); // Only the colony Network can call this function
-    require(this == IColonyNetwork(colonyNetworkAddress).getMetaColony(), "colony-access-denied-only-meta-colony-allowed"); // Function only valid on the Meta Colony
+    // Only the colony Network can call this function
+    require(msg.sender == colonyNetworkAddress, "colony-access-denied-only-network-allowed");
+    // Function only valid on the Meta Colony
+    require(this == IColonyNetwork(colonyNetworkAddress).getMetaColony(), "colony-access-denied-only-meta-colony-allowed");
     token.mint(_wad);
     token.transfer(colonyNetworkAddress, _wad);
   }
@@ -145,16 +147,6 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   function getDomainCount() public view returns (uint256) {
     return domainCount;
   }
-  function setFunctionReviewers(bytes4 _sig, uint8 _firstReviewer, uint8 _secondReviewer)
-  private
-  {
-    uint8[2] memory _reviewers = [_firstReviewer, _secondReviewer];
-    reviewers[_sig] = _reviewers;
-  }
-
-  function setRoleAssignmentFunction(bytes4 _sig) private {
-    roleAssignmentSigs[_sig] = true;
-  }
 
   modifier verifyKey(bytes key) {
     uint256 colonyAddress;
@@ -175,7 +167,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
   function verifyReputationProof(bytes key, bytes value, uint branchMask, bytes32[] siblings)  // solium-disable-line security/no-assign-params
   verifyKey(key)
-  public returns (bool)
+  public view returns (bool)
   {
     // Get roothash from colonynetwork
     bytes32 rootHash = IColonyNetwork(colonyNetworkAddress).getReputationRootHash();
@@ -193,6 +185,17 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     require(newResolver != 0x0);
     EtherRouter e = EtherRouter(address(this));
     e.setResolver(newResolver);
+  }
+
+  function setFunctionReviewers(bytes4 _sig, uint8 _firstReviewer, uint8 _secondReviewer)
+  private
+  {
+    uint8[2] memory _reviewers = [_firstReviewer, _secondReviewer];
+    reviewers[_sig] = _reviewers;
+  }
+
+  function setRoleAssignmentFunction(bytes4 _sig) private {
+    roleAssignmentSigs[_sig] = true;
   }
 
   function initialiseDomain(uint256 _skillId) private skillExists(_skillId) {

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -245,7 +245,13 @@ contract ColonyFunding is ColonyStorage, DSMath {
 
   function getRewardPayoutInfo(uint256 _payoutId) public view returns (bytes32, uint256, uint256, address, uint256) {
     RewardPayoutCycle memory rewardPayoutInfo = rewardPayoutCycles[_payoutId];
-    return (rewardPayoutInfo.reputationState, rewardPayoutInfo.totalTokens, rewardPayoutInfo.amount, rewardPayoutInfo.tokenAddress, rewardPayoutInfo.blockTimestamp);
+    return (
+      rewardPayoutInfo.reputationState,
+      rewardPayoutInfo.totalTokens,
+      rewardPayoutInfo.amount,
+      rewardPayoutInfo.tokenAddress,
+      rewardPayoutInfo.blockTimestamp
+    );
   }
 
   function updateTaskPayoutsWeCannotMakeAfterPotChange(uint256 _id, address _token, uint _prev) internal {

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -18,14 +18,11 @@
 pragma solidity ^0.4.23;
 pragma experimental "v0.5.0";
 
-import "../lib/dappsys/math.sol";
-import "./ERC20Extended.sol";
-import "./IColonyNetwork.sol";
 import "./ColonyStorage.sol";
 import "./ITokenLocking.sol";
 
 
-contract ColonyFunding is ColonyStorage, DSMath {
+contract ColonyFunding is ColonyStorage {
   event RewardPayoutCycleStarted(uint256 indexed id);
   event RewardPayoutCycleEnded(uint256 indexed id);
   event TaskWorkerPayoutChanged(uint256 indexed id, address token, uint256 amount);

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -245,6 +245,13 @@ contract ColonyNetwork is ColonyNetworkStorage {
     uint nParents = skills[_skillId].nParents;
     // TODO: Is it cheaper to check if _amount is <0, and if not, just set nChildren to 0, because children won't be updated for such an update?
     uint nChildren = skills[_skillId].nChildren;
-    IReputationMiningCycle(inactiveReputationMiningCycle).appendReputationUpdateLog(_user, _amount, _skillId, msg.sender, nParents, nChildren);
+    IReputationMiningCycle(inactiveReputationMiningCycle).appendReputationUpdateLog(
+      _user,
+      _amount,
+      _skillId,
+      msg.sender,
+      nParents,
+      nChildren
+    );
   }
 }

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -18,11 +18,8 @@
 pragma solidity ^0.4.23;
 pragma experimental "v0.5.0";
 
-import "../lib/dappsys/auth.sol";
 import "./Authority.sol";
-import "./IColony.sol";
 import "./EtherRouter.sol";
-import "./Token.sol";
 import "./ColonyNetworkStorage.sol";
 import "./IReputationMiningCycle.sol";
 

--- a/contracts/ColonyNetworkAuction.sol
+++ b/contracts/ColonyNetworkAuction.sol
@@ -18,10 +18,7 @@
 pragma solidity ^0.4.23;
 pragma experimental "v0.5.0";
 
-import "../lib/dappsys/math.sol";
 import "./ColonyNetworkStorage.sol";
-import "./ERC20Extended.sol";
-import "./IColony.sol";
 
 
 contract ColonyNetworkAuction is ColonyNetworkStorage {
@@ -49,7 +46,7 @@ contract DutchAuction is DSMath {
   uint public endTime;
   uint public minPrice;
   uint public constant TOKEN_MULTIPLIER = 10 ** 18;
-  
+
   // Keep track of all CLNY wei received
   uint public receivedTotal;
   uint public bidCount;
@@ -58,7 +55,7 @@ contract DutchAuction is DSMath {
   // Final price in CLNY per 10**18 Tokens (min 1, max 1e18)
   uint public finalPrice;
   bool public finalized;
-  
+
   mapping (address => uint256) public bids;
 
   modifier auctionNotStarted {
@@ -87,7 +84,7 @@ contract DutchAuction is DSMath {
   modifier auctionFinalized {
     require(finalized);
     _;
-  } 
+  }
 
   modifier allBidsClaimed  {
     require(claimCount == bidCount);
@@ -119,7 +116,7 @@ contract DutchAuction is DSMath {
     started = true;
   }
 
-  function totalToEndAuction() public view 
+  function totalToEndAuction() public view
   auctionStartedAndOpen
   returns (uint)
   {
@@ -156,7 +153,7 @@ contract DutchAuction is DSMath {
       amount = remainingToEndAuction;
       endTime = now;
     }
-    
+
     if (bids[msg.sender] == 0) {
       bidCount += 1;
     }
@@ -164,7 +161,7 @@ contract DutchAuction is DSMath {
     clnyToken.transferFrom(msg.sender, this, amount);
     bids[msg.sender] = add(bids[msg.sender], amount);
     receivedTotal = add(receivedTotal, amount);
-    
+
     emit AuctionBid(msg.sender, amount, sub(remainingToEndAuction, amount));
   }
 
@@ -180,7 +177,7 @@ contract DutchAuction is DSMath {
     emit AuctionFinalized(finalPrice);
   }
 
-  function claim() public 
+  function claim() public
   auctionFinalized
   returns (bool)
   {
@@ -189,7 +186,7 @@ contract DutchAuction is DSMath {
 
     uint tokens = mul(amount, TOKEN_MULTIPLIER) / finalPrice;
     claimCount += 1;
-    
+
     // Set receiver bid to 0 before transferring the tokens
     bids[msg.sender] = 0;
     uint beforeClaimBalance = token.balanceOf(msg.sender);

--- a/contracts/ColonyNetworkStaking.sol
+++ b/contracts/ColonyNetworkStaking.sol
@@ -127,7 +127,8 @@ contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
 
     IColony(metaColony).mintTokensForColonyNetwork(stakers.length * reward); // This should be the total amount of new tokens we're awarding.
 
-    ReputationMiningCycle(inactiveReputationMiningCycle).rewardStakersWithReputation(stakers, metaColony, reward, rootGlobalSkillId + 2); // This gives them reputation in the next update cycle.
+    // This gives them reputation in the next update cycle.
+    ReputationMiningCycle(inactiveReputationMiningCycle).rewardStakersWithReputation(stakers, metaColony, reward, rootGlobalSkillId + 2);
 
     for (uint256 i = 0; i < stakers.length; i++) {
       // Also give them some newly minted tokens.

--- a/contracts/ColonyNetworkStaking.sol
+++ b/contracts/ColonyNetworkStaking.sol
@@ -18,17 +18,11 @@
 pragma solidity ^0.4.23;
 pragma experimental "v0.5.0";
 
-import "../lib/dappsys/auth.sol";
-import "./Authority.sol";
-import "./IColony.sol";
-import "./EtherRouter.sol";
-import "./ERC20Extended.sol";
 import "./ColonyNetworkStorage.sol";
-import "./IColonyNetwork.sol";
 import "./ReputationMiningCycle.sol";
 
 
-contract ColonyNetworkStaking is ColonyNetworkStorage, DSMath {
+contract ColonyNetworkStaking is ColonyNetworkStorage {
   // TODO: Can we handle a dispute regarding the very first hash that should be set?
 
   modifier onlyReputationMiningCycle () {

--- a/contracts/ColonyNetworkStorage.sol
+++ b/contracts/ColonyNetworkStorage.sol
@@ -19,14 +19,12 @@ pragma solidity ^0.4.23;
 pragma experimental "v0.5.0";
 
 import "../lib/dappsys/auth.sol";
-import "../lib/dappsys/roles.sol";
-import "./Authority.sol";
+import "../lib/dappsys/math.sol";
+import "./ERC20Extended.sol";
 import "./IColony.sol";
-import "./EtherRouter.sol";
-import "./Token.sol";
 
 
-contract ColonyNetworkStorage is DSAuth {
+contract ColonyNetworkStorage is DSAuth, DSMath {
   // Address of the Resolver contract used by EtherRouter for lookups and routing
   address resolver;
   // Number of colonies in the network

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -19,12 +19,13 @@ pragma solidity ^0.4.23;
 pragma experimental "v0.5.0";
 
 import "../lib/dappsys/auth.sol";
+import "../lib/dappsys/math.sol";
 import "./ERC20Extended.sol";
 import "./IColonyNetwork.sol";
 import "./Authority.sol";
 
 
-contract ColonyStorage is DSAuth {
+contract ColonyStorage is DSAuth, DSMath {
   // When adding variables, do not make them public, otherwise all contracts that inherit from
   // this one will have the getters. Make custom getters in the contract that seems most appropriate,
   // and add it to IColony.sol
@@ -38,7 +39,7 @@ contract ColonyStorage is DSAuth {
 
   // Mapping function signature to 2 task roles whose approval is needed to execute
   mapping (bytes4 => uint8[2]) reviewers;
-  
+
   // Role assignment functions require special type of sign-off.
   // This keeps track of which functions are related to role assignment
   mapping (bytes4 => bool) roleAssignmentSigs;

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -18,13 +18,11 @@
 pragma solidity ^0.4.23;
 pragma experimental "v0.5.0";
 
-import "../lib/dappsys/math.sol";
 import "./ColonyStorage.sol";
-import "./IColony.sol";
 import "./SafeMath.sol";
 
 
-contract ColonyTask is ColonyStorage, DSMath {
+contract ColonyTask is ColonyStorage {
   uint256 constant RATING_COMMIT_TIMEOUT = 432000;
   uint256 constant RATING_REVEAL_TIMEOUT = 432000;
 

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -218,7 +218,14 @@ contract IColony {
   /// @param _value The transaction value, i.e. number of wei to be sent when the transaction is executed
   /// Currently we only accept 0 value transactions but this is kept as a future option
   /// @param _data The transaction data
-  function executeTaskChange(uint8[] _sigV, bytes32[] _sigR, bytes32[] _sigS, uint8[] _mode, uint256 _value, bytes _data) public;
+  function executeTaskChange(
+    uint8[] _sigV,
+    bytes32[] _sigR,
+    bytes32[] _sigS,
+    uint8[] _mode,
+    uint256 _value,
+    bytes _data
+    ) public;
 
   /// @notice Executes a task role update transaction `_data` which is approved and signed by two of addresses
   /// depending of which function we are calling. Allowed functions are `setTaskManagerRole`, `setTaskEvaluatorRole` and `setTaskWorkerRole`.
@@ -230,7 +237,14 @@ contract IColony {
   /// @param _value The transaction value, i.e. number of wei to be sent when the transaction is executed
   /// Currently we only accept 0 value transactions but this is kept as a future option
   /// @param _data The transaction data
-  function executeTaskRoleAssignment(uint8[] _sigV, bytes32[] _sigR, bytes32[] _sigS, uint8[] _mode, uint256 _value, bytes _data) public;
+  function executeTaskRoleAssignment(
+    uint8[] _sigV,
+    bytes32[] _sigR,
+    bytes32[] _sigS,
+    uint8[] _mode,
+    uint256 _value,
+    bytes _data
+    ) public;
 
   /// @notice Submit a hashed secret of the rating for work in task `_id` which was performed by user with task role id `_role`
   /// Allowed within 5 days period starting which whichever is first from either the deliverable being submitted or the dueDate been reached

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -25,7 +25,19 @@ contract IReputationMiningCycle {
   /// @param round The dispute round to query
   /// @param index The index in the dispute round to query
   /// @return The elements of the Submission struct for the submission requested. See ReputationMiningCycle.sol for the full description
-  function disputeRounds(uint256 round, uint256 index) public view returns (bytes32 proposedNewRootHash, uint256 nNodes, uint256 lastResponseTimestamp, uint256 challengeStepCompleted, bytes32 jrh, bytes32 intermediateReputationHash, uint256 intermediateReputationNNodes, uint256 jrhNnodes, uint256 lowerBound, uint256 upperBound, uint256 providedPreviousReputationUID);
+  function disputeRounds(uint256 round, uint256 index) public view returns (
+    bytes32 proposedNewRootHash,
+    uint256 nNodes,
+    uint256 lastResponseTimestamp,
+    uint256 challengeStepCompleted,
+    bytes32 jrh,
+    bytes32 intermediateReputationHash,
+    uint256 intermediateReputationNNodes,
+    uint256 jrhNnodes,
+    uint256 lowerBound,
+    uint256 upperBound,
+    uint256 providedPreviousReputationUID
+    );
 
   /// @notice Get the hash for the corresponding entry.
   /// @param submitter The address that submitted the hash
@@ -126,7 +138,14 @@ contract IReputationMiningCycle {
   /// @param _colonyAddress The address of the colony the reputation is being affected in
   /// @param _nParents The number of parent skills the skill defined by the skillId has
   /// @param _nChildren The number of child skills the skill defined by the skillId has
-  function appendReputationUpdateLog(address _user, int _amount, uint _skillId, address _colonyAddress, uint _nParents, uint _nChildren) public;
+  function appendReputationUpdateLog(
+    address _user,
+    int _amount,
+    uint _skillId,
+    address _colonyAddress,
+    uint _nParents,
+    uint _nChildren
+    ) public;
 
   /// @notice Get the length of the ReputationUpdateLog stored on this instance of the ReputationMiningCycle contract
   /// @return nUpdates

--- a/contracts/PatriciaTree/IPatriciaTree.sol
+++ b/contracts/PatriciaTree/IPatriciaTree.sol
@@ -30,7 +30,7 @@ contract IPatriciaTree {
 
   /// @notice Calculates and returns a root hash for the `key`, `value`, `branchMask` and `siblings`
   /// @return The calculated hash
-  function getImpliedRoot(bytes key, bytes value, uint branchMask, bytes32[] siblings) public view returns (bytes32);
+  function getImpliedRoot(bytes key, bytes value, uint branchMask, bytes32[] siblings) public pure returns (bytes32);
 
   /// @notice Insert the `key`/`value`in the appropriate place in the tree
   function insert(bytes key, bytes value) public;

--- a/contracts/PatriciaTree/PatriciaTreeProofs.sol
+++ b/contracts/PatriciaTree/PatriciaTreeProofs.sol
@@ -14,8 +14,7 @@ contract PatriciaTreeProofs {
   using Data for Data.Label;
 
   function getImpliedRoot(bytes key, bytes value, uint branchMask, bytes32[] siblings) public // solium-disable-line security/no-assign-params
-  view
-  returns (bytes32)
+  pure returns (bytes32)
   {
     Data.Label memory k = Data.Label(keccak256(key), 256);
     Data.Edge memory e;

--- a/contracts/PatriciaTree/PatriciaTreeProofs.sol
+++ b/contracts/PatriciaTree/PatriciaTreeProofs.sol
@@ -5,6 +5,7 @@ pragma experimental "ABIEncoderV2";
 import {Data} from "./Data.sol";
 import {Bits} from "./Bits.sol";
 
+
 /// @title Functions related to checking Patricia Tree proofs
 /// @notice More info at: https://github.com/chriseth/patricia-trie
 contract PatriciaTreeProofs {
@@ -12,7 +13,10 @@ contract PatriciaTreeProofs {
   using Data for Data.Edge;
   using Data for Data.Label;
 
-  function getImpliedRoot(bytes key, bytes value, uint branchMask, bytes32[] siblings) public view returns (bytes32) { // solium-disable-line security/no-assign-params
+  function getImpliedRoot(bytes key, bytes value, uint branchMask, bytes32[] siblings) public // solium-disable-line security/no-assign-params
+  view
+  returns (bytes32)
+  {
     Data.Label memory k = Data.Label(keccak256(key), 256);
     Data.Edge memory e;
     e.node = keccak256(value);

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -569,7 +569,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
                                               // Not sure what the alternative would be anyway.
     }
     bool decayCalculation = false;
-    if (decayCalculation) {
+    if (decayCalculation) { // solium-disable-line no-empty-blocks, whitespace
     } else {
       require(expectedAddress == userAddress);
       require(logEntry.colony == colonyAddress);
@@ -577,9 +577,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     }
   }
 
-  function getExpectedSkillIdAndAddress(ReputationLogEntry storage logEntry, uint256 updateNumber)
-  internal
-  view
+  function getExpectedSkillIdAndAddress(ReputationLogEntry storage logEntry, uint256 updateNumber) internal view
   returns (uint256 expectedSkillId, address expectedAddress)
   {
     // Work out the expected userAddress and skillId for this updateNumber in this logEntry.
@@ -597,7 +595,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     uint nParents;
     (nParents, ) = IColonyNetwork(colonyNetworkAddress).getSkill(logEntry.skillId);
     uint nChildUpdates;
-    if (logEntry.amount >= 0) {
+    if (logEntry.amount >= 0) { // solium-disable-line no-empty-blocks, whitespace
       // Then we have no child updates to consider
     } else {
       nChildUpdates = logEntry.nUpdates/2 - 1 - nParents;

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -118,9 +118,12 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     // Here, the minimum stake is 10**15.
     require(entryIndex <= IColonyNetwork(colonyNetworkAddress).getStakedBalance(msg.sender) / 10**15);
     require(entryIndex > 0);
-    if (reputationHashSubmissions[msg.sender].proposedNewRootHash != 0x0) {                // If this user has submitted before during this round...
-      require(newHash == reputationHashSubmissions[msg.sender].proposedNewRootHash);       // ...require that they are submitting the same hash ...
-      require(nNodes == reputationHashSubmissions[msg.sender].nNodes);      // ...require that they are submitting the same number of nodes for that hash ...
+    // If this user has submitted before during this round...
+    if (reputationHashSubmissions[msg.sender].proposedNewRootHash != 0x0) {
+      // ...require that they are submitting the same hash ...
+      require(newHash == reputationHashSubmissions[msg.sender].proposedNewRootHash);
+      // ...require that they are submitting the same number of nodes for that hash ...
+      require(nNodes == reputationHashSubmissions[msg.sender].nNodes);
       require (submittedEntries[newHash][msg.sender][entryIndex] == false); // ... but not this exact entry
     }
     _;
@@ -143,13 +146,13 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     _;
   }
 
-  function getEntryHash(address submitter, uint256 entryIndex, bytes32 newHash) public pure returns (bytes32) {
-    return keccak256(abi.encodePacked(submitter, entryIndex, newHash));
-  }
-
   /// @notice Constructor for this contract.
   constructor() public {
     colonyNetworkAddress = msg.sender;
+  }
+
+  function getEntryHash(address submitter, uint256 entryIndex, bytes32 newHash) public pure returns (bytes32) {
+    return keccak256(abi.encodePacked(submitter, entryIndex, newHash));
   }
 
   function resetWindow() public {
@@ -216,7 +219,11 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   {
     // TODO: Require some amount of time to have passed (i.e. people have had a chance to submit other hashes)
     Submission storage submission = disputeRounds[roundNumber][0];
-    IColonyNetwork(colonyNetworkAddress).setReputationRootHash(submission.proposedNewRootHash, submission.nNodes, submittedHashes[submission.proposedNewRootHash][submission.nNodes]);
+    IColonyNetwork(colonyNetworkAddress).setReputationRootHash(
+      submission.proposedNewRootHash,
+      submission.nNodes,
+      submittedHashes[submission.proposedNewRootHash][submission.nNodes]
+    );
     selfdestruct(colonyNetworkAddress);
   }
 
@@ -296,12 +303,22 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     //TODO: Can we do some deleting to make calling this as cheap as possible for people?
   }
 
-  function respondToBinarySearchForChallenge(uint256 round, uint256 idx, bytes jhIntermediateValue, uint256 branchMask, bytes32[] siblings) public {
+  function respondToBinarySearchForChallenge(
+    uint256 round,
+    uint256 idx,
+    bytes jhIntermediateValue,
+    uint256 branchMask,
+    bytes32[] siblings
+  ) public
+  {
     // TODO: Check this challenge is active.
     // This require is necessary, but not a sufficient check (need to check we have an opponent, at least).
     require(disputeRounds[round][idx].lowerBound!=disputeRounds[round][idx].upperBound);
 
-    uint256 targetNode = add(disputeRounds[round][idx].lowerBound, sub(disputeRounds[round][idx].upperBound, disputeRounds[round][idx].lowerBound) / 2);
+    uint256 targetNode = add(
+      disputeRounds[round][idx].lowerBound,
+      sub(disputeRounds[round][idx].upperBound, disputeRounds[round][idx].lowerBound) / 2
+    );
     bytes32 jrh = disputeRounds[round][idx].jrh;
 
     bytes memory targetNodeBytes = new bytes(32);
@@ -373,9 +390,6 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     if (u[U_REQUIRE_REPUTATION_CHECK]==1) {
       checkPreviousReputationInState(
         u,
-        _reputationKey,
-        reputationSiblings,
-        agreeStateReputationValue,
         agreeStateSiblings,
         previousNewReputationKey,
         previousNewReputationValue,
@@ -420,7 +434,15 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     disputeRounds[round][index].upperBound = disputeRounds[round][index].jrhNnodes;
   }
 
-  function appendReputationUpdateLog(address _user, int _amount, uint256 _skillId, address _colonyAddress, uint256 _nParents, uint256 _nChildren) public {
+  function appendReputationUpdateLog(
+    address _user,
+    int _amount,
+    uint256 _skillId,
+    address _colonyAddress,
+    uint256 _nParents,
+    uint256 _nChildren
+  ) public
+  {
     require(colonyNetworkAddress == msg.sender);
     uint reputationUpdateLogLength = reputationUpdateLog.length;
     uint nPreviousUpdates = 0;
@@ -520,7 +542,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     disputeRounds[round][opponentIdx].lastResponseTimestamp = now;
   }
 
-  function checkKey( uint256 round, uint256 idx, uint256 logEntryNumber, bytes memory _reputationKey) internal {
+  function checkKey(uint256 round, uint256 idx, uint256 logEntryNumber, bytes memory _reputationKey) internal view {
     // If the state transition we're checking is less than the number of nodes in the currently accepted state, it's a decay transition (TODO: not implemented)
     // Otherwise, look up the corresponding entry in the reputation log.
     uint256 updateNumber = disputeRounds[round][idx].lowerBound - 1;
@@ -555,7 +577,11 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     }
   }
 
-  function getExpectedSkillIdAndAddress( ReputationLogEntry storage logEntry, uint256 updateNumber ) internal returns (uint256 expectedSkillId, address expectedAddress) {
+  function getExpectedSkillIdAndAddress(ReputationLogEntry storage logEntry, uint256 updateNumber)
+  internal
+  view
+  returns (uint256 expectedSkillId, address expectedAddress)
+  {
     // Work out the expected userAddress and skillId for this updateNumber in this logEntry.
     if ((updateNumber - logEntry.nPreviousUpdates + 1) <= logEntry.nUpdates / 2 ) {
       // Then we're updating a colony-wide total, so we expect an address of 0x0
@@ -588,9 +614,17 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     }
   }
 
-  function proveBeforeReputationValue(uint256[10] u, bytes _reputationKey, bytes32[] reputationSiblings, bytes agreeStateReputationValue, bytes32[] agreeStateSiblings) internal {
+  function proveBeforeReputationValue(
+    uint256[10] u,
+    bytes _reputationKey,
+    bytes32[] reputationSiblings,
+    bytes agreeStateReputationValue,
+    bytes32[] agreeStateSiblings
+  ) internal
+  {
     bytes32 jrh = disputeRounds[u[U_ROUND]][u[U_IDX]].jrh;
-    uint256 lastAgreeIdx = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1; // We binary searched to the first disagreement, so the last agreement is the one before.
+    // We binary searched to the first disagreement, so the last agreement is the one before.
+    uint256 lastAgreeIdx = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1;
     uint256 reputationValue;
     assembly {
         reputationValue := mload(add(agreeStateReputationValue, 32))
@@ -624,7 +658,14 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     // where we don't prove anything with merkle proofs in this whole dance is here.
   }
 
-  function proveAfterReputationValue(uint256[10] u, bytes _reputationKey, bytes32[] reputationSiblings, bytes disagreeStateReputationValue, bytes32[] disagreeStateSiblings) internal {
+  function proveAfterReputationValue(
+    uint256[10] u,
+    bytes _reputationKey,
+    bytes32[] reputationSiblings,
+    bytes disagreeStateReputationValue,
+    bytes32[] disagreeStateSiblings
+  ) internal view
+  {
     bytes32 jrh = disputeRounds[u[U_ROUND]][u[U_IDX]].jrh;
     uint256 firstDisagreeIdx = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound;
     bytes32 reputationRootHash = getImpliedRoot(_reputationKey, disagreeStateReputationValue, u[U_REPUTATION_BRANCH_MASK], reputationSiblings);
@@ -644,11 +685,16 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     require(jrh==impliedRoot, "colony-invalid-after-reputation-proof");
   }
 
-  function performReputationCalculation(uint256[10] u, bytes agreeStateReputationValueBytes, bytes disagreeStateReputationValueBytes, bytes previousNewReputationValueBytes) internal {
+  function performReputationCalculation(
+    uint256[10] u,
+    bytes agreeStateReputationValueBytes,
+    bytes disagreeStateReputationValueBytes,
+    bytes previousNewReputationValueBytes
+  ) internal view
+  {
     // TODO: Possibility of decay calculation
     // TODO: Possibility of reputation loss - child reputations do not lose the whole of logEntry.amount, but the same fraction logEntry amount is of the user's reputation in skill given by logEntry.skillId
     ReputationLogEntry storage logEntry = reputationUpdateLog[u[U_LOG_ENTRY_NUMBER]];
-    int256 amount;
     uint256 agreeStateReputationValue;
     uint256 disagreeStateReputationValue;
     uint256 agreeStateReputationUID;
@@ -693,18 +739,21 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
 
   function checkPreviousReputationInState(
     uint256[10] u,
-    bytes _reputationKey,
-    bytes32[] reputationSiblings,
-    bytes agreeStateReputationValue,
     bytes32[] agreeStateSiblings,
     bytes previousNewReputationKey,
     bytes previousNewReputationValue,
-    bytes32[] previousNewReputationSiblings)
-  internal
+    bytes32[] previousNewReputationSiblings
+    ) internal view
   {
-    uint256 lastAgreeIdx = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1; // We binary searched to the first disagreement, so the last agreement is the one before
+    // We binary searched to the first disagreement, so the last agreement is the one before
+    uint256 lastAgreeIdx = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1;
 
-    bytes32 reputationRootHash = getImpliedRoot(previousNewReputationKey, previousNewReputationValue, u[U_PREVIOUS_NEW_REPUTATION_BRANCH_MASK], previousNewReputationSiblings);
+    bytes32 reputationRootHash = getImpliedRoot(
+      previousNewReputationKey,
+      previousNewReputationValue,
+      u[U_PREVIOUS_NEW_REPUTATION_BRANCH_MASK],
+      previousNewReputationSiblings
+    );
     bytes memory jhLeafValue = new bytes(64);
     bytes memory lastAgreeIdxBytes = new bytes(32);
     assembly {
@@ -727,7 +776,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     disputeRounds[u[U_ROUND]][u[U_IDX]].provedPreviousReputationUID = previousReputationUID;
   }
 
-  function checkJRHProof1(bytes32 jrh, uint256 branchMask1, bytes32[] siblings1) internal {
+  function checkJRHProof1(bytes32 jrh, uint256 branchMask1, bytes32[] siblings1) internal view {
     // Proof 1 needs to prove that they started with the current reputation root hash
     bytes32 reputationRootHash = IColonyNetwork(colonyNetworkAddress).getReputationRootHash();
     uint256 reputationRootHashNNodes = IColonyNetwork(colonyNetworkAddress).getReputationRootHashNNodes();

--- a/packages/reputation-miner/patricia.js
+++ b/packages/reputation-miner/patricia.js
@@ -102,7 +102,7 @@ function removePrefix(label, prefix) {
 // //////
 // Patricia Tree
 // //////////////////
-exports.PatriciaTree = function() {
+exports.PatriciaTree = function PatriciaTree() {
   // Label: { data, length } (data is the path, length says how many bits are used)
   // Edge: { nodeHash, label }
   // Node: [leftEdge, rightEdge] (no actual node)
@@ -150,6 +150,7 @@ exports.PatriciaTree = function() {
     let length = 0;
     let branchMask = new BN(0, 16);
 
+    // eslint-disable-next-line no-constant-condition
     while (true) {
       const [prefix, suffix] = splitCommonPrefix(label, edge.label);
 


### PR DESCRIPTION
Changes include:
- Refactored Authority contract to avoid stack depth error
- Removed unused imports
- Fixed compile and solium warnings such as:
  - line length
  - formating of more than 5 function arguments
  - unused function arguments
  - etc.

There are solium warnings for experimental features, im not sure if its safe to remove these.
Solc warnings for external libraries will unfortunately stay: https://github.com/ethereum/solidity/issues/2675