### PR TITLE
Make GreenKeeper lockfile updates strictly execute first in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,50 @@
 version: 2
 
+job_common: &job_common
+  docker:
+    - image: circleci/node:9.11.2
+  working_directory: ~/colonyNetwork
+step_save_cache: &step_save_cache
+  save_cache:
+    paths:
+      - ~/.cache/yarn
+    key: node-modules-{{ checksum "yarn.lock" }}
+step_restore_cache: &step_restore_cache
+  restore_cache:
+    keys:
+      - node-modules-{{ checksum "yarn.lock" }}
+      - node-modules-
+step_setup_global_packages: &step_setup_global_packages
+  run:
+    name: "Set up global packages"
+    command: |
+      yarn --pure-lockfile
+      git submodule update --init
+step_setup_greenkeeper: &step_setup_greenkeeper
+  run:
+    name: "Add greenkeeper-lockfile-update"
+    command: yarn global add greenkeeper-lockfile@1
 jobs:
-  lint-and-unit-test:
-    docker:
-      - image: circleci/node:9.11.2
-    working_directory: ~/colonyNetwork
+  greenkeeper-updates:
+    <<: *job_common
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - node-modules-{{ checksum "yarn.lock" }}
-            - node-modules-
+      - <<: *step_restore_cache
+      - <<: *step_setup_global_packages
+      - <<: *step_setup_greenkeeper
       - run:
-          name: "Set up global packages"
-          command: |
-            yarn global add greenkeeper-lockfile@1
-            yarn --pure-lockfile
-            git submodule update --init
+          name: "Run Greenkeeper lockfile update"
+          command: $(yarn global bin)/greenkeeper-lockfile-update
+          environment:
+            GK_LOCK_YARN_OPTS: "--ignore-workspace-root-check"
+      - <<: *step_save_cache
+  lint-and-unit-test:
+    <<: *job_common
+    steps:
+      - checkout
+      - <<: *step_restore_cache
+      - <<: *step_setup_global_packages
+      - <<: *step_setup_greenkeeper
       - run:
           name: "Setup parity"
           command: |
@@ -28,20 +56,11 @@ jobs:
             sed -i "s/xxxxx/$(parity --keys-path ./keys --password ./parityPassword account new)/g" ./parity-genesis.json
             sed -i "s/yyyyy/$(parity --keys-path ./keys --password ./parityPassword account new)/g" ./parity-genesis.json
             sed -i "s/zzzzz/$(parity --keys-path ./keys --password ./parityPassword account new)/g" ./parity-genesis.json
-      - save_cache:
-          paths:
-            - node_modules
-          key: node-modules-{{ checksum "yarn.lock" }}
       - run:
           name: "Install lsof"
           command: |
             sudo apt-get update
             sudo apt-get install lsof
-      - run:
-          name: "Greenkeeper lockfile update"
-          command: $(yarn global bin)/greenkeeper-lockfile-update
-          environment:
-            GK_LOCK_YARN_OPTS: "--ignore-workspace-root-check"
       - run:
           name: "Linting JavaScript"
           command: yarn run eslint
@@ -66,6 +85,7 @@ jobs:
       - run:
           name: "Running colony-contract-loader-network tests"
           command: cd packages/colony-js-contract-loader-network && yarn run test
+      - <<: *step_save_cache
       - run:
           name: "Greenkeeper uploading lockfile"
           command: $(yarn global bin)/greenkeeper-lockfile-upload
@@ -74,27 +94,15 @@ jobs:
           path: test-results.xml
       - store_artifacts:
           path: test-results.xml
-
   test-coverage:
-    docker:
-      - image: circleci/node:9.11.2
-    working_directory: ~/colonyNetwork
+    <<: *job_common
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - node-modules-{{ checksum "yarn.lock" }}
-            - node-modules-
-      - run:
-          name: "Set up global packages"
-          command: |
-            yarn global add greenkeeper-lockfile@1
-            yarn --pure-lockfile
-            git submodule update --init
+      - <<: *step_restore_cache
+      - <<: *step_setup_global_packages
       - run:
           name: "Running unit tests with coverage"
           command: yarn run test:contracts:coverage
-
       # Save coverage artifacts
       - store_artifacts:
           path: coverage
@@ -103,5 +111,10 @@ workflows:
   version: 2
   commit:
     jobs:
-      - lint-and-unit-test
-      - test-coverage
+      - greenkeeper-updates
+      - lint-and-unit-test:
+          requires:
+            - greenkeeper-updates
+      - test-coverage:
+          requires:
+            - greenkeeper-updates


### PR DESCRIPTION
Continuing attempts to make GK update the package lockfile in its PRs. This time we're potentially fixing the issue of GK requirement that it is the first job to be run and exiting before successful lockfile upload with `Only running on first push of a new branch` , example in  https://circleci.com/gh/JoinColony/colonyNetwork/2411

To ensure it is the first job to be run, we isolate the GreenKeeper updates using [sequential job execution](https://circleci.com/docs/2.0/workflows/#sequential-job-execution-example) to ensure the job that runs `greenkeeper-lockfile` is always executed first.

Solution inspired by https://github.com/greenkeeperio/greenkeeper-lockfile/issues/50

Resulting workflow build https://circleci.com/workflow-run/2cf9a44a-b22a-450c-a8a5-81114a67098a

Additionally we make some improvements to the circle config by using templates to isolate repeating steps and moving the `node_modules` cache to its own `~/.cache/yarn`