### PR TITLE
Introduce reputation decay

### DIFF
--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -117,7 +117,7 @@ contract IReputationMiningCycle {
   /// @dev If you know that the disagreement doesn't involve a new reputation being added, the arguments corresponding to the previous new reputation can be zeroed, as they will not be used. You must be sure
   /// that this is the case, however, otherwise you risk being found incorrect. Zeroed arguments will result in a cheaper call to this function.
   function respondToChallenge(
-    uint256[10] u, //An array of 10 UINT Params, ordered as given above.
+    uint256[11] u, //An array of 10 UINT Params, ordered as given above.
     bytes _reputationKey,
     bytes32[] reputationSiblings,
     bytes agreeStateReputationValue,

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -105,6 +105,7 @@ contract IReputationMiningCycle {
   /// * 9. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code.
   /// *10. The index of the log entry that the update in question was implied by. Each log entry can imply multiple reputation updates, and so we expect the clients to pass
   ///      the log entry index corresponding to the update to avoid us having to iterate over the log.
+  /// *11. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code.
   /// @param _reputationKey The key of the reputation being changed that the disagreement is over.
   /// @param reputationSiblings The siblings of the Merkle proof that the reputation corresponding to `_reputationKey` is in the reputation state before and after the disagreement
   /// @param agreeStateReputationValue The value of the reputation at key `_reputationKey` in the last reputation state the submitted hashes agreed on

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -820,7 +820,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
       // TODO: Account for potential overflow during this calculation. This could be done by capping reputation at some
       // value where this calculation can never overflow, doing the calculation the other way around once it is over some threshold,
       // or some other solution.
-      require(disagreeStateReputationValue == (agreeStateReputationValue*999306852819440)/1000000000000000);
+      require(disagreeStateReputationValue == (agreeStateReputationValue*999679150010888)/1000000000000000);
     } else {
       if (logEntry.amount < 0 && uint(logEntry.amount * -1) > agreeStateReputationValue ) {
         require(disagreeStateReputationValue == 0);

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -642,7 +642,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   }
 
   function checkKeyLogEntry(uint256 round, uint256 idx, uint256 logEntryNumber, bytes memory _reputationKey) internal {
-    uint256 updateNumber = disputeRounds[round][idx].lowerBound - 1;
+    uint256 updateNumber = disputeRounds[round][idx].lowerBound - 1 - IColonyNetwork(colonyNetworkAddress).getReputationRootHashNNodes();
 
     ReputationLogEntry storage logEntry = reputationUpdateLog[logEntryNumber];
 
@@ -892,8 +892,11 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     // TODO: Account for decay calculations
     uint256 nLogEntries = reputationUpdateLog.length;
     // The total number of updates we expect is the nPreviousUpdates in the last entry of the log plus the number
-    // of updates that log entry implies by itself.
-    uint256 nUpdates = reputationUpdateLog[nLogEntries-1].nUpdates + reputationUpdateLog[nLogEntries-1].nPreviousUpdates;
+    // of updates that log entry implies by itself, plus the number of decays (the number of nodes in current state)
+    // TODO: we're calling this twice during submitJRH. Should only need to call once.
+    uint256 reputationRootHashNNodes = IColonyNetwork(colonyNetworkAddress).getReputationRootHashNNodes();
+
+    uint256 nUpdates = reputationUpdateLog[nLogEntries-1].nUpdates + reputationUpdateLog[nLogEntries-1].nPreviousUpdates + reputationRootHashNNodes;
     bytes memory nUpdatesBytes = new bytes(32);
     disputeRounds[round][index].jrhNnodes = nUpdates + 1;
     bytes32 submittedHash = disputeRounds[round][index].proposedNewRootHash;

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -615,7 +615,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   }
 
   function checkKey(uint256[11] u, bytes memory _reputationKey, bytes memory _reputationValue) internal {
-    // If the state transition we're checking is less than the number of nodes in the currently accepted state, it's a decay transition (TODO: not implemented)
+    // If the state transition we're checking is less than the number of nodes in the currently accepted state, it's a decay transition
     // Otherwise, look up the corresponding entry in the reputation log.
     uint256 updateNumber = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1;
     if (updateNumber < IColonyNetwork(colonyNetworkAddress).getReputationRootHashNNodes()) {

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -353,9 +353,10 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   uint constant U_PREVIOUS_NEW_REPUTATION_BRANCH_MASK = 7;
   uint constant U_REQUIRE_REPUTATION_CHECK = 8;
   uint constant U_LOG_ENTRY_NUMBER = 9;
+  uint constant U_DECAY_TRANSITION = 10;
 
   function respondToChallenge(
-    uint256[10] u, //An array of 10 UINT Params, ordered as given above.
+    uint256[11] u, //An array of 11 UINT Params, ordered as given above.
     bytes _reputationKey,
     bytes32[] reputationSiblings,
     bytes agreeStateReputationValue,
@@ -369,6 +370,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     challengeOpen(u[U_ROUND], u[U_IDX])
   {
     u[U_REQUIRE_REPUTATION_CHECK] = 0;
+    u[U_DECAY_TRANSITION] = 0;
     // TODO: More checks that this is an appropriate time to respondToChallenge (maybe in modifier);
     /* bytes32 jrh = disputeRounds[round][idx].jrh; */
     // The contract knows
@@ -384,7 +386,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     //    that it's a decay calculation - not yet implemented.)
 
     // Check the supplied key is appropriate.
-    checkKey(u[U_ROUND], u[U_IDX], u[U_LOG_ENTRY_NUMBER], _reputationKey);
+    checkKey(u, _reputationKey, agreeStateReputationValue);
 
     // Prove the reputation's starting value is in some state, and that state is in the appropriate index in our JRH
     proveBeforeReputationValue(u, _reputationKey, reputationSiblings, agreeStateReputationValue, agreeStateSiblings);
@@ -612,10 +614,36 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     disputeRounds[round][opponentIdx].lastResponseTimestamp = now;
   }
 
-  function checkKey(uint256 round, uint256 idx, uint256 logEntryNumber, bytes memory _reputationKey) internal view {
+  function checkKey(uint256[11] u, bytes memory _reputationKey, bytes memory _reputationValue) internal {
     // If the state transition we're checking is less than the number of nodes in the currently accepted state, it's a decay transition (TODO: not implemented)
     // Otherwise, look up the corresponding entry in the reputation log.
+    uint256 updateNumber = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1;
+    if (updateNumber < IColonyNetwork(colonyNetworkAddress).getReputationRootHashNNodes()) {
+      checkKeyDecay(updateNumber, _reputationValue);
+      u[U_DECAY_TRANSITION] = 1;
+    } else {
+      checkKeyLogEntry(u[U_ROUND], u[U_IDX], u[U_LOG_ENTRY_NUMBER], _reputationKey);
+    }
+  }
+
+  function checkKeyDecay(uint256 _updateNumber, bytes memory _reputationValue) internal {
+    uint256 uid;
+    bytes memory reputationValue = new bytes(64);
+    reputationValue = _reputationValue;
+    assembly {
+      // NB first 32 bytes contain the length of the bytes object, so we are still correctly loading the second 32 bytes of the
+      // reputationValue, which contains the UID
+      uid := mload(add(reputationValue,64))
+    }
+    // We check that the reputation UID is right for the decay transition being disputed.
+    // The key is then implicitly checked when they prove that the key+value they supplied is in the
+    // right intermediate state in their justification tree.
+    require(uid-1 == _updateNumber);
+  }
+
+  function checkKeyLogEntry(uint256 round, uint256 idx, uint256 logEntryNumber, bytes memory _reputationKey) internal {
     uint256 updateNumber = disputeRounds[round][idx].lowerBound - 1;
+
     ReputationLogEntry storage logEntry = reputationUpdateLog[logEntryNumber];
 
     // Check that the supplied log entry corresponds to this update number
@@ -638,13 +666,9 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
                                               // any unintended side effects here, but I'm not quite confortable enough with EVM's stack to be sure.
                                               // Not sure what the alternative would be anyway.
     }
-    bool decayCalculation = false;
-    if (decayCalculation) { // solium-disable-line no-empty-blocks, whitespace
-    } else {
-      require(expectedAddress == userAddress);
-      require(logEntry.colony == colonyAddress);
-      require(expectedSkillId == skillId);
-    }
+    require(expectedAddress == userAddress);
+    require(logEntry.colony == colonyAddress);
+    require(expectedSkillId == skillId);
   }
 
   function getExpectedSkillIdAndAddress(ReputationLogEntry storage logEntry, uint256 updateNumber) internal view
@@ -683,7 +707,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   }
 
   function proveBeforeReputationValue(
-    uint256[10] u,
+    uint256[11] u,
     bytes _reputationKey,
     bytes32[] reputationSiblings,
     bytes agreeStateReputationValue,
@@ -727,7 +751,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   }
 
   function proveAfterReputationValue(
-    uint256[10] u,
+    uint256[11] u,
     bytes _reputationKey,
     bytes32[] reputationSiblings,
     bytes disagreeStateReputationValue,
@@ -754,13 +778,12 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   }
 
   function performReputationCalculation(
-    uint256[10] u,
+    uint256[11] u,
     bytes agreeStateReputationValueBytes,
     bytes disagreeStateReputationValueBytes,
     bytes previousNewReputationValueBytes
   ) internal view
   {
-    // TODO: Possibility of decay calculation
     // TODO: Possibility of reputation loss - child reputations do not lose the whole of logEntry.amount, but the same fraction logEntry amount is of the user's reputation in skill given by logEntry.skillId
     ReputationLogEntry storage logEntry = reputationUpdateLog[u[U_LOG_ENTRY_NUMBER]];
     uint256 agreeStateReputationValue;
@@ -793,20 +816,24 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
 
     // We don't care about underflows for the purposes of comparison, but for the calculation we deem 'correct'.
     // i.e. a reputation can't be negative.
-    if (logEntry.amount < 0 && uint(logEntry.amount * -1) > agreeStateReputationValue ) {
-      require(disagreeStateReputationValue == 0);
-    } else if (uint(logEntry.amount) + agreeStateReputationValue < agreeStateReputationValue) {
-      // We also don't allow reputation to overflow
-      require(disagreeStateReputationValue == 2**256 - 1);
+    if (u[U_DECAY_TRANSITION]==1) {
+      require(disagreeStateReputationValue == (agreeStateReputationValue*999306852819440)/1000000000000000);
     } else {
-      // TODO: Is this safe? I think so, because even if there's over/underflows, they should
-      // still be the same number.
-      require(int(agreeStateReputationValue)+logEntry.amount == int(disagreeStateReputationValue));
+      if (logEntry.amount < 0 && uint(logEntry.amount * -1) > agreeStateReputationValue ) {
+        require(disagreeStateReputationValue == 0);
+      } else if (uint(logEntry.amount) + agreeStateReputationValue < agreeStateReputationValue) {
+        // We also don't allow reputation to overflow
+        require(disagreeStateReputationValue == 2**256 - 1);
+      } else {
+        // TODO: Is this safe? I think so, because even if there's over/underflows, they should
+        // still be the same number.
+        require(int(agreeStateReputationValue)+logEntry.amount == int(disagreeStateReputationValue));
+      }
     }
   }
 
   function checkPreviousReputationInState(
-    uint256[10] u,
+    uint256[11] u,
     bytes32[] agreeStateSiblings,
     bytes previousNewReputationKey,
     bytes previousNewReputationValue,
@@ -835,7 +862,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     require(impliedRoot == disputeRounds[u[U_ROUND]][u[U_IDX]].jrh);
   }
 
-  function saveProvedReputation(uint256[10] u, bytes previousNewReputationValue) internal {
+  function saveProvedReputation(uint256[11] u, bytes previousNewReputationValue) internal {
     uint256 previousReputationUID;
     assembly {
       previousReputationUID := mload(add(previousNewReputationValue,0x40))

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -817,6 +817,9 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     // We don't care about underflows for the purposes of comparison, but for the calculation we deem 'correct'.
     // i.e. a reputation can't be negative.
     if (u[U_DECAY_TRANSITION]==1) {
+      // TODO: Account for potential overflow during this calculation. This could be done by capping reputation at some
+      // value where this calculation can never overflow, doing the calculation the other way around once it is over some threshold,
+      // or some other solution.
       require(disagreeStateReputationValue == (agreeStateReputationValue*999306852819440)/1000000000000000);
     } else {
       if (logEntry.amount < 0 && uint(logEntry.amount * -1) > agreeStateReputationValue ) {

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -817,10 +817,12 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     // We don't care about underflows for the purposes of comparison, but for the calculation we deem 'correct'.
     // i.e. a reputation can't be negative.
     if (u[U_DECAY_TRANSITION]==1) {
-      // TODO: Account for potential overflow during this calculation. This could be done by capping reputation at some
-      // value where this calculation can never overflow, doing the calculation the other way around once it is over some threshold,
-      // or some other solution.
-      require(disagreeStateReputationValue == (agreeStateReputationValue*999679150010888)/1000000000000000);
+      // Very large reputation decays are calculated the 'other way around' to avoid overflows.
+      if (agreeStateReputationValue > uint256(2**256 - 1)/uint256(10**15)) {
+        require(disagreeStateReputationValue == (agreeStateReputationValue/1000000000000000)*999679150010888);
+      } else {
+        require(disagreeStateReputationValue == (agreeStateReputationValue*999679150010888)/1000000000000000);
+      }
     } else {
       if (logEntry.amount < 0 && uint(logEntry.amount * -1) > agreeStateReputationValue ) {
         require(disagreeStateReputationValue == 0);

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -196,7 +196,7 @@ class ReputationMiner {
     let logEntry;
     if (updateNumber.lt(this.nReputationsBeforeLatestLog)) {
       const key = await Object.keys(this.reputations)[updateNumber];
-      const newReputation = new BN(this.reputations[key].slice(2, 66), 16).mul(new BN("999306852819440")).div(new BN("1000000000000000"));
+      const newReputation = new BN(this.reputations[key].slice(2, 66), 16).mul(new BN("999679150010888")).div(new BN("1000000000000000"));
       let reputationChange = newReputation.sub(new BN(this.reputations[key].slice(2, 66), 16));
       reputationChange = ethers.utils.bigNumberify(reputationChange.toString());
       logEntry = [undefined, reputationChange, undefined, key.slice(2, 42)];

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -196,7 +196,13 @@ class ReputationMiner {
     let logEntry;
     if (updateNumber.lt(this.nReputationsBeforeLatestLog)) {
       const key = await Object.keys(this.reputations)[updateNumber];
-      const newReputation = new BN(this.reputations[key].slice(2, 66), 16).mul(new BN("999679150010888")).div(new BN("1000000000000000"));
+      const reputation = new BN(this.reputations[key].slice(2, 66), 16);
+      let newReputation;
+      if (reputation.gt(new BN("2").pow(new BN("256").subn(1).div(new BN("10").pow(new BN("15")))))) {
+        newReputation = new BN(this.reputations[key].slice(2, 66), 16).div(new BN("1000000000000000")).mul(new BN("999679150010888"));
+      } else {
+        newReputation = new BN(this.reputations[key].slice(2, 66), 16).mul(new BN("999679150010888")).div(new BN("1000000000000000"));
+      }
       let reputationChange = newReputation.sub(new BN(this.reputations[key].slice(2, 66), 16));
       reputationChange = ethers.utils.bigNumberify(reputationChange.toString());
       logEntry = [undefined, reputationChange, undefined, key.slice(2, 42)];

--- a/packages/reputation-miner/test/MaliciousReputationMinerExtraRep.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerExtraRep.js
@@ -9,8 +9,8 @@ class MaliciousReputationMinerExtraRep extends ReputationMiner {
     this.amountToFalsify = amountToFalsify.toString();
   }
 
-  getScore(i, logEntry) {
-    let score = logEntry[1];
+  getScore(i, _score) {
+    let score = _score;
     if (i.toString() === this.entryToFalsify) {
       score = score.add(this.amountToFalsify);
     }

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -35,7 +35,8 @@ class MaliciousReputationMiningWrongProofLogEntry extends ReputationMiningClient
         `0x${disagreeStateBranchMask.toString(16)}`,
         this.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.branchMask,
         0,
-        logEntryNumber.toString()
+        logEntryNumber.toString(),
+        0
       ],
       reputationKey,
       this.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.siblings,

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -22,7 +22,7 @@ class MaliciousReputationMiningWrongProofLogEntry extends ReputationMiningClient
     // console.log('get justification tree');
     const [agreeStateBranchMask, agreeStateSiblings] = await this.justificationTree.getProof(`0x${lastAgreeIdx.toString(16, 64)}`);
     const [disagreeStateBranchMask, disagreeStateSiblings] = await this.justificationTree.getProof(`0x${firstDisagreeIdx.toString(16, 64)}`);
-    const logEntryNumber = await this.getLogEntryNumberForUpdateNumber(lastAgreeIdx.toString());
+    const logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(lastAgreeIdx.toString());
     logEntryNumber.iadd(this.amountToFalsify);
     const tx = await repCycle.respondToChallenge(
       [

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -2122,8 +2122,8 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
       badClient = new MaliciousReputationMinerExtraRep(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
-        27,
-        new BN("-1000000000000000000000000000000000000000000")
+        29,
+        new BN("-10").pow(new BN("75")).muln(2)
       );
       await badClient.initialise(colonyNetwork.address);
 
@@ -2132,22 +2132,37 @@ contract("ColonyNetworkMining", accounts => {
       let repCycle = ReputationMiningCycle.at(addr);
       const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId.call();
 
+      await goodClient.insert(
+        metaColony.address,
+        rootGlobalSkill,
+        "0x0000000000000000000000000000000000000000",
+        new BN("2").pow(new BN("256")).subn(2),
+        0
+      );
       await goodClient.insert(metaColony.address, rootGlobalSkill, MAIN_ACCOUNT, new BN("2").pow(new BN("256")).subn(2), 0);
+      await badClient.insert(
+        metaColony.address,
+        rootGlobalSkill,
+        "0x0000000000000000000000000000000000000000",
+        new BN("2").pow(new BN("256")).subn(2),
+        0
+      );
       await badClient.insert(metaColony.address, rootGlobalSkill, MAIN_ACCOUNT, new BN("2").pow(new BN("256")).subn(2), 0);
       const rootHash = await goodClient.getRootHash();
+      await fundColonyWithTokens(metaColony, clny, new BN("4").mul(new BN("10").pow(new BN("75"))).toString());
       const taskId = await setupRatedTask({
         colonyNetwork,
         colony: metaColony,
         worker: MAIN_ACCOUNT,
-        managerPayout: 1000000000000,
-        evaluatorPayout: 1000000000000,
-        workerPayout: 1000000000000,
+        managerPayout: new BN("10").pow(new BN("75")).toString(),
+        evaluatorPayout: new BN("10").pow(new BN("75")).toString(),
+        workerPayout: new BN("10").pow(new BN("75")).toString(),
         managerRating: 3,
         workerRating: 3
       });
       await metaColony.finalizeTask(taskId);
 
-      await repCycle.submitRootHash(rootHash, 1, 10);
+      await repCycle.submitRootHash(rootHash, 2, 10);
       await repCycle.confirmNewHash(0);
       await forwardTime(3600, this);
 

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -1605,7 +1605,7 @@ contract("ColonyNetworkMining", accounts => {
 
       // Now get all the information needed to fire off a respondToChallenge call
       const [round, index] = await goodClient.getMySubmissionRoundAndIndex();
-      const submission = await repCycle.disputeRounds(round.toString(), index.toString());
+      const submission = await repCycle.getDisputeRounds(round.toString(), index.toString());
       const firstDisagreeIdx = new BN(submission[8].toString());
       const lastAgreeIdx = firstDisagreeIdx.subn(1);
       const reputationKey = await goodClient.getKeyForUpdateNumber(lastAgreeIdx.toString());


### PR DESCRIPTION
Closes #54. Implements decays element of https://github.com/JoinColony/colonyNetwork/issues/51

An important part of reputation is that it decays over time, by about 0.5 every three months. This is the approximate rate described in the whitepaper, though the constant defined there was based on blocks, and so is not equal to what has been used here (which is the solution to `x**(24*30*4) = 0.5`).

Decays of very large reputations are calculated differently from other reputations to avoid overflows yet maintain as much precision as possible for small overflows.

Decay calculations are done in the order of ascending UID that the reputations have in the reputation state.

The structure of the Reputation Miner has been altered slightly to treat reputation decays and updates from the reputation log as similarly as possible. Note that `nPreviousUpdates` in the reputation log only counts updates in the reputation log that have come before - it does not include any decays that will have taken place before the log is applied. Some of the language in the reputation miner has been changed to make this more explicit, and some functions have been changed to account for that.

I am not very happy with the introduction of `nReputationsBeforeLatestLog`, but cleaning up the reputation mining client should probably be considered out-of-scope here.