### PR TITLE
Upgrade to Truffle v5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
       - <<: *step_restore_cache
       - <<: *step_setup_global_packages
       - <<: *step_setup_greenkeeper
+      - setup_remote_docker
       - <<: *step_pull_solc_docker
       - run:
           name: "Setup parity"
@@ -108,6 +109,7 @@ jobs:
       - checkout
       - <<: *step_restore_cache
       - <<: *step_setup_global_packages
+      - setup_remote_docker
       - <<: *step_pull_solc_docker
       - run:
           name: "Running unit tests with coverage"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,10 @@ step_setup_greenkeeper: &step_setup_greenkeeper
   run:
     name: "Add greenkeeper-lockfile-update"
     command: yarn global add greenkeeper-lockfile@1
+step_pull_solc_docker: &step_pull_solc_docker
+    run:
+      name: "Pull solc 0.4.23 docker image"
+      command: docker pull ethereum/solc:0.4.23
 jobs:
   greenkeeper-updates:
     <<: *job_common
@@ -45,6 +49,7 @@ jobs:
       - <<: *step_restore_cache
       - <<: *step_setup_global_packages
       - <<: *step_setup_greenkeeper
+      - <<: *step_pull_solc_docker
       - run:
           name: "Setup parity"
           command: |
@@ -103,6 +108,7 @@ jobs:
       - checkout
       - <<: *step_restore_cache
       - <<: *step_setup_global_packages
+      - <<: *step_pull_solc_docker
       - run:
           name: "Running unit tests with coverage"
           command: yarn run test:contracts:coverage

--- a/.solcover.js
+++ b/.solcover.js
@@ -8,5 +8,5 @@ module.exports = {
     ],
     compileCommand: '../node_modules/.bin/truffle compile',
     testCommand: '../node_modules/.bin/truffle test --network coverage',
-    testrpcOptions: `--port 8555 -i coverage --acctKeys="./coverageEnv/ganache-accounts.json" --noVMErrorsOnRPCResponse`
+    testrpcOptions: `--port 8555 -i 1999 --acctKeys="./coverageEnv/ganache-accounts.json" --noVMErrorsOnRPCResponse`
 };

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -186,7 +186,7 @@ contract ColonyStorage is DSAuth, DSMath {
   }
 
   modifier isInBootstrapPhase() {
-    require(taskCount == 0);
+    require(taskCount == 0, "colony-not-in-bootstrap-mode");
     _;
   }
 

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -79,17 +79,17 @@ contract("All", accounts => {
     const tokenArgs = getTokenArgs();
     token = await Token.new(...tokenArgs);
 
-    const tokenLockingAddress = await colonyNetwork.getTokenLocking.call();
+    const tokenLockingAddress = await colonyNetwork.getTokenLocking();
     tokenLocking = await ITokenLocking.at(tokenLockingAddress);
 
     const { logs } = await colonyNetwork.createColony(token.address);
     const { colonyAddress } = logs[0].args;
     await token.setOwner(colonyAddress);
     colony = await IColony.at(colonyAddress);
-    tokenAddress = await colony.getToken.call();
+    tokenAddress = await colony.getToken();
     await IColony.defaults({ gasPrice });
 
-    const metaColonyAddress = await colonyNetwork.getMetaColony.call();
+    const metaColonyAddress = await colonyNetwork.getMetaColony();
     metaColony = await IColony.at(metaColonyAddress);
 
     const otherTokenArgs = getTokenArgs();
@@ -237,7 +237,7 @@ contract("All", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, STAKER2, big);
       await giveUserCLNYTokensAndStake(colonyNetwork, STAKER3, big);
 
-      let repCycleAddr = await colonyNetwork.getReputationMiningCycle.call(true);
+      let repCycleAddr = await colonyNetwork.getReputationMiningCycle(true);
 
       await oneHourLater();
       let repCycle = await ReputationMiningCycle.at(repCycleAddr);
@@ -245,7 +245,7 @@ contract("All", accounts => {
       await repCycle.confirmNewHash(0);
       await oneHourLater();
 
-      repCycleAddr = await colonyNetwork.getReputationMiningCycle.call(true);
+      repCycleAddr = await colonyNetwork.getReputationMiningCycle(true);
       repCycle = await ReputationMiningCycle.at(repCycleAddr);
 
       const goodClient = new ReputationMiner({ loader: contractLoader, minerAddress: STAKER1, realProviderPort: REAL_PROVIDER_PORT });

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -241,7 +241,7 @@ contract("All", accounts => {
 
       await oneHourLater();
       let repCycle = await ReputationMiningCycle.at(repCycleAddr);
-      await repCycle.submitRootHash("0x01", 0, 1);
+      await repCycle.submitRootHash("0x00", 0, 1);
       await repCycle.confirmNewHash(0);
       await oneHourLater();
 

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -7,9 +7,6 @@ import BN from "bn.js";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
 import {
-  MANAGER,
-  EVALUATOR,
-  WORKER,
   MANAGER_ROLE,
   WORKER_ROLE,
   MANAGER_RATING,
@@ -56,6 +53,10 @@ const contractLoader = new TruffleLoader({
 contract("All", accounts => {
   const gasPrice = 20e9;
 
+  const MANAGER = accounts[0];
+  const EVALUATOR = accounts[1];
+  const WORKER = accounts[2];
+
   let colony;
   let token;
   let tokenAddress;
@@ -79,7 +80,7 @@ contract("All", accounts => {
     token = await Token.new(...tokenArgs);
 
     const tokenLockingAddress = await colonyNetwork.getTokenLocking.call();
-    tokenLocking = ITokenLocking.at(tokenLockingAddress);
+    tokenLocking = await ITokenLocking.at(tokenLockingAddress);
 
     const { logs } = await colonyNetwork.createColony(token.address);
     const { colonyAddress } = logs[0].args;
@@ -239,13 +240,13 @@ contract("All", accounts => {
       let repCycleAddr = await colonyNetwork.getReputationMiningCycle.call(true);
 
       await oneHourLater();
-      let repCycle = ReputationMiningCycle.at(repCycleAddr);
+      let repCycle = await ReputationMiningCycle.at(repCycleAddr);
       await repCycle.submitRootHash("0x0", 0, 1);
       await repCycle.confirmNewHash(0);
       await oneHourLater();
 
       repCycleAddr = await colonyNetwork.getReputationMiningCycle.call(true);
-      repCycle = ReputationMiningCycle.at(repCycleAddr);
+      repCycle = await ReputationMiningCycle.at(repCycleAddr);
 
       const goodClient = new ReputationMiner({ loader: contractLoader, minerAddress: STAKER1, realProviderPort: REAL_PROVIDER_PORT });
       const badClient = new MaliciousReputationMinerExtraRep(
@@ -335,7 +336,7 @@ contract("All", accounts => {
       const newToken = await Token.new(...tokenArgs);
       const { logs } = await colonyNetwork.createColony(newToken.address);
       const { colonyAddress } = logs[0].args;
-      const newColony = IColony.at(colonyAddress);
+      const newColony = await IColony.at(colonyAddress);
       await newToken.setOwner(colonyAddress);
 
       await fundColonyWithTokens(newColony, otherToken, initialFunding.toString());

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -241,7 +241,7 @@ contract("All", accounts => {
 
       await oneHourLater();
       let repCycle = await ReputationMiningCycle.at(repCycleAddr);
-      await repCycle.submitRootHash("0x0", 0, 1);
+      await repCycle.submitRootHash("0x01", 0, 1);
       await repCycle.confirmNewHash(0);
       await oneHourLater();
 

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -26,7 +26,7 @@ const RATING_1_SALT = web3Utils.soliditySha3(getRandomString(10));
 const RATING_2_SALT = web3Utils.soliditySha3(getRandomString(10));
 const RATING_1_SECRET = web3Utils.soliditySha3(RATING_1_SALT, MANAGER_RATING);
 const RATING_2_SECRET = web3Utils.soliditySha3(RATING_2_SALT, WORKER_RATING);
-const ACCOUNTS = await web3GetAccounts();
+const ACCOUNTS = web3GetAccounts();
 
 module.exports = {
   MANAGER: MANAGER || ACCOUNTS[0],

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -1,5 +1,5 @@
 import web3Utils from "web3-utils";
-import { getRandomString, web3GetAccounts } from "./test-helper";
+import { getRandomString } from "./test-helper";
 
 const MANAGER_ROLE = 0;
 const EVALUATOR_ROLE = 1;

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -1,5 +1,5 @@
 import web3Utils from "web3-utils";
-import { getRandomString } from "./test-helper";
+import { getRandomString, web3GetAccounts } from "./test-helper";
 
 let MANAGER;
 let EVALUATOR;
@@ -26,12 +26,13 @@ const RATING_1_SALT = web3Utils.soliditySha3(getRandomString(10));
 const RATING_2_SALT = web3Utils.soliditySha3(getRandomString(10));
 const RATING_1_SECRET = web3Utils.soliditySha3(RATING_1_SALT, MANAGER_RATING);
 const RATING_2_SECRET = web3Utils.soliditySha3(RATING_2_SALT, WORKER_RATING);
+const ACCOUNTS = await web3GetAccounts();
 
 module.exports = {
-  MANAGER: MANAGER || web3.eth.accounts[0],
-  EVALUATOR: EVALUATOR || web3.eth.accounts[1],
-  WORKER: WORKER || web3.eth.accounts[2],
-  OTHER: OTHER || web3.eth.accounts[3],
+  MANAGER: MANAGER || ACCOUNTS[0],
+  EVALUATOR: EVALUATOR || ACCOUNTS[1],
+  WORKER: WORKER || ACCOUNTS[2],
+  OTHER: OTHER || ACCOUNTS[3],
   MANAGER_ROLE,
   EVALUATOR_ROLE,
   WORKER_ROLE,

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -1,10 +1,6 @@
 import web3Utils from "web3-utils";
 import { getRandomString, web3GetAccounts } from "./test-helper";
 
-let MANAGER;
-let EVALUATOR;
-let WORKER;
-let OTHER;
 const MANAGER_ROLE = 0;
 const EVALUATOR_ROLE = 1;
 const WORKER_ROLE = 2;
@@ -26,13 +22,8 @@ const RATING_1_SALT = web3Utils.soliditySha3(getRandomString(10));
 const RATING_2_SALT = web3Utils.soliditySha3(getRandomString(10));
 const RATING_1_SECRET = web3Utils.soliditySha3(RATING_1_SALT, MANAGER_RATING);
 const RATING_2_SECRET = web3Utils.soliditySha3(RATING_2_SALT, WORKER_RATING);
-const ACCOUNTS = web3GetAccounts();
 
 module.exports = {
-  MANAGER: MANAGER || ACCOUNTS[0],
-  EVALUATOR: EVALUATOR || ACCOUNTS[1],
-  WORKER: WORKER || ACCOUNTS[2],
-  OTHER: OTHER || ACCOUNTS[3],
   MANAGER_ROLE,
   EVALUATOR_ROLE,
   WORKER_ROLE,

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -243,7 +243,8 @@ export async function giveUserCLNYTokens(colonyNetwork, address, _amount) {
   const amount = new BN(_amount);
   const mainStartingBalance = await clny.balanceOf.call(manager);
   const targetStartingBalance = await clny.balanceOf.call(address);
-  await metaColony.mintTokens(amount * 3);
+  await metaColony.mintTokens(amount.muln(3).toString());
+
   await metaColony.claimColonyFunds(clny.address);
   const taskId = await setupRatedTask({
     colonyNetwork,

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -3,9 +3,6 @@ import web3Utils from "web3-utils";
 import { BN } from "bn.js";
 
 import {
-  MANAGER,
-  EVALUATOR,
-  WORKER,
   MANAGER_PAYOUT,
   EVALUATOR_PAYOUT,
   WORKER_PAYOUT,
@@ -225,9 +222,9 @@ export async function setupRatedTask({
 
 export async function giveUserCLNYTokens(colonyNetwork, address, _amount) {
   const metaColonyAddress = await colonyNetwork.getMetaColony();
-  const metaColony = IColony.at(metaColonyAddress);
+  const metaColony = await IColony.at(metaColonyAddress);
   const clnyAddress = await metaColony.getToken.call();
-  const clny = Token.at(clnyAddress);
+  const clny = await Token.at(clnyAddress);
   const amount = new BN(_amount);
   const mainStartingBalance = await clny.balanceOf.call(MANAGER);
   const targetStartingBalance = await clny.balanceOf.call(address);
@@ -262,13 +259,13 @@ export async function giveUserCLNYTokens(colonyNetwork, address, _amount) {
 
 export async function giveUserCLNYTokensAndStake(colonyNetwork, address, _amount) {
   const metaColonyAddress = await colonyNetwork.getMetaColony.call();
-  const metaColony = IColony.at(metaColonyAddress);
+  const metaColony = await IColony.at(metaColonyAddress);
   const clnyAddress = await metaColony.getToken.call();
-  const clny = Token.at(clnyAddress);
+  const clny = await Token.at(clnyAddress);
 
   await giveUserCLNYTokens(colonyNetwork, address, _amount);
   const tokenLockingAddress = await colonyNetwork.getTokenLocking();
-  const tokenLocking = ITokenLocking.at(tokenLockingAddress);
+  const tokenLocking = await ITokenLocking.at(tokenLockingAddress);
   await clny.approve(tokenLocking.address, _amount.toString(), { from: address });
   await tokenLocking.deposit(clny.address, _amount.toString(), { from: address });
 }

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -30,7 +30,7 @@ export async function makeTask({ colony, hash = SPECIFICATION_HASH, domainId = 1
 }
 
 async function getSigsAndTransactionData({ colony, functionName, taskId, signers, sigTypes, args }) {
-  const txData = await colony.contract[functionName].getData(...args);
+  const txData = await colony.contract.methods[functionName](...args).encodeABI();
   const sigsPromises = sigTypes.map((type, i) => {
     if (type === 0) {
       return createSignatures(colony, taskId, [signers[i]], 0, txData);

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -54,9 +54,9 @@ export async function executeSignedRoleAssignment({ colony, functionName, taskId
 export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain = 1, skill = 0, evaluator, worker }) {
   const accounts = await web3GetAccounts();
   const manager = accounts[0];
-  evaluator = evaluator ? evaluator : accounts[1];
-  worker = worker ? worker : accounts[2];
-  
+  evaluator = evaluator || accounts[1]; // eslint-disable-line no-param-reassign
+  worker = worker || accounts[2]; // eslint-disable-line no-param-reassign
+
   const taskId = await makeTask({ colony, domainId: domain });
   // If the skill is not specified, default to the root global skill
   if (skill === 0) {
@@ -138,8 +138,8 @@ export async function setupFundedTask({
   const accounts = await web3GetAccounts();
   const manager = accounts[0];
   let tokenAddress;
-  evaluator = evaluator ? evaluator : accounts[1];
-  worker = worker ? worker : accounts[2];
+  evaluator = evaluator || accounts[1]; // eslint-disable-line no-param-reassign
+  worker = worker || accounts[2]; // eslint-disable-line no-param-reassign
 
   if (token === undefined) {
     tokenAddress = await colony.getToken.call();
@@ -208,8 +208,8 @@ export async function setupRatedTask({
   workerRatingSalt = RATING_2_SALT
 }) {
   const accounts = await web3GetAccounts();
-  evaluator = evaluator ? evaluator : accounts[1];
-  worker = worker ? worker : accounts[2];
+  evaluator = evaluator || accounts[1]; // eslint-disable-line no-param-reassign
+  worker = worker || accounts[2]; // eslint-disable-line no-param-reassign
 
   const taskId = await setupFundedTask({
     colonyNetwork,

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -26,7 +26,7 @@ const Token = artifacts.require("Token");
 export async function makeTask({ colony, hash = SPECIFICATION_HASH, domainId = 1 }) {
   const { logs } = await colony.makeTask(hash, domainId);
   // Reading the ID out of the event triggered by our transaction will allow us to make multiple tasks in parallel in the future.
-  return logs.filter(log => log.event === "TaskAdded")[0].args.id.toNumber();
+  return logs.filter(log => log.event === "TaskAdded")[0].args.id;
 }
 
 async function getSigsAndTransactionData({ colony, functionName, taskId, signers, sigTypes, args }) {

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -23,8 +23,8 @@ const IColony = artifacts.require("IColony");
 const ITokenLocking = artifacts.require("ITokenLocking");
 const Token = artifacts.require("Token");
 
-export async function makeTask({ colony, hash = SPECIFICATION_HASH, domainId = 1, opts }) {
-  const { logs } = await colony.makeTask(hash, domainId, opts);
+export async function makeTask({ colony, hash = SPECIFICATION_HASH, domainId = 1 }) {
+  const { logs } = await colony.makeTask(hash, domainId);
   // Reading the ID out of the event triggered by our transaction will allow us to make multiple tasks in parallel in the future.
   return logs.filter(log => log.event === "TaskAdded")[0].args.id.toNumber();
 }

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -60,7 +60,7 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
   const taskId = await makeTask({ colony, domainId: domain });
   // If the skill is not specified, default to the root global skill
   if (skill === 0) {
-    const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId.call();
+    const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId();
     if (rootGlobalSkill.toNumber() === 0) throw new Error("Meta Colony is not setup and therefore the root global skill does not exist");
 
     await executeSignedTaskChange({
@@ -142,12 +142,12 @@ export async function setupFundedTask({
   worker = worker || accounts[2]; // eslint-disable-line no-param-reassign
 
   if (token === undefined) {
-    tokenAddress = await colony.getToken.call();
+    tokenAddress = await colony.getToken();
   } else {
     tokenAddress = token === 0x0 ? 0x0 : token.address;
   }
   const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate, domain, skill, evaluator, worker });
-  const task = await colony.getTask.call(taskId);
+  const task = await colony.getTask(taskId);
   const potId = task[6].toNumber();
   const managerPayoutBN = new BN(managerPayout);
   const evaluatorPayoutBN = new BN(evaluatorPayout);
@@ -238,11 +238,11 @@ export async function giveUserCLNYTokens(colonyNetwork, address, _amount) {
   const manager = accounts[0];
   const metaColonyAddress = await colonyNetwork.getMetaColony();
   const metaColony = await IColony.at(metaColonyAddress);
-  const clnyAddress = await metaColony.getToken.call();
+  const clnyAddress = await metaColony.getToken();
   const clny = await Token.at(clnyAddress);
   const amount = new BN(_amount);
-  const mainStartingBalance = await clny.balanceOf.call(manager);
-  const targetStartingBalance = await clny.balanceOf.call(address);
+  const mainStartingBalance = await clny.balanceOf(manager);
+  const targetStartingBalance = await clny.balanceOf(address);
   await metaColony.mintTokens(amount.muln(3).toString());
 
   await metaColony.claimColonyFunds(clny.address);
@@ -256,7 +256,7 @@ export async function giveUserCLNYTokens(colonyNetwork, address, _amount) {
   await metaColony.finalizeTask(taskId);
   await metaColony.claimPayout(taskId, MANAGER_ROLE, clny.address);
 
-  let mainBalance = await clny.balanceOf.call(manager);
+  let mainBalance = await clny.balanceOf(manager);
   await clny.transfer(
     0x0,
     mainBalance
@@ -265,18 +265,18 @@ export async function giveUserCLNYTokens(colonyNetwork, address, _amount) {
       .toString()
   );
   await clny.transfer(address, amount.toString());
-  mainBalance = await clny.balanceOf.call(manager);
+  mainBalance = await clny.balanceOf(manager);
   if (address !== manager) {
     await clny.transfer(0x0, mainBalance.sub(mainStartingBalance).toString());
   }
-  const userBalance = await clny.balanceOf.call(address);
+  const userBalance = await clny.balanceOf(address);
   assert.equal(targetStartingBalance.add(amount).toString(), userBalance.toString());
 }
 
 export async function giveUserCLNYTokensAndStake(colonyNetwork, address, _amount) {
-  const metaColonyAddress = await colonyNetwork.getMetaColony.call();
+  const metaColonyAddress = await colonyNetwork.getMetaColony();
   const metaColony = await IColony.at(metaColonyAddress);
-  const clnyAddress = await metaColony.getToken.call();
+  const clnyAddress = await metaColony.getToken();
   const clny = await Token.at(clnyAddress);
 
   await giveUserCLNYTokens(colonyNetwork, address, _amount);
@@ -287,7 +287,7 @@ export async function giveUserCLNYTokensAndStake(colonyNetwork, address, _amount
 }
 
 export async function fundColonyWithTokens(colony, token, tokenAmount) {
-  const colonyToken = await colony.getToken.call();
+  const colonyToken = await colony.getToken();
   if (colonyToken === token.address) {
     await colony.mintTokens(tokenAmount);
   } else {

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -78,7 +78,7 @@ export function web3GetCode(a) {
   });
 }
 
-export function _web3GetAccounts() {
+export function web3GetAccounts() {
   return new Promise((resolve, reject) => {
     web3.eth.getAccounts((err, res) => {
       if (err !== null) return reject(err);
@@ -212,18 +212,20 @@ export function getFunctionSignature(sig) {
 export async function createSignatures(colony, taskId, signers, value, data) {
   const sourceAddress = colony.address;
   const destinationAddress = colony.address;
-  const nonce = await colony.getTaskChangeNonce.call(taskId);
+  const nonce = await colony.getTaskChangeNonce(taskId);
   const accountsJson = JSON.parse(fs.readFileSync("./ganache-accounts.json", "utf8"));
-  const input = `0x${sourceAddress.slice(2)}${destinationAddress.slice(2)}${web3Utils.padLeft(value.toString("16"), "64", "0")}${data.slice(
+
+  const input = `0x${sourceAddress.slice(2)}${destinationAddress.slice(2)}${web3Utils.padLeft(value.toString(16), "64", "0")}${data.slice(
     2
-  )}${web3Utils.padLeft(nonce.toString("16"), "64", "0")}`; // eslint-disable-line max-len
+  )}${web3Utils.padLeft(nonce.toString(16), "64", "0")}`; // eslint-disable-line max-len
   const sigV = [];
   const sigR = [];
   const sigS = [];
   const msgHash = web3Utils.soliditySha3(input);
 
   for (let i = 0; i < signers.length; i += 1) {
-    const user = signers[i].toString();
+    let user = signers[i].toString();
+    user = user.toLowerCase();
     const privKey = accountsJson.private_keys[user];
     const prefixedMessageHash = ethUtils.hashPersonalMessage(Buffer.from(msgHash.slice(2), "hex"));
     const sig = ethUtils.ecsign(prefixedMessageHash, Buffer.from(privKey, "hex"));
@@ -241,9 +243,9 @@ export async function createSignaturesTrezor(colony, taskId, signers, value, dat
   const destinationAddress = colony.address;
   const nonce = await colony.getTaskChangeNonce.call(taskId);
   const accountsJson = JSON.parse(fs.readFileSync("./ganache-accounts.json", "utf8"));
-  const input = `0x${sourceAddress.slice(2)}${destinationAddress.slice(2)}${web3Utils.padLeft(value.toString("16"), "64", "0")}${data.slice(
+  const input = `0x${sourceAddress.slice(2)}${destinationAddress.slice(2)}${web3Utils.padLeft(value.toString(16), "64", "0")}${data.slice(
     2
-  )}${web3Utils.padLeft(nonce.toString("16"), "64", "0")}`; // eslint-disable-line max-len
+  )}${web3Utils.padLeft(nonce.toString(16), "64", "0")}`; // eslint-disable-line max-len
   const sigV = [];
   const sigR = [];
   const sigS = [];

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -98,22 +98,18 @@ export async function checkErrorRevert(promise, errorMessage) {
   // We have to have this special function that we use to catch the error.
   let tx;
   let receipt;
-  let reason;
+  let reason; // eslint-disable-line no-unused-vars
   try {
     tx = await promise;
     receipt = await web3GetTransactionReceipt(tx);
   } catch (err) {
+    console.log(err);
     ({ tx, receipt, reason } = err);
     // TODO: address as part of https://github.com/JoinColony/colonyNetwork/issues/201#issuecomment-407634292
-    /// assert.equal(reason, errorMessage);
+    // / assert.equal(reason, errorMessage);
   }
-
   // Check the receipt `status` to ensure transaction failed.
   assert.equal(receipt.status, 0x00);
-}
-
-export function checkErrorNonPayableFunction(tx) {
-  assert.equal(tx, "Error: Cannot send value to non-payable function");
 }
 
 export function getRandomString(_length) {

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -8,7 +8,7 @@ import fs from "fs";
 
 export function web3GetNetwork() {
   return new Promise((resolve, reject) => {
-    web3.version.getNetwork((err, res) => {
+    web3.eth.net.getId((err, res) => {
       if (err !== null) return reject(err);
       return resolve(res);
     });
@@ -17,7 +17,7 @@ export function web3GetNetwork() {
 
 export function web3GetClient() {
   return new Promise((resolve, reject) => {
-    web3.version.getNode((err, res) => {
+    web3.eth.getNodeInfo((err, res) => {
       if (err !== null) return reject(err);
       return resolve(res);
     });

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -167,7 +167,9 @@ export async function expectAllEvents(tx, eventNames) {
 }
 
 export async function forwardTime(seconds, test) {
-  const client = await web3GetClient();
+  // TODO: Get the client via web3GetClient() which requires web3 beta34 for `getNodeInfo`.
+  // Current version of truffle 5.0.0-next.6
+  const client = "TestRPC";
   const p = new Promise((resolve, reject) => {
     if (client.indexOf("TestRPC") === -1) {
       resolve(test.skip());

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -103,10 +103,9 @@ export async function checkErrorRevert(promise, errorMessage) {
     tx = await promise;
     receipt = await web3GetTransactionReceipt(tx);
   } catch (err) {
-    console.log(err);
     ({ tx, receipt, reason } = err);
     // TODO: address as part of https://github.com/JoinColony/colonyNetwork/issues/201#issuecomment-407634292
-    // / assert.equal(reason, errorMessage);
+    // assert.equal(reason, errorMessage);
   }
   // Check the receipt `status` to ensure transaction failed.
   assert.equal(receipt.status, 0x00);

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -78,7 +78,7 @@ export function web3GetCode(a) {
   });
 }
 
-export function web3GetAccounts() {
+export function _web3GetAccounts() {
   return new Promise((resolve, reject) => {
     web3.eth.getAccounts((err, res) => {
       if (err !== null) return reject(err);

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -98,12 +98,13 @@ export async function checkErrorRevert(promise, errMsg) {
   // We have to have this special function that we use to catch the error.
   let tx;
   let receipt;
+  let reason;
   try {
     tx = await promise;
     receipt = await web3GetTransactionReceipt(tx);
   } catch (err) {
-    // TODO: Check errMsg == err.Error or wherever truffle decides ot put this
-    ({ tx, receipt } = err);
+    ({ tx, receipt, reason } = err);
+    assert.equal(reason, errMsg);
   }
 
   // Check the receipt `status` to ensure transaction failed.

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -88,7 +88,7 @@ export function web3GetAccounts() {
 }
 
 // eslint-disable-next-line no-unused-vars
-export async function checkErrorRevert(promise, errMsg) {
+export async function checkErrorRevert(promise, errorMessage) {
   // There is a discrepancy between how ganache-cli handles errors
   // (throwing an exception all the way up to these tests) and how geth/parity handle them
   // (still making a valid transaction and returning a txid). For the explanation of why
@@ -104,7 +104,8 @@ export async function checkErrorRevert(promise, errMsg) {
     receipt = await web3GetTransactionReceipt(tx);
   } catch (err) {
     ({ tx, receipt, reason } = err);
-    assert.equal(reason, errMsg);
+    // TODO: address as part of https://github.com/JoinColony/colonyNetwork/issues/201#issuecomment-407634292
+    /// assert.equal(reason, errorMessage);
   }
 
   // Check the receipt `status` to ensure transaction failed.

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -241,7 +241,8 @@ export async function createSignaturesTrezor(colony, taskId, signers, value, dat
   const msgHash = web3Utils.soliditySha3(input);
 
   for (let i = 0; i < signers.length; i += 1) {
-    const user = signers[i].toString();
+    let user = signers[i].toString();
+    user = user.toLowerCase();
     const privKey = accountsJson.private_keys[user];
     const prefixedMessageHash = web3Utils.soliditySha3("\x19Ethereum Signed Message:\n\x20", msgHash);
     const sig = ethUtils.ecsign(Buffer.from(prefixedMessageHash.slice(2), "hex"), Buffer.from(privKey, "hex"));

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -78,6 +78,15 @@ export function web3GetCode(a) {
   });
 }
 
+export function web3GetAccounts() {
+  return new Promise((resolve, reject) => {
+    web3.eth.getAccounts((err, res) => {
+      if (err !== null) return reject(err);
+      return resolve(res);
+    });
+  });
+}
+
 // eslint-disable-next-line no-unused-vars
 export async function checkErrorRevert(promise, errMsg) {
   // There is a discrepancy between how ganache-cli handles errors

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -240,7 +240,7 @@ export async function createSignatures(colony, taskId, signers, value, data) {
 export async function createSignaturesTrezor(colony, taskId, signers, value, data) {
   const sourceAddress = colony.address;
   const destinationAddress = colony.address;
-  const nonce = await colony.getTaskChangeNonce.call(taskId);
+  const nonce = await colony.getTaskChangeNonce(taskId);
   const accountsJson = JSON.parse(fs.readFileSync("./ganache-accounts.json", "utf8"));
   const input = `0x${sourceAddress.slice(2)}${destinationAddress.slice(2)}${web3Utils.padLeft(value.toString(16), "64", "0")}${data.slice(
     2

--- a/helpers/upgradable-contracts.js
+++ b/helpers/upgradable-contracts.js
@@ -53,7 +53,7 @@ export async function setupEtherRouter(interfaceContract, deployedImplementation
   const promises = Object.keys(functionsToResolve).map(async fName => {
     const sig = `${fName}(${functionsToResolve[fName].inputs.join(",")})`;
     const address = functionsToResolve[fName].definedIn;
-    const sigHash = web3Utils.soliditySha3(sig).substr(0, 10);
+    const sigHash = await web3Utils.soliditySha3(sig).substr(0, 10);
     await resolver.register(sig, address);
     const destination = await resolver.lookup.call(sigHash);
     assert.equal(destination, address, `${sig} has not been registered correctly. Is it defined?`);

--- a/helpers/upgradable-contracts.js
+++ b/helpers/upgradable-contracts.js
@@ -55,7 +55,7 @@ export async function setupEtherRouter(interfaceContract, deployedImplementation
     const address = functionsToResolve[fName].definedIn;
     const sigHash = await web3Utils.soliditySha3(sig).substr(0, 10);
     await resolver.register(sig, address);
-    const destination = await resolver.lookup.call(sigHash);
+    const destination = await resolver.lookup(sigHash);
     assert.equal(destination, address, `${sig} has not been registered correctly. Is it defined?`);
   });
   return Promise.all(promises);
@@ -67,7 +67,7 @@ export async function setupUpgradableToken(token, resolver, etherRouter) {
   await setupEtherRouter("ERC20Extended", deployedImplementations, resolver);
 
   await etherRouter.setResolver(resolver.address);
-  const registeredResolver = await etherRouter.resolver.call();
+  const registeredResolver = await etherRouter.resolver();
   assert.equal(registeredResolver, resolver.address);
 }
 
@@ -79,9 +79,9 @@ export async function setupColonyVersionResolver(colony, colonyTask, colonyFundi
 
   await setupEtherRouter("IColony", deployedImplementations, resolver);
 
-  const version = await colony.version.call();
+  const version = await colony.version();
   await colonyNetwork.addColonyVersion(version.toNumber(), resolver.address);
-  const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
+  const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
   assert.equal(version, currentColonyVersion.toNumber());
 }
 
@@ -110,6 +110,6 @@ export async function setupUpgradableTokenLocking(etherRouter, resolver, tokenLo
   await setupEtherRouter("ITokenLocking", deployedImplementations, resolver);
 
   await etherRouter.setResolver(resolver.address);
-  const registeredResolver = await etherRouter.resolver.call();
+  const registeredResolver = await etherRouter.resolver();
   assert.equal(registeredResolver, resolver.address);
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -19,13 +19,13 @@ artifacts.require("./ReputationMiningCycle");
 
 module.exports = (deployer, network) => {
   console.log(`## ${network} network ##`);
-  deployer.deploy([SafeMath]);
+  deployer.deploy(SafeMath);
   deployer.link(SafeMath, ColonyTask);
-  deployer.deploy([ColonyNetwork]);
-  deployer.deploy([ColonyNetworkMining]);
-  deployer.deploy([ColonyNetworkAuction]);
-  deployer.deploy([ColonyNetworkRegistrar]);
-  deployer.deploy([ENSRegistry]);
-  deployer.deploy([EtherRouter]);
-  deployer.deploy([Resolver]);
+  deployer.deploy(ColonyNetwork);
+  deployer.deploy(ColonyNetworkMining);
+  deployer.deploy(ColonyNetworkAuction);
+  deployer.deploy(ColonyNetworkRegistrar);
+  deployer.deploy(ENSRegistry);
+  deployer.deploy(EtherRouter);
+  deployer.deploy(Resolver);
 };

--- a/migrations/4_setup_colony_version_resolver.js
+++ b/migrations/4_setup_colony_version_resolver.js
@@ -30,7 +30,7 @@ module.exports = deployer => {
     })
     .then(instance => {
       colonyTask = instance;
-      return colony.version.call();
+      return colony.version();
     })
     .then(_version => {
       version = _version.toNumber();

--- a/migrations/5_setup_token_locking.js
+++ b/migrations/5_setup_token_locking.js
@@ -26,9 +26,11 @@ module.exports = deployer => {
     .then(() => EtherRouter.deployed())
     .then(_colonyNetworkEtherRouter => {
       colonyNetworkEtherRouter = _colonyNetworkEtherRouter;
-      return IColonyNetwork.at(_colonyNetworkEtherRouter.address).setTokenLocking(etherRouter.address);
+      return IColonyNetwork.at(_colonyNetworkEtherRouter.address);
     })
-    .then(() => TokenLocking.at(etherRouter.address).setColonyNetwork(colonyNetworkEtherRouter.address))
+    .then(iColonyNetwork => iColonyNetwork.setTokenLocking(etherRouter.address))
+    .then(() => TokenLocking.at(etherRouter.address))
+    .then(tokenLocking => tokenLocking.setColonyNetwork(colonyNetworkEtherRouter.address))
     .then(() => {
       console.log("### Token locking setup at ", etherRouter.address, "with Resolver", resolver.address);
     })

--- a/migrations/6_setup_meta_colony.js
+++ b/migrations/6_setup_meta_colony.js
@@ -35,10 +35,10 @@ module.exports = deployer => {
     .then(() => ITokenLocking.at(tokenLocking))
     .then(iTokenLocking => iTokenLocking.deposit(token.address, "10000000000000000"))
     .then(() => colonyNetwork.startNextCycle())
-    .then(() => colonyNetwork.getSkillCount.call())
+    .then(() => colonyNetwork.getSkillCount())
     .then(skillCount => {
       assert.equal(skillCount.toNumber(), 3);
-      return colonyNetwork.getMetaColony.call();
+      return colonyNetwork.getMetaColony();
     })
     .then(metaColonyAddress => {
       token.setOwner(metaColonyAddress);

--- a/migrations/6_setup_meta_colony.js
+++ b/migrations/6_setup_meta_colony.js
@@ -32,7 +32,8 @@ module.exports = deployer => {
       tokenLocking = address;
       return token.approve(tokenLocking, "10000000000000000");
     })
-    .then(() => ITokenLocking.at(tokenLocking).deposit(token.address, "10000000000000000"))
+    .then(() => ITokenLocking.at(tokenLocking))
+    .then(iTokenLocking => iTokenLocking.deposit(token.address, "10000000000000000"))
     .then(() => colonyNetwork.startNextCycle())
     .then(() => colonyNetwork.getSkillCount.call())
     .then(skillCount => {

--- a/migrations/7_setup_ens_registry.js
+++ b/migrations/7_setup_ens_registry.js
@@ -14,8 +14,9 @@ module.exports = deployer => {
 
   deployer
     .then(() => EtherRouter.deployed())
-    .then(instance => {
-      colonyNetwork = IColonyNetwork.at(instance.address);
+    .then(instance => IColonyNetwork.at(instance.address))
+    .then(network => {
+      colonyNetwork = network;
       return ENSRegistry.deployed();
     })
     .then(instance => {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "solidity-coverage": "0.5.5",
     "solidity-parser-antlr": "^0.3.0",
     "solium": "^1.1.8",
-    "truffle": "^5.0.0-next.6",
+    "truffle": "^5.0.0-next.7",
     "web3-utils": "^1.0.0-beta.34"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "solidity-coverage": "0.5.5",
     "solidity-parser-antlr": "^0.3.0",
     "solium": "^1.1.8",
-    "truffle": "^4.1.11",
+    "truffle": "^5.0.0-next.5",
     "web3-utils": "^1.0.0-beta.34"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "solidity-coverage": "0.5.5",
     "solidity-parser-antlr": "^0.3.0",
     "solium": "^1.1.8",
-    "truffle": "^5.0.0-next.5",
+    "truffle": "^5.0.0-next.6",
     "web3-utils": "^1.0.0-beta.34"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "babel-register": "^6.26.0",
+    "bn-chai": "^1.0.1",
     "bn.js": "^4.11.8",
     "chai": "^4.1.2",
     "eslint": "^5.0.1",

--- a/parity-genesis.template.json
+++ b/parity-genesis.template.json
@@ -27,7 +27,7 @@
         "timestamp": "0x00",
         "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "extraData": "0x",
-        "gasLimit": "0x6ACFC0"
+        "gasLimit": "0x6691B7"
     },
     "accounts": {
         "0000000000000000000000000000000000000001": { "balance": "1", "nonce": "1048576", "builtin": { "name": "ecrecover", "pricing": { "linear": { "base": 3000, "word": 0 } } } },

--- a/parity-genesis.template.json
+++ b/parity-genesis.template.json
@@ -8,7 +8,7 @@
         "gasLimitBoundDivisor": "0x400",
         "maximumExtraDataSize": "0x20",
         "minGasLimit": "0x1388",
-        "networkID" : "0x2",
+        "networkID" : "0x7CE",
         "eip658Transition": "0x0",
         "eip140Transition": "0x0",
         "eip211Transition": "0x0",

--- a/scripts/start-blockchain-client.sh
+++ b/scripts/start-blockchain-client.sh
@@ -44,7 +44,7 @@ start_parity() {
     --author ${addresses[0]} \
     --unlock ${addresses[0]},${addresses[1]},${addresses[2]},${addresses[3]} \
     --keys-path ./keys --geth --no-dapps \
-    --tx-gas-limit 0x6ACFC0 --gasprice 0x0 --gas-floor-target 0x6ACFC0 \
+    --tx-gas-limit 0x6691B7 --gasprice 0x0 --gas-floor-target 0x6691B7 \
     --reseal-on-txs all --reseal-min-period 0 \
     --jsonrpc-interface all --jsonrpc-hosts all --jsonrpc-cors="http://localhost:3000" \
     --password ./parityPassword >/dev/null 2>&1

--- a/scripts/start-blockchain-client.sh
+++ b/scripts/start-blockchain-client.sh
@@ -19,7 +19,7 @@ bc_client_running() {
 }
 
 start_ganache() {
-  node_modules/.bin/ganache-cli --acctKeys="./ganache-accounts.json" --noVMErrorsOnRPCResponse --gasLimit 6700000 \
+  node_modules/.bin/ganache-cli --acctKeys="./ganache-accounts.json" --noVMErrorsOnRPCResponse \
     --account="0x0355596cdb5e5242ad082c4fe3f8bbe48c9dba843fe1f99dd8272f487e70efae, 100000000000000000000" \
     --account="0xe9aebe8791ad1ebd33211687e9c53f13fe8cca53b271a6529c7d7ba05eda5ce2, 100000000000000000000" \
     --account="0x6f36842c663f5afc0ef3ac986ec62af9d09caa1bbf59a50cdb7334c9cc880e65, 100000000000000000000" \

--- a/scripts/start-blockchain-client.sh
+++ b/scripts/start-blockchain-client.sh
@@ -19,7 +19,7 @@ bc_client_running() {
 }
 
 start_ganache() {
-  node_modules/.bin/ganache-cli --acctKeys="./ganache-accounts.json" --noVMErrorsOnRPCResponse \
+  node_modules/.bin/ganache-cli --acctKeys="./ganache-accounts.json" --noVMErrorsOnRPCResponse --gasLimit 6721975 \
     --account="0x0355596cdb5e5242ad082c4fe3f8bbe48c9dba843fe1f99dd8272f487e70efae, 100000000000000000000" \
     --account="0xe9aebe8791ad1ebd33211687e9c53f13fe8cca53b271a6529c7d7ba05eda5ce2, 100000000000000000000" \
     --account="0x6f36842c663f5afc0ef3ac986ec62af9d09caa1bbf59a50cdb7334c9cc880e65, 100000000000000000000" \

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -17,7 +17,6 @@ contract("Colony Funding", accounts => {
   const MANAGER = accounts[0];
   const EVALUATOR = accounts[1];
   const WORKER = accounts[2];
-  const OTHER = accounts[3];
 
   let colony;
   let token;

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -28,7 +28,7 @@ contract("Colony Funding", accounts => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
 
-    const tokenLockingAddress = await colonyNetwork.getTokenLocking.call();
+    const tokenLockingAddress = await colonyNetwork.getTokenLocking();
     tokenLocking = await ITokenLocking.at(tokenLockingAddress);
   });
 
@@ -47,16 +47,16 @@ contract("Colony Funding", accounts => {
     it("should not put the tokens straight in to the pot", async () => {
       await otherToken.mint(100);
       await otherToken.transfer(colony.address, 100);
-      let colonyRewardPotBalance = await colony.getPotBalance.call(0, otherToken.address);
-      let colonyPotBalance = await colony.getPotBalance.call(1, otherToken.address);
-      let colonyTokenBalance = await otherToken.balanceOf.call(colony.address);
+      let colonyRewardPotBalance = await colony.getPotBalance(0, otherToken.address);
+      let colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      let colonyTokenBalance = await otherToken.balanceOf(colony.address);
       assert.equal(colonyTokenBalance.toNumber(), 100);
       assert.equal(colonyPotBalance.toNumber(), 0);
       assert.equal(colonyRewardPotBalance.toNumber(), 0);
       await colony.claimColonyFunds(otherToken.address);
-      colonyRewardPotBalance = await colony.getPotBalance.call(0, otherToken.address);
-      colonyPotBalance = await colony.getPotBalance.call(1, otherToken.address);
-      colonyTokenBalance = await otherToken.balanceOf.call(colony.address);
+      colonyRewardPotBalance = await colony.getPotBalance(0, otherToken.address);
+      colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      colonyTokenBalance = await otherToken.balanceOf(colony.address);
       assert.equal(colonyTokenBalance.toNumber(), 100);
       assert.equal(colonyPotBalance.toNumber(), 99);
       assert.equal(colonyRewardPotBalance.toNumber(), 1);
@@ -64,9 +64,9 @@ contract("Colony Funding", accounts => {
 
     it("should not put its own tokens in to the reward pot", async () => {
       await fundColonyWithTokens(colony, token, 100);
-      const colonyRewardPotBalance = await colony.getPotBalance.call(0, token.address);
-      const colonyPotBalance = await colony.getPotBalance.call(1, token.address);
-      const colonyTokenBalance = await token.balanceOf.call(colony.address);
+      const colonyRewardPotBalance = await colony.getPotBalance(0, token.address);
+      const colonyPotBalance = await colony.getPotBalance(1, token.address);
+      const colonyTokenBalance = await token.balanceOf(colony.address);
       assert.equal(colonyTokenBalance.toNumber(), 100);
       assert.equal(colonyPotBalance.toNumber(), 100);
       assert.equal(colonyRewardPotBalance.toNumber(), 0);
@@ -76,9 +76,9 @@ contract("Colony Funding", accounts => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await makeTask({ colony });
       await colony.moveFundsBetweenPots(1, 2, 51, otherToken.address);
-      const colonyPotBalance = await colony.getPotBalance.call(1, otherToken.address);
-      const colonyTokenBalance = await otherToken.balanceOf.call(colony.address);
-      const pot2Balance = await colony.getPotBalance.call(2, otherToken.address);
+      const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      const colonyTokenBalance = await otherToken.balanceOf(colony.address);
+      const pot2Balance = await colony.getPotBalance(2, otherToken.address);
       assert.equal(colonyTokenBalance.toNumber(), 100);
       assert.equal(colonyPotBalance.toNumber(), 48);
       assert.equal(pot2Balance.toNumber(), 51);
@@ -89,10 +89,10 @@ contract("Colony Funding", accounts => {
       await makeTask({ colony });
 
       await checkErrorRevert(colony.moveFundsBetweenPots(0, 2, 1, otherToken.address), "colonyFunding-cannot-move-funds-from-pot-0");
-      const colonyPotBalance = await colony.getPotBalance.call(1, otherToken.address);
-      const colonyRewardPotBalance = await colony.getPotBalance.call(0, otherToken.address);
-      const colonyTokenBalance = await otherToken.balanceOf.call(colony.address);
-      const pot2Balance = await colony.getPotBalance.call(2, otherToken.address);
+      const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      const colonyRewardPotBalance = await colony.getPotBalance(0, otherToken.address);
+      const colonyTokenBalance = await otherToken.balanceOf(colony.address);
+      const pot2Balance = await colony.getPotBalance(2, otherToken.address);
       assert.equal(colonyTokenBalance.toNumber(), 100);
       assert.equal(colonyPotBalance.toNumber(), 99);
       assert.equal(pot2Balance.toNumber(), 0);
@@ -103,9 +103,9 @@ contract("Colony Funding", accounts => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await makeTask({ colony });
       await checkErrorRevert(colony.moveFundsBetweenPots(1, 2, 51, otherToken.address, { from: EVALUATOR }));
-      const colonyPotBalance = await colony.getPotBalance.call(1, otherToken.address);
-      const colonyTokenBalance = await otherToken.balanceOf.call(colony.address);
-      const pot2Balance = await colony.getPotBalance.call(2, otherToken.address);
+      const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      const colonyTokenBalance = await otherToken.balanceOf(colony.address);
+      const pot2Balance = await colony.getPotBalance(2, otherToken.address);
       assert.equal(colonyTokenBalance.toNumber(), 100);
       assert.equal(colonyPotBalance.toNumber(), 99);
       assert.equal(pot2Balance.toNumber(), 0);
@@ -118,10 +118,10 @@ contract("Colony Funding", accounts => {
       await colony.moveFundsBetweenPots(1, 2, 40, otherToken.address);
 
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 3, 50, otherToken.address));
-      const colonyPotBalance = await colony.getPotBalance.call(1, otherToken.address);
-      const colonyTokenBalance = await otherToken.balanceOf.call(colony.address);
-      const pot2Balance = await colony.getPotBalance.call(2, otherToken.address);
-      const pot3Balance = await colony.getPotBalance.call(3, otherToken.address);
+      const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      const colonyTokenBalance = await otherToken.balanceOf(colony.address);
+      const pot2Balance = await colony.getPotBalance(2, otherToken.address);
+      const pot3Balance = await colony.getPotBalance(3, otherToken.address);
       assert.equal(colonyTokenBalance.toNumber(), 100);
       assert.equal(colonyPotBalance.toNumber(), 59);
       assert.equal(pot2Balance.toNumber(), 40);
@@ -169,13 +169,13 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 0]
       });
-      let task = await colony.getTask.call(taskId);
+      let task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 0, Payout 0
       // Pot was equal to payout, transition to pot being equal by changing pot (17)
       await colony.moveFundsBetweenPots(1, 2, 0, otherToken.address);
-      task = await colony.getTask.call(taskId);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 0, Payout 0
@@ -188,19 +188,19 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 40]
       });
-      task = await colony.getTask.call(taskId);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 1);
 
       // Pot 0, Payout 40
       // Pot was below payout, transition to being equal by increasing pot (1)
       await colony.moveFundsBetweenPots(1, 2, 40, otherToken.address);
-      task = await colony.getTask.call(taskId);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 40, Payout 40
       // Pot was equal to payout, transition to being above by increasing pot (5)
       await colony.moveFundsBetweenPots(1, 2, 40, otherToken.address);
-      task = await colony.getTask.call(taskId);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 80, Payout 40
@@ -213,7 +213,7 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 80]
       });
-      task = await colony.getTask.call(taskId);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 80, Payout 80
@@ -226,13 +226,13 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 40]
       });
-      task = await colony.getTask.call(taskId);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 80, Payout 40
       // Pot was above payout, transition to being equal by decreasing pot (11)
       await colony.moveFundsBetweenPots(2, 1, 40, otherToken.address);
-      task = await colony.getTask.call(taskId);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 40, Payout 40
@@ -261,7 +261,7 @@ contract("Colony Funding", accounts => {
       // Pot 20, Payout 40
       // Pot was below payout, change to being above by changing pot (3)
       await colony.moveFundsBetweenPots(1, 2, 60, otherToken.address);
-      task = await colony.getTask.call(taskId);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 80, Payout 40
@@ -297,7 +297,7 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 10]
       });
-      task = await colony.getTask.call(taskId);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 20, Payout 10
@@ -310,13 +310,13 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 5]
       });
-      task = await colony.getTask.call(taskId);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 20, Payout 5
       // Pot was above, change to being above by changing pot (15)
       await colony.moveFundsBetweenPots(2, 1, 10, otherToken.address);
-      task = await colony.getTask.call(taskId);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 10, Payout 5
@@ -329,7 +329,7 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 40]
       });
-      task = await colony.getTask.call(taskId);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 1);
 
       // Pot 10, Payout 40
@@ -342,7 +342,7 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 30]
       });
-      task = await colony.getTask.call(taskId);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 1);
 
       // Pot 10, Payout 30
@@ -378,7 +378,7 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 5]
       });
-      task = await colony.getTask.call(taskId);
+      task = await colony.getTask(taskId);
       assert.equal(task[5].toNumber(), 0);
 
       // Pot 5, Payout 5
@@ -387,9 +387,9 @@ contract("Colony Funding", accounts => {
     it("should pay fees on revenue correctly", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await fundColonyWithTokens(colony, otherToken, 200);
-      const colonyPotBalance = await colony.getPotBalance.call(1, otherToken.address);
-      const colonyRewardPotBalance = await colony.getPotBalance.call(0, otherToken.address);
-      const colonyTokenBalance = await otherToken.balanceOf.call(colony.address);
+      const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      const colonyRewardPotBalance = await colony.getPotBalance(0, otherToken.address);
+      const colonyTokenBalance = await otherToken.balanceOf(colony.address);
       assert.equal(colonyTokenBalance.toNumber(), 300);
       assert.equal(colonyRewardPotBalance.toNumber(), 3);
       assert.equal(colonyPotBalance.toNumber(), 297);
@@ -398,7 +398,7 @@ contract("Colony Funding", accounts => {
     it("should not allow contributions to nonexistent pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await checkErrorRevert(colony.moveFundsBetweenPots(1, 5, 40, otherToken.address));
-      const colonyPotBalance = await colony.getPotBalance.call(1, otherToken.address);
+      const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
       assert.equal(colonyPotBalance.toNumber(), 99);
     });
 
@@ -407,7 +407,7 @@ contract("Colony Funding", accounts => {
       const taskId = await setupRatedTask({ colonyNetwork, colony, token: otherToken });
       await colony.finalizeTask(taskId);
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 40, otherToken.address), "colony-funding-task-bad-state");
-      const colonyPotBalance = await colony.getPotBalance.call(2, otherToken.address);
+      const colonyPotBalance = await colony.getPotBalance(2, otherToken.address);
       assert.isTrue(colonyPotBalance.eq(toBN(350 * 1e18)));
     });
 
@@ -421,7 +421,7 @@ contract("Colony Funding", accounts => {
       await colony.claimPayout(taskId, EVALUATOR_ROLE, otherToken.address, { from: EVALUATOR });
       await colony.moveFundsBetweenPots(2, 1, 10, otherToken.address);
 
-      const colonyPotBalance = await colony.getPotBalance.call(2, otherToken.address);
+      const colonyPotBalance = await colony.getPotBalance(2, otherToken.address);
       assert.equal(colonyPotBalance.toNumber(), 0);
     });
 
@@ -439,7 +439,7 @@ contract("Colony Funding", accounts => {
       await colony.claimPayout(taskId, EVALUATOR_ROLE, token.address, { from: EVALUATOR });
       await colony.claimPayout(taskId, WORKER_ROLE, token.address, { from: WORKER });
 
-      const taskInfo = await colony.getTask.call(taskId);
+      const taskInfo = await colony.getTask(taskId);
       const taskPotId = taskInfo[6].toNumber();
       const remainingPotBalance = await colony.getPotBalance(taskPotId, token.address);
       assert.equal(remainingPotBalance.toString(), WORKER_PAYOUT.toString(), "should have remaining pot balance equal to worker payout");
@@ -454,15 +454,15 @@ contract("Colony Funding", accounts => {
   describe("when receiving ether", () => {
     it("should not put the ether straight in to the pot", async () => {
       await colony.send(100);
-      let colonyPotBalance = await colony.getPotBalance.call(1, 0x0);
+      let colonyPotBalance = await colony.getPotBalance(1, 0x0);
       let colonyEtherBalance = await web3GetBalance(colony.address);
-      let colonyRewardBalance = await colony.getPotBalance.call(0, 0x0);
+      let colonyRewardBalance = await colony.getPotBalance(0, 0x0);
       assert.equal(colonyEtherBalance, 100);
       assert.isTrue(colonyPotBalance.isZero());
       await colony.claimColonyFunds(0x0);
-      colonyPotBalance = await colony.getPotBalance.call(1, 0x0);
+      colonyPotBalance = await colony.getPotBalance(1, 0x0);
       colonyEtherBalance = await web3GetBalance(colony.address);
-      colonyRewardBalance = await colony.getPotBalance.call(0, 0x0);
+      colonyRewardBalance = await colony.getPotBalance(0, 0x0);
       assert.equal(colonyEtherBalance, 100);
       assert.equal(colonyRewardBalance.toNumber(), 1);
       assert.equal(colonyPotBalance.toNumber(), 99);
@@ -473,9 +473,9 @@ contract("Colony Funding", accounts => {
       await colony.claimColonyFunds(0x0);
       await makeTask({ colony });
       await colony.moveFundsBetweenPots(1, 2, 51, 0x0);
-      const colonyPotBalance = await colony.getPotBalance.call(1, 0x0);
+      const colonyPotBalance = await colony.getPotBalance(1, 0x0);
       const colonyEtherBalance = await web3GetBalance(colony.address);
-      const pot2Balance = await colony.getPotBalance.call(2, 0x0);
+      const pot2Balance = await colony.getPotBalance(2, 0x0);
       assert.equal(colonyEtherBalance, 100);
       assert.equal(colonyPotBalance.toNumber(), 48);
       assert.equal(pot2Balance.toNumber(), 51);
@@ -490,9 +490,9 @@ contract("Colony Funding", accounts => {
 
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 3, 50, 0x0));
       const colonyEtherBalance = await web3GetBalance(colony.address);
-      const colonyPotBalance = await colony.getPotBalance.call(1, 0x0);
-      const pot2Balance = await colony.getPotBalance.call(2, 0x0);
-      const pot3Balance = await colony.getPotBalance.call(3, 0x0);
+      const colonyPotBalance = await colony.getPotBalance(1, 0x0);
+      const pot2Balance = await colony.getPotBalance(2, 0x0);
+      const pot3Balance = await colony.getPotBalance(3, 0x0);
       assert.equal(colonyEtherBalance, 100);
       assert.equal(colonyPotBalance.toNumber(), 59);
       assert.equal(pot2Balance.toNumber(), 40);
@@ -563,10 +563,10 @@ contract("Colony Funding", accounts => {
       await colony.claimColonyFunds(0x0);
       await colony.send(200);
       await colony.claimColonyFunds(0x0);
-      const colonyPotBalance = await colony.getPotBalance.call(1, 0x0);
-      const colonyRewardPotBalance = await colony.getPotBalance.call(0, 0x0);
+      const colonyPotBalance = await colony.getPotBalance(1, 0x0);
+      const colonyRewardPotBalance = await colony.getPotBalance(0, 0x0);
       const colonyEtherBalance = await web3GetBalance(colony.address);
-      const nonRewardPotsTotal = await colony.getNonRewardPotsTotal.call(0x0);
+      const nonRewardPotsTotal = await colony.getNonRewardPotsTotal(0x0);
       assert.equal(colonyEtherBalance, 300);
       assert.equal(colonyPotBalance.toNumber(), 297);
       assert.equal(colonyRewardPotBalance.toNumber(), 3);

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -408,7 +408,7 @@ contract("Colony Funding", accounts => {
       await colony.finalizeTask(taskId);
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 40, otherToken.address), "colony-funding-task-bad-state");
       const colonyPotBalance = await colony.getPotBalance.call(2, otherToken.address);
-      assert.equal(colonyPotBalance.toNumber(), 350 * 1e18);
+      assert.isTrue(colonyPotBalance.eq(toBN(350 * 1e18)));
     });
 
     it("should allow funds to be removed from a task if there are no more payouts of that token to be claimed", async () => {
@@ -457,13 +457,13 @@ contract("Colony Funding", accounts => {
       let colonyPotBalance = await colony.getPotBalance.call(1, 0x0);
       let colonyEtherBalance = await web3GetBalance(colony.address);
       let colonyRewardBalance = await colony.getPotBalance.call(0, 0x0);
-      assert.equal(colonyEtherBalance.toNumber(), 100);
-      assert.equal(colonyPotBalance.toNumber(), 0);
+      assert.equal(colonyEtherBalance, 100);
+      assert.isTrue(colonyPotBalance.isZero());
       await colony.claimColonyFunds(0x0);
       colonyPotBalance = await colony.getPotBalance.call(1, 0x0);
       colonyEtherBalance = await web3GetBalance(colony.address);
       colonyRewardBalance = await colony.getPotBalance.call(0, 0x0);
-      assert.equal(colonyEtherBalance.toNumber(), 100);
+      assert.equal(colonyEtherBalance, 100);
       assert.equal(colonyRewardBalance.toNumber(), 1);
       assert.equal(colonyPotBalance.toNumber(), 99);
     });
@@ -476,7 +476,7 @@ contract("Colony Funding", accounts => {
       const colonyPotBalance = await colony.getPotBalance.call(1, 0x0);
       const colonyEtherBalance = await web3GetBalance(colony.address);
       const pot2Balance = await colony.getPotBalance.call(2, 0x0);
-      assert.equal(colonyEtherBalance.toNumber(), 100);
+      assert.equal(colonyEtherBalance, 100);
       assert.equal(colonyPotBalance.toNumber(), 48);
       assert.equal(pot2Balance.toNumber(), 51);
     });
@@ -493,7 +493,7 @@ contract("Colony Funding", accounts => {
       const colonyPotBalance = await colony.getPotBalance.call(1, 0x0);
       const pot2Balance = await colony.getPotBalance.call(2, 0x0);
       const pot3Balance = await colony.getPotBalance.call(3, 0x0);
-      assert.equal(colonyEtherBalance.toNumber(), 100);
+      assert.equal(colonyEtherBalance, 100);
       assert.equal(colonyPotBalance.toNumber(), 59);
       assert.equal(pot2Balance.toNumber(), 40);
       assert.equal(pot3Balance.toNumber(), 0);
@@ -567,7 +567,7 @@ contract("Colony Funding", accounts => {
       const colonyRewardPotBalance = await colony.getPotBalance.call(0, 0x0);
       const colonyEtherBalance = await web3GetBalance(colony.address);
       const nonRewardPotsTotal = await colony.getNonRewardPotsTotal.call(0x0);
-      assert.equal(colonyEtherBalance.toNumber(), 300);
+      assert.equal(colonyEtherBalance, 300);
       assert.equal(colonyPotBalance.toNumber(), 297);
       assert.equal(colonyRewardPotBalance.toNumber(), 3);
       assert.equal(nonRewardPotsTotal.toNumber(), 297);
@@ -1211,7 +1211,7 @@ contract("Colony Funding", accounts => {
         console.log(
           "Percentage Wrong: ",
           solidityReward
-            .minus(reward)
+            .sub(reward)
             .div(reward)
             .times(100)
             .toString(),

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -1213,7 +1213,7 @@ contract("Colony Funding", accounts => {
           solidityReward
             .sub(reward)
             .div(reward)
-            .times(100)
+            .muln(100)
             .toString(),
           "%"
         );

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -1,10 +1,14 @@
 /* globals artifacts */
-
 import { toBN, sha3 } from "web3-utils";
+import chai from "chai";
+import bnChai from "bn-chai";
 
 import { MANAGER_ROLE, EVALUATOR_ROLE, WORKER_ROLE, WORKER_PAYOUT, INITIAL_FUNDING } from "../helpers/constants";
 import { getTokenArgs, checkErrorRevert, web3GetBalance, forwardTime, currentBlockTime, bnSqrt } from "../helpers/test-helper";
 import { fundColonyWithTokens, setupRatedTask, executeSignedTaskChange, executeSignedRoleAssignment, makeTask } from "../helpers/test-data-generator";
+
+const { expect } = chai;
+chai.use(bnChai(web3.utils.BN));
 
 const EtherRouter = artifacts.require("EtherRouter");
 const IColony = artifacts.require("IColony");
@@ -408,7 +412,7 @@ contract("Colony Funding", accounts => {
       await colony.finalizeTask(taskId);
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 40, otherToken.address), "colony-funding-task-bad-state");
       const colonyPotBalance = await colony.getPotBalance(2, otherToken.address);
-      assert.isTrue(colonyPotBalance.eq(toBN(350 * 1e18)));
+      expect(colonyPotBalance).to.eq.BN(toBN(350 * 10 ** 18));
     });
 
     it("should allow funds to be removed from a task if there are no more payouts of that token to be claimed", async () => {
@@ -458,7 +462,7 @@ contract("Colony Funding", accounts => {
       let colonyEtherBalance = await web3GetBalance(colony.address);
       let colonyRewardBalance = await colony.getPotBalance(0, 0x0);
       assert.equal(colonyEtherBalance, 100);
-      assert.isTrue(colonyPotBalance.isZero());
+      expect(colonyPotBalance).to.be.zero; // eslint-disable-line no-unused-expressions
       await colony.claimColonyFunds(0x0);
       colonyPotBalance = await colony.getPotBalance(1, 0x0);
       colonyEtherBalance = await web3GetBalance(colony.address);

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -1156,7 +1156,7 @@ contract("Colony Funding", accounts => {
         });
 
         ({ logs } = await newColony.startNextRewardPayout(payoutToken.address));
-        const payoutId = logs[0].args.id.toNumber();
+        const payoutId = logs[0].args.id;
 
         // Getting total amount available for payout
         const amountAvailableForPayout = await newColony.getPotBalance(0, payoutToken.address);

--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -1,8 +1,13 @@
 /* globals artifacts */
 import { BN } from "bn.js";
+import chai from "chai";
+import bnChai from "bn-chai";
 
 import { getTokenArgs, web3GetTransactionReceipt, web3GetCode, checkErrorRevert, forwardTime, getBlockTime } from "../helpers/test-helper";
 import { giveUserCLNYTokens } from "../helpers/test-data-generator";
+
+const { expect } = chai;
+chai.use(bnChai(web3.utils.BN));
 
 const EtherRouter = artifacts.require("EtherRouter");
 const IColony = artifacts.require("IColony");
@@ -180,13 +185,13 @@ contract("ColonyNetworkAuction", accounts => {
         const currentPriceString = currentPrice.toString(10);
         // Chai assert.closeTo does not work with Big Numbers so some manual comaring to error margin is required
         const differencePrices = auctionProp.price.sub(new BN(currentPriceString));
-        assert.isTrue(differencePrices.lte(errorMarginPrice));
+        expect(differencePrices).to.be.lte.BN(errorMarginPrice);
 
         const totalToEndAuction = await tokenAuction.totalToEndAuction();
         const amount = new BN(currentPriceString).mul(quantity).div(new BN(10).pow(new BN(18)));
         const errorMarginQuantity = amount.divn(100);
         const differenceQuantity = totalToEndAuction.sub(amount);
-        assert.isTrue(differenceQuantity.lte(errorMarginQuantity));
+        expect(differenceQuantity).to.be.lte.BN(errorMarginQuantity);
       });
     });
 

--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -30,7 +30,7 @@ contract("ColonyNetworkAuction", accounts => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
 
-    const metaColonyAddress = await colonyNetwork.getMetaColony.call();
+    const metaColonyAddress = await colonyNetwork.getMetaColony();
     metaColony = await IColony.at(metaColonyAddress);
   });
 
@@ -51,9 +51,9 @@ contract("ColonyNetworkAuction", accounts => {
 
   describe("when initialising an auction", async () => {
     it("should initialise auction with correct given parameters", async () => {
-      const clnyAddress = await tokenAuction.clnyToken.call();
+      const clnyAddress = await tokenAuction.clnyToken();
       assert.equal(clnyAddress, clny.address);
-      const tokenAddress = await tokenAuction.token.call();
+      const tokenAddress = await tokenAuction.token();
       assert.equal(tokenAddress, token.address);
     });
 
@@ -74,10 +74,10 @@ contract("ColonyNetworkAuction", accounts => {
 
   describe("when starting an auction", async () => {
     it("should set the `quantity` correctly and minPrice to 1", async () => {
-      const quantityNow = await tokenAuction.quantity.call();
+      const quantityNow = await tokenAuction.quantity();
       assert.equal(quantityNow.toString(10), quantity.toString());
 
-      const minPrice = await tokenAuction.minPrice.call();
+      const minPrice = await tokenAuction.minPrice();
       assert.equal(minPrice.toString(10), 1);
     });
 
@@ -89,7 +89,7 @@ contract("ColonyNetworkAuction", accounts => {
       const { logs } = await colonyNetwork.startTokenAuction(otherToken.address);
       const auctionAddress = logs[0].args.auction;
       tokenAuction = await DutchAuction.at(auctionAddress);
-      const minPrice = await tokenAuction.minPrice.call();
+      const minPrice = await tokenAuction.minPrice();
       assert.equal(minPrice.toString(10), 10);
     });
 
@@ -102,7 +102,7 @@ contract("ColonyNetworkAuction", accounts => {
     });
 
     it("should set the `started` property correctly", async () => {
-      const started = await tokenAuction.started.call();
+      const started = await tokenAuction.started();
       assert.isTrue(started);
     });
 
@@ -174,7 +174,7 @@ contract("ColonyNetworkAuction", accounts => {
     auctionProps.forEach(async auctionProp => {
       it(`should correctly calculate price and remaining CLNY amount to end auction at duration ${auctionProp.duration}`, async () => {
         await forwardTime(auctionProp.duration, this);
-        const currentPrice = await tokenAuction.price.call();
+        const currentPrice = await tokenAuction.price();
         // Expect up to 1% error margin because of forwarding block time inaccuracies
         const errorMarginPrice = auctionProp.price.divn(100);
         const currentPriceString = currentPrice.toString(10);
@@ -182,7 +182,7 @@ contract("ColonyNetworkAuction", accounts => {
         const differencePrices = auctionProp.price.sub(new BN(currentPriceString));
         assert.isTrue(differencePrices.lte(errorMarginPrice));
 
-        const totalToEndAuction = await tokenAuction.totalToEndAuction.call();
+        const totalToEndAuction = await tokenAuction.totalToEndAuction();
         const amount = new BN(currentPriceString).mul(quantity).div(new BN(10).pow(new BN(18)));
         const errorMarginQuantity = amount.divn(100);
         const differenceQuantity = totalToEndAuction.sub(amount);
@@ -208,9 +208,9 @@ contract("ColonyNetworkAuction", accounts => {
       await giveUserCLNYTokens(colonyNetwork, BIDDER_1, "1000000000000000000");
       await clny.approve(tokenAuction.address, "1000000000000000000", { from: BIDDER_1 });
       await tokenAuction.bid("1000000000000000000", { from: BIDDER_1 });
-      const bid = await tokenAuction.bids.call(BIDDER_1);
+      const bid = await tokenAuction.bids(BIDDER_1);
       assert.equal(bid, "1000000000000000000");
-      const bidCount = await tokenAuction.bidCount.call();
+      const bidCount = await tokenAuction.bidCount();
       assert.equal(bidCount.toNumber(), 1);
     });
 
@@ -218,7 +218,7 @@ contract("ColonyNetworkAuction", accounts => {
       await giveUserCLNYTokens(colonyNetwork, BIDDER_1, "1000000000000000000");
       await clny.approve(tokenAuction.address, "1000000000000000000", { from: BIDDER_1 });
       await tokenAuction.bid("1000000000000000000", { from: BIDDER_1 });
-      const lockedTokens = await clny.balanceOf.call(tokenAuction.address);
+      const lockedTokens = await clny.balanceOf(tokenAuction.address);
       assert.equal(lockedTokens.toString(), "1000000000000000000");
     });
 
@@ -227,7 +227,7 @@ contract("ColonyNetworkAuction", accounts => {
       await clny.approve(tokenAuction.address, "2000000000000000000", { from: BIDDER_1 });
       await tokenAuction.bid("1100000000000000000", { from: BIDDER_1 });
       await tokenAuction.bid("900000000000000000", { from: BIDDER_1 });
-      const bidCount = await tokenAuction.bidCount.call();
+      const bidCount = await tokenAuction.bidCount();
       assert.equal(bidCount.toNumber(), 1);
     });
 
@@ -246,10 +246,10 @@ contract("ColonyNetworkAuction", accounts => {
       const receipt = await web3GetTransactionReceipt(tx);
       const bidReceiptBlock = receipt.blockNumber;
       const blockTime = await getBlockTime(bidReceiptBlock);
-      const endTime = await tokenAuction.endTime.call();
+      const endTime = await tokenAuction.endTime();
       assert.equal(endTime.toString(), blockTime);
 
-      const bidCount = await tokenAuction.bidCount.call();
+      const bidCount = await tokenAuction.bidCount();
       assert.equal(bidCount.toNumber(), 3);
     });
 
@@ -257,10 +257,10 @@ contract("ColonyNetworkAuction", accounts => {
       const amount = clnyNeededForMaxPriceAuctionSellout.addn(20).toString();
       await giveUserCLNYTokens(colonyNetwork, BIDDER_1, amount);
       await clny.approve(tokenAuction.address, amount, { from: BIDDER_1 });
-      const totalToEndAuction = await tokenAuction.totalToEndAuction.call();
+      const totalToEndAuction = await tokenAuction.totalToEndAuction();
       await tokenAuction.bid(amount, { from: BIDDER_1 });
-      const receivedTotal = await tokenAuction.receivedTotal.call();
-      const bid = await tokenAuction.bids.call(BIDDER_1);
+      const receivedTotal = await tokenAuction.receivedTotal();
+      const bid = await tokenAuction.bids(BIDDER_1);
       assert(bid.lte(totalToEndAuction));
       assert(receivedTotal.lte(totalToEndAuction));
       assert.equal(receivedTotal.toString(), bid.toString());
@@ -294,28 +294,28 @@ contract("ColonyNetworkAuction", accounts => {
 
     it("sets correct final token price", async () => {
       await tokenAuction.finalize();
-      const receivedTotal = await tokenAuction.receivedTotal.call();
+      const receivedTotal = await tokenAuction.receivedTotal();
       const endPrice = new BN(10)
         .pow(new BN(18))
         .mul(new BN(receivedTotal.toString(10)))
         .div(quantity)
         .addn(1);
-      const finalPrice = await tokenAuction.finalPrice.call();
+      const finalPrice = await tokenAuction.finalPrice();
       assert.equal(endPrice.toString(), finalPrice.toString(10));
     });
 
     it("sets the finalized property", async () => {
       await tokenAuction.finalize();
-      const finalized = await tokenAuction.finalized.call();
+      const finalized = await tokenAuction.finalized();
       assert.isTrue(finalized);
     });
 
     it("Colony network gets all CLNY sent to the auction in bids", async () => {
-      const balanceBefore = await clny.balanceOf.call(colonyNetwork.address);
+      const balanceBefore = await clny.balanceOf(colonyNetwork.address);
       await tokenAuction.finalize();
-      const receivedTotal = await tokenAuction.receivedTotal.call();
+      const receivedTotal = await tokenAuction.receivedTotal();
       assert.isFalse(receivedTotal.isZero());
-      const balanceAfter = await clny.balanceOf.call(colonyNetwork.address);
+      const balanceAfter = await clny.balanceOf(colonyNetwork.address);
       assert.equal(balanceBefore.add(receivedTotal).toString(), balanceAfter.toString());
     });
 
@@ -355,7 +355,7 @@ contract("ColonyNetworkAuction", accounts => {
       await tokenAuction.bid(bidAmount3.toString(), { from: BIDDER_3 });
 
       await tokenAuction.finalize();
-      const finalPrice = await tokenAuction.finalPrice.call();
+      const finalPrice = await tokenAuction.finalPrice();
       const finalPriceString = finalPrice.toString();
 
       let claimCount;
@@ -363,10 +363,10 @@ contract("ColonyNetworkAuction", accounts => {
       let tokensToClaim;
 
       await tokenAuction.claim({ from: BIDDER_1 });
-      claimCount = await tokenAuction.claimCount.call();
+      claimCount = await tokenAuction.claimCount();
       assert.equal(claimCount.toNumber(), 1);
 
-      tokenBidderBalance = await token.balanceOf.call(BIDDER_1);
+      tokenBidderBalance = await token.balanceOf(BIDDER_1);
       tokensToClaim = new BN(10)
         .pow(new BN(18))
         .mul(bidAmount1)
@@ -374,20 +374,20 @@ contract("ColonyNetworkAuction", accounts => {
       assert.equal(tokenBidderBalance.toString(10), tokensToClaim.toString());
 
       await tokenAuction.claim({ from: BIDDER_2 });
-      claimCount = await tokenAuction.claimCount.call();
+      claimCount = await tokenAuction.claimCount();
       assert.equal(claimCount.toNumber(), 2);
-      tokenBidderBalance = await token.balanceOf.call(BIDDER_2);
+      tokenBidderBalance = await token.balanceOf(BIDDER_2);
       tokensToClaim = new BN(10)
         .pow(new BN(18))
         .mul(bidAmount2)
         .div(new BN(finalPriceString));
       assert.equal(tokenBidderBalance.toString(10), tokensToClaim.toString());
 
-      const bid3 = await tokenAuction.bids.call(BIDDER_3);
+      const bid3 = await tokenAuction.bids(BIDDER_3);
       await tokenAuction.claim({ from: BIDDER_3 });
-      claimCount = await tokenAuction.claimCount.call();
+      claimCount = await tokenAuction.claimCount();
       assert.equal(claimCount.toNumber(), 3);
-      tokenBidderBalance = await token.balanceOf.call(BIDDER_3);
+      tokenBidderBalance = await token.balanceOf(BIDDER_3);
       const bid3BN = new BN(bid3.toString(10));
       tokensToClaim = new BN(10)
         .pow(new BN(18))
@@ -402,7 +402,7 @@ contract("ColonyNetworkAuction", accounts => {
       await tokenAuction.bid(clnyNeededForMaxPriceAuctionSellout.toString(), { from: BIDDER_1 });
       await tokenAuction.finalize();
       await tokenAuction.claim({ from: BIDDER_1 });
-      const bid = await tokenAuction.bids.call(BIDDER_1);
+      const bid = await tokenAuction.bids(BIDDER_1);
       assert.equal(bid.toNumber(), 0);
     });
   });

--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -232,7 +232,7 @@ contract("ColonyNetworkAuction", accounts => {
     });
 
     it("once target reached, endTime is set correctly", async () => {
-      const amount = clnyNeededForMaxPriceAuctionSellout.divn(3).toString();
+      const amount = clnyNeededForMaxPriceAuctionSellout.divn(3).toString(10);
       await giveUserCLNYTokens(colonyNetwork, BIDDER_1, amount);
       await giveUserCLNYTokens(colonyNetwork, BIDDER_2, amount);
       await giveUserCLNYTokens(colonyNetwork, BIDDER_3, amount);

--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -28,10 +28,10 @@ contract("ColonyNetworkAuction", accounts => {
     quantity = new BN(10).pow(new BN(36)).muln(3);
     clnyNeededForMaxPriceAuctionSellout = new BN(10).pow(new BN(54)).muln(3);
     const etherRouter = await EtherRouter.deployed();
-    colonyNetwork = IColonyNetwork.at(etherRouter.address);
+    colonyNetwork = await IColonyNetwork.at(etherRouter.address);
 
     const metaColonyAddress = await colonyNetwork.getMetaColony.call();
-    metaColony = IColony.at(metaColonyAddress);
+    metaColony = await IColony.at(metaColonyAddress);
   });
 
   beforeEach(async () => {
@@ -46,7 +46,7 @@ contract("ColonyNetworkAuction", accounts => {
     const { logs, receipt } = await colonyNetwork.startTokenAuction(token.address);
     createAuctionTxReceipt = receipt;
     const auctionAddress = logs[0].args.auction;
-    tokenAuction = DutchAuction.at(auctionAddress);
+    tokenAuction = await DutchAuction.at(auctionAddress);
   });
 
   describe("when initialising an auction", async () => {
@@ -88,7 +88,7 @@ contract("ColonyNetworkAuction", accounts => {
       await otherToken.transfer(colonyNetwork.address, 1e17);
       const { logs } = await colonyNetwork.startTokenAuction(otherToken.address);
       const auctionAddress = logs[0].args.auction;
-      tokenAuction = DutchAuction.at(auctionAddress);
+      tokenAuction = await DutchAuction.at(auctionAddress);
       const minPrice = await tokenAuction.minPrice.call();
       assert.equal(minPrice.toString(10), 10);
     });

--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -232,7 +232,7 @@ contract("ColonyNetworkAuction", accounts => {
     });
 
     it("once target reached, endTime is set correctly", async () => {
-      const amount = clnyNeededForMaxPriceAuctionSellout.divn(3).toString(10);
+      const amount = clnyNeededForMaxPriceAuctionSellout.divn(3).toString();
       await giveUserCLNYTokens(colonyNetwork, BIDDER_1, amount);
       await giveUserCLNYTokens(colonyNetwork, BIDDER_2, amount);
       await giveUserCLNYTokens(colonyNetwork, BIDDER_3, amount);
@@ -314,7 +314,7 @@ contract("ColonyNetworkAuction", accounts => {
       const balanceBefore = await clny.balanceOf.call(colonyNetwork.address);
       await tokenAuction.finalize();
       const receivedTotal = await tokenAuction.receivedTotal.call();
-      assert.notEqual(receivedTotal.toNumber(), 0);
+      assert.isFalse(receivedTotal.isZero());
       const balanceAfter = await clny.balanceOf.call(colonyNetwork.address);
       assert.equal(balanceBefore.add(receivedTotal).toString(), balanceAfter.toString());
     });

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -1984,9 +1984,8 @@ contract("ColonyNetworkMining", accounts => {
           await repCycle.confirmNewHash(0);
 
           addr = await colonyNetwork.getReputationMiningCycle(true);
-          repCycle = ReputationMiningCycle.at(addr);
+          repCycle = await ReputationMiningCycle.at(addr);
           await forwardTime(3600, this);
-          const repCycle = await ReputationMiningCycle.at(addr);
 
           badClient = new MaliciousReputationMinerExtraRep(
             { loader: contractLoader, minerAddress: MAIN_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -77,7 +77,7 @@ contract("ColonyNetworkMining", accounts => {
     let repCycle = await ReputationMiningCycle.at(addr);
 
     await forwardTime(3600, this);
-    await repCycle.submitRootHash("0x0", 0, 10);
+    await repCycle.submitRootHash("0x01", 0, 10);
     await repCycle.confirmNewHash(0);
 
     // Advance another reputation cycle
@@ -1467,7 +1467,13 @@ contract("ColonyNetworkMining", accounts => {
       let addr = await colonyNetwork.getReputationMiningCycle(true);
       await forwardTime(3600, this);
       let repCycle = await ReputationMiningCycle.at(addr);
+      await repCycle.submitRootHash("0x01", 0, 10);
       await repCycle.confirmNewHash(0);
+      await forwardTime(3600, this);
+      addr = await colonyNetwork.getReputationMiningCycle(true);
+      repCycle = await ReputationMiningCycle.at(addr);
+
+      badClient = new MaliciousReputationMinerExtraRep(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         27,
         0xfffffffff
@@ -1980,7 +1986,7 @@ contract("ColonyNetworkMining", accounts => {
           let addr = await colonyNetwork.getReputationMiningCycle(true);
           let repCycle = await ReputationMiningCycle.at(addr);
           await forwardTime(3600, this);
-          await repCycle.submitRootHash("0x0", 0, 10);
+          await repCycle.submitRootHash("0x01", 0, 10);
           await repCycle.confirmNewHash(0);
 
           addr = await colonyNetwork.getReputationMiningCycle(true);
@@ -2554,7 +2560,7 @@ contract("ColonyNetworkMining", accounts => {
       await metaColony.finalizeTask(taskId);
 
       let addr = await colonyNetwork.getReputationMiningCycle(true);
-      let repCycle = ReputationMiningCycle.at(addr);
+      let repCycle = await ReputationMiningCycle.at(addr);
       await forwardTime(3600, this);
       await repCycle.submitRootHash("0x12345678", 0, 10);
       await repCycle.confirmNewHash(0);
@@ -2563,7 +2569,7 @@ contract("ColonyNetworkMining", accounts => {
       // update cycle, and 2x4 reputation updates for the task completions (manager, worker (domain and skill), evaluator);
       // That's 9 in total.
       addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = ReputationMiningCycle.at(addr);
+      repCycle = await ReputationMiningCycle.at(addr);
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 9);
 
@@ -2638,14 +2644,14 @@ contract("ColonyNetworkMining", accounts => {
 
       // Get current cycle & advance to next
       let addr = await colonyNetwork.getReputationMiningCycle(true);
-      let repCycle = ReputationMiningCycle.at(addr);
+      let repCycle = await ReputationMiningCycle.at(addr);
       await forwardTime(3600, this);
       await repCycle.submitRootHash("0x12345678", 0, 10);
       await repCycle.confirmNewHash(0);
 
       // Get current cycle
       addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = ReputationMiningCycle.at(addr);
+      repCycle = await ReputationMiningCycle.at(addr);
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 13);
 

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -808,7 +808,7 @@ contract("ColonyNetworkMining", accounts => {
       addr = await colonyNetwork.getReputationMiningCycle(true);
       repCycle = await ReputationMiningCycle.at(addr);
       await forwardTime(3600, this);
-      await repCycle.submitRootHash("0x12345679", 0, 10);
+      await repCycle.submitRootHash("0x00", 0, 10);
       await repCycle.confirmNewHash(0);
       addr = await colonyNetwork.getReputationMiningCycle(true);
       repCycle = await ReputationMiningCycle.at(addr);
@@ -913,6 +913,12 @@ contract("ColonyNetworkMining", accounts => {
         addr = await colonyNetwork.getReputationMiningCycle(true);
         repCycle = await ReputationMiningCycle.at(addr);
         await forwardTime(3600, this);
+        await repCycle.submitRootHash("0x00", 0, 10);
+        await repCycle.confirmNewHash(0);
+
+        addr = await colonyNetwork.getReputationMiningCycle(true);
+        repCycle = await ReputationMiningCycle.at(addr);
+
         await goodClient.addLogContentsToReputationTree();
         await goodClient.submitRootHash();
 
@@ -962,7 +968,7 @@ contract("ColonyNetworkMining", accounts => {
       addr = await colonyNetwork.getReputationMiningCycle(true);
       repCycle = await ReputationMiningCycle.at(addr);
       await forwardTime(3600, this);
-      await repCycle.submitRootHash("0x12345679", 0, 10);
+      await repCycle.submitRootHash("0x00", 0, 10);
       await repCycle.confirmNewHash(0);
       addr = await colonyNetwork.getReputationMiningCycle(true);
       repCycle = await ReputationMiningCycle.at(addr);
@@ -1099,7 +1105,7 @@ contract("ColonyNetworkMining", accounts => {
       addr = await colonyNetwork.getReputationMiningCycle(true);
       repCycle = await ReputationMiningCycle.at(addr);
       await forwardTime(3600, this);
-      await repCycle.submitRootHash("0x12345679", 0, 10);
+      await repCycle.submitRootHash("0x00", 0, 10);
       await repCycle.confirmNewHash(0);
       addr = await colonyNetwork.getReputationMiningCycle(true);
       repCycle = await ReputationMiningCycle.at(addr);
@@ -1179,7 +1185,7 @@ contract("ColonyNetworkMining", accounts => {
       addr = await colonyNetwork.getReputationMiningCycle(true);
       repCycle = await ReputationMiningCycle.at(addr);
       await forwardTime(3600, this);
-      await repCycle.submitRootHash("0x12345679", 0, 10);
+      await repCycle.submitRootHash("0x00", 0, 10);
       await repCycle.confirmNewHash(0);
       addr = await colonyNetwork.getReputationMiningCycle(true);
       repCycle = await ReputationMiningCycle.at(addr);
@@ -1790,7 +1796,7 @@ contract("ColonyNetworkMining", accounts => {
       let reputationMiningCycleAddress = await colonyNetwork.getReputationMiningCycle(true);
       let repCycle = await ReputationMiningCycle.at(reputationMiningCycleAddress);
       await forwardTime(3600, this);
-      await repCycle.submitRootHash("0x12345679", 0, 10);
+      await repCycle.submitRootHash("0x00", 0, 10);
       await repCycle.confirmNewHash(0);
 
       const clients = await Promise.all(
@@ -2063,7 +2069,7 @@ contract("ColonyNetworkMining", accounts => {
       let reputationMiningCycleAddress = await colonyNetwork.getReputationMiningCycle(true);
       let repCycle = await ReputationMiningCycle.at(reputationMiningCycleAddress);
       await forwardTime(3600, this);
-      await repCycle.submitRootHash("0x12345679", 0, 10);
+      await repCycle.submitRootHash("0x00", 0, 10);
       await repCycle.confirmNewHash(0);
       const clients = await Promise.all(
         accounts.slice(0, nClients).map(async (addr, index) => {
@@ -2205,7 +2211,7 @@ contract("ColonyNetworkMining", accounts => {
         workerRating: 1
       });
       await metaColony.finalizeTask(taskId);
-      await repCycle.submitRootHash("0x12345679", 0, 10);
+      await repCycle.submitRootHash("0x00", 0, 10);
       await repCycle.confirmNewHash(0);
       await forwardTime(3600, this);
 
@@ -2251,7 +2257,7 @@ contract("ColonyNetworkMining", accounts => {
       });
       await metaColony.finalizeTask(taskId);
 
-      await repCycle.submitRootHash("0x12345679", 0, 10);
+      await repCycle.submitRootHash("0x00", 0, 10);
       await repCycle.confirmNewHash(0);
       await forwardTime(3600, this);
 
@@ -2689,7 +2695,7 @@ contract("ColonyNetworkMining", accounts => {
       await forwardTime(3600, this);
       addr = await colonyNetwork.getReputationMiningCycle(true);
       repCycle = await ReputationMiningCycle.at(addr);
-      await repCycle.submitRootHash("0x12345679", 10, 10);
+      await repCycle.submitRootHash("0x00", 10, 10);
       await repCycle.confirmNewHash(0);
 
       const client = new ReputationMiner({ loader: contractLoader, minerAddress: MAIN_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree });

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -1958,7 +1958,7 @@ contract("ColonyNetworkMining", accounts => {
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
 
-      await checkErrorRevert(repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 0x0, [], 0x0, [], 0x0, [], 0, 0, []));
+      await checkErrorRevert(repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "0x01", [], "0x01", [], "0x01", [], "0x01", "0x01", []));
 
       // Cleanup
       await badClient.respondToBinarySearchForChallenge();

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -200,8 +200,8 @@ contract("ColonyNetworkMining", accounts => {
       accounts.map(async address => {
         const info = await tokenLocking.getUserLock(clny.address, address);
         const stakedBalance = info[1];
-        if (stakedBalance.toNumber() > 0) {
-          await tokenLocking.withdraw(clny.address, stakedBalance.toNumber(), { from: address });
+        if (stakedBalance.gt(new BN(0))) {
+          await tokenLocking.withdraw(clny.address, stakedBalance.toString(), { from: address });
         }
         const userBalance = await clny.balanceOf.call(address);
         return clny.transfer(0x0, userBalance, { from: address });

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -859,10 +859,10 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
       let addr = await colonyNetwork.getReputationMiningCycle(true);
-      let repCycle = ReputationMiningCycle.at(addr);
+      let repCycle = await ReputationMiningCycle.at(addr);
       await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = ReputationMiningCycle.at(addr);
+      repCycle = await ReputationMiningCycle.at(addr);
       await forwardTime(3600, this);
       await goodClient.addLogContentsToReputationTree();
       await goodClient.submitRootHash();
@@ -879,7 +879,7 @@ contract("ColonyNetworkMining", accounts => {
 
       await repCycle.confirmNewHash(0);
       addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = ReputationMiningCycle.at(addr);
+      repCycle = await ReputationMiningCycle.at(addr);
 
       await goodClient.addLogContentsToReputationTree();
       await badClient.addLogContentsToReputationTree();
@@ -934,7 +934,7 @@ contract("ColonyNetworkMining", accounts => {
 
         await repCycle.confirmNewHash(0);
         addr = await colonyNetwork.getReputationMiningCycle(true);
-        repCycle = ReputationMiningCycle.at(addr);
+        repCycle = await ReputationMiningCycle.at(addr);
 
         await goodClient.addLogContentsToReputationTree();
         await badClient.addLogContentsToReputationTree();
@@ -1328,18 +1328,18 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
       let addr = await colonyNetwork.getReputationMiningCycle(true);
-      let repCycle = ReputationMiningCycle.at(addr);
+      let repCycle = await ReputationMiningCycle.at(addr);
       await forwardTime(3600, this);
       await repCycle.submitRootHash("0x12345678", 10, 10);
       await repCycle.confirmNewHash(0);
       await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = ReputationMiningCycle.at(addr);
+      repCycle = await ReputationMiningCycle.at(addr);
       await forwardTime(3600, this);
       await repCycle.submitRootHash("0x0", 0, 10);
       await repCycle.confirmNewHash(0);
       addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = ReputationMiningCycle.at(addr);
+      repCycle = await ReputationMiningCycle.at(addr);
 
       await goodClient.addLogContentsToReputationTree();
 
@@ -1389,7 +1389,7 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
       addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = ReputationMiningCycle.at(addr);
+      repCycle = await ReputationMiningCycle.at(addr);
       await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
 
       await badClient.addLogContentsToReputationTree();
@@ -1568,12 +1568,12 @@ contract("ColonyNetworkMining", accounts => {
 
       let addr = await colonyNetwork.getReputationMiningCycle(true);
       await forwardTime(3600, this);
-      let repCycle = ReputationMiningCycle.at(addr);
+      let repCycle = await ReputationMiningCycle.at(addr);
       await repCycle.submitRootHash("0x0", 0, 10);
       await repCycle.confirmNewHash(0);
       await forwardTime(3600, this);
       addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = ReputationMiningCycle.at(addr);
+      repCycle = await ReputationMiningCycle.at(addr);
       await badClient.initialise(colonyNetwork.address);
 
       badClient.entryToFalsify = "-1";
@@ -1584,7 +1584,7 @@ contract("ColonyNetworkMining", accounts => {
       await repCycle.confirmNewHash(0);
       await forwardTime(3600, this);
       addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = ReputationMiningCycle.at(addr);
+      repCycle = await ReputationMiningCycle.at(addr);
 
       badClient.entryToFalsify = "1";
 
@@ -2326,7 +2326,7 @@ contract("ColonyNetworkMining", accounts => {
       await forwardTime(3600, this);
 
       addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = ReputationMiningCycle.at(addr);
+      repCycle = await ReputationMiningCycle.at(addr);
 
       await goodClient.addLogContentsToReputationTree();
       await badClient.addLogContentsToReputationTree();
@@ -2353,7 +2353,7 @@ contract("ColonyNetworkMining", accounts => {
 
       await forwardTime(3600, this);
       let addr = await colonyNetwork.getReputationMiningCycle(true);
-      let repCycle = ReputationMiningCycle.at(addr);
+      let repCycle = await ReputationMiningCycle.at(addr);
       const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId();
 
       await goodClient.insert(
@@ -2731,7 +2731,7 @@ contract("ColonyNetworkMining", accounts => {
 
       await forwardTime(3600, this);
       let addr = await colonyNetwork.getReputationMiningCycle(true);
-      let repCycle = ReputationMiningCycle.at(addr);
+      let repCycle = await ReputationMiningCycle.at(addr);
       const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId;
 
       await goodClient.insert(metaColony.address, rootGlobalSkill, "0x0000000000000000000000000000000000000000", new BN("1"), 0);
@@ -2752,7 +2752,7 @@ contract("ColonyNetworkMining", accounts => {
       );
 
       addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = ReputationMiningCycle.at(addr);
+      repCycle = await ReputationMiningCycle.at(addr);
 
       await goodClient.addLogContentsToReputationTree();
       await badClient.addLogContentsToReputationTree();
@@ -2801,7 +2801,7 @@ contract("ColonyNetworkMining", accounts => {
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
 
       addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = ReputationMiningCycle.at(addr);
+      repCycle = await ReputationMiningCycle.at(addr);
       await repCycle.confirmNewHash(1);
 
       // Check it 'decayed' from 0 to 0

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -1267,7 +1267,7 @@ contract("ColonyNetworkMining", accounts => {
       let addr = await colonyNetwork.getReputationMiningCycle.call(true);
       await forwardTime(3600, this);
       let repCycle = ReputationMiningCycle.at(addr);
-      await repCycle.submitRootHash("0x0", 0, 10);
+      await repCycle.submitRootHash("0x01", 0, 10);
       await repCycle.confirmNewHash(0);
       await forwardTime(3600, this);
       addr = await colonyNetwork.getReputationMiningCycle.call(true);
@@ -1467,7 +1467,7 @@ contract("ColonyNetworkMining", accounts => {
       let addr = await colonyNetwork.getReputationMiningCycle.call(true);
       await forwardTime(3600, this);
       let repCycle = ReputationMiningCycle.at(addr);
-      await repCycle.submitRootHash("0x0", 0, 10);
+      await repCycle.submitRootHash("0x01", 0, 10);
       await repCycle.confirmNewHash(0);
       await forwardTime(3600, this);
       addr = await colonyNetwork.getReputationMiningCycle.call(true);

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -206,8 +206,8 @@ contract("ColonyNetwork", accounts => {
       const token = await Token.new(...TOKEN_ARGS);
       const { logs } = await colonyNetwork.createColony(token.address);
       const { colonyAddress } = logs[0].args;
-      const colonyEtherRouter = EtherRouter.at(colonyAddress);
-      const colony = Colony.at(colonyAddress);
+      const colonyEtherRouter = await EtherRouter.at(colonyAddress);
+      const colony = await Colony.at(colonyAddress);
 
       const sampleResolver = "0x65a760e7441cf435086ae45e14a0c8fc1080f54c";
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
@@ -230,14 +230,14 @@ contract("ColonyNetwork", accounts => {
       const newVersion = currentColonyVersion.add(1).toNumber();
       await colonyNetwork.addColonyVersion(newVersion, sampleResolver);
 
-      await checkErrorRevert(EtherRouter.at(colony.address).setResolver(sampleResolver));
+      await checkErrorRevert(await EtherRouter.at(colony.address).setResolver(sampleResolver));
     });
 
     it("should NOT be able to upgrade a colony to a lower version", async () => {
       const token = await Token.new(...TOKEN_ARGS);
       const { logs } = await colonyNetwork.createColony(token.address);
       const { colonyAddress } = logs[0].args;
-      const colony = Colony.at(colonyAddress);
+      const colony = await Colony.at(colonyAddress);
 
       const sampleResolver = "0x65a760e7441cf435086ae45e14a0c8fc1080f54c";
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
@@ -254,7 +254,7 @@ contract("ColonyNetwork", accounts => {
       const { colonyAddress } = logs[0].args;
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
       const newVersion = currentColonyVersion.add(1).toNumber();
-      const colony = Colony.at(colonyAddress);
+      const colony = await Colony.at(colonyAddress);
 
       await checkErrorRevert(colony.upgrade(newVersion));
       assert.equal(version.toNumber(), currentColonyVersion.toNumber());
@@ -266,7 +266,7 @@ contract("ColonyNetwork", accounts => {
       const { colonyAddress } = logs[0].args;
       const colonyEtherRouter = await EtherRouter.at(colonyAddress);
       const colonyResolver = await colonyEtherRouter.resolver.call();
-      const colony = Colony.at(colonyAddress);
+      const colony = await Colony.at(colonyAddress);
 
       const sampleResolver = "0x65a760e7441cf435086ae45e14a0c8fc1080f54c";
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -28,7 +28,7 @@ contract("ColonyNetwork", accounts => {
 
   before(async () => {
     const network = await web3GetNetwork();
-    createColonyGas = network === "coverage" ? "0xfffffffffff" : 4e6;
+    createColonyGas = network === "1999" ? "0xfffffffffff" : 4e6;
     resolverColonyNetworkDeployed = await Resolver.deployed();
   });
 

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -34,7 +34,7 @@ contract("ColonyNetwork", accounts => {
 
   beforeEach(async () => {
     const colony = await Colony.new();
-    version = await colony.version.call();
+    version = await colony.version();
     resolver = await Resolver.new();
     colonyFunding = await ColonyFunding.new();
     colonyTask = await ColonyTask.new();
@@ -53,33 +53,33 @@ contract("ColonyNetwork", accounts => {
     });
 
     it("should have the correct current Colony version set", async () => {
-      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
+      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       assert.equal(version.toNumber(), currentColonyVersion.toNumber());
     });
 
     it("should have the Resolver for current Colony version set", async () => {
-      const currentResolver = await colonyNetwork.getColonyVersionResolver.call(version.toNumber());
+      const currentResolver = await colonyNetwork.getColonyVersionResolver(version.toNumber());
       assert.equal(currentResolver, resolver.address);
     });
 
     it("should be able to register a higher Colony contract version", async () => {
       const sampleResolver = "0x65a760e7441cf435086ae45e14a0c8fc1080f54c";
-      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
+      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       const updatedVersion = currentColonyVersion.addn(1).toNumber();
       await colonyNetwork.addColonyVersion(updatedVersion, sampleResolver);
 
-      const updatedColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
+      const updatedColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       assert.equal(updatedColonyVersion.toNumber(), updatedVersion);
-      const currentResolver = await colonyNetwork.getColonyVersionResolver.call(updatedVersion);
+      const currentResolver = await colonyNetwork.getColonyVersionResolver(updatedVersion);
       assert.equal(currentResolver.toLowerCase(), sampleResolver);
     });
 
     it("when registering a lower version of the Colony contract, should NOT update the current (latest) colony version", async () => {
       const sampleResolver = "0x65a760e7441cf435086ae45e14a0c8fc1080f54c";
-      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
+      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       await colonyNetwork.addColonyVersion(currentColonyVersion.subn(1).toNumber(), sampleResolver);
 
-      const updatedColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
+      const updatedColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       assert.equal(updatedColonyVersion.toNumber(), currentColonyVersion.toNumber());
     });
   });
@@ -89,7 +89,7 @@ contract("ColonyNetwork", accounts => {
       const token = await Token.new(...TOKEN_ARGS);
       const { logs } = await colonyNetwork.createColony(token.address);
       const { colonyAddress } = logs[0].args;
-      const colonyCount = await colonyNetwork.getColonyCount.call();
+      const colonyCount = await colonyNetwork.getColonyCount();
       assert.notEqual(colonyAddress, 0x0);
       assert.equal(colonyCount.toNumber(), 1);
     });
@@ -103,59 +103,59 @@ contract("ColonyNetwork", accounts => {
       await colonyNetwork.createColony(token.address);
       await colonyNetwork.createColony(token.address);
       await colonyNetwork.createColony(token.address);
-      const colonyCount = await colonyNetwork.getColonyCount.call();
+      const colonyCount = await colonyNetwork.getColonyCount();
       assert.equal(colonyCount.toNumber(), 7);
     });
 
     it("when meta colony is created, should have the root global and local skills initialised, plus the local mining skill", async () => {
       const token = await Token.new(...TOKEN_ARGS);
       await colonyNetwork.createMetaColony(token.address);
-      const skillCount = await colonyNetwork.getSkillCount.call();
+      const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 3);
-      const rootGlobalSkill = await colonyNetwork.getSkill.call(1);
+      const rootGlobalSkill = await colonyNetwork.getSkill(1);
       assert.equal(rootGlobalSkill[0].toNumber(), 0);
       assert.equal(rootGlobalSkill[1].toNumber(), 0);
 
-      const globalSkill1 = await colonyNetwork.getSkill.call(1);
+      const globalSkill1 = await colonyNetwork.getSkill(1);
       assert.isTrue(globalSkill1[2]);
 
-      const globalSkill2 = await colonyNetwork.getSkill.call(2);
+      const globalSkill2 = await colonyNetwork.getSkill(2);
       assert.isFalse(globalSkill2[2]);
 
-      const localSkill1 = await colonyNetwork.getSkill.call(3);
+      const localSkill1 = await colonyNetwork.getSkill(3);
       assert.isFalse(localSkill1[2]);
 
-      const rootGlobalSkillId = await colonyNetwork.getRootGlobalSkillId.call();
+      const rootGlobalSkillId = await colonyNetwork.getRootGlobalSkillId();
       assert.equal(rootGlobalSkillId, 1);
     });
 
     it("should fail to create meta colony if it already exists", async () => {
       const token = await Token.new(...TOKEN_ARGS);
       await colonyNetwork.createMetaColony(token.address);
-      const metaColonyAddress1 = await colonyNetwork.getMetaColony.call();
+      const metaColonyAddress1 = await colonyNetwork.getMetaColony();
 
       await checkErrorRevert(colonyNetwork.createMetaColony(token.address));
-      const metaColonyAddress2 = await colonyNetwork.getMetaColony.call();
+      const metaColonyAddress2 = await colonyNetwork.getMetaColony();
       assert.equal(metaColonyAddress1, metaColonyAddress2);
     });
 
     it("when any colony is created, should have the root local skill initialised", async () => {
       const token = await Token.new(...TOKEN_ARGS);
       const { logs } = await colonyNetwork.createColony(token.address);
-      const rootLocalSkill = await colonyNetwork.getSkill.call(1);
+      const rootLocalSkill = await colonyNetwork.getSkill(1);
       assert.equal(rootLocalSkill[0].toNumber(), 0);
       assert.equal(rootLocalSkill[1].toNumber(), 0);
 
-      const skill = await colonyNetwork.getSkill.call(2);
+      const skill = await colonyNetwork.getSkill(2);
       assert.isFalse(skill[2]);
 
       const { colonyAddress } = logs[0].args;
       const colony = await Colony.at(colonyAddress);
-      const rootDomain = await colony.getDomain.call(1);
+      const rootDomain = await colony.getDomain(1);
       assert.equal(rootDomain[0].toNumber(), 1);
       assert.equal(rootDomain[1].toNumber(), 1);
 
-      const domainCount = await colony.getDomainCount.call();
+      const domainCount = await colony.getDomainCount();
       assert.equal(domainCount.toNumber(), 1);
     });
 
@@ -179,12 +179,12 @@ contract("ColonyNetwork", accounts => {
       await colonyNetwork.createColony(token.address);
       await colonyNetwork.createColony(token.address);
       await colonyNetwork.createColony(token.address);
-      const colonyAddress = await colonyNetwork.getColony.call(3);
+      const colonyAddress = await colonyNetwork.getColony(3);
       assert.notEqual(colonyAddress, "0x0000000000000000000000000000000000000000");
     });
 
     it("should return an empty address if there is no colony for the index provided", async () => {
-      const colonyAddress = await colonyNetwork.getColony.call(15);
+      const colonyAddress = await colonyNetwork.getColony(15);
       assert.equal(colonyAddress, "0x0000000000000000000000000000000000000000");
     });
 
@@ -193,7 +193,7 @@ contract("ColonyNetwork", accounts => {
       const { logs } = await colonyNetwork.createColony(token.address);
       const { colonyAddress } = logs[0].args;
       const colony = await Colony.at(colonyAddress);
-      const actualColonyVersion = await colony.version.call();
+      const actualColonyVersion = await colony.version();
       assert.equal(version.toNumber(), actualColonyVersion.toNumber());
     });
   });
@@ -207,12 +207,12 @@ contract("ColonyNetwork", accounts => {
       const colony = await Colony.at(colonyAddress);
 
       const sampleResolver = "0x65a760e7441cf435086ae45e14a0c8fc1080f54c";
-      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
+      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       const newVersion = currentColonyVersion.addn(1).toNumber();
       await colonyNetwork.addColonyVersion(newVersion, sampleResolver);
 
       await colony.upgrade(newVersion);
-      const colonyResolver = await colonyEtherRouter.resolver.call();
+      const colonyResolver = await colonyEtherRouter.resolver();
       assert.equal(colonyResolver.toLowerCase(), sampleResolver);
     });
 
@@ -223,7 +223,7 @@ contract("ColonyNetwork", accounts => {
       const colony = await EtherRouter.at(colonyAddress);
 
       const sampleResolver = "0x65a760e7441cf435086ae45e14a0c8fc1080f54c";
-      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
+      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       const newVersion = currentColonyVersion.addn(1).toNumber();
       await colonyNetwork.addColonyVersion(newVersion, sampleResolver);
       await checkErrorRevert(colony.setResolver(sampleResolver));
@@ -236,7 +236,7 @@ contract("ColonyNetwork", accounts => {
       const colony = await Colony.at(colonyAddress);
 
       const sampleResolver = "0x65a760e7441cf435086ae45e14a0c8fc1080f54c";
-      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
+      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       const newVersion = currentColonyVersion.subn(1).toNumber();
       await colonyNetwork.addColonyVersion(newVersion, sampleResolver);
 
@@ -248,7 +248,7 @@ contract("ColonyNetwork", accounts => {
       const token = await Token.new(...TOKEN_ARGS);
       const { logs } = await colonyNetwork.createColony(token.address);
       const { colonyAddress } = logs[0].args;
-      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
+      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       const newVersion = currentColonyVersion.addn(1).toNumber();
       const colony = await Colony.at(colonyAddress);
 
@@ -261,11 +261,11 @@ contract("ColonyNetwork", accounts => {
       const { logs } = await colonyNetwork.createColony(token.address);
       const { colonyAddress } = logs[0].args;
       const colonyEtherRouter = await EtherRouter.at(colonyAddress);
-      const colonyResolver = await colonyEtherRouter.resolver.call();
+      const colonyResolver = await colonyEtherRouter.resolver();
       const colony = await Colony.at(colonyAddress);
 
       const sampleResolver = "0x65a760e7441cf435086ae45e14a0c8fc1080f54c";
-      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
+      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       const newVersion = currentColonyVersion.addn(1).toNumber();
       await colonyNetwork.addColonyVersion(newVersion, sampleResolver);
 
@@ -284,14 +284,14 @@ contract("ColonyNetwork", accounts => {
 
     it("should not be able to add a global skill, by an address that is not the meta colony ", async () => {
       await checkErrorRevert(colonyNetwork.addSkill(1, true));
-      const skillCount = await colonyNetwork.getSkillCount.call();
+      const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 1);
     });
 
     it("should NOT be able to add a local skill, by an address that is not a Colony", async () => {
       await checkErrorRevert(colonyNetwork.addSkill(2, false));
 
-      const skillCount = await colonyNetwork.getSkillCount.call();
+      const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 1);
     });
   });

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -65,7 +65,7 @@ contract("ColonyNetwork", accounts => {
     it("should be able to register a higher Colony contract version", async () => {
       const sampleResolver = "0x65a760e7441cf435086ae45e14a0c8fc1080f54c";
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
-      const updatedVersion = currentColonyVersion.add(1).toNumber();
+      const updatedVersion = currentColonyVersion.addn(1).toNumber();
       await colonyNetwork.addColonyVersion(updatedVersion, sampleResolver);
 
       const updatedColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
@@ -211,7 +211,7 @@ contract("ColonyNetwork", accounts => {
 
       const sampleResolver = "0x65a760e7441cf435086ae45e14a0c8fc1080f54c";
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
-      const newVersion = currentColonyVersion.add(1).toNumber();
+      const newVersion = currentColonyVersion.addn(1).toNumber();
       await colonyNetwork.addColonyVersion(newVersion, sampleResolver);
 
       await colony.upgrade(newVersion);
@@ -227,7 +227,7 @@ contract("ColonyNetwork", accounts => {
 
       const sampleResolver = "0x65a760e7441cf435086ae45e14a0c8fc1080f54c";
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
-      const newVersion = currentColonyVersion.add(1).toNumber();
+      const newVersion = currentColonyVersion.addn(1).toNumber();
       await colonyNetwork.addColonyVersion(newVersion, sampleResolver);
 
       await checkErrorRevert(await EtherRouter.at(colony.address).setResolver(sampleResolver));
@@ -253,7 +253,7 @@ contract("ColonyNetwork", accounts => {
       const { logs } = await colonyNetwork.createColony(token.address);
       const { colonyAddress } = logs[0].args;
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
-      const newVersion = currentColonyVersion.add(1).toNumber();
+      const newVersion = currentColonyVersion.addn(1).toNumber();
       const colony = await Colony.at(colonyAddress);
 
       await checkErrorRevert(colony.upgrade(newVersion));
@@ -270,7 +270,7 @@ contract("ColonyNetwork", accounts => {
 
       const sampleResolver = "0x65a760e7441cf435086ae45e14a0c8fc1080f54c";
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
-      const newVersion = currentColonyVersion.add(1).toNumber();
+      const newVersion = currentColonyVersion.addn(1).toNumber();
       await colonyNetwork.addColonyVersion(newVersion, sampleResolver);
 
       await checkErrorRevert(colony.upgrade(newVersion, { from: OTHER_ACCOUNT }));

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -49,7 +49,7 @@ contract("ColonyNetwork", accounts => {
     it("should accept ether", async () => {
       await colonyNetwork.send(1);
       const colonyNetworkBalance = await web3GetBalance(colonyNetwork.address);
-      assert.equal(colonyNetworkBalance.toNumber(), 1);
+      assert.equal(colonyNetworkBalance, 1);
     });
 
     it("should have the correct current Colony version set", async () => {
@@ -167,7 +167,7 @@ contract("ColonyNetwork", accounts => {
         checkErrorNonPayableFunction(err);
       }
       const colonyNetworkBalance = await web3GetBalance(colonyNetwork.address);
-      assert.equal(0, colonyNetworkBalance.toNumber());
+      assert.equal(0, colonyNetworkBalance);
     });
 
     it("should log a ColonyAdded event", async () => {

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -55,18 +55,18 @@ contract("Colony Task Work Rating", accounts => {
 
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
       const currentTime1 = await currentBlockTime();
-      const rating1 = await colony.getTaskWorkRatings.call(taskId);
+      const rating1 = await colony.getTaskWorkRatings(taskId);
       assert.equal(rating1[0], 1);
       assert.closeTo(rating1[1].toNumber(), currentTime1, 2);
-      const ratingSecret1 = await colony.getTaskWorkRatingSecret.call(taskId, WORKER_ROLE);
+      const ratingSecret1 = await colony.getTaskWorkRatingSecret(taskId, WORKER_ROLE);
       assert.equal(ratingSecret1, RATING_2_SECRET);
 
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
       const currentTime2 = await currentBlockTime();
-      const rating2 = await colony.getTaskWorkRatings.call(taskId);
+      const rating2 = await colony.getTaskWorkRatings(taskId);
       assert.equal(rating2[0].toNumber(), 2);
       assert.closeTo(rating2[1].toNumber(), currentTime2, 2);
-      const ratingSecret2 = await colony.getTaskWorkRatingSecret.call(taskId, MANAGER_ROLE);
+      const ratingSecret2 = await colony.getTaskWorkRatingSecret(taskId, MANAGER_ROLE);
       assert.equal(ratingSecret2, RATING_1_SECRET);
     });
 
@@ -75,9 +75,9 @@ contract("Colony Task Work Rating", accounts => {
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
 
-      const ratingSecret2 = await colony.getTaskWorkRatingSecret.call(taskId, MANAGER_ROLE);
+      const ratingSecret2 = await colony.getTaskWorkRatingSecret(taskId, MANAGER_ROLE);
       assert.equal(ratingSecret2, RATING_1_SECRET);
-      const ratingSecret1 = await colony.getTaskWorkRatingSecret.call(taskId, WORKER_ROLE);
+      const ratingSecret1 = await colony.getTaskWorkRatingSecret(taskId, WORKER_ROLE);
       assert.equal(ratingSecret1, RATING_2_SECRET);
     });
 
@@ -86,21 +86,21 @@ contract("Colony Task Work Rating", accounts => {
       dueDate += SECONDS_PER_DAY * 7;
       const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await checkErrorRevert(colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR }));
-      const ratingSecrets = await colony.getTaskWorkRatings.call(taskId);
+      const ratingSecrets = await colony.getTaskWorkRatings(taskId);
       assert.equal(ratingSecrets[0].toNumber(), 0);
     });
 
     it("should fail if I try to rate work on behalf of a worker", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
       await checkErrorRevert(colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: OTHER }));
-      const ratingSecrets = await colony.getTaskWorkRatings.call(taskId);
+      const ratingSecrets = await colony.getTaskWorkRatings(taskId);
       assert.equal(ratingSecrets[0], 0);
     });
 
     it("should fail if I try to rate work for a role that's not setup to be rated", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
       await checkErrorRevert(colony.submitTaskWorkRating(taskId, EVALUATOR_ROLE, RATING_2_SECRET, { from: EVALUATOR }));
-      const ratingSecrets = await colony.getTaskWorkRatings.call(taskId);
+      const ratingSecrets = await colony.getTaskWorkRatings(taskId);
       assert.equal(ratingSecrets[0].toNumber(), 0);
     });
 
@@ -109,9 +109,9 @@ contract("Colony Task Work Rating", accounts => {
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
 
       await checkErrorRevert(colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_1_SECRET, { from: EVALUATOR }));
-      const ratingSecrets = await colony.getTaskWorkRatings.call(taskId);
+      const ratingSecrets = await colony.getTaskWorkRatings(taskId);
       assert.equal(ratingSecrets[0], 1);
-      const ratingSecret = await colony.getTaskWorkRatingSecret.call(taskId, WORKER_ROLE);
+      const ratingSecret = await colony.getTaskWorkRatingSecret(taskId, WORKER_ROLE);
       assert.equal(ratingSecret, RATING_2_SECRET);
     });
 
@@ -120,7 +120,7 @@ contract("Colony Task Work Rating", accounts => {
 
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
       await checkErrorRevert(colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR }));
-      const ratingSecrets = await colony.getTaskWorkRatings.call(taskId);
+      const ratingSecrets = await colony.getTaskWorkRatings(taskId);
       assert.equal(ratingSecrets[0].toNumber(), 0);
     });
 
@@ -128,7 +128,7 @@ contract("Colony Task Work Rating", accounts => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
 
       await checkErrorRevert(colony.submitTaskWorkRating(10, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR }));
-      const ratingSecrets = await colony.getTaskWorkRatings.call(taskId);
+      const ratingSecrets = await colony.getTaskWorkRatings(taskId);
       assert.equal(ratingSecrets[0], 0);
     });
   });
@@ -138,14 +138,14 @@ contract("Colony Task Work Rating", accounts => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony, token });
 
-      const roleManager = await colony.getTaskRole.call(taskId, MANAGER_ROLE);
+      const roleManager = await colony.getTaskRole(taskId, MANAGER_ROLE);
       assert.equal(roleManager[2].toNumber(), MANAGER_RATING);
 
-      const roleWorker = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      const roleWorker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.isFalse(roleWorker[1]);
       assert.equal(roleWorker[2].toNumber(), WORKER_RATING);
 
-      const roleEvaluator = await colony.getTaskRole.call(taskId, EVALUATOR_ROLE);
+      const roleEvaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
       assert.isFalse(roleEvaluator[1]);
     });
 
@@ -159,10 +159,10 @@ contract("Colony Task Work Rating", accounts => {
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
       await colony.revealTaskWorkRating(1, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR });
 
-      const roleWorker = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      const roleWorker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(roleWorker[2].toNumber(), WORKER_RATING);
 
-      const roleEvaluator = await colony.getTaskRole.call(taskId, EVALUATOR_ROLE);
+      const roleEvaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
       assert.isFalse(roleEvaluator[1]);
     });
 
@@ -172,7 +172,7 @@ contract("Colony Task Work Rating", accounts => {
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
       await checkErrorRevert(colony.revealTaskWorkRating(taskId, MANAGER_ROLE, MANAGER_RATING, RATING_2_SALT, { from: WORKER }));
 
-      const roleManager = await colony.getTaskRole.call(taskId, MANAGER_ROLE);
+      const roleManager = await colony.getTaskRole(taskId, MANAGER_ROLE);
       assert.equal(roleManager[2].toNumber(), 0);
     });
 
@@ -184,7 +184,7 @@ contract("Colony Task Work Rating", accounts => {
       await forwardTime(SECONDS_PER_DAY * 5 + 2, this);
       await checkErrorRevert(colony.revealTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR }));
 
-      const roleWorker = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      const roleWorker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(roleWorker[2].toNumber(), 0);
     });
 
@@ -196,7 +196,7 @@ contract("Colony Task Work Rating", accounts => {
       await forwardTime(SECONDS_PER_DAY * 5 + 2, this);
       await checkErrorRevert(colony.revealTaskWorkRating(taskId, MANAGER_ROLE, MANAGER_RATING, RATING_1_SALT, { from: WORKER }));
 
-      const roleManager = await colony.getTaskRole.call(1, MANAGER_ROLE);
+      const roleManager = await colony.getTaskRole(1, MANAGER_ROLE);
       assert.equal(roleManager[2].toNumber(), 0);
     });
 
@@ -206,7 +206,7 @@ contract("Colony Task Work Rating", accounts => {
       await forwardTime(SECONDS_PER_DAY * 4, this);
       await checkErrorRevert(colony.revealTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR }));
 
-      const roleWorker = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      const roleWorker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(roleWorker[2].toNumber(), 0);
     });
 
@@ -217,7 +217,7 @@ contract("Colony Task Work Rating", accounts => {
       await forwardTime(SECONDS_PER_DAY * 10 + 1, this);
       await checkErrorRevert(colony.revealTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR }));
 
-      const roleWorker = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      const roleWorker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(roleWorker[2].toNumber(), 0);
     });
 
@@ -246,14 +246,14 @@ contract("Colony Task Work Rating", accounts => {
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
       await colony.assignWorkRating(taskId);
 
-      const roleWorker = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      const roleWorker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.isTrue(roleWorker[1]);
       assert.equal(roleWorker[2].toNumber(), WORKER_RATING);
 
-      const roleManager = await colony.getTaskRole.call(taskId, MANAGER_ROLE);
+      const roleManager = await colony.getTaskRole(taskId, MANAGER_ROLE);
       assert.equal(roleManager[2].toNumber(), 3);
 
-      const roleEvaluator = await colony.getTaskRole.call(taskId, EVALUATOR_ROLE);
+      const roleEvaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
       assert.isFalse(roleEvaluator[1]);
     });
 
@@ -265,16 +265,16 @@ contract("Colony Task Work Rating", accounts => {
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
       await colony.assignWorkRating(taskId);
 
-      const roleWorker = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      const roleWorker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.isFalse(roleWorker[1]);
       assert.equal(roleWorker[2].toNumber(), 3);
 
-      const roleManager = await colony.getTaskRole.call(taskId, MANAGER_ROLE);
+      const roleManager = await colony.getTaskRole(taskId, MANAGER_ROLE);
       assert.isFalse(roleManager[1]);
       assert.equal(roleManager[2].toNumber(), MANAGER_RATING);
 
       await colony.finalizeTask(taskId);
-      const roleEvaluator = await colony.getTaskRole.call(taskId, EVALUATOR_ROLE);
+      const roleEvaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
       assert.isTrue(roleEvaluator[1]);
       assert.equal(roleEvaluator[2].toNumber(), 1);
     });
@@ -284,16 +284,16 @@ contract("Colony Task Work Rating", accounts => {
       await forwardTime(SECONDS_PER_DAY * 10 + 1, this);
       await colony.assignWorkRating(taskId);
 
-      const roleWorker = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      const roleWorker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.isTrue(roleWorker[1]);
       assert.equal(roleWorker[2].toNumber(), 3);
 
-      const roleManager = await colony.getTaskRole.call(taskId, MANAGER_ROLE);
+      const roleManager = await colony.getTaskRole(taskId, MANAGER_ROLE);
       assert.isFalse(roleManager[1]);
       assert.equal(roleManager[2].toNumber(), 3);
 
       await colony.finalizeTask(taskId);
-      const roleEvaluator = await colony.getTaskRole.call(taskId, EVALUATOR_ROLE);
+      const roleEvaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
       assert.isTrue(roleEvaluator[1]);
       assert.equal(roleEvaluator[2].toNumber(), 1);
     });
@@ -302,7 +302,7 @@ contract("Colony Task Work Rating", accounts => {
       await setupAssignedTask({ colonyNetwork, colony });
       await forwardTime(SECONDS_PER_DAY * 6, this);
       await checkErrorRevert(colony.assignWorkRating(1));
-      const roleWorker = await colony.getTaskRole.call(1, WORKER_ROLE);
+      const roleWorker = await colony.getTaskRole(1, WORKER_ROLE);
       assert.isFalse(roleWorker[1]);
     });
   });

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -1,9 +1,6 @@
 /* globals artifacts */
 
 import {
-  EVALUATOR,
-  WORKER,
-  OTHER,
   MANAGER_RATING,
   WORKER_RATING,
   RATING_1_SALT,
@@ -25,7 +22,12 @@ const IColonyNetwork = artifacts.require("IColonyNetwork");
 const EtherRouter = artifacts.require("EtherRouter");
 const Token = artifacts.require("Token");
 
-contract("Colony Task Work Rating", () => {
+contract("Colony Task Work Rating", accounts => {
+  const MANAGER = accounts[0];
+  const EVALUATOR = accounts[1];
+  const WORKER = accounts[2];
+  const OTHER = accounts[3];
+
   let colony;
   let colonyNetwork;
   let token;

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -23,7 +23,6 @@ const EtherRouter = artifacts.require("EtherRouter");
 const Token = artifacts.require("Token");
 
 contract("Colony Task Work Rating", accounts => {
-  const MANAGER = accounts[0];
   const EVALUATOR = accounts[1];
   const WORKER = accounts[2];
   const OTHER = accounts[3];

--- a/test/colony.js
+++ b/test/colony.js
@@ -267,7 +267,7 @@ contract("Colony", addresses => {
   });
 
   describe("when creating tasks", () => {
-    it.only("should allow admins to make task", async () => {
+    it("should allow admins to make task", async () => {
       await makeTask({ colony });
       const task = await colony.getTask.call(1);
       assert.equal(task[0], SPECIFICATION_HASH);

--- a/test/colony.js
+++ b/test/colony.js
@@ -417,7 +417,7 @@ contract("Colony", addresses => {
 
       const sigTypes = [0, 0];
       const signers = [MANAGER, WORKER];
-      const txData = await colony.contract.setTaskWorkerRole.getData(taskId, WORKER);
+      const txData = await colony.contract.methods["setTaskWorkerRole"](taskId, WORKER).encodeABI();
       const sigsPromises = sigTypes.map((type, i) => createSignatures(colony, taskId, [signers[i]], 0, txData));
       const sigs = await Promise.all(sigsPromises);
       const sigV = sigs.map(sig => sig.sigV[0]);

--- a/test/colony.js
+++ b/test/colony.js
@@ -1729,25 +1729,25 @@ contract("Colony", accounts => {
 
   describe("Recovery Mode", () => {
     it("should be able to add and remove recovery roles when not in recovery", async () => {
-      const owner = addresses[0];
+      const owner = accounts[0];
       let numRecoveryRoles;
 
       numRecoveryRoles = await colony.numRecoveryRoles();
       assert.equal(numRecoveryRoles.toNumber(), 0);
 
       await colony.setRecoveryRole(owner, { from: owner });
-      await colony.setRecoveryRole(addresses[1], { from: owner });
-      await colony.setRecoveryRole(addresses[2], { from: owner });
+      await colony.setRecoveryRole(accounts[1], { from: owner });
+      await colony.setRecoveryRole(accounts[2], { from: owner });
       numRecoveryRoles = await colony.numRecoveryRoles();
       assert.equal(numRecoveryRoles.toNumber(), 3);
 
       // Can remove recovery roles
-      await colony.removeRecoveryRole(addresses[2], { from: owner });
+      await colony.removeRecoveryRole(accounts[2], { from: owner });
       numRecoveryRoles = await colony.numRecoveryRoles();
       assert.equal(numRecoveryRoles.toNumber(), 2);
 
       // Can't remove twice
-      await colony.removeRecoveryRole(addresses[2], { from: owner });
+      await colony.removeRecoveryRole(accounts[2], { from: owner });
       numRecoveryRoles = await colony.numRecoveryRoles();
       assert.equal(numRecoveryRoles.toNumber(), 2);
 
@@ -1758,18 +1758,18 @@ contract("Colony", accounts => {
     });
 
     it("should not be able to add and remove roles when in recovery", async () => {
-      const owner = addresses[0];
+      const owner = accounts[0];
       await colony.setRecoveryRole(owner, { from: owner });
       await colony.enterRecoveryMode({ from: owner });
-      await checkErrorRevert(colony.setOwnerRole(addresses[1], { from: owner }));
-      await checkErrorRevert(colony.setAdminRole(addresses[1], { from: owner }));
-      await checkErrorRevert(colony.removeAdminRole(addresses[1], { from: owner }));
-      await checkErrorRevert(colony.setRecoveryRole(addresses[1], { from: owner }));
-      await checkErrorRevert(colony.removeRecoveryRole(addresses[1], { from: owner }));
+      await checkErrorRevert(colony.setOwnerRole(accounts[1], { from: owner }));
+      await checkErrorRevert(colony.setAdminRole(accounts[1], { from: owner }));
+      await checkErrorRevert(colony.removeAdminRole(accounts[1], { from: owner }));
+      await checkErrorRevert(colony.setRecoveryRole(accounts[1], { from: owner }));
+      await checkErrorRevert(colony.removeRecoveryRole(accounts[1], { from: owner }));
     });
 
     it("should not be able to call normal functions while in recovery", async () => {
-      const owner = addresses[0];
+      const owner = accounts[0];
       await colony.setRecoveryRole(owner, { from: owner });
       await colony.enterRecoveryMode({ from: owner });
       await checkErrorRevert(colony.initialiseColony("0x0", { from: owner }));
@@ -1779,11 +1779,11 @@ contract("Colony", accounts => {
     });
 
     it("should exit recovery mode with sufficient approvals", async () => {
-      const owner = addresses[0];
+      const owner = accounts[0];
       const version = await colony.version();
       await colony.setRecoveryRole(owner, { from: owner });
-      await colony.setRecoveryRole(addresses[1], { from: owner });
-      await colony.setRecoveryRole(addresses[2], { from: owner });
+      await colony.setRecoveryRole(accounts[1], { from: owner });
+      await colony.setRecoveryRole(accounts[2], { from: owner });
 
       await colony.enterRecoveryMode({ from: owner });
       await colony.setStorageSlotRecovery(5, "0xdeadbeef", { from: owner });
@@ -1796,27 +1796,27 @@ contract("Colony", accounts => {
       await checkErrorRevert(colony.exitRecoveryMode(version.toNumber()), { from: owner });
 
       // 2/3 approve
-      await colony.approveExitRecovery({ from: addresses[1] });
+      await colony.approveExitRecovery({ from: accounts[1] });
       await colony.exitRecoveryMode(version.toNumber(), { from: owner });
     });
 
     it("recovery users can work in recovery mode", async () => {
-      const owner = addresses[0];
+      const owner = accounts[0];
       const version = await colony.version();
       await colony.setRecoveryRole(owner, { from: owner });
-      await colony.setRecoveryRole(addresses[1], { from: owner });
+      await colony.setRecoveryRole(accounts[1], { from: owner });
 
       await colony.enterRecoveryMode({ from: owner });
-      await colony.setStorageSlotRecovery(5, "0xdeadbeef", { from: addresses[1] });
+      await colony.setStorageSlotRecovery(5, "0xdeadbeef", { from: accounts[1] });
 
       // 2/2 approve
       await colony.approveExitRecovery({ from: owner });
-      await colony.approveExitRecovery({ from: addresses[1] });
-      await colony.exitRecoveryMode(version.toNumber(), { from: addresses[1] });
+      await colony.approveExitRecovery({ from: accounts[1] });
+      await colony.exitRecoveryMode(version.toNumber(), { from: accounts[1] });
     });
 
     it("users cannot approve twice", async () => {
-      const owner = addresses[0];
+      const owner = accounts[0];
       await colony.setRecoveryRole(owner, { from: owner });
       await colony.enterRecoveryMode({ from: owner });
       await colony.setStorageSlotRecovery(5, "0xdeadbeef", { from: owner });
@@ -1826,14 +1826,14 @@ contract("Colony", accounts => {
     });
 
     it("users cannot approve if unauthorized", async () => {
-      const owner = addresses[0];
+      const owner = accounts[0];
       await colony.setRecoveryRole(owner, { from: owner });
       await colony.enterRecoveryMode({ from: owner });
-      await checkErrorRevert(colony.approveExitRecovery({ from: addresses[1] }));
+      await checkErrorRevert(colony.approveExitRecovery({ from: accounts[1] }));
     });
 
     it("should allow editing of general variables", async () => {
-      const owner = addresses[0];
+      const owner = accounts[0];
       await colony.setRecoveryRole(owner, { from: owner });
       await colony.enterRecoveryMode({ from: owner });
       await colony.setStorageSlotRecovery(5, "0xdeadbeef", { from: owner });
@@ -1843,7 +1843,7 @@ contract("Colony", accounts => {
     });
 
     it("should not allow editing of protected variables", async () => {
-      const owner = addresses[0];
+      const owner = accounts[0];
       const protectedLoc = 0;
 
       await colony.setRecoveryRole(owner, { from: owner });

--- a/test/colony.js
+++ b/test/colony.js
@@ -267,7 +267,7 @@ contract("Colony", addresses => {
   });
 
   describe("when creating tasks", () => {
-    it("should allow admins to make task", async () => {
+    it.only("should allow admins to make task", async () => {
       await makeTask({ colony });
       const task = await colony.getTask.call(1);
       assert.equal(task[0], SPECIFICATION_HASH);

--- a/test/colony.js
+++ b/test/colony.js
@@ -417,7 +417,7 @@ contract("Colony", addresses => {
 
       const sigTypes = [0, 0];
       const signers = [MANAGER, WORKER];
-      const txData = await colony.contract.methods["setTaskWorkerRole"](taskId, WORKER).encodeABI();
+      const txData = await colony.contract.methods.setTaskWorkerRole(taskId, WORKER).encodeABI();
       const sigsPromises = sigTypes.map((type, i) => createSignatures(colony, taskId, [signers[i]], 0, txData));
       const sigs = await Promise.all(sigsPromises);
       const sigV = sigs.map(sig => sig.sigV[0]);

--- a/test/colony.js
+++ b/test/colony.js
@@ -3,10 +3,6 @@
 import { toBN } from "web3-utils";
 
 import {
-  MANAGER,
-  EVALUATOR,
-  WORKER,
-  OTHER,
   MANAGER_ROLE,
   EVALUATOR_ROLE,
   WORKER_ROLE,
@@ -60,7 +56,12 @@ const ColonyFunding = artifacts.require("ColonyFunding");
 const ColonyTask = artifacts.require("ColonyTask");
 const ReputationMiningCycle = artifacts.require("ReputationMiningCycle");
 
-contract("Colony", addresses => {
+contract("Colony", accounts => {
+  const MANAGER = accounts[0];
+  const EVALUATOR = accounts[1];
+  const WORKER = accounts[2];
+  const OTHER = accounts[3];
+
   let colony;
   let token;
   let otherToken;
@@ -153,8 +154,8 @@ contract("Colony", addresses => {
   describe("when working with permissions", () => {
     it("should allow current owner role to transfer role to another address", async () => {
       const ownerRole = 0;
-      const currentOwner = addresses[0];
-      const futureOwner = addresses[2];
+      const currentOwner = accounts[0];
+      const futureOwner = accounts[2];
 
       let hasRole = await authority.hasUserRole(currentOwner, ownerRole);
       assert(hasRole, `${currentOwner} does not have owner role`);
@@ -168,8 +169,8 @@ contract("Colony", addresses => {
     it("should allow admin to assign colony admin role", async () => {
       const adminRole = 1;
 
-      const user1 = addresses[1];
-      const user5 = addresses[5];
+      const user1 = accounts[1];
+      const user5 = accounts[5];
 
       await colony.setAdminRole(user1);
 
@@ -188,7 +189,7 @@ contract("Colony", addresses => {
     it("should allow owner to remove colony admin role", async () => {
       const adminRole = 1;
 
-      const user1 = addresses[1];
+      const user1 = accounts[1];
 
       await colony.setAdminRole(user1);
 
@@ -204,8 +205,8 @@ contract("Colony", addresses => {
     it("should not allow admin to remove admin role", async () => {
       const adminRole = 1;
 
-      const user1 = addresses[1];
-      const user2 = addresses[2];
+      const user1 = accounts[1];
+      const user2 = accounts[2];
 
       await colony.setAdminRole(user1);
       await colony.setAdminRole(user2);
@@ -226,7 +227,7 @@ contract("Colony", addresses => {
     });
 
     it("should allow admin to call predetermined functions", async () => {
-      const user3 = addresses[3];
+      const user3 = accounts[3];
 
       await colony.setAdminRole(user3);
 
@@ -317,7 +318,7 @@ contract("Colony", addresses => {
 
   describe("when bootstrapping the colony", () => {
     const INITIAL_REPUTATIONS = [toBN(5 * 1e18).toString(), toBN(4 * 1e18).toString(), toBN(3 * 1e18).toString(), toBN(2 * 1e18).toString()];
-    const INITIAL_ADDRESSES = addresses.slice(0, 4);
+    const INITIAL_ADDRESSES = accounts.slice(0, 4);
 
     it("should assign reputation correctly when bootstrapping the colony", async () => {
       const skillCount = await colonyNetwork.getSkillCount.call();
@@ -325,7 +326,7 @@ contract("Colony", addresses => {
       await colony.mintTokens(toBN(14 * 1e18).toString());
       await colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS);
       const inactiveReputationMiningCycleAddress = await colonyNetwork.getReputationMiningCycle(false);
-      const inactiveReputationMiningCycle = ReputationMiningCycle.at(inactiveReputationMiningCycleAddress);
+      const inactiveReputationMiningCycle = await ReputationMiningCycle.at(inactiveReputationMiningCycleAddress);
       const numberOfReputationLogs = await inactiveReputationMiningCycle.getReputationUpdateLogLength();
       assert.equal(numberOfReputationLogs.toNumber(), INITIAL_ADDRESSES.length);
       const updateLog = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(0);
@@ -384,7 +385,7 @@ contract("Colony", addresses => {
       await colony.mintTokens(toBN(14 * 1e18).toString());
       await checkErrorRevert(
         colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS, {
-          from: addresses[1]
+          from: accounts[1]
         })
       );
     });

--- a/test/colony.js
+++ b/test/colony.js
@@ -92,7 +92,7 @@ contract("Colony", accounts => {
     const { colonyAddress } = logs[0].args;
     await token.setOwner(colonyAddress);
     colony = await IColony.at(colonyAddress);
-    const authorityAddress = await colony.authority.call();
+    const authorityAddress = await colony.authority();
     authority = await Authority.at(authorityAddress);
     const otherTokenArgs = getTokenArgs();
     otherToken = await Token.new(...otherTokenArgs);
@@ -106,17 +106,17 @@ contract("Colony", accounts => {
     });
 
     it("should not have owner", async () => {
-      const owner = await colony.owner.call();
+      const owner = await colony.owner();
       assert.equal(owner, "0x0000000000000000000000000000000000000000");
     });
 
     it("should return zero task count", async () => {
-      const taskCount = await colony.getTaskCount.call();
+      const taskCount = await colony.getTaskCount();
       assert.equal(taskCount, 0);
     });
 
     it("should return zero for taskChangeNonce", async () => {
-      const taskChangeNonce = await colony.getTaskChangeNonce.call(1);
+      const taskChangeNonce = await colony.getTaskChangeNonce(1);
       assert.equal(taskChangeNonce, 0);
     });
 
@@ -129,24 +129,24 @@ contract("Colony", accounts => {
     });
 
     it("should correctly generate a rating secret", async () => {
-      const ratingSecret1 = await colony.generateSecret.call(RATING_1_SALT, MANAGER_RATING);
+      const ratingSecret1 = await colony.generateSecret(RATING_1_SALT, MANAGER_RATING);
       assert.equal(ratingSecret1, RATING_1_SECRET);
-      const ratingSecret2 = await colony.generateSecret.call(RATING_2_SALT, WORKER_RATING);
+      const ratingSecret2 = await colony.generateSecret(RATING_2_SALT, WORKER_RATING);
       assert.equal(ratingSecret2, RATING_2_SECRET);
     });
 
     it("should initialise the root domain", async () => {
       // There should be one domain (the root domain)
-      const domainCount = await colony.getDomainCount.call();
+      const domainCount = await colony.getDomainCount();
       assert.equal(domainCount, 1);
 
-      const domain = await colony.getDomain.call(domainCount);
+      const domain = await colony.getDomain(domainCount);
 
       // The first pot should have been created and assigned to the domain
       assert.equal(domain[1], 1);
 
       // A root skill should have been created for the Colony
-      const rootLocalSkillId = await colonyNetwork.getSkillCount.call();
+      const rootLocalSkillId = await colonyNetwork.getSkillCount();
       assert.equal(domain[0].toNumber(), rootLocalSkillId.toNumber());
     });
   });
@@ -270,7 +270,7 @@ contract("Colony", accounts => {
   describe("when creating tasks", () => {
     it("should allow admins to make task", async () => {
       await makeTask({ colony });
-      const task = await colony.getTask.call(1);
+      const task = await colony.getTask(1);
       assert.equal(task[0], SPECIFICATION_HASH);
       assert.equal(task[1], "0x0000000000000000000000000000000000000000000000000000000000000000");
       assert.isFalse(task[2]);
@@ -281,15 +281,15 @@ contract("Colony", accounts => {
 
     it("should fail if a non-admin user tries to make a task", async () => {
       await checkErrorRevert(colony.makeTask(SPECIFICATION_HASH, 1, { from: OTHER }));
-      const taskCount = await colony.getTaskCount.call();
+      const taskCount = await colony.getTaskCount();
       assert.equal(taskCount.toNumber(), 0);
     });
 
     it("should set the task manager as the creator", async () => {
       await makeTask({ colony });
-      const taskCount = await colony.getTaskCount.call();
+      const taskCount = await colony.getTaskCount();
       assert.equal(taskCount.toNumber(), 1);
-      const taskManager = await colony.getTaskRole.call(1, MANAGER_ROLE);
+      const taskManager = await colony.getTaskRole(1, MANAGER_ROLE);
       assert.equal(taskManager[0], MANAGER);
     });
 
@@ -299,7 +299,7 @@ contract("Colony", accounts => {
       await makeTask({ colony });
       await makeTask({ colony });
       await makeTask({ colony });
-      const taskCount = await colony.getTaskCount.call();
+      const taskCount = await colony.getTaskCount();
 
       assert.equal(taskCount.toNumber(), 5);
     });
@@ -307,7 +307,7 @@ contract("Colony", accounts => {
     it("should set the task domain correctly", async () => {
       await colony.addDomain(1);
       await makeTask({ colony, domainId: 2 });
-      const task = await colony.getTask.call(1);
+      const task = await colony.getTask(1);
       assert.equal(task[8].toNumber(), 2);
     });
 
@@ -321,7 +321,7 @@ contract("Colony", accounts => {
     const INITIAL_ADDRESSES = accounts.slice(0, 4);
 
     it("should assign reputation correctly when bootstrapping the colony", async () => {
-      const skillCount = await colonyNetwork.getSkillCount.call();
+      const skillCount = await colonyNetwork.getSkillCount();
 
       await colony.mintTokens(toBN(14 * 1e18).toString());
       await colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS);
@@ -470,7 +470,7 @@ contract("Colony", accounts => {
         })
       );
 
-      const evaluator = await colony.getTaskRole.call(taskId, EVALUATOR_ROLE);
+      const evaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
       assert.equal(evaluator[0], "0x0000000000000000000000000000000000000000");
 
       await checkErrorRevert(
@@ -484,7 +484,7 @@ contract("Colony", accounts => {
         })
       );
 
-      const worker = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      const worker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(worker[0], "0x0000000000000000000000000000000000000000");
     });
 
@@ -544,7 +544,7 @@ contract("Colony", accounts => {
         args: [taskId, WORKER]
       });
 
-      let workerInfo = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      let workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(workerInfo[0], WORKER);
 
       await executeSignedTaskChange({
@@ -556,7 +556,7 @@ contract("Colony", accounts => {
         args: [taskId]
       });
 
-      workerInfo = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(workerInfo[0], "0x0000000000000000000000000000000000000000");
     });
 
@@ -583,7 +583,7 @@ contract("Colony", accounts => {
         })
       );
 
-      const workerInfo = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      const workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(workerInfo[0], WORKER);
     });
 
@@ -601,7 +601,7 @@ contract("Colony", accounts => {
         })
       );
 
-      const workerInfo = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      const workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(workerInfo[0], "0x0000000000000000000000000000000000000000");
     });
 
@@ -626,10 +626,10 @@ contract("Colony", accounts => {
         args: [taskId, MANAGER]
       });
 
-      const evaluatorInfo = await colony.getTaskRole.call(taskId, EVALUATOR_ROLE);
+      const evaluatorInfo = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
       assert.equal(evaluatorInfo[0], MANAGER);
 
-      const workerInfo = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      const workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(workerInfo[0], MANAGER);
     });
 
@@ -658,10 +658,10 @@ contract("Colony", accounts => {
         })
       );
 
-      const evaluatorInfo = await colony.getTaskRole.call(taskId, EVALUATOR_ROLE);
+      const evaluatorInfo = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
       assert.equal(evaluatorInfo[0], "0x0000000000000000000000000000000000000000");
 
-      const workerInfo = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      const workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(workerInfo[0], "0x0000000000000000000000000000000000000000");
     });
 
@@ -705,7 +705,7 @@ contract("Colony", accounts => {
         args: [taskId, WORKER]
       });
 
-      const worker = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      const worker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(worker[0], WORKER);
     });
 
@@ -723,7 +723,7 @@ contract("Colony", accounts => {
         })
       );
 
-      const worker = await colony.getTaskRole.call(taskId, WORKER_ROLE);
+      const worker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(worker[0], "0x0000000000000000000000000000000000000000");
     });
 
@@ -877,7 +877,7 @@ contract("Colony", accounts => {
         args: [taskId, SPECIFICATION_HASH_UPDATED]
       });
 
-      let taskChangeNonce = await colony.getTaskChangeNonce.call(taskId);
+      let taskChangeNonce = await colony.getTaskChangeNonce(taskId);
       assert.equal(taskChangeNonce, 1);
 
       // Change the due date
@@ -892,7 +892,7 @@ contract("Colony", accounts => {
         args: [taskId, dueDate]
       });
 
-      taskChangeNonce = await colony.getTaskChangeNonce.call(taskId);
+      taskChangeNonce = await colony.getTaskChangeNonce(taskId);
       assert.equal(taskChangeNonce, 2);
     });
 
@@ -909,7 +909,7 @@ contract("Colony", accounts => {
         sigTypes: [0],
         args: [taskId1, SPECIFICATION_HASH_UPDATED]
       });
-      let taskChangeNonce = await colony.getTaskChangeNonce.call(taskId1);
+      let taskChangeNonce = await colony.getTaskChangeNonce(taskId1);
       assert.equal(taskChangeNonce, 1);
 
       await executeSignedTaskChange({
@@ -921,7 +921,7 @@ contract("Colony", accounts => {
         args: [taskId2, SPECIFICATION_HASH_UPDATED]
       });
 
-      taskChangeNonce = await colony.getTaskChangeNonce.call(taskId2);
+      taskChangeNonce = await colony.getTaskChangeNonce(taskId2);
       assert.equal(taskChangeNonce, 1);
 
       // Change the task2 due date
@@ -936,7 +936,7 @@ contract("Colony", accounts => {
         args: [taskId2, dueDate]
       });
 
-      taskChangeNonce = await colony.getTaskChangeNonce.call(taskId2);
+      taskChangeNonce = await colony.getTaskChangeNonce(taskId2);
       assert.equal(taskChangeNonce, 2);
     });
 
@@ -951,7 +951,7 @@ contract("Colony", accounts => {
         sigTypes: [0],
         args: [taskId, SPECIFICATION_HASH_UPDATED]
       });
-      const task = await colony.getTask.call(taskId);
+      const task = await colony.getTask(taskId);
       assert.equal(task[0], SPECIFICATION_HASH_UPDATED);
     });
 
@@ -975,7 +975,7 @@ contract("Colony", accounts => {
         sigTypes: [0, 0],
         args: [taskId, SPECIFICATION_HASH_UPDATED]
       });
-      const task = await colony.getTask.call(taskId);
+      const task = await colony.getTask(taskId);
       assert.equal(task[0], SPECIFICATION_HASH_UPDATED);
     });
 
@@ -999,7 +999,7 @@ contract("Colony", accounts => {
         sigTypes: [1, 1],
         args: [taskId, SPECIFICATION_HASH_UPDATED]
       });
-      const task = await colony.getTask.call(taskId);
+      const task = await colony.getTask(taskId);
       assert.equal(task[0], SPECIFICATION_HASH_UPDATED);
     });
 
@@ -1023,7 +1023,7 @@ contract("Colony", accounts => {
         sigTypes: [0, 1],
         args: [taskId, SPECIFICATION_HASH_UPDATED]
       });
-      const task = await colony.getTask.call(taskId);
+      const task = await colony.getTask(taskId);
       assert.equal(task[0], SPECIFICATION_HASH_UPDATED);
     });
 
@@ -1049,7 +1049,7 @@ contract("Colony", accounts => {
           args: [taskId, SPECIFICATION_HASH_UPDATED]
         })
       );
-      const task = await colony.getTask.call(taskId);
+      const task = await colony.getTask(taskId);
       assert.equal(task[0], SPECIFICATION_HASH);
     });
 
@@ -1076,7 +1076,7 @@ contract("Colony", accounts => {
         args: [taskId, dueDate]
       });
 
-      const task = await colony.getTask.call(taskId);
+      const task = await colony.getTask(taskId);
       assert.equal(task[4], dueDate);
     });
 
@@ -1226,11 +1226,11 @@ contract("Colony", accounts => {
       const taskId = await makeTask({ colony });
 
       // Acquire meta colony, create new global skill, assign new task's skill
-      const metaColonyAddress = await colonyNetwork.getMetaColony.call();
+      const metaColonyAddress = await colonyNetwork.getMetaColony();
       const metaColony = await IColony.at(metaColonyAddress);
       await metaColony.addGlobalSkill(1);
 
-      const skillCount = await colonyNetwork.getSkillCount.call();
+      const skillCount = await colonyNetwork.getSkillCount();
 
       await expectEvent(
         executeSignedTaskChange({
@@ -1275,12 +1275,12 @@ contract("Colony", accounts => {
       dueDate += SECONDS_PER_DAY * 4;
       await setupAssignedTask({ colonyNetwork, colony, dueDate });
 
-      let task = await colony.getTask.call(1);
+      let task = await colony.getTask(1);
       assert.equal(task[1], "0x0000000000000000000000000000000000000000000000000000000000000000");
 
       const currentTime = await currentBlockTime();
       await colony.submitTaskDeliverable(1, DELIVERABLE_HASH, { from: WORKER });
-      task = await colony.getTask.call(1);
+      task = await colony.getTask(1);
       assert.equal(task[1], DELIVERABLE_HASH);
       assert.closeTo(task[7].toNumber(), currentTime, 2);
     });
@@ -1310,7 +1310,7 @@ contract("Colony", accounts => {
       await colony.submitTaskDeliverable(1, DELIVERABLE_HASH, { from: WORKER });
 
       await checkErrorRevert(colony.submitTaskDeliverable(1, SPECIFICATION_HASH, { from: WORKER }));
-      const task = await colony.getTask.call(1);
+      const task = await colony.getTask(1);
       assert.equal(task[1], DELIVERABLE_HASH);
     });
 
@@ -1320,7 +1320,7 @@ contract("Colony", accounts => {
       await setupAssignedTask({ colonyNetwork, colony, dueDate });
 
       await checkErrorRevert(colony.submitTaskDeliverable(1, SPECIFICATION_HASH, { from: OTHER }));
-      const task = await colony.getTask.call(1);
+      const task = await colony.getTask(1);
       assert.notEqual(task[1], DELIVERABLE_HASH);
     });
 
@@ -1343,7 +1343,7 @@ contract("Colony", accounts => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony, token });
       await colony.finalizeTask(taskId);
-      const task = await colony.getTask.call(taskId);
+      const task = await colony.getTask(taskId);
       assert.isTrue(task[2]);
     });
 
@@ -1379,16 +1379,16 @@ contract("Colony", accounts => {
       const taskId = await setupRatedTask({ colonyNetwork, colony, token });
 
       await colony.cancelTask(taskId);
-      const task = await colony.getTask.call(taskId);
+      const task = await colony.getTask(taskId);
       assert.isTrue(task[3]);
     });
 
     it("should be possible to return funds back to the domain", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupFundedTask({ colonyNetwork, colony, token });
-      const task = await colony.getTask.call(taskId);
+      const task = await colony.getTask(taskId);
       const domainId = task[8].toNumber();
-      const domain = await colony.getDomain.call(domainId);
+      const domain = await colony.getDomain(domainId);
       const taskPotId = task[6];
       const domainPotId = domain[1];
 
@@ -1558,19 +1558,19 @@ contract("Colony", accounts => {
       await colony.revealTaskWorkRating(taskId, MANAGER_ROLE, MANAGER_RATING, RATING_1_SALT, { from: WORKER });
       await colony.finalizeTask(taskId);
 
-      const taskPayoutManager1 = await colony.getTaskPayout.call(taskId, MANAGER_ROLE, 0x0);
+      const taskPayoutManager1 = await colony.getTaskPayout(taskId, MANAGER_ROLE, 0x0);
       assert.equal(taskPayoutManager1.toNumber(), 5000);
-      const taskPayoutManager2 = await colony.getTaskPayout.call(taskId, MANAGER_ROLE, token.address);
+      const taskPayoutManager2 = await colony.getTaskPayout(taskId, MANAGER_ROLE, token.address);
       assert.equal(taskPayoutManager2.toNumber(), 100);
 
-      const taskPayoutEvaluator1 = await colony.getTaskPayout.call(taskId, EVALUATOR_ROLE, 0x0);
+      const taskPayoutEvaluator1 = await colony.getTaskPayout(taskId, EVALUATOR_ROLE, 0x0);
       assert.equal(taskPayoutEvaluator1.toNumber(), 1000);
-      const taskPayoutEvaluator2 = await colony.getTaskPayout.call(taskId, EVALUATOR_ROLE, token.address);
+      const taskPayoutEvaluator2 = await colony.getTaskPayout(taskId, EVALUATOR_ROLE, token.address);
       assert.equal(taskPayoutEvaluator2.toNumber(), 40);
 
-      const taskPayoutWorker1 = await colony.getTaskPayout.call(taskId, WORKER_ROLE, 0x0);
+      const taskPayoutWorker1 = await colony.getTaskPayout(taskId, WORKER_ROLE, 0x0);
       assert.equal(taskPayoutWorker1.toNumber(), 98000);
-      const taskPayoutWorker2 = await colony.getTaskPayout.call(taskId, WORKER_ROLE, token.address);
+      const taskPayoutWorker2 = await colony.getTaskPayout(taskId, WORKER_ROLE, token.address);
       assert.equal(taskPayoutWorker2.toNumber(), 200);
     });
 
@@ -1616,13 +1616,13 @@ contract("Colony", accounts => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony, token });
       await colony.finalizeTask(taskId);
-      const networkBalanceBefore = await token.balanceOf.call(colonyNetwork.address);
+      const networkBalanceBefore = await token.balanceOf(colonyNetwork.address);
       await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
-      const networkBalanceAfter = await token.balanceOf.call(colonyNetwork.address);
+      const networkBalanceAfter = await token.balanceOf(colonyNetwork.address);
       assert.isTrue(networkBalanceAfter.sub(networkBalanceBefore).eq(toBN(1 * 1e18)));
-      const balance = await token.balanceOf.call(MANAGER);
+      const balance = await token.balanceOf(MANAGER);
       assert.isTrue(balance.eq(toBN(99 * 1e18)));
-      const potBalance = await colony.getPotBalance.call(2, token.address);
+      const potBalance = await colony.getPotBalance(2, token.address);
       assert.isTrue(potBalance.eq(toBN(250 * 1e18)));
     });
 
@@ -1641,7 +1641,7 @@ contract("Colony", accounts => {
         workerPayout: 200
       });
       await colony.finalizeTask(taskId);
-      const metaColonyAddress = await colonyNetwork.getMetaColony.call();
+      const metaColonyAddress = await colonyNetwork.getMetaColony();
       const balanceBefore = await web3GetBalance(MANAGER);
       const metaBalanceBefore = await web3GetBalance(metaColonyAddress);
       await colony.claimPayout(taskId, MANAGER_ROLE, 0x0, { gasPrice: 0 });
@@ -1659,7 +1659,7 @@ contract("Colony", accounts => {
           .toNumber(),
         1
       );
-      const potBalance = await colony.getPotBalance.call(2, 0x0);
+      const potBalance = await colony.getPotBalance(2, 0x0);
       assert.equal(potBalance.toNumber(), 250);
     });
 

--- a/test/colony.js
+++ b/test/colony.js
@@ -1,6 +1,8 @@
 /* globals artifacts */
 
 import { toBN } from "web3-utils";
+import chai from "chai";
+import bnChai from "bn-chai";
 
 import {
   MANAGER_ROLE,
@@ -44,6 +46,9 @@ import {
 } from "../helpers/test-data-generator";
 
 import { setupColonyVersionResolver } from "../helpers/upgradable-contracts";
+
+const { expect } = chai;
+chai.use(bnChai(web3.utils.BN));
 
 const Colony = artifacts.require("Colony");
 const Resolver = artifacts.require("Resolver");
@@ -1435,9 +1440,9 @@ contract("Colony", accounts => {
       assert.equal(cancelledTaskEtherBalance.toNumber(), 0);
       assert.equal(cancelledTaskTokenBalance.toNumber(), 0);
       assert.equal(cancelledTaskOtherTokenBalance.toNumber(), 0);
-      assert.isTrue(originalDomainEtherBalance.add(originalTaskEtherBalance).eq(cancelledDomainEtherBalance));
-      assert.isTrue(originalDomainTokenBalance.add(originalTaskTokenBalance).eq(cancelledDomainTokenBalance));
-      assert.isTrue(originalDomainOtherTokenBalance.add(originalTaskOtherTokenBalance).eq(cancelledDomainOtherTokenBalance));
+      expect(originalDomainEtherBalance.add(originalTaskEtherBalance)).to.eq.BN(cancelledDomainEtherBalance);
+      expect(originalDomainTokenBalance.add(originalTaskTokenBalance)).to.eq.BN(cancelledDomainTokenBalance);
+      expect(originalDomainOtherTokenBalance.add(originalTaskOtherTokenBalance)).to.eq.BN(cancelledDomainOtherTokenBalance);
     });
 
     it("should fail if manager tries to cancel a task that was finalized", async () => {
@@ -1619,11 +1624,11 @@ contract("Colony", accounts => {
       const networkBalanceBefore = await token.balanceOf(colonyNetwork.address);
       await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
       const networkBalanceAfter = await token.balanceOf(colonyNetwork.address);
-      assert.isTrue(networkBalanceAfter.sub(networkBalanceBefore).eq(toBN(1 * 1e18)));
+      expect(networkBalanceAfter.sub(networkBalanceBefore)).to.eq.BN(toBN(1 * 1e18));
       const balance = await token.balanceOf(MANAGER);
-      assert.isTrue(balance.eq(toBN(99 * 1e18)));
+      expect(balance).to.eq.BN(toBN(99 * 1e18));
       const potBalance = await colony.getPotBalance(2, token.address);
-      assert.isTrue(potBalance.eq(toBN(250 * 1e18)));
+      expect(potBalance).to.eq.BN(toBN(250 * 1e18));
     });
 
     it("should payout agreed ether for a task", async () => {

--- a/test/colony.js
+++ b/test/colony.js
@@ -1165,9 +1165,9 @@ contract("Colony", accounts => {
           colony,
           functionName: "setTaskBrief",
           taskId,
-          signers: [MANAGER, EVALUATOR],
-          sigTypes: [0, 0],
-          args: [10, 0]
+          signers: [MANAGER],
+          sigTypes: [0],
+          args: [10, SPECIFICATION_HASH_UPDATED]
         })
       );
     });

--- a/test/colony.js
+++ b/test/colony.js
@@ -102,7 +102,7 @@ contract("Colony", accounts => {
     it("should accept ether", async () => {
       await colony.send(1);
       const colonyBalance = await web3GetBalance(colony.address);
-      assert.equal(colonyBalance.toNumber(), 1);
+      assert.equal(colonyBalance, 1);
     });
 
     it("should not have owner", async () => {
@@ -1426,12 +1426,12 @@ contract("Colony", accounts => {
       const cancelledDomainTokenBalance = await colony.getPotBalance.call(domainPotId, token.address);
       const cancelledTaskOtherTokenBalance = await colony.getPotBalance.call(taskPotId, otherToken.address);
       const cancelledDomainOtherTokenBalance = await colony.getPotBalance.call(domainPotId, otherToken.address);
-      assert.notEqual(originalTaskEtherBalance.toNumber(), cancelledTaskEtherBalance.toNumber());
-      assert.notEqual(originalDomainEtherBalance.toNumber(), cancelledDomainEtherBalance.toNumber());
-      assert.notEqual(originalTaskTokenBalance.toNumber(), cancelledTaskTokenBalance.toNumber());
-      assert.notEqual(originalDomainTokenBalance.toNumber(), cancelledDomainTokenBalance.toNumber());
-      assert.notEqual(originalTaskOtherTokenBalance.toNumber(), cancelledTaskOtherTokenBalance.toNumber());
-      assert.notEqual(originalDomainOtherTokenBalance.toNumber(), cancelledDomainOtherTokenBalance.toNumber());
+      assert.isTrue(originalTaskEtherBalance.eq(cancelledTaskEtherBalance));
+      assert.isTrue(originalDomainEtherBalance.eq(cancelledDomainEtherBalance));
+      assert.isTrue(originalTaskTokenBalance.eq(cancelledTaskTokenBalance));
+      assert.isTrue(originalDomainTokenBalance.eq(cancelledDomainTokenBalance));
+      assert.isTrue(originalTaskOtherTokenBalance.eq(cancelledTaskOtherTokenBalance));
+      assert.isTrue(originalDomainOtherTokenBalance.eq(cancelledDomainOtherTokenBalance));
       assert.equal(cancelledTaskEtherBalance.toNumber(), 0);
       assert.equal(cancelledTaskTokenBalance.toNumber(), 0);
       assert.equal(cancelledTaskOtherTokenBalance.toNumber(), 0);
@@ -1619,7 +1619,7 @@ contract("Colony", accounts => {
       const networkBalanceBefore = await token.balanceOf.call(colonyNetwork.address);
       await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
       const networkBalanceAfter = await token.balanceOf.call(colonyNetwork.address);
-      assert.equal(networkBalanceAfter.minus(networkBalanceBefore).toNumber(), 1 * 1e18);
+      assert.equal(networkBalanceAfter.sub(networkBalanceBefore).eq(toBN(1 * 1e18)));
       const balance = await token.balanceOf.call(MANAGER);
       assert.equal(balance.toNumber(), 99 * 1e18);
       const potBalance = await colony.getPotBalance.call(2, token.address);
@@ -1647,8 +1647,18 @@ contract("Colony", accounts => {
       await colony.claimPayout(taskId, MANAGER_ROLE, 0x0, { gasPrice: 0 });
       const balanceAfter = await web3GetBalance(MANAGER);
       const metaBalanceAfter = await web3GetBalance(metaColonyAddress);
-      assert.equal(balanceAfter.minus(balanceBefore).toNumber(), 99);
-      assert.equal(metaBalanceAfter.minus(metaBalanceBefore).toNumber(), 1);
+      assert.equal(
+        toBN(balanceAfter)
+          .sub(toBN(balanceBefore))
+          .toNumber(),
+        99
+      );
+      assert.equal(
+        toBN(metaBalanceAfter)
+          .sub(toBN(metaBalanceBefore))
+          .toNumber(),
+        1
+      );
       const potBalance = await colony.getPotBalance.call(2, 0x0);
       assert.equal(potBalance.toNumber(), 250);
     });

--- a/test/colony.js
+++ b/test/colony.js
@@ -1775,7 +1775,7 @@ contract("Colony", accounts => {
       await checkErrorRevert(colony.initialiseColony("0x0", { from: owner }));
       await checkErrorRevert(colony.mintTokens(1000, { from: owner }));
       await checkErrorRevert(colony.addGlobalSkill(0, { from: owner }));
-      await checkErrorRevert(colony.makeTask("0x0", 0, { from: owner }));
+      await checkErrorRevert(colony.makeTask(SPECIFICATION_HASH, 0, { from: owner }));
     });
 
     it("should exit recovery mode with sufficient approvals", async () => {

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -42,7 +42,7 @@ contract("Meta Colony", accounts => {
 
     metaColonyToken = await Token.new("Colony Network Token", "CLNY", 18);
     await colonyNetwork.createMetaColony(metaColonyToken.address);
-    const metaColonyAddress = await colonyNetwork.getMetaColony.call();
+    const metaColonyAddress = await colonyNetwork.getMetaColony();
     metaColony = await IColony.at(metaColonyAddress);
 
     await colonyNetwork.startNextCycle();
@@ -55,12 +55,12 @@ contract("Meta Colony", accounts => {
     });
 
     it("token `decimals` property is correct", async () => {
-      const tokenDecimals = await metaColonyToken.decimals.call();
+      const tokenDecimals = await metaColonyToken.decimals();
       assert.equal(tokenDecimals.toString(), "18");
     });
 
     it("token `name` property is correct", async () => {
-      const tokenName = await metaColonyToken.name.call();
+      const tokenName = await metaColonyToken.name();
       assert.equal(tokenName, "Colony Network Token");
     });
   });
@@ -69,19 +69,19 @@ contract("Meta Colony", accounts => {
     it("should be able to add a new skill as a child to the root skill", async () => {
       await metaColony.addGlobalSkill(1);
 
-      const skillCount = await colonyNetwork.getSkillCount.call();
+      const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 4);
 
-      const newSkill = await colonyNetwork.getSkill.call(skillCount);
+      const newSkill = await colonyNetwork.getSkill(skillCount);
       assert.equal(newSkill[0].toNumber(), 1);
       assert.equal(newSkill[1].toNumber(), 0);
 
       // Check rootSkill.nChildren is now 1
-      const rootSkill = await colonyNetwork.getSkill.call(1);
+      const rootSkill = await colonyNetwork.getSkill(1);
       assert.equal(rootSkill[1].toNumber(), 1);
 
       // Check rootSkill.children first element is the id of the new skill
-      const rootSkillChild = await colonyNetwork.getChildSkillId.call(1, 0);
+      const rootSkillChild = await colonyNetwork.getChildSkillId(1, 0);
       assert.equal(rootSkillChild.toNumber(), 4);
     });
 
@@ -94,31 +94,31 @@ contract("Meta Colony", accounts => {
       await metaColony.addGlobalSkill(1);
       await metaColony.addGlobalSkill(1);
 
-      const skillCount = await colonyNetwork.getSkillCount.call();
+      const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 6);
 
-      const newSkill1 = await colonyNetwork.getSkill.call(4);
+      const newSkill1 = await colonyNetwork.getSkill(4);
       assert.equal(newSkill1[0].toNumber(), 1);
       assert.equal(newSkill1[1].toNumber(), 0);
 
-      const newSkill2 = await colonyNetwork.getSkill.call(5);
+      const newSkill2 = await colonyNetwork.getSkill(5);
       assert.equal(newSkill2[0].toNumber(), 1);
       assert.equal(newSkill2[1].toNumber(), 0);
 
-      const newSkill3 = await colonyNetwork.getSkill.call(6);
+      const newSkill3 = await colonyNetwork.getSkill(6);
       assert.equal(newSkill3[0].toNumber(), 1);
       assert.equal(newSkill3[1].toNumber(), 0);
 
       // Check rootSkill.nChildren is now 3
-      const rootSkill = await colonyNetwork.getSkill.call(1);
+      const rootSkill = await colonyNetwork.getSkill(1);
       assert.equal(rootSkill[1].toNumber(), 3);
 
       // Check rootSkill.children contains the ids of the new skills
-      const rootSkillChild1 = await colonyNetwork.getChildSkillId.call(1, 0);
+      const rootSkillChild1 = await colonyNetwork.getChildSkillId(1, 0);
       assert.equal(rootSkillChild1.toNumber(), 4);
-      const rootSkillChild2 = await colonyNetwork.getChildSkillId.call(1, 1);
+      const rootSkillChild2 = await colonyNetwork.getChildSkillId(1, 1);
       assert.equal(rootSkillChild2.toNumber(), 5);
-      const rootSkillChild3 = await colonyNetwork.getChildSkillId.call(1, 2);
+      const rootSkillChild3 = await colonyNetwork.getChildSkillId(1, 2);
       assert.equal(rootSkillChild3.toNumber(), 6);
     });
 
@@ -128,13 +128,13 @@ contract("Meta Colony", accounts => {
       await metaColony.addGlobalSkill(1);
 
       await checkErrorRevert(metaColony.addGlobalSkill(6));
-      const skillCount = await colonyNetwork.getSkillCount.call();
+      const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 5);
     });
 
     it("should NOT be able to add a child skill to a local skill parent", async () => {
       await checkErrorRevert(metaColony.addGlobalSkill(2));
-      const skillCount = await colonyNetwork.getSkillCount.call();
+      const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 3);
     });
 
@@ -146,68 +146,68 @@ contract("Meta Colony", accounts => {
       await metaColony.addGlobalSkill(4);
       await metaColony.addGlobalSkill(5);
 
-      const rootSkill = await colonyNetwork.getSkill.call(1);
+      const rootSkill = await colonyNetwork.getSkill(1);
       assert.equal(rootSkill[0].toNumber(), 0);
       assert.equal(rootSkill[1].toNumber(), 6);
-      const rootSkillChildSkillId1 = await colonyNetwork.getChildSkillId.call(1, 0);
+      const rootSkillChildSkillId1 = await colonyNetwork.getChildSkillId(1, 0);
       assert.equal(rootSkillChildSkillId1.toNumber(), 4);
-      const rootSkillChildSkillId2 = await colonyNetwork.getChildSkillId.call(1, 1);
+      const rootSkillChildSkillId2 = await colonyNetwork.getChildSkillId(1, 1);
       assert.equal(rootSkillChildSkillId2.toNumber(), 5);
-      const rootSkillChildSkillId3 = await colonyNetwork.getChildSkillId.call(1, 2);
+      const rootSkillChildSkillId3 = await colonyNetwork.getChildSkillId(1, 2);
       assert.equal(rootSkillChildSkillId3.toNumber(), 6);
-      const rootSkillChildSkillId4 = await colonyNetwork.getChildSkillId.call(1, 3);
+      const rootSkillChildSkillId4 = await colonyNetwork.getChildSkillId(1, 3);
       assert.equal(rootSkillChildSkillId4.toNumber(), 7);
-      const rootSkillChildSkillId5 = await colonyNetwork.getChildSkillId.call(1, 4);
+      const rootSkillChildSkillId5 = await colonyNetwork.getChildSkillId(1, 4);
       assert.equal(rootSkillChildSkillId5.toNumber(), 8);
-      const rootSkillChildSkillId6 = await colonyNetwork.getChildSkillId.call(1, 5);
+      const rootSkillChildSkillId6 = await colonyNetwork.getChildSkillId(1, 5);
       assert.equal(rootSkillChildSkillId6.toNumber(), 9);
 
-      const skill1 = await colonyNetwork.getSkill.call(4);
+      const skill1 = await colonyNetwork.getSkill(4);
       assert.equal(skill1[0].toNumber(), 1);
       assert.equal(skill1[1].toNumber(), 1);
-      const skill1ParentSkillId1 = await colonyNetwork.getParentSkillId.call(4, 0);
+      const skill1ParentSkillId1 = await colonyNetwork.getParentSkillId(4, 0);
       assert.equal(skill1ParentSkillId1.toNumber(), 1);
-      const skill1ChildSkillId1 = await colonyNetwork.getChildSkillId.call(4, 0);
+      const skill1ChildSkillId1 = await colonyNetwork.getChildSkillId(4, 0);
       assert.equal(skill1ChildSkillId1.toNumber(), 8);
 
-      const skill2 = await colonyNetwork.getSkill.call(5);
+      const skill2 = await colonyNetwork.getSkill(5);
       assert.equal(skill2[0].toNumber(), 1);
       assert.equal(skill2[1].toNumber(), 2);
-      const skill2ParentSkillId1 = await colonyNetwork.getParentSkillId.call(5, 0);
+      const skill2ParentSkillId1 = await colonyNetwork.getParentSkillId(5, 0);
       assert.equal(skill2ParentSkillId1.toNumber(), 1);
-      const skill2ChildSkillId1 = await colonyNetwork.getChildSkillId.call(5, 0);
+      const skill2ChildSkillId1 = await colonyNetwork.getChildSkillId(5, 0);
       assert.equal(skill2ChildSkillId1.toNumber(), 6);
-      const skill2ChildSkillId2 = await colonyNetwork.getChildSkillId.call(5, 1);
+      const skill2ChildSkillId2 = await colonyNetwork.getChildSkillId(5, 1);
       assert.equal(skill2ChildSkillId2.toNumber(), 9);
 
-      const skill3 = await colonyNetwork.getSkill.call(6);
+      const skill3 = await colonyNetwork.getSkill(6);
       assert.equal(skill3[0].toNumber(), 2);
       assert.equal(skill3[1].toNumber(), 0);
-      const skill3ParentSkillId1 = await colonyNetwork.getParentSkillId.call(6, 0);
+      const skill3ParentSkillId1 = await colonyNetwork.getParentSkillId(6, 0);
       assert.equal(skill3ParentSkillId1.toNumber(), 5);
-      const skill3ParentSkillId2 = await colonyNetwork.getParentSkillId.call(6, 1);
+      const skill3ParentSkillId2 = await colonyNetwork.getParentSkillId(6, 1);
       assert.equal(skill3ParentSkillId2.toNumber(), 1);
 
-      const skill4 = await colonyNetwork.getSkill.call(7);
+      const skill4 = await colonyNetwork.getSkill(7);
       assert.equal(skill4[0].toNumber(), 1);
       assert.equal(skill4[1].toNumber(), 0);
-      const skill4ParentSkillId1 = await colonyNetwork.getParentSkillId.call(7, 0);
+      const skill4ParentSkillId1 = await colonyNetwork.getParentSkillId(7, 0);
       assert.equal(skill4ParentSkillId1.toNumber(), 1);
 
-      const skill5 = await colonyNetwork.getSkill.call(8);
+      const skill5 = await colonyNetwork.getSkill(8);
       assert.equal(skill5[0].toNumber(), 2);
       assert.equal(skill5[1].toNumber(), 0);
-      const skill5ParentSkillId1 = await colonyNetwork.getParentSkillId.call(8, 0);
+      const skill5ParentSkillId1 = await colonyNetwork.getParentSkillId(8, 0);
       assert.equal(skill5ParentSkillId1.toNumber(), 4);
-      const skill5ParentSkillId2 = await colonyNetwork.getParentSkillId.call(8, 1);
+      const skill5ParentSkillId2 = await colonyNetwork.getParentSkillId(8, 1);
       assert.equal(skill5ParentSkillId2.toNumber(), 1);
 
-      const skill6 = await colonyNetwork.getSkill.call(9);
+      const skill6 = await colonyNetwork.getSkill(9);
       assert.equal(skill6[0].toNumber(), 2);
       assert.equal(skill6[1].toNumber(), 0);
-      const skill6ParentSkillId1 = await colonyNetwork.getParentSkillId.call(9, 0);
+      const skill6ParentSkillId1 = await colonyNetwork.getParentSkillId(9, 0);
       assert.equal(skill6ParentSkillId1.toNumber(), 5);
-      const skill6ParentSkillId2 = await colonyNetwork.getParentSkillId.call(9, 1);
+      const skill6ParentSkillId2 = await colonyNetwork.getParentSkillId(9, 1);
       assert.equal(skill6ParentSkillId2.toNumber(), 1);
     });
 
@@ -224,28 +224,28 @@ contract("Meta Colony", accounts => {
 
       // 1 -> 4 -> 5 -> 6 -> 7 -> 8 -> 9 -> 10 -> 11 -> 12
 
-      const [numParents, numChildren] = await colonyNetwork.getSkill.call(12);
+      const [numParents, numChildren] = await colonyNetwork.getSkill(12);
       assert.equal(numParents.toNumber(), 9);
       assert.equal(numChildren.toNumber(), 0);
 
       let parentId;
-      parentId = await colonyNetwork.getParentSkillId.call(12, 0);
+      parentId = await colonyNetwork.getParentSkillId(12, 0);
       assert.equal(parentId.toNumber(), 11);
-      parentId = await colonyNetwork.getParentSkillId.call(12, 1);
+      parentId = await colonyNetwork.getParentSkillId(12, 1);
       assert.equal(parentId.toNumber(), 10);
-      parentId = await colonyNetwork.getParentSkillId.call(12, 2);
+      parentId = await colonyNetwork.getParentSkillId(12, 2);
       assert.equal(parentId.toNumber(), 9);
-      parentId = await colonyNetwork.getParentSkillId.call(12, 3);
+      parentId = await colonyNetwork.getParentSkillId(12, 3);
       assert.equal(parentId.toNumber(), 8);
-      parentId = await colonyNetwork.getParentSkillId.call(12, 4);
+      parentId = await colonyNetwork.getParentSkillId(12, 4);
       assert.equal(parentId.toNumber(), 7);
-      parentId = await colonyNetwork.getParentSkillId.call(12, 5);
+      parentId = await colonyNetwork.getParentSkillId(12, 5);
       assert.equal(parentId.toNumber(), 6);
-      parentId = await colonyNetwork.getParentSkillId.call(12, 6);
+      parentId = await colonyNetwork.getParentSkillId(12, 6);
       assert.equal(parentId.toNumber(), 5);
-      parentId = await colonyNetwork.getParentSkillId.call(12, 7);
+      parentId = await colonyNetwork.getParentSkillId(12, 7);
       assert.equal(parentId.toNumber(), 4);
-      parentId = await colonyNetwork.getParentSkillId.call(12, 8);
+      parentId = await colonyNetwork.getParentSkillId(12, 8);
       assert.equal(parentId.toNumber(), 1);
 
       // Higher indices return 0
@@ -260,7 +260,7 @@ contract("Meta Colony", accounts => {
     it("should NOT be able to add a new root global skill", async () => {
       await checkErrorRevert(metaColony.addGlobalSkill(0));
 
-      const skillCount = await colonyNetwork.getSkillCount.call();
+      const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 3);
     });
   });
@@ -269,22 +269,22 @@ contract("Meta Colony", accounts => {
     it("should be able to add new domains as children to the root domain", async () => {
       await metaColony.addDomain(1);
 
-      const skillCount = await colonyNetwork.getSkillCount.call();
+      const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 4);
-      const domainCount = await metaColony.getDomainCount.call();
+      const domainCount = await metaColony.getDomainCount();
       assert.equal(domainCount.toNumber(), 2);
 
-      const newDomain = await metaColony.getDomain.call(1);
+      const newDomain = await metaColony.getDomain(1);
       assert.equal(newDomain[0].toNumber(), 2);
       assert.equal(newDomain[1].toNumber(), 1);
 
       // Check root local skill.nChildren is now 2
       // One special mining skill, and the skill associated with the domain we just added
-      const rootLocalSkill = await colonyNetwork.getSkill.call(2);
+      const rootLocalSkill = await colonyNetwork.getSkill(2);
       assert.equal(rootLocalSkill[1].toNumber(), 2);
 
       // Check root local skill.children second element is the id of the new skill
-      const rootSkillChild = await colonyNetwork.getChildSkillId.call(2, 1);
+      const rootSkillChild = await colonyNetwork.getChildSkillId(2, 1);
       assert.equal(rootSkillChild.toNumber(), 4);
     });
 
@@ -292,9 +292,9 @@ contract("Meta Colony", accounts => {
       await metaColony.addDomain(1);
       await checkErrorRevert(metaColony.addDomain(2));
 
-      const skillCount = await colonyNetwork.getSkillCount.call();
+      const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 4);
-      const domainCount = await metaColony.getDomainCount.call();
+      const domainCount = await metaColony.getDomainCount();
       assert.equal(domainCount.toNumber(), 2);
     });
   });
@@ -306,7 +306,7 @@ contract("Meta Colony", accounts => {
       const { logs } = await colonyNetwork.createColony(newToken.address);
       const { colonyAddress } = logs[0].args;
       colony = await IColony.at(colonyAddress);
-      const tokenAddress = await colony.getToken.call();
+      const tokenAddress = await colony.getToken();
       token = await Token.at(tokenAddress);
     });
 
@@ -319,48 +319,48 @@ contract("Meta Colony", accounts => {
       await colony.addDomain(1);
       await colony.addDomain(1);
 
-      const skillCount = await colonyNetwork.getSkillCount.call();
+      const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 7);
-      const domainCount = await colony.getDomainCount.call();
+      const domainCount = await colony.getDomainCount();
       assert.equal(domainCount.toNumber(), 4);
 
       // TODO: I think newDomain1 is the root domain of the colony?
-      const newDomain1 = await colony.getDomain.call(1);
+      const newDomain1 = await colony.getDomain(1);
       assert.equal(newDomain1[0].toNumber(), 4);
       assert.equal(newDomain1[1].toNumber(), 1);
 
-      const newDomain2 = await colony.getDomain.call(2);
+      const newDomain2 = await colony.getDomain(2);
       assert.equal(newDomain2[0].toNumber(), 5);
       assert.equal(newDomain2[1].toNumber(), 2);
 
-      const newDomain3 = await colony.getDomain.call(3);
+      const newDomain3 = await colony.getDomain(3);
       assert.equal(newDomain3[0].toNumber(), 6);
       assert.equal(newDomain3[1].toNumber(), 3);
       // Check root local skill.nChildren is now 3
-      const rootLocalSkill = await colonyNetwork.getSkill.call(4);
+      const rootLocalSkill = await colonyNetwork.getSkill(4);
       assert.equal(rootLocalSkill[1].toNumber(), 3);
       // Check root local skill.children are the ids of the new skills
-      const rootSkillChild1 = await colonyNetwork.getChildSkillId.call(4, 0);
+      const rootSkillChild1 = await colonyNetwork.getChildSkillId(4, 0);
       assert.equal(rootSkillChild1.toNumber(), 5);
-      const rootSkillChild2 = await colonyNetwork.getChildSkillId.call(4, 1);
+      const rootSkillChild2 = await colonyNetwork.getChildSkillId(4, 1);
       assert.equal(rootSkillChild2.toNumber(), 6);
-      const rootSkillChild3 = await colonyNetwork.getChildSkillId.call(4, 2);
+      const rootSkillChild3 = await colonyNetwork.getChildSkillId(4, 2);
       assert.equal(rootSkillChild3.toNumber(), 7);
     });
 
     it("should NOT be able to add a new local skill by anyone but a Colony", async () => {
       await checkErrorRevert(colonyNetwork.addSkill(2, false));
 
-      const skillCount = await colonyNetwork.getSkillCount.call();
+      const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 4);
     });
 
     it("should NOT be able to add a new root local skill", async () => {
-      const skillCountBefore = await colonyNetwork.getSkillCount.call();
+      const skillCountBefore = await colonyNetwork.getSkillCount();
       const rootDomain = await colony.getDomain(1);
       const rootLocalSkillId = rootDomain[0].toNumber();
       await checkErrorRevert(colonyNetwork.addSkill(rootLocalSkillId, false));
-      const skillCountAfter = await colonyNetwork.getSkillCount.call();
+      const skillCountAfter = await colonyNetwork.getSkillCount();
 
       assert.equal(skillCountBefore.toNumber(), skillCountAfter.toNumber());
     });
@@ -382,7 +382,7 @@ contract("Meta Colony", accounts => {
 
       await colony.setTaskDomain(taskId, 2);
 
-      const task = await colony.getTask.call(taskId);
+      const task = await colony.getTask(taskId);
       assert.equal(task[8].toNumber(), 2);
     });
 
@@ -390,7 +390,7 @@ contract("Meta Colony", accounts => {
       await colony.addDomain(1);
       await makeTask({ colony });
       await checkErrorRevert(colony.setTaskDomain(1, 2, { from: OTHER_ACCOUNT }));
-      const task = await colony.getTask.call(1);
+      const task = await colony.getTask(1);
       assert.equal(task[8].toNumber(), 1);
     });
 
@@ -402,7 +402,7 @@ contract("Meta Colony", accounts => {
       await makeTask({ colony });
       await checkErrorRevert(colony.setTaskDomain(1, 20));
 
-      const task = await colony.getTask.call(1);
+      const task = await colony.getTask(1);
       assert.equal(task[8].toNumber(), 1);
     });
 
@@ -428,7 +428,7 @@ contract("Meta Colony", accounts => {
         args: [taskId, 6]
       });
 
-      const task = await colony.getTask.call(taskId);
+      const task = await colony.getTask(taskId);
       assert.equal(task[9][0].toNumber(), 6);
     });
 
@@ -438,7 +438,7 @@ contract("Meta Colony", accounts => {
 
       await makeTask({ colony });
       await checkErrorRevert(colony.setTaskSkill(1, 5, { from: OTHER_ACCOUNT }));
-      const task = await colony.getTask.call(1);
+      const task = await colony.getTask(1);
       assert.equal(task[9][0].toNumber(), 0);
     });
 
@@ -454,7 +454,7 @@ contract("Meta Colony", accounts => {
       await colony.finalizeTask(taskId);
       await checkErrorRevert(colony.setTaskSkill(taskId, 6));
 
-      const task = await colony.getTask.call(taskId);
+      const task = await colony.getTask(taskId);
       assert.equal(task[9][0].toNumber(), 1);
     });
 
@@ -471,12 +471,12 @@ contract("Meta Colony", accounts => {
 
   describe("when getting a skill", () => {
     it("should return a true flag if the skill is global", async () => {
-      const globalSkill = await colonyNetwork.getSkill.call(1);
+      const globalSkill = await colonyNetwork.getSkill(1);
       assert.isTrue(globalSkill[2]);
     });
 
     it("should return a false flag if the skill is local", async () => {
-      const localSkill = await colonyNetwork.getSkill.call(2);
+      const localSkill = await colonyNetwork.getSkill(2);
       assert.isFalse(localSkill[2]);
     });
   });

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -1,5 +1,5 @@
 /* globals artifacts */
-import { INITIAL_FUNDING, MANAGER } from "../helpers/constants";
+import { INITIAL_FUNDING } from "../helpers/constants";
 import { checkErrorRevert, getTokenArgs } from "../helpers/test-helper";
 import { fundColonyWithTokens, setupRatedTask, executeSignedTaskChange, makeTask } from "../helpers/test-data-generator";
 
@@ -16,6 +16,7 @@ const Token = artifacts.require("Token");
 
 contract("Meta Colony", accounts => {
   let TOKEN_ARGS;
+  const MANAGER = accounts[0];
   const OTHER_ACCOUNT = accounts[1];
 
   let metaColony;

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -224,7 +224,9 @@ contract("Meta Colony", accounts => {
 
       // 1 -> 4 -> 5 -> 6 -> 7 -> 8 -> 9 -> 10 -> 11 -> 12
 
-      const [numParents, numChildren] = await colonyNetwork.getSkill(12);
+      const skill = await colonyNetwork.getSkill(12);
+      const numParents = skill[0];
+      const numChildren = skill[1];
       assert.equal(numParents.toNumber(), 9);
       assert.equal(numChildren.toNumber(), 0);
 

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -1,12 +1,17 @@
 /* globals artifacts */
 import { toBN } from "web3-utils";
 import { BN } from "bn.js";
+import chai from "chai";
+import bnChai from "bn-chai";
 
 import { MANAGER_PAYOUT, WORKER_PAYOUT } from "../helpers/constants";
 import { getTokenArgs, checkErrorRevert } from "../helpers/test-helper";
 import { fundColonyWithTokens, setupRatedTask } from "../helpers/test-data-generator";
 
 import { setupColonyVersionResolver } from "../helpers/upgradable-contracts";
+
+const { expect } = chai;
+chai.use(bnChai(web3.utils.BN));
 
 const EtherRouter = artifacts.require("EtherRouter");
 const IColony = artifacts.require("IColony");
@@ -66,7 +71,7 @@ contract("Colony Reputation Updates", accounts => {
 
       const repLogEntryManager = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(0);
       assert.equal(repLogEntryManager[0], MANAGER);
-      assert.isTrue(repLogEntryManager[1].eq(toBN(100 * 1e18)));
+      expect(repLogEntryManager[1]).to.eq.BN(toBN(100 * 1e18));
       assert.equal(repLogEntryManager[2].toNumber(), 2);
       assert.equal(repLogEntryManager[3], metaColony.address);
       assert.equal(repLogEntryManager[4].toNumber(), 2);
@@ -74,7 +79,7 @@ contract("Colony Reputation Updates", accounts => {
 
       const repLogEntryEvaluator = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(1);
       assert.equal(repLogEntryEvaluator[0], EVALUATOR);
-      assert.isTrue(repLogEntryEvaluator[1].eq(toBN(50 * 1e18)));
+      expect(repLogEntryEvaluator[1]).to.eq.BN(toBN(50 * 1e18));
       assert.equal(repLogEntryEvaluator[2].toNumber(), 2);
       assert.equal(repLogEntryEvaluator[3], metaColony.address);
       assert.equal(repLogEntryEvaluator[4].toNumber(), 2);
@@ -82,7 +87,7 @@ contract("Colony Reputation Updates", accounts => {
 
       const repLogEntryWorker = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(2);
       assert.equal(repLogEntryWorker[0], WORKER);
-      assert.isTrue(repLogEntryWorker[1].eq(toBN(300 * 1e18)));
+      expect(repLogEntryWorker[1]).to.eq.BN(toBN(300 * 1e18));
       assert.equal(repLogEntryWorker[2].toNumber(), 2);
       assert.equal(repLogEntryWorker[3], metaColony.address);
       assert.equal(repLogEntryWorker[4].toNumber(), 2);
@@ -228,7 +233,7 @@ contract("Colony Reputation Updates", accounts => {
 
       // Check the task pot is correctly funded with the max amount
       const taskPotBalance = await metaColony.getPotBalance(2, colonyToken.address);
-      assert.isTrue(taskPotBalance.eq(maxUIntNumber));
+      expect(taskPotBalance).to.eq.BN(maxUIntNumber);
 
       await checkErrorRevert(metaColony.finalizeTask(taskId));
     });

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -1,5 +1,5 @@
 /* globals artifacts */
-import web3Utils from "web3-utils";
+import { toBN } from "web3-utils";
 import { BN } from "bn.js";
 
 import { MANAGER_PAYOUT, WORKER_PAYOUT } from "../helpers/constants";
@@ -66,7 +66,7 @@ contract("Colony Reputation Updates", accounts => {
 
       const repLogEntryManager = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(0);
       assert.equal(repLogEntryManager[0], MANAGER);
-      assert.equal(repLogEntryManager[1].toNumber(), 100 * 1e18);
+      assert.isTrue(repLogEntryManager[1].eq(toBN(100 * 1e18)));
       assert.equal(repLogEntryManager[2].toNumber(), 2);
       assert.equal(repLogEntryManager[3], metaColony.address);
       assert.equal(repLogEntryManager[4].toNumber(), 2);
@@ -191,8 +191,7 @@ contract("Colony Reputation Updates", accounts => {
       });
       await metaColony.finalizeTask(taskId1);
       let repLogEntryWorker = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(3);
-      const result = web3Utils
-        .toBN(WORKER_PAYOUT)
+      const result = toBN(WORKER_PAYOUT)
         .muln(3)
         .divn(2);
       assert.equal(repLogEntryWorker[1].toString(), result.toString());
@@ -232,7 +231,7 @@ contract("Colony Reputation Updates", accounts => {
 
       // Check the task pot is correctly funded with the max amount
       const taskPotBalance = await metaColony.getPotBalance.call(2, colonyToken.address);
-      assert.isTrue(taskPotBalance.equals(maxUIntNumber));
+      assert.isTrue(taskPotBalance.eq(maxUIntNumber));
 
       await checkErrorRevert(metaColony.finalizeTask(taskId));
     });

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -210,9 +210,7 @@ contract("Colony Reputation Updates", accounts => {
 
     it("should revert on reputation amount overflow", async () => {
       // Fund colony with maximum possible int number of tokens
-      const maxUIntNumber = new BN(2)
-        .pow(new BN(255))
-        .sub(new BN(1));
+      const maxUIntNumber = new BN(2).pow(new BN(255)).sub(new BN(1));
       await fundColonyWithTokens(metaColony, colonyToken, maxUIntNumber);
       // Split the tokens as payouts between the manager and worker
       const managerPayout = new BN("2");

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -23,7 +23,7 @@ contract("Colony Reputation Updates", accounts => {
   const EVALUATOR = accounts[1];
   const WORKER = accounts[2];
   const OTHER = accounts[3];
-  
+
   let colonyNetwork;
   let metaColony;
   let resolverColonyNetworkDeployed;

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -46,7 +46,7 @@ contract("Colony Reputation Updates", accounts => {
     const tokenArgs = getTokenArgs();
     colonyToken = await Token.new(...tokenArgs);
     await colonyNetwork.createMetaColony(colonyToken.address);
-    const metaColonyAddress = await colonyNetwork.getMetaColony.call();
+    const metaColonyAddress = await colonyNetwork.getMetaColony();
     await colonyToken.setOwner(metaColonyAddress);
     metaColony = await IColony.at(metaColonyAddress);
     const amount = new BN(10)
@@ -168,14 +168,14 @@ contract("Colony Reputation Updates", accounts => {
       initialRepLogLength = initialRepLogLength.toNumber();
       const taskId1 = await setupRatedTask({ colonyNetwork, colony: metaColony });
       await metaColony.finalizeTask(taskId1);
-      let repLogEntry = await inactiveReputationMiningCycle.getReputationUpdateLogEntry.call(initialRepLogLength);
+      let repLogEntry = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(initialRepLogLength);
       const nPrevious = repLogEntry[5].toNumber();
-      repLogEntry = await inactiveReputationMiningCycle.getReputationUpdateLogEntry.call(initialRepLogLength + 1);
+      repLogEntry = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(initialRepLogLength + 1);
       assert.equal(repLogEntry[5].toNumber(), 2 + nPrevious);
 
       const taskId2 = await setupRatedTask({ colonyNetwork, colony: metaColony });
       await metaColony.finalizeTask(taskId2);
-      repLogEntry = await inactiveReputationMiningCycle.getReputationUpdateLogEntry.call(initialRepLogLength + 2);
+      repLogEntry = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(initialRepLogLength + 2);
       assert.equal(repLogEntry[5].toNumber(), 4 + nPrevious);
     });
 
@@ -227,7 +227,7 @@ contract("Colony Reputation Updates", accounts => {
       });
 
       // Check the task pot is correctly funded with the max amount
-      const taskPotBalance = await metaColony.getPotBalance.call(2, colonyToken.address);
+      const taskPotBalance = await metaColony.getPotBalance(2, colonyToken.address);
       assert.isTrue(taskPotBalance.eq(maxUIntNumber));
 
       await checkErrorRevert(metaColony.finalizeTask(taskId));

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -2,7 +2,7 @@
 import web3Utils from "web3-utils";
 import { BN } from "bn.js";
 
-import { MANAGER, WORKER, EVALUATOR, OTHER, MANAGER_PAYOUT, WORKER_PAYOUT } from "../helpers/constants";
+import { MANAGER_PAYOUT, WORKER_PAYOUT } from "../helpers/constants";
 import { getTokenArgs, checkErrorRevert } from "../helpers/test-helper";
 import { fundColonyWithTokens, setupRatedTask } from "../helpers/test-data-generator";
 
@@ -18,7 +18,12 @@ const ColonyTask = artifacts.require("ColonyTask");
 const Token = artifacts.require("Token");
 const ReputationMiningCycle = artifacts.require("ReputationMiningCycle");
 
-contract("Colony Reputation Updates", () => {
+contract("Colony Reputation Updates", accounts => {
+  const MANAGER = accounts[0];
+  const EVALUATOR = accounts[1];
+  const WORKER = accounts[2];
+  const OTHER = accounts[3];
+  
   let colonyNetwork;
   let metaColony;
   let resolverColonyNetworkDeployed;
@@ -51,7 +56,7 @@ contract("Colony Reputation Updates", () => {
     await fundColonyWithTokens(metaColony, colonyToken, amount);
     await colonyNetwork.startNextCycle();
     const inactiveReputationMiningCycleAddress = await colonyNetwork.getReputationMiningCycle(false);
-    inactiveReputationMiningCycle = ReputationMiningCycle.at(inactiveReputationMiningCycleAddress);
+    inactiveReputationMiningCycle = await ReputationMiningCycle.at(inactiveReputationMiningCycleAddress);
   });
 
   describe("when added", () => {

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -74,7 +74,7 @@ contract("Colony Reputation Updates", accounts => {
 
       const repLogEntryEvaluator = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(1);
       assert.equal(repLogEntryEvaluator[0], EVALUATOR);
-      assert.equal(repLogEntryEvaluator[1].toNumber(), 50 * 1e18);
+      assert.isTrue(repLogEntryEvaluator[1].eq(toBN(50 * 1e18)));
       assert.equal(repLogEntryEvaluator[2].toNumber(), 2);
       assert.equal(repLogEntryEvaluator[3], metaColony.address);
       assert.equal(repLogEntryEvaluator[4].toNumber(), 2);
@@ -82,7 +82,7 @@ contract("Colony Reputation Updates", accounts => {
 
       const repLogEntryWorker = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(2);
       assert.equal(repLogEntryWorker[0], WORKER);
-      assert.equal(repLogEntryWorker[1].toNumber(), 300 * 1e18);
+      assert.isTrue(repLogEntryWorker[1].eq(toBN(300 * 1e18)));
       assert.equal(repLogEntryWorker[2].toNumber(), 2);
       assert.equal(repLogEntryWorker[3], metaColony.address);
       assert.equal(repLogEntryWorker[4].toNumber(), 2);
@@ -212,13 +212,12 @@ contract("Colony Reputation Updates", accounts => {
       // Fund colony with maximum possible int number of tokens
       const maxUIntNumber = new BN(2)
         .pow(new BN(255))
-        .sub(new BN(1))
-        .toString(10);
+        .sub(new BN(1));
       await fundColonyWithTokens(metaColony, colonyToken, maxUIntNumber);
       // Split the tokens as payouts between the manager and worker
       const managerPayout = new BN("2");
       const evaluatorPayout = new BN("1");
-      const workerPayout = new BN(maxUIntNumber).sub(managerPayout).sub(evaluatorPayout);
+      const workerPayout = maxUIntNumber.sub(managerPayout).sub(evaluatorPayout);
       const taskId = await setupRatedTask({
         colonyNetwork,
         colony: metaColony,

--- a/test/router-resolver.js
+++ b/test/router-resolver.js
@@ -35,7 +35,7 @@ contract("EtherRouter / Resolver", accounts => {
     });
 
     it("should not change resolver on EtherRouter if there have been insufficient number of confirmations", async () => {
-      const txData = await etherRouter.contract.methods["setResolver"]("0xb3e2b6020926af4763d706b5657446b95795de57").encodeABI();
+      const txData = await etherRouter.contract.methods.setResolver("0xb3e2b6020926af4763d706b5657446b95795de57").encodeABI();
       const tx = await multisig.submitTransaction(etherRouter.address, 0, txData, { from: ACCOUNT_TWO });
       const { transactionId } = tx.logs[0].args;
       const isConfirmed = await multisig.isConfirmed.call(transactionId);

--- a/test/router-resolver.js
+++ b/test/router-resolver.js
@@ -30,7 +30,7 @@ contract("EtherRouter / Resolver", accounts => {
   describe("EtherRouter", () => {
     it("should revert if non-owner tries to change the Resolver on EtherRouter", async () => {
       await checkErrorRevert(etherRouter.setResolver("0xb3e2b6020926af4763d706b5657446b95795de57", { from: COINBASE_ACCOUNT }));
-      const resolverUpdated = await etherRouter.resolver.call();
+      const resolverUpdated = await etherRouter.resolver();
       assert.equal(resolverUpdated, resolver.address);
     });
 
@@ -38,8 +38,8 @@ contract("EtherRouter / Resolver", accounts => {
       const txData = await etherRouter.contract.methods.setResolver("0xb3e2b6020926af4763d706b5657446b95795de57").encodeABI();
       const tx = await multisig.submitTransaction(etherRouter.address, 0, txData, { from: ACCOUNT_TWO });
       const { transactionId } = tx.logs[0].args;
-      const isConfirmed = await multisig.isConfirmed.call(transactionId);
-      const resolverUpdated = await etherRouter.resolver.call();
+      const isConfirmed = await multisig.isConfirmed(transactionId);
+      const resolverUpdated = await etherRouter.resolver();
       assert.isFalse(isConfirmed);
       assert.equal(resolverUpdated, resolver.address);
     });
@@ -48,18 +48,18 @@ contract("EtherRouter / Resolver", accounts => {
   describe("Resolver", () => {
     it("should return correct destination for given function", async () => {
       const deployedColonyNetwork = await ColonyNetwork.deployed();
-      const signature = await resolver.stringToSig.call("createColony(address)");
-      const destination = await resolver.lookup.call(signature);
+      const signature = await resolver.stringToSig("createColony(address)");
+      const destination = await resolver.lookup(signature);
       assert.equal(destination, deployedColonyNetwork.address);
     });
 
     it("when checking destination for a function that doesn't exist, should return 0", async () => {
-      const destination = await resolver.lookup.call("0xdeadbeef");
+      const destination = await resolver.lookup("0xdeadbeef");
       assert.equal(destination, 0);
     });
 
     it("should return correctly encoded function signature", async () => {
-      const signature = await resolver.stringToSig.call("transferFrom(address,address,uint256)");
+      const signature = await resolver.stringToSig("transferFrom(address,address,uint256)");
       assert.equal(signature, "0x23b872dd");
     });
   });

--- a/test/router-resolver.js
+++ b/test/router-resolver.js
@@ -35,7 +35,7 @@ contract("EtherRouter / Resolver", accounts => {
     });
 
     it("should not change resolver on EtherRouter if there have been insufficient number of confirmations", async () => {
-      const txData = await etherRouter.contract.setResolver.getData("0xb3e2b6020926af4763d706b5657446b95795de57");
+      const txData = await etherRouter.contract.methods["setResolver"]("0xb3e2b6020926af4763d706b5657446b95795de57").encodeABI();
       const tx = await multisig.submitTransaction(etherRouter.address, 0, txData, { from: ACCOUNT_TWO });
       const { transactionId } = tx.logs[0].args;
       const isConfirmed = await multisig.isConfirmed.call(transactionId);

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -41,11 +41,11 @@ contract("TokenLocking", accounts => {
   describe("when locking tokens", async () => {
     it("should correctly set colony network address", async () => {
       await tokenLocking.setColonyNetwork(0x0);
-      let colonyNetworkAddress = await tokenLocking.getColonyNetwork.call();
+      let colonyNetworkAddress = await tokenLocking.getColonyNetwork();
       assert.equal(colonyNetworkAddress, 0x0);
 
       await tokenLocking.setColonyNetwork(colonyNetwork.address);
-      colonyNetworkAddress = await tokenLocking.getColonyNetwork.call();
+      colonyNetworkAddress = await tokenLocking.getColonyNetwork();
       assert.equal(colonyNetworkAddress, colonyNetwork.address);
     });
 

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -8,9 +8,9 @@ const IColony = artifacts.require("IColony");
 const ITokenLocking = artifacts.require("ITokenLocking");
 const Token = artifacts.require("Token");
 
-contract("TokenLocking", addresses => {
+contract("TokenLocking", accounts => {
   const usersTokens = 6;
-  const userAddress = addresses[1];
+  const userAddress = accounts[1];
   let token;
   let tokenLocking;
   let otherToken;
@@ -19,9 +19,9 @@ contract("TokenLocking", addresses => {
 
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
-    colonyNetwork = IColonyNetwork.at(etherRouter.address);
-    const tokenLockingAddress = await colonyNetwork.getTokenLocking.call();
-    tokenLocking = ITokenLocking.at(tokenLockingAddress);
+    colonyNetwork = await IColonyNetwork.at(etherRouter.address);
+    const tokenLockingAddress = await colonyNetwork.getTokenLocking();
+    tokenLocking = await ITokenLocking.at(tokenLockingAddress);
   });
 
   beforeEach(async () => {
@@ -35,7 +35,7 @@ contract("TokenLocking", addresses => {
 
     const { logs } = await colonyNetwork.createColony(token.address);
     const { colonyAddress } = logs[0].args;
-    colony = IColony.at(colonyAddress);
+    colony = await IColony.at(colonyAddress);
   });
 
   describe("when locking tokens", async () => {
@@ -313,7 +313,7 @@ contract("TokenLocking", addresses => {
     });
 
     it('should not allow "punishStakers" to be called from an account that is not not reputationMiningCycle', async () => {
-      await checkErrorRevert(tokenLocking.punishStakers([addresses[0], addresses[1]]), "token-locking-sender-not-reputation-mining-cycle");
+      await checkErrorRevert(tokenLocking.punishStakers([accounts[0], accounts[1]]), "token-locking-sender-not-reputation-mining-cycle");
     });
   });
 });

--- a/truffle.js
+++ b/truffle.js
@@ -12,14 +12,14 @@ module.exports = {
       host: "localhost",
       port: 8545,
       gasPrice: 0,
-      network_id: "integration"
+      network_id: "1998"
     },
     coverage: {
       host: "localhost",
-      network_id: "*",
       port: 8555, // <-- Use port 8555
       gas: 0xfffffffffff, // <-- Use this high gas value
-      gasPrice: 0x01 // <-- Use this low gas price
+      gasPrice: 0x01, // <-- Use this low gas price
+      network_id: "1999"
     }
   },
   mocha: {

--- a/truffle.js
+++ b/truffle.js
@@ -12,16 +12,14 @@ module.exports = {
       host: "localhost",
       port: 8545,
       gasPrice: 0,
-      network_id: "integration",
-      websockets: true
+      network_id: "integration"
     },
     coverage: {
       host: "localhost",
       network_id: "*",
       port: 8555, // <-- Use port 8555
       gas: 0xfffffffffff, // <-- Use this high gas value
-      gasPrice: 0x01, // <-- Use this low gas price
-      websockets: true
+      gasPrice: 0x01 // <-- Use this low gas price
     }
   },
   mocha: {

--- a/truffle.js
+++ b/truffle.js
@@ -7,21 +7,24 @@ module.exports = {
       port: 8545,
       gas: 6700000,
       gasPrice: 0,
-      network_id: "*"
+      network_id: "*",
+      websockets: true
     },
     integration: {
       host: "localhost",
       port: 8545,
       gas: 6700000,
       gasPrice: 0,
-      network_id: "integration"
+      network_id: "integration",
+      websockets: true
     },
     coverage: {
       host: "localhost",
       network_id: "*",
       port: 8555, // <-- Use port 8555
       gas: 0xfffffffffff, // <-- Use this high gas value
-      gasPrice: 0x01 // <-- Use this low gas price
+      gasPrice: 0x01, // <-- Use this low gas price
+      websockets: true
     }
   },
   mocha: {
@@ -33,10 +36,10 @@ module.exports = {
     },
     slow: 1000
   },
-  solc: {
-    optimizer: {
-      enabled: true,
-      runs: 200
+  compilers: {
+    solc: {
+      version: "0.4.23",
+      docker: true
     }
   }
 };

--- a/truffle.js
+++ b/truffle.js
@@ -5,7 +5,6 @@ module.exports = {
     development: {
       host: "localhost",
       port: 8545,
-      gas: 6700000,
       gasPrice: 0,
       network_id: "*",
       websockets: true
@@ -13,7 +12,6 @@ module.exports = {
     integration: {
       host: "localhost",
       port: 8545,
-      gas: 6700000,
       gasPrice: 0,
       network_id: "integration",
       websockets: true
@@ -39,7 +37,14 @@ module.exports = {
   compilers: {
     solc: {
       version: "0.4.23",
-      docker: true
+      docker: true,
+      settings: {
+        optimizer: {
+          enabled: true,
+          runs: 200
+        },
+        evmVersion: "byzantium"
+      }
     }
   }
 };

--- a/truffle.js
+++ b/truffle.js
@@ -6,8 +6,7 @@ module.exports = {
       host: "localhost",
       port: 8545,
       gasPrice: 0,
-      network_id: "*",
-      websockets: true
+      network_id: "*"
     },
     integration: {
       host: "localhost",

--- a/upgrade-test/colony-network-upgrade.js
+++ b/upgrade-test/colony-network-upgrade.js
@@ -38,7 +38,7 @@ contract("ColonyNetwork contract upgrade", () => {
 
   describe("when upgrading ColonyNetwork contract", () => {
     it("should return correct total number of colonies", async () => {
-      const updatedColonyCount = await updatedColonyNetwork.getColonyCount.call();
+      const updatedColonyCount = await updatedColonyNetwork.getColonyCount();
       assert.equal(3, updatedColonyCount.toNumber());
     });
 

--- a/upgrade-test/colony-upgrade.js
+++ b/upgrade-test/colony-upgrade.js
@@ -38,9 +38,9 @@ contract("Colony contract upgrade", accounts => {
     colony = await IColony.at(colonyAddress);
     colonyTask = await ColonyTask.new();
     colonyFunding = await ColonyFunding.new();
-    const authorityAddress = await colony.authority.call();
+    const authorityAddress = await colony.authority();
     authority = await Authority.at(authorityAddress);
-    const tokenAddress = await colony.getToken.call();
+    const tokenAddress = await colony.getToken();
     token = await Token.at(tokenAddress);
 
     await makeTask({ colony });
@@ -51,7 +51,7 @@ contract("Colony contract upgrade", accounts => {
     await resolver.register("isUpdated()", updatedColonyContract.address);
     await setupColonyVersionResolver(updatedColonyContract, colonyTask, colonyFunding, resolver, colonyNetwork);
     // Check new Colony contract version is registered successfully
-    updatedColonyVersion = await colonyNetwork.getCurrentColonyVersion.call();
+    updatedColonyVersion = await colonyNetwork.getCurrentColonyVersion();
 
     // Upgrade our existing colony
     await colony.upgrade(updatedColonyVersion.toNumber());
@@ -60,29 +60,29 @@ contract("Colony contract upgrade", accounts => {
 
   describe("when upgrading Colony contract", () => {
     it("should have updated the version number", async () => {
-      const newVersion = await updatedColony.version.call();
+      const newVersion = await updatedColony.version();
       assert.equal(newVersion.toNumber(), updatedColonyVersion.toNumber());
     });
 
     it("should be able to lookup newly registered function on Colony", async () => {
-      const y = await updatedColony.isUpdated.call();
+      const y = await updatedColony.isUpdated();
       assert.isTrue(y);
     });
 
     it("should return correct total number of tasks", async () => {
-      const updatedTaskCount = await updatedColony.getTaskCount.call();
+      const updatedTaskCount = await updatedColony.getTaskCount();
       assert.equal(2, updatedTaskCount.toNumber());
     });
 
     it("should return correct tasks", async () => {
-      const task1 = await updatedColony.getTask.call(1);
+      const task1 = await updatedColony.getTask(1);
       assert.equal(task1[0], SPECIFICATION_HASH);
       assert.isFalse(task1[2]);
       assert.isFalse(task1[3]);
       assert.equal(task1[4].toNumber(), 0);
       assert.equal(task1[5].toNumber(), 0);
 
-      const task2 = await updatedColony.getTask.call(2);
+      const task2 = await updatedColony.getTask(2);
       assert.equal(task2[0], SPECIFICATION_HASH_UPDATED);
       assert.isFalse(task2[2]);
       assert.isFalse(task2[3]);
@@ -91,12 +91,12 @@ contract("Colony contract upgrade", accounts => {
     });
 
     it("should return correct permissions", async () => {
-      const owner = await authority.hasUserRole.call(ACCOUNT_ONE, 0);
+      const owner = await authority.hasUserRole(ACCOUNT_ONE, 0);
       assert.isTrue(owner);
     });
 
     it("should return correct token address", async () => {
-      const tokenAddress = await updatedColony.getToken.call();
+      const tokenAddress = await updatedColony.getToken();
       assert.equal(token.address, tokenAddress);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1348,6 +1348,10 @@ bluebird@^3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
+bn-chai@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bn-chai/-/bn-chai-1.0.1.tgz#5d6e9654162602a527b08a1546e60cfb44213725"
+
 bn.js@4.11.6:
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8304,9 +8304,9 @@ trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
 
-truffle@^5.0.0-next.6:
-  version "5.0.0-next.6"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.0-next.6.tgz#6275caf2e9229630dbed74b77f3e6b6641297ff4"
+truffle@^5.0.0-next.7:
+  version "5.0.0-next.7"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.0-next.7.tgz#f6d6a4a82a1efc520a46a19d5467c9e7bb0def8a"
   dependencies:
     mocha "^4.1.0"
     original-require "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6284,7 +6284,7 @@ ora@^0.2.3:
     cli-spinners "^0.1.2"
     object-assign "^4.0.1"
 
-original-require@^1.0.1:
+original-require@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/original-require/-/original-require-1.0.1.tgz#0f130471584cd33511c5ec38c8d59213f9ac5e20"
 
@@ -8304,12 +8304,12 @@ trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
 
-truffle@^4.1.11:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-4.1.11.tgz#a4df812ebf4a564892900c4a1dac1131104a0799"
+truffle@^5.0.0-next.5:
+  version "5.0.0-next.5"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.0-next.5.tgz#891d00f1d453a23a59e13afd623e5d4d3129b96a"
   dependencies:
     mocha "^4.1.0"
-    original-require "^1.0.1"
+    original-require "1.0.1"
     solc "0.4.24"
 
 tty-browserify@0.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8304,9 +8304,9 @@ trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
 
-truffle@^5.0.0-next.5:
-  version "5.0.0-next.5"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.0-next.5.tgz#891d00f1d453a23a59e13afd623e5d4d3129b96a"
+truffle@^5.0.0-next.6:
+  version "5.0.0-next.6"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.0-next.6.tgz#6275caf2e9229630dbed74b77f3e6b6641297ff4"
   dependencies:
     mocha "^4.1.0"
     original-require "1.0.1"


### PR DESCRIPTION
Choosing to do an early upgrade as that has a number of features we probably can't live without for the production ready mvp of the network including:

- support for revert reason strings - we can watch/test for error reasons 🎉 
- support for function overloads - we can have as many combinations of the `makeTask` function inputs as we like, ref #251 
- choosing the `solc` version to compile with rather that the hard fixed version that truffle gives us. This decoupling gives us a lot of freedom
- `truffle-contract` which is used in testing is upgraded to `web3v1`

Plus a number of other really nice to have updates like docker support for faster tests and events emitter interface and probably more I haven't yet discovered.

Early release notes I am following for this upgrade, kindly provided by @cgewecke here https://github.com/trufflesuite/truffle/pull/1129

![image](https://user-images.githubusercontent.com/703848/42994366-94808452-8c16-11e8-93c4-bb5278ab6ceb.png)

**Notable changes**:
- `revert` error strings are returned and can be asserted for in `checkErrorRevert`. We are all eagerly awaiting @KevinLiLu to plug this in all ~190 instances as part of #201 💪  
- `await` all `.at` calls, in the truffle console too, sorry @area
- Since the sync web3 api is gone, things like `web3.eth.accounts` in `constants` is gone too. It's easiest to use the `accounts` input that truffle gives us anyway in tests. There's the `web3GetAccounts` helper if you want to get accounts (async only) anywhere
- All function returns are now `BN.js` rather than `BigNumber.js`. No more thinking of what bignumber implementation you are working on and frees up brain for more important processing 🥇 
- No more `..contract.function.getData`, use `encodeABI`, e.g. 
`etherRouter.contract.setResolver.getData` -> `etherRouter.contract.methods.setResolver("0xb3e2b6020926af4763d706b5657446b95795de57").encodeABI()`
- Parity is now initialised with network id `1998` to match the `integration` network id in truffle. Otherwise when deploying to some network ids (1,2, etc) `trufflev5` automatically triggers dry-run as a safety precaution meaning the main client is actually never used. There is wip to have a config option that disables that behaviour but for now it's the default.

**todos added**:
- Get the client via web3GetClient() which requires web3 beta34 for `getNodeInfo`. But this only means our tests will temporarily not work on `parity`. 

Bad tests:
- `respondToChallenge` called with 9 rather than 10 member array parameter
https://github.com/JoinColony/colonyNetwork/blob/develop/test/colony-network-mining.js#L1723
- swapped parameter values (i.e. in the wrong order)
https://github.com/JoinColony/colonyNetwork/pull/288/files#diff-29fe366dfa20b2486ba3b3a71852fa5eL395

In addition here we introduce `bn-chai` for big numbers testing, replacing all `isTrue(someBN.eq(otherBN))` occurrences. https://github.com/JoinColony/colonyNetwork/issues/305 is logged to deal with the remaining few hundred of them as it is too big a refactoring to be included here.