### PR TITLE
Token issuance rate, initial supply, supply ceiling

### DIFF
--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -52,6 +52,12 @@ contract ColonyAuthority is CommonAuthority {
     setOwnerRoleCapability(colony, "setRewardInverse(uint256)");
     // Add colony version to the network
     setOwnerRoleCapability(colony, "addNetworkColonyVersion(uint256,address)");
+    // Set token issuance rate
+    setOwnerRoleCapability(colony, "setTokenIssuanceRate(uint128)");
+    // Mint initial tokens
+    setOwnerRoleCapability(colony, "mintTokens(uint256)");
+    // Set token supply ceiling
+    setOwnerRoleCapability(colony, "setTokenSupplyCeiling(uint256)");
 
     // Allocate funds
     setAdminRoleCapability(colony, "moveFundsBetweenPots(uint256,uint256,uint256,address)");

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -38,6 +38,22 @@ contract ColonyStorage is CommonStorage, DSMath {
   ERC20Extended token;
   uint256 rewardInverse;
 
+  struct TokenIssuanceRate {
+    // Amount describing how many tokens can be issued for one month
+    uint128 amount;
+    // Last time the token issuance rate is changed
+    // It is used to assure that rate can be changed once every 4 weeks
+    uint256 timestamp;
+    // Keeps track of how many tokens are issued in terms of seconds
+    // TODO: If we decide to mint entire available amount in `mintTokens`, there will be no need for this variable
+    uint256 totalAmountIssuedUnderRate;
+  }
+
+  // Keeps information about token issuance rate amount and last change timestamp
+  TokenIssuanceRate tokenIssuanceRate;
+  // Amount of tokens allowed in circulation
+  uint256 tokenSupplyCeiling;
+
   // Mapping function signature to 2 task roles whose approval is needed to execute
   mapping (bytes4 => uint8[2]) reviewers;
 

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -164,9 +164,33 @@ contract IColony is IRecovery {
   /// @param _amount Amount of reputation/tokens for every address
   function bootstrapColony(address[] _users, int[] _amount) public;
 
-  /// @notice Mint `_wad` amount of colony tokens. Secured function to authorised members
-  /// @param _wad Amount to mint
-  function mintTokens(uint256 _wad) public;
+  /// @notice Mint `_amount` amount of colony tokens. Function secured to authorised members
+  /// Amount of tokens available for minting is dictated by issuance rate and the supply ceiling
+  /// @param _amount Amount to mint
+  function mintTokens(uint256 _amount) public;
+
+  /// @notice Sets colony's token issuance rate. Can only be called once every 4 weeks by authorised members
+  /// @param _amount Amount of tokens
+  function setTokenIssuanceRate(uint128 _amount) public;
+
+  /// @notice Get token issuance rate
+  /// @return amount Amount of tokens
+  /// @return timestamp Timestamp of the last change of issuance rate
+  /// @return totalAmountIssuedUnderRate How many tokens are issued in terms of seconds
+  function getTokenIssuanceRate() public view returns (uint256 amount, uint256 timestamp, uint256 totalAmountIssuedUnderRate);
+
+  /// @notice Get amount of available tokens for issuance and seconds since last issuance
+  /// @return amount Amount of tokens
+  /// @return secondsSinceLastIssuance Seconds since last issuance
+  function getAvailableIssuanceAmountAndSeconds() public view returns (uint256 amount, uint256 secondsSinceLastIssuance);
+
+  /// @notice Sets token supply ceiling
+  /// @param _amount Maximum amount of tokens allowed to be minted
+  function setTokenSupplyCeiling(uint256 _amount) public;
+
+  /// @notice Get token supply ceiling
+  /// @return tokenSupplyCeiling Token supply ceiling
+  function getTokenSupplyCeiling() public view returns (uint256 tokenSupplyCeiling);
 
   /// @notice Register colony's ENS label
   /// @param colonyName The label to register.

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -64,6 +64,22 @@ contract("Colony Funding", accounts => {
 
     const tokenLockingAddress = await colonyNetwork.getTokenLocking();
     tokenLocking = await ITokenLocking.at(tokenLockingAddress);
+
+    const metaColonyAddress = await colonyNetwork.getMetaColony();
+    const metaColony = await IColony.at(metaColonyAddress);
+    await metaColony.setTokenSupplyCeiling(
+      toBN(2)
+        .pow(toBN(256))
+        .subn(1)
+        .toString()
+    );
+    await forwardTime(2419200);
+    await metaColony.setTokenIssuanceRate(
+      toBN(2)
+        .pow(toBN(128))
+        .subn(1)
+        .toString()
+    );
   });
 
   beforeEach(async () => {
@@ -74,6 +90,12 @@ contract("Colony Funding", accounts => {
     await token.setOwner(colonyAddress);
     colony = await IColony.at(colonyAddress);
     await colony.setRewardInverse(100);
+    await colony.setTokenSupplyCeiling(
+      toBN(2)
+        .pow(toBN(256))
+        .subn(1)
+        .toString()
+    );
     const otherTokenArgs = getTokenArgs();
     otherToken = await Token.new(...otherTokenArgs);
   });
@@ -834,6 +856,12 @@ contract("Colony Funding", accounts => {
 
       await newToken.setOwner(newColony.address);
       const funding = toBN(360 * 1e18);
+      await newColony.setTokenSupplyCeiling(
+        toBN(2)
+          .pow(toBN(256))
+          .subn(1)
+          .toString()
+      );
       await fundColonyWithTokens(newColony, newToken, funding.toString());
 
       await newColony.addDomain(1);
@@ -898,6 +926,12 @@ contract("Colony Funding", accounts => {
       const newColony = await IColony.at(colonyAddress);
       await newColony.setRewardInverse(100);
 
+      await newColony.setTokenSupplyCeiling(
+        toBN(2)
+          .pow(toBN(256))
+          .subn(1)
+          .toString()
+      );
       await newToken.setOwner(newColony.address);
       await newColony.mintTokens(userTokens.toString());
       await newColony.bootstrapColony([userAddress1], [userTokens.toString()]);
@@ -1294,6 +1328,13 @@ contract("Colony Funding", accounts => {
       const colony2 = await IColony.at(colonyAddress);
       await colony2.setRewardInverse(100);
 
+      const tokenSupplyCeiling = toBN(2)
+        .pow(toBN(256))
+        .subn(1)
+        .toString();
+      await colony1.setTokenSupplyCeiling(tokenSupplyCeiling);
+      await colony2.setTokenSupplyCeiling(tokenSupplyCeiling);
+
       // Giving both colonies the capability to call `mint` function
       const adminRole = 1;
       const newRoles = await DSRoles.new();
@@ -1428,6 +1469,13 @@ contract("Colony Funding", accounts => {
       ({ colonyAddress } = logs[0].args);
       const colony2 = await IColony.at(colonyAddress);
       await colony2.setRewardInverse(100);
+
+      const tokenSupplyCeiling = toBN(2)
+        .pow(toBN(256))
+        .subn(1)
+        .toString();
+      await colony1.setTokenSupplyCeiling(tokenSupplyCeiling);
+      await colony2.setTokenSupplyCeiling(tokenSupplyCeiling);
 
       // Giving both colonies the capability to call `mint` function
       const adminRole = 1;
@@ -1582,6 +1630,12 @@ contract("Colony Funding", accounts => {
         await newToken.setOwner(colonyAddress);
         const newColony = await IColony.at(colonyAddress);
         await newColony.setRewardInverse(100);
+
+        const tokenSupplyCeiling = toBN(2)
+          .pow(toBN(256))
+          .subn(1)
+          .toString();
+        await newColony.setTokenSupplyCeiling(tokenSupplyCeiling);
 
         const payoutTokenArgs = getTokenArgs();
         const payoutToken = await Token.new(...payoutTokenArgs);

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -1,5 +1,7 @@
 /* globals artifacts */
 
+import { toBN } from "web3-utils";
+
 import {
   MANAGER_RATING,
   WORKER_RATING,
@@ -43,6 +45,12 @@ contract("Colony Task Work Rating", accounts => {
     const { logs } = await colonyNetwork.createColony(colonyToken.address);
     const { colonyAddress } = logs[0].args;
     colony = await IColony.at(colonyAddress);
+    await colony.setTokenSupplyCeiling(
+      toBN(2)
+        .pow(toBN(256))
+        .subn(1)
+        .toString()
+    );
     const otherTokenArgs = getTokenArgs();
     token = await Token.new(...otherTokenArgs);
   });

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -81,6 +81,20 @@ contract("ColonyTask", accounts => {
     otherToken = await Token.new(...otherTokenArgs);
 
     await colony.setAdminRole(COLONY_ADMIN);
+
+    await colony.setTokenSupplyCeiling(
+      toBN(2)
+        .pow(toBN(256))
+        .subn(1)
+        .toString()
+    );
+    await forwardTime(2419200);
+    await colony.setTokenIssuanceRate(
+      toBN(2)
+        .pow(toBN(128))
+        .subn(1)
+        .toString()
+    );
   });
 
   describe("when creating tasks", () => {

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -1,4 +1,6 @@
 /* globals artifacts */
+
+import { toBN } from "web3-utils";
 import { INITIAL_FUNDING, DELIVERABLE_HASH } from "../helpers/constants";
 import { checkErrorRevert, getTokenArgs } from "../helpers/test-helper";
 import { fundColonyWithTokens, setupFundedTask, setupRatedTask, executeSignedTaskChange, makeTask } from "../helpers/test-data-generator";
@@ -385,6 +387,12 @@ contract("Meta Colony", accounts => {
       const { colonyAddress } = logs[0].args;
       await token.setOwner(colonyAddress);
       colony = await IColony.at(colonyAddress);
+      await colony.setTokenSupplyCeiling(
+        toBN(2)
+          .pow(toBN(256))
+          .subn(1)
+          .toString()
+      );
     });
 
     it("should be able to set domain on task", async () => {

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -59,6 +59,12 @@ contract("Colony Reputation Updates", accounts => {
     const metaColonyAddress = await colonyNetwork.getMetaColony();
     await colonyToken.setOwner(metaColonyAddress);
     metaColony = await IMetaColony.at(metaColonyAddress);
+    await metaColony.setTokenSupplyCeiling(
+      toBN(2)
+        .pow(toBN(256))
+        .subn(1)
+        .toString()
+    );
     const amount = new BN(10)
       .pow(new BN(18))
       .mul(new BN(1000))


### PR DESCRIPTION
Closes #25 , Closes #26 , Closes #27 

## Tokens issuance rate
For calculating rate change used this formula:
a1 - current rate amount
a2 - new rate amount
```
11*a1 >= 10*a2 if a2 > a1
9*a1 <= 10*a2 if a2 < a1
```
This change is not calculated the first time the rate is set, so basically users can set any rate they want, because every token has a different value, therefore requires different rate.

## Initial supply
When colony is in bootstrap state `mintTokens` can be called without any constraints.

## Token supply ceiling
Is a limit for how many tokens there are in the circulation. Constraints that ensures that we don't exceed this limit are set in `mintTokens`.

## Other
A lot of tests were failing because of token issuance limit, so they are refactored. Because amount issued in tests are too big, we are issuing them in bootstrap mode, or by setting very high rates.