### PR TITLE
Use existing CLNY contract at start of mining test

### DIFF
--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -47,9 +47,8 @@ contract("ColonyNetworkMining", accounts => {
     tokenLocking = ITokenLocking.at(tokenLockingAddress);
     const metaColonyAddress = await colonyNetwork.getMetaColony.call();
     metaColony = IColony.at(metaColonyAddress);
-    clny = await Token.new("Colony Network Token", "CLNY", 18);
-    await metaColony.setToken(clny.address);
-    await clny.setOwner(metaColony.address);
+    const clnyAddress = await metaColony.getToken();
+    clny = Token.at(clnyAddress);
   });
 
   beforeEach(async () => {


### PR DESCRIPTION
Not sure why we did it like this originally, there was no need, as a CLNY instance is deployed alongside everything already.

However, by doing it like that, if you tried to use `it.only` on a mining test (that used a real client), you'd get errors because `reputationMiningCycle` is now instantiated with the CLNY address, rather than (effectively) looking it up from `ColonyNetwork` every time.

Now, `it.only` will work again with all of the tests in this file.