### PR TITLE
Proving reputation in reward payouts

### DIFF
--- a/contracts/Authority.sol
+++ b/contracts/Authority.sol
@@ -58,8 +58,8 @@ contract Authority is DSRoles {
     setAdminRoleCapability(colony, "makeTask(bytes32,uint256,uint256,uint256)");
     setOwnerRoleCapability(colony, "makeTask(bytes32,uint256,uint256,uint256)");
     // Start next reward payout
-    setAdminRoleCapability(colony, "startNextRewardPayout(address)");
-    setOwnerRoleCapability(colony, "startNextRewardPayout(address)");
+    setAdminRoleCapability(colony, "startNextRewardPayout(address,bytes,bytes,uint256,bytes32[])");
+    setOwnerRoleCapability(colony, "startNextRewardPayout(address,bytes,bytes,uint256,bytes32[])");
     // Cancel task
     setAdminRoleCapability(colony, "cancelTask(uint256)");
     setOwnerRoleCapability(colony, "cancelTask(uint256)");

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -22,7 +22,7 @@ import "./ColonyStorage.sol";
 import "./EtherRouter.sol";
 
 
-contract Colony is ColonyStorage {
+contract Colony is ColonyStorage, PatriciaTreeProofs {
 
   // This function, exactly as defined, is used in build scripts. Take care when updating.
   // Version number should be upped with every change in Colony or its dependency contracts or libraries.

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -19,11 +19,10 @@ pragma solidity ^0.4.23;
 pragma experimental "v0.5.0";
 
 import "./ColonyStorage.sol";
-import "./PatriciaTree/PatriciaTreeProofs.sol";
 import "./EtherRouter.sol";
 
 
-contract Colony is ColonyStorage, PatriciaTreeProofs {
+contract Colony is ColonyStorage {
 
   // This function, exactly as defined, is used in build scripts. Take care when updating.
   // Version number should be upped with every change in Colony or its dependency contracts or libraries.

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -22,7 +22,7 @@ import "./ColonyStorage.sol";
 import "./ITokenLocking.sol";
 
 
-contract ColonyFunding is ColonyStorage {
+contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   event RewardPayoutCycleStarted(uint256 indexed id);
   event RewardPayoutCycleEnded(uint256 indexed id);
   event TaskWorkerPayoutChanged(uint256 indexed id, address token, uint256 amount);
@@ -194,7 +194,7 @@ contract ColonyFunding is ColonyStorage {
     require(!activeRewardPayouts[_token], "colony-reward-payout-token-active");
 
     uint256 totalTokens = sub(token.totalSupply(), token.balanceOf(address(this)));
-    require(token.totalSupply() > 0, "colony-reward-payout-invalid-total-tokens");
+    require(totalTokens > 0, "colony-reward-payout-invalid-total-tokens");
 
     bytes32 rootHash = IColonyNetwork(colonyNetworkAddress).getReputationRootHash();
     uint256 colonyWideReputation = checkReputation(

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -26,7 +26,7 @@ import "./Authority.sol";
 import "./PatriciaTree/PatriciaTreeProofs.sol";
 
 
-contract ColonyStorage is DSAuth, DSMath, PatriciaTreeProofs {
+contract ColonyStorage is DSAuth, DSMath {
   // When adding variables, do not make them public, otherwise all contracts that inherit from
   // this one will have the getters. Make custom getters in the contract that seems most appropriate,
   // and add it to IColony.sol

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -23,9 +23,10 @@ import "../lib/dappsys/math.sol";
 import "./ERC20Extended.sol";
 import "./IColonyNetwork.sol";
 import "./Authority.sol";
+import "./PatriciaTree/PatriciaTreeProofs.sol";
 
 
-contract ColonyStorage is DSAuth, DSMath {
+contract ColonyStorage is DSAuth, DSMath, PatriciaTreeProofs {
   // When adding variables, do not make them public, otherwise all contracts that inherit from
   // this one will have the getters. Make custom getters in the contract that seems most appropriate,
   // and add it to IColony.sol
@@ -55,6 +56,8 @@ contract ColonyStorage is DSAuth, DSMath {
   struct RewardPayoutCycle {
     // Reputation root hash at the time of reward payout creation
     bytes32 reputationState;
+    // Colony wide reputation
+    uint256 colonyWideReputation;
     // Total tokens at the time of reward payout creation
     uint256 totalTokens;
     // Amount alocated for reward payout

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -502,7 +502,11 @@ contract IColony {
   /// @notice Start next reward payout for `_token`. All funds in the reward pot for `_token` will become unavailable.
   /// All tokens will be locked, and can be unlocked by calling `waiveRewardPayout` or `claimRewardPayout`.
   /// @param _token Address of the token used for reward payout
-  function startNextRewardPayout(address _token) public;
+  /// @param key Some Reputation hash tree key
+  /// @param value Reputation value
+  /// @param branchMask The branchmask of the proof
+  /// @param siblings The siblings of the proof
+  function startNextRewardPayout(address _token, bytes key, bytes value, uint256 branchMask, bytes32[] siblings) public;
 
   /// @notice Claim the reward payout at `_payoutId`. User needs to provide their reputation and colony-wide reputation
   /// which will be proven via Merkle proof inside this function.
@@ -517,19 +521,30 @@ contract IColony {
   /// _squareRoots[4] - square root of numerator (user reputation * user tokens)
   /// _squareRoots[5] - square root of denominator (total reputation * total tokens)
   /// _squareRoots[6] - square root of payout amount
-  /// @param _userReputation User reputation at the point of creation of reward payout cycle
-  /// @param _totalReputation Total reputation at the point of creation of reward payout cycle
-  function claimRewardPayout(uint256 _payoutId, uint256[7] _squareRoots, uint256 _userReputation, uint256 _totalReputation) public;
+  /// @param key Some Reputation hash tree key
+  /// @param value Reputation value
+  /// @param branchMask The branchmask of the proof
+  /// @param siblings The siblings of the proof
+  function claimRewardPayout(
+    uint256 _payoutId,
+    uint256[7] _squareRoots,
+    bytes key,
+    bytes value,
+    uint256 branchMask,
+    bytes32[] siblings
+    ) public;
 
   /// @notice Get useful information about specific reward payout
   /// @param _payoutId Id of the reward payout
   /// @return reputationState Reputation root hash at the time of creation
+  /// @return colonyWideReputation Colony wide reputation in `reputationState`
   /// @return totalTokens Total colony tokens at the time of creation
   /// @return amount Total amount of tokens taken aside for reward payout
   /// @return tokenAddress Token address
   /// @return blockTimestamp Block number at the time of creation
   function getRewardPayoutInfo(uint256 _payoutId) public view returns (
     bytes32 reputationState,
+    uint256 colonyWideReputation,
     uint256 totalTokens,
     uint256 amount,
     address tokenAddress,

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -337,8 +337,8 @@ contract("All", accounts => {
 
       let addr = await colonyNetwork.getReputationMiningCycle.call(true);
       await forwardTime(3600, this);
-      let repCycle = ReputationMiningCycle.at(addr);
-      await repCycle.submitRootHash("0x0", 0, 10);
+      let repCycle = await ReputationMiningCycle.at(addr);
+      await repCycle.submitRootHash("0x00", 0, 10);
       await repCycle.confirmNewHash(0);
 
       await giveUserCLNYTokensAndStake(colonyNetwork, accounts[4], toBN(10).pow(toBN(18)));
@@ -355,10 +355,11 @@ contract("All", accounts => {
       await miningClient.submitRootHash();
 
       addr = await colonyNetwork.getReputationMiningCycle.call(true);
-      repCycle = ReputationMiningCycle.at(addr);
+      repCycle = await ReputationMiningCycle.at(addr);
       await repCycle.confirmNewHash(0);
 
-      const [rootDomainSkill] = await newColony.getDomain(1);
+      const result = await newColony.getDomain(1);
+      const rootDomainSkill = result.skillId;
       const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill.toNumber());
       let { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
       const colonyWideReputationProof = [key, value, branchMask, siblings];

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -255,7 +255,10 @@ class ReputationMiner {
     // TODO: Include updates for all child skills if x.amount is negative
     // We update colonywide sums first (children, parents, skill)
     // Then the user-specifc sums in the order children, parents, skill.
-    await this.insert(colonyAddress, skillId, userAddress, score, updateNumber);
+
+    // Converting to decimal, since its going to be converted to hex inside `insert`
+    const skillIdDecimal = new BN(skillId, 16).toString();
+    await this.insert(colonyAddress, skillIdDecimal, userAddress, score, updateNumber);
   }
 
   /**

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -224,11 +224,12 @@ class ReputationMiner {
     // TODO This 'if' statement is only in for now to make tests easier to write, should be removed in the future.
     if (updateNumber.eq(0)) {
       const nNodes = await this.colonyNetwork.getReputationRootHashNNodes();
-      if (!nNodes.eq(0)) {
+      const rootHash = await this.colonyNetwork.getReputationRootHash(); // eslint-disable-line no-await-in-loop
+      if (!nNodes.eq(0) && rootHash !== interimHash) {
         console.log("Warning: client being initialized in bad state. Was the previous rootHash submitted correctly?");
       }
       // TODO If it's not already this value, then something has gone wrong, and we're working with the wrong state.
-      interimHash = await this.colonyNetwork.getReputationRootHash(); // eslint-disable-line no-await-in-loop
+      interimHash = rootHash;
       jhLeafValue = this.getJRHEntryValueAsBytes(interimHash, this.nReputations);
     } else {
       const prevKey = await this.getKeyForUpdateNumber(updateNumber.sub(1));

--- a/scripts/generate-test-contracts.sh
+++ b/scripts/generate-test-contracts.sh
@@ -15,6 +15,6 @@ sed -i.bak "s/contract ColonyNetwork/contract UpdatedColonyNetwork/g" ./contract
 sed -i.bak "s/address resolver;/address resolver;function isUpdated() public pure returns(bool) {return true;}/g" ./contracts/UpdatedColonyNetwork.sol
 sed -i.bak "s/contract Colony/contract UpdatedColony/g" ./contracts/UpdatedColony.sol
 sed -i.bak "s/function version() public pure returns (uint256) { return ${version}/function version() public pure returns (uint256) { return ${updated_version}/g" ./contracts/UpdatedColony.sol
-sed -i.bak "s/contract UpdatedColony is ColonyStorage, PatriciaTreeProofs {/contract UpdatedColony is ColonyStorage, PatriciaTreeProofs {function isUpdated() public pure returns(bool) {return true;}/g" ./contracts/UpdatedColony.sol
+sed -i.bak "s/contract UpdatedColony is ColonyStorage {/contract UpdatedColony is ColonyStorage {function isUpdated() public pure returns(bool) {return true;}/g" ./contracts/UpdatedColony.sol
 sed -i.bak "s/contract IColony/contract IUpdatedColony/g" ./contracts/IUpdatedColony.sol
 sed -i.bak "s/contract IUpdatedColony {/contract IUpdatedColony {function isUpdated() public pure returns(bool);/g" ./contracts/IUpdatedColony.sol

--- a/scripts/generate-test-contracts.sh
+++ b/scripts/generate-test-contracts.sh
@@ -15,6 +15,6 @@ sed -i.bak "s/contract ColonyNetwork/contract UpdatedColonyNetwork/g" ./contract
 sed -i.bak "s/address resolver;/address resolver;function isUpdated() public pure returns(bool) {return true;}/g" ./contracts/UpdatedColonyNetwork.sol
 sed -i.bak "s/contract Colony/contract UpdatedColony/g" ./contracts/UpdatedColony.sol
 sed -i.bak "s/function version() public pure returns (uint256) { return ${version}/function version() public pure returns (uint256) { return ${updated_version}/g" ./contracts/UpdatedColony.sol
-sed -i.bak "s/contract UpdatedColony is ColonyStorage {/contract UpdatedColony is ColonyStorage {function isUpdated() public pure returns(bool) {return true;}/g" ./contracts/UpdatedColony.sol
+sed -i.bak "s/contract UpdatedColony is ColonyStorage, PatriciaTreeProofs {/contract UpdatedColony is ColonyStorage, PatriciaTreeProofs {function isUpdated() public pure returns(bool) {return true;}/g" ./contracts/UpdatedColony.sol
 sed -i.bak "s/contract IColony/contract IUpdatedColony/g" ./contracts/IUpdatedColony.sol
 sed -i.bak "s/contract IUpdatedColony {/contract IUpdatedColony {function isUpdated() public pure returns(bool);/g" ./contracts/IUpdatedColony.sol

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -1349,7 +1349,7 @@ contract("Colony Funding", accounts => {
         repCycle = await ReputationMiningCycle.at(addr);
         await repCycle.confirmNewHash(0);
 
-        const result = await colony.getDomain(1);
+        const result = await newColony.getDomain(1);
         const rootDomainSkill = result.skillId;
         const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill.toNumber());
         let { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey, true);
@@ -1438,8 +1438,8 @@ contract("Colony Funding", accounts => {
           "Percentage Wrong: ",
           solidityReward
             .sub(reward)
-            .div(reward)
             .muln(100)
+            .div(reward)
             .toString(),
           "%"
         );

--- a/test/colony.js
+++ b/test/colony.js
@@ -249,7 +249,7 @@ contract("Colony", accounts => {
       canCall = await authority.canCall(user3, colony.address, functionSig);
       assert.equal(canCall, true);
 
-      functionSig = getFunctionSignature("startNextRewardPayout(address)");
+      functionSig = getFunctionSignature("startNextRewardPayout(address,bytes,bytes,uint256,bytes32[])");
       canCall = await authority.canCall(user3, colony.address, functionSig);
       assert.equal(canCall, true);
 

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -53,8 +53,8 @@ contract("TokenLocking", addresses => {
 
     let addr = await colonyNetwork.getReputationMiningCycle.call(true);
     await forwardTime(3600, this);
-    let repCycle = ReputationMiningCycle.at(addr);
-    await repCycle.submitRootHash("0x0", 0, 10);
+    let repCycle = await ReputationMiningCycle.at(addr);
+    await repCycle.submitRootHash("0x00", 0, 10);
     await repCycle.confirmNewHash(0);
 
     await giveUserCLNYTokensAndStake(colonyNetwork, addresses[4], toBN(10).pow(toBN(18)));
@@ -71,10 +71,11 @@ contract("TokenLocking", addresses => {
     await miningClient.submitRootHash();
 
     addr = await colonyNetwork.getReputationMiningCycle.call(true);
-    repCycle = ReputationMiningCycle.at(addr);
+    repCycle = await ReputationMiningCycle.at(addr);
     await repCycle.confirmNewHash(0);
 
-    const [rootDomainSkill] = await colony.getDomain(1);
+    const result = await colony.getDomain(1);
+    const rootDomainSkill = result.skillId;
     const colonyWideReputationKey = makeReputationKey(colony.address, rootDomainSkill.toNumber());
     const { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
     colonyWideReputationProof = [key, value, branchMask, siblings];

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -1,21 +1,35 @@
 /* globals artifacts */
+import { toBN } from "web3-utils";
+import path from "path";
+import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
+import { getTokenArgs, checkErrorRevert, forwardTime, makeReputationKey } from "../helpers/test-helper";
+import { giveUserCLNYTokensAndStake } from "../helpers/test-data-generator";
 
-import { getTokenArgs, checkErrorRevert } from "../helpers/test-helper";
+import ReputationMiner from "../packages/reputation-miner/ReputationMiner";
 
 const EtherRouter = artifacts.require("EtherRouter");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const IColony = artifacts.require("IColony");
 const ITokenLocking = artifacts.require("ITokenLocking");
 const Token = artifacts.require("Token");
+const ReputationMiningCycle = artifacts.require("ReputationMiningCycle");
 
-contract("TokenLocking", accounts => {
-  const usersTokens = 6;
-  const userAddress = accounts[1];
+const contractLoader = new TruffleLoader({
+  contractDir: path.resolve(__dirname, "..", "build", "contracts")
+});
+
+const REAL_PROVIDER_PORT = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
+
+contract("TokenLocking", addresses => {
+  const usersTokens = 10;
+  const otherUserTokens = 100;
+  const userAddress = addresses[1];
   let token;
   let tokenLocking;
   let otherToken;
   let colonyNetwork;
   let colony;
+  let colonyWideReputationProof;
 
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
@@ -27,15 +41,43 @@ contract("TokenLocking", accounts => {
   beforeEach(async () => {
     let tokenArgs = getTokenArgs();
     token = await Token.new(...tokenArgs);
-    await token.mint(usersTokens);
-    await token.transfer(userAddress, usersTokens);
-
     tokenArgs = getTokenArgs();
     otherToken = await Token.new(...tokenArgs);
 
     const { logs } = await colonyNetwork.createColony(token.address);
     const { colonyAddress } = logs[0].args;
     colony = await IColony.at(colonyAddress);
+    await token.setOwner(colony.address);
+    await colony.mintTokens(usersTokens + otherUserTokens);
+    await colony.bootstrapColony([userAddress], [usersTokens]);
+
+    let addr = await colonyNetwork.getReputationMiningCycle.call(true);
+    await forwardTime(3600, this);
+    let repCycle = ReputationMiningCycle.at(addr);
+    await repCycle.submitRootHash("0x0", 0, 10);
+    await repCycle.confirmNewHash(0);
+
+    await giveUserCLNYTokensAndStake(colonyNetwork, addresses[4], toBN(10).pow(toBN(18)));
+
+    const miningClient = new ReputationMiner({
+      loader: contractLoader,
+      minerAddress: addresses[4],
+      realProviderPort: REAL_PROVIDER_PORT,
+      useJsTree: true
+    });
+    await miningClient.initialise(colonyNetwork.address);
+    await miningClient.addLogContentsToReputationTree();
+    await forwardTime(3600, this);
+    await miningClient.submitRootHash();
+
+    addr = await colonyNetwork.getReputationMiningCycle.call(true);
+    repCycle = ReputationMiningCycle.at(addr);
+    await repCycle.confirmNewHash(0);
+
+    const [rootDomainSkill] = await colony.getDomain(1);
+    const colonyWideReputationKey = makeReputationKey(colony.address, rootDomainSkill.toNumber());
+    const { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
+    colonyWideReputationProof = [key, value, branchMask, siblings];
   });
 
   describe("when locking tokens", async () => {
@@ -78,8 +120,7 @@ contract("TokenLocking", accounts => {
     });
 
     it("should not be able to withdraw if specified amount is greated than deposited", async () => {
-      const otherUserTokens = 100;
-      await token.mint(otherUserTokens);
+      await colony.bootstrapColony([addresses[0]], [otherUserTokens]);
       await token.approve(tokenLocking.address, otherUserTokens);
       await tokenLocking.deposit(token.address, otherUserTokens);
 
@@ -156,7 +197,7 @@ contract("TokenLocking", accounts => {
       await tokenLocking.deposit(token.address, usersTokens, {
         from: userAddress
       });
-      await colony.startNextRewardPayout(otherToken.address);
+      await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const totalLockCount = await tokenLocking.getTotalLockCount(token.address);
       assert.equal(totalLockCount.toNumber(), 1);
     });
@@ -168,7 +209,7 @@ contract("TokenLocking", accounts => {
       await tokenLocking.deposit(token.address, usersTokens, {
         from: userAddress
       });
-      const { logs } = await colony.startNextRewardPayout(otherToken.address);
+      const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.id;
 
       await tokenLocking.incrementLockCounterTo(token.address, payoutId, {
@@ -180,7 +221,7 @@ contract("TokenLocking", accounts => {
     });
 
     it("should not be able to waive to id that does not exist", async () => {
-      await colony.startNextRewardPayout(otherToken.address);
+      await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
 
       await checkErrorRevert(
         tokenLocking.incrementLockCounterTo(token.address, 10, {
@@ -207,7 +248,7 @@ contract("TokenLocking", accounts => {
       await tokenLocking.deposit(token.address, usersTokens, {
         from: userAddress
       });
-      const { logs } = await colony.startNextRewardPayout(otherToken.address);
+      const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.id;
       await checkErrorRevert(tokenLocking.unlockTokenForUser(token.address, userAddress, payoutId), "colony-token-locking-sender-not-colony");
     });
@@ -234,7 +275,7 @@ contract("TokenLocking", accounts => {
       await tokenLocking.deposit(token.address, usersTokens, {
         from: userAddress
       });
-      await colony.startNextRewardPayout(otherToken.address);
+      await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       await checkErrorRevert(
         tokenLocking.deposit(token.address, usersTokens, {
           from: userAddress
@@ -250,7 +291,7 @@ contract("TokenLocking", accounts => {
       await tokenLocking.deposit(token.address, usersTokens, {
         from: userAddress
       });
-      await colony.startNextRewardPayout(otherToken.address);
+      await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       await checkErrorRevert(
         tokenLocking.withdraw(token.address, usersTokens, {
           from: userAddress
@@ -266,7 +307,7 @@ contract("TokenLocking", accounts => {
       await tokenLocking.deposit(token.address, usersTokens, {
         from: userAddress
       });
-      const { logs } = await colony.startNextRewardPayout(otherToken.address);
+      const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.id;
       await tokenLocking.incrementLockCounterTo(token.address, payoutId, {
         from: userAddress
@@ -286,18 +327,18 @@ contract("TokenLocking", accounts => {
       await tokenLocking.deposit(token.address, usersTokens, {
         from: userAddress
       });
-      await colony.startNextRewardPayout(otherToken.address);
+      await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
 
       const tokenArgs = getTokenArgs();
       const newToken = await Token.new(...tokenArgs);
-      await colony.startNextRewardPayout(newToken.address);
+      await colony.startNextRewardPayout(newToken.address, ...colonyWideReputationProof);
 
       const totalLockCount = await tokenLocking.getTotalLockCount(token.address);
       assert.equal(totalLockCount.toNumber(), 2);
     });
 
     it("should be able to set user lock count equal to total lock count when depositing if user had 0 deposited tokens", async () => {
-      await colony.startNextRewardPayout(otherToken.address);
+      await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
 
       await token.approve(tokenLocking.address, usersTokens, {
         from: userAddress
@@ -314,7 +355,7 @@ contract("TokenLocking", accounts => {
     });
 
     it('should not allow "punishStakers" to be called from an account that is not not reputationMiningCycle', async () => {
-      await checkErrorRevert(tokenLocking.punishStakers([accounts[0], accounts[1]]), "colony-token-locking-sender-not-reputation-mining-cycle");
+      await checkErrorRevert(tokenLocking.punishStakers([addresses[0], addresses[1]]), "colony-token-locking-sender-not-reputation-mining-cycle");
     });
   });
 });


### PR DESCRIPTION
Unexpected changes include:
- Refactored `claimRewardPayout` to avoid stack depth error
- Proving colony wide reputation inside `startNextRewardPayout` to avoid too many function arguments.