### PR TITLE
Add contract and test error messages

### DIFF
--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -11,6 +11,7 @@
     "security/no-call-value": 0,
     "security/no-block-members": 0,
     "no-experimental": 0,
-    "error-reason": 0
+    "error-reason": "error",
+    "max-len": "error"
   }
 }

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -185,8 +185,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     colonyAddress >>= 96;
     userAddress >>= 96;
     // Require that the user is proving their own reputation in this colony.
-    require(address(colonyAddress) == address(this), "colony-invalid-colony-reputation-owner");
-    require(address(userAddress) == msg.sender, "colony-invalid-user-reputation-owner");
+    require(address(colonyAddress) == address(this), "colony-invalid-reputation-key-colony-address");
+    require(address(userAddress) == msg.sender, "colony-invalid-reputation-key-user-address");
     _;
   }
 

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -47,7 +47,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
   // Can only be called by the owner role.
   function setRecoveryRole(address _user) public stoppable auth {
-    require(recoveryRolesCount < ~uint64(0), "maximum-num-recovery-roles");
+    require(recoveryRolesCount < ~uint64(0), "colony-maximum-num-recovery-roles");
     if (!Authority(authority).hasUserRole(_user, RECOVERY_ROLE)) {
       Authority(authority).setUserRole(_user, RECOVERY_ROLE, true);
       recoveryRolesCount++;
@@ -185,8 +185,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     colonyAddress >>= 96;
     userAddress >>= 96;
     // Require that the user is proving their own reputation in this colony.
-    require(address(colonyAddress) == address(this));
-    require(address(userAddress) == msg.sender);
+    require(address(colonyAddress) == address(this), "colony-invalid-colony-reputation-owner");
+    require(address(userAddress) == msg.sender, "colony-invalid-user-reputation-owner");
     _;
   }
 
@@ -206,10 +206,10 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   function upgrade(uint256 _newVersion) public stoppable auth {
     // Upgrades can only go up in version
     uint256 currentVersion = version();
-    require(_newVersion > currentVersion);
+    require(_newVersion > currentVersion, "colony-version-must-be-newer");
     // Requested version has to be registered
     address newResolver = IColonyNetwork(colonyNetworkAddress).getColonyVersionResolver(_newVersion);
-    require(newResolver != 0x0);
+    require(newResolver != 0x0, "colony-version-must-be-registered");
     EtherRouter e = EtherRouter(address(this));
     e.setResolver(newResolver);
   }

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -152,7 +152,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   domainExists(_parentDomainId)
   {
     // Note: Remove when we want to allow more domain hierarchy levels
-    require(_parentDomainId == 1, "colony-parent-skill-not-root");
+    require(_parentDomainId == 1, "colony-parent-domain-not-root");
 
     uint256 parentSkillId = domains[_parentDomainId].skillId;
 

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -226,10 +226,10 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   uint256 constant COLONY_NETWORK_ADDRESS_SLOT = 3;
 
   function setStorageSlotRecovery(uint256 _slot, bytes32 _value) public recovery auth {
-    require(_slot != AUTHORITY_SLOT, "protected-variable");
-    require(_slot != OWNER_SLOT, "protected-variable");
-    require(_slot != RESOLVER_SLOT, "protected-variable");
-    require(_slot != COLONY_NETWORK_ADDRESS_SLOT, "protected-variable");
+    require(_slot != AUTHORITY_SLOT, "colony-protected-variable");
+    require(_slot != OWNER_SLOT, "colony-protected-variable");
+    require(_slot != RESOLVER_SLOT, "colony-protected-variable");
+    require(_slot != COLONY_NETWORK_ADDRESS_SLOT, "colony-protected-variable");
 
     // Protect key variables
     uint64 _recoveryRolesCount = recoveryRolesCount;
@@ -251,14 +251,14 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   }
 
   function approveExitRecovery() public recovery auth {
-    require(recoveryApprovalTimestamps[msg.sender] < recoveryEditedTimestamp, "recovery-approval-already-given");
+    require(recoveryApprovalTimestamps[msg.sender] < recoveryEditedTimestamp, "colony-recovery-approval-already-given");
     recoveryApprovalTimestamps[msg.sender] = now;
     recoveryApprovalCount++;
   }
 
   function exitRecoveryMode(uint256 _newVersion) public recovery auth {
     uint numRequired = recoveryRolesCount / 2 + 1;
-    require(recoveryApprovalCount >= numRequired, "recovery-exit-insufficient-approvals");
+    require(recoveryApprovalCount >= numRequired, "colony-recovery-exit-insufficient-approvals");
 
     recoveryMode = false;
     if (_newVersion > version()) {

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -112,7 +112,7 @@ contract ColonyFunding is ColonyStorage {
   auth
   {
     // Prevent people moving funds from the pot for paying out token holders
-    require(_fromPot > 0, "colony-funding-cannot-move-funds-from-pot");
+    require(_fromPot > 0, "colony-funding-cannot-move-funds-from-rewards-pot");
 
     // TODO Only allow sending from created pots - perhaps not necessary explicitly, but if not, note as such here.
     require(_toPot <= potCount, "colony-funding-nonexistent-pot"); // Only allow sending to created pots

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -112,7 +112,7 @@ contract ColonyFunding is ColonyStorage {
   auth
   {
     // Prevent people moving funds from the pot for paying out token holders
-    require(_fromPot > 0, "colony-funding-cannot-move-funds-from-pot-0");
+    require(_fromPot > 0, "colony-funding-cannot-move-funds-from-pot");
 
     // TODO Only allow sending from created pots - perhaps not necessary explicitly, but if not, note as such here.
     require(_toPot <= potCount, "colony-funding-nonexistent-pot"); // Only allow sending to created pots

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -175,7 +175,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
     Skill storage parentSkill = skills[_parentSkillId];
 
     // Global and local skill trees are kept separate
-    require(parentSkill.globalSkill == _globalSkill, "colony-global-skill-id-does-not-match");
+    require(parentSkill.globalSkill == _globalSkill, "colony-global-and-local-skill-trees-are-separate");
 
     Skill memory s;
     s.nParents = parentSkill.nParents + 1;

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -32,20 +32,20 @@ contract ColonyNetwork is ColonyNetworkStorage {
   // All colonies are able to manage their Local (domain associated) skills
   modifier allowedToAddSkill(bool globalSkill) {
     if (globalSkill) {
-      require(msg.sender == metaColony);
+      require(msg.sender == metaColony, "colony-must-be-meta-colony");
     } else {
-      require(_isColony[msg.sender] || msg.sender == address(this));
+      require(_isColony[msg.sender] || msg.sender == address(this), "colony-must-be-colony");
     }
     _;
   }
 
   modifier skillExists(uint skillId) {
-    require(skillCount >= skillId);
+    require(skillCount >= skillId, "colony-invalid-skill-id");
     _;
   }
 
   modifier nonZero(uint256 parentSkillId) {
-    require(parentSkillId > 0);
+    require(parentSkillId > 0, "colony-invalid-parent-skill-id");
     _;
   }
 
@@ -94,7 +94,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
   auth
   {
     // Token locking address can't be changed
-    require(tokenLocking == 0x0);
+    require(tokenLocking == 0x0, "colony-invalid-token-locking-address");
     tokenLocking = _tokenLocking;
   }
 
@@ -105,7 +105,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
   function createMetaColony(address _tokenAddress) public
   auth
   {
-    require(metaColony == 0);
+    require(metaColony == 0, "colony-meta-colony-exists-already");
     // Add the root global skill
     skillCount += 1;
     Skill memory rootGlobalSkill;
@@ -175,7 +175,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
     Skill storage parentSkill = skills[_parentSkillId];
 
     // Global and local skill trees are kept separate
-    require(parentSkill.globalSkill == _globalSkill);
+    require(parentSkill.globalSkill == _globalSkill, "colony-global-skill-id-does-not-match");
 
     Skill memory s;
     s.nParents = parentSkill.nParents + 1;

--- a/contracts/ColonyNetworkAuction.sol
+++ b/contracts/ColonyNetworkAuction.sol
@@ -63,35 +63,35 @@ contract DutchAuction is DSMath {
   mapping (address => uint256) public bids;
 
   modifier auctionNotStarted {
-    require(startTime == 0);
-    require(!started);
+    require(startTime == 0, "colony-auction-already-started");
+    require(!started, "colony-auction-already-started");
     _;
   }
 
   modifier auctionStartedAndOpen {
-    require(started);
-    require(startTime > 0);
-    require(endTime == 0);
+    require(started, "colony-auction-not-started");
+    require(startTime > 0, "colony-auction-not-started");
+    require(endTime == 0, "colony-auction-closed");
     _;
   }
 
   modifier auctionClosed {
-    require(endTime > 0);
+    require(endTime > 0, "colony-auction-not-closed");
     _;
   }
 
   modifier auctionNotFinalized() {
-    require(!finalized);
+    require(!finalized, "colony-auction-already-finalized");
     _;
   }
 
   modifier auctionFinalized {
-    require(finalized);
+    require(finalized, "colony-auction-not-finalized");
     _;
   }
 
   modifier allBidsClaimed  {
-    require(claimCount == bidCount);
+    require(claimCount == bidCount, "colony-auction-not-all-bids-claimed");
     _;
   }
 
@@ -101,7 +101,7 @@ contract DutchAuction is DSMath {
 
   constructor(address _clnyToken, address _token) public {
     colonyNetwork = msg.sender;
-    require(_clnyToken != 0x0 && _token != 0x0);
+    require(_clnyToken != 0x0 && _token != 0x0, "colony-auction-cannot-use-ether");
     assert(_token != _clnyToken);
     clnyToken = ERC20Extended(_clnyToken);
     token = ERC20Extended(_token);
@@ -144,7 +144,7 @@ contract DutchAuction is DSMath {
   function bid(uint256 _amount) public
   auctionStartedAndOpen
   {
-    require(_amount > 0);
+    require(_amount > 0, "colony-auction-invalid-bid");
     uint _totalToEndAuction = totalToEndAuction();
     uint remainingToEndAuction = sub(_totalToEndAuction, receivedTotal);
 
@@ -186,7 +186,7 @@ contract DutchAuction is DSMath {
   returns (bool)
   {
     uint amount = bids[msg.sender];
-    require(amount > 0);
+    require(amount > 0, "colony-auction-zero-bid-total");
 
     uint tokens = mul(amount, TOKEN_MULTIPLIER) / finalPrice;
     claimCount += 1;
@@ -194,7 +194,7 @@ contract DutchAuction is DSMath {
     // Set receiver bid to 0 before transferring the tokens
     bids[msg.sender] = 0;
     uint beforeClaimBalance = token.balanceOf(msg.sender);
-    require(token.transfer(msg.sender, tokens));
+    require(token.transfer(msg.sender, tokens), "colony-auction-transfer-failed");
     assert(token.balanceOf(msg.sender) == add(beforeClaimBalance, tokens));
     assert(bids[msg.sender] == 0);
 

--- a/contracts/ColonyNetworkAuction.sol
+++ b/contracts/ColonyNetworkAuction.sol
@@ -101,7 +101,7 @@ contract DutchAuction is DSMath {
 
   constructor(address _clnyToken, address _token) public {
     colonyNetwork = msg.sender;
-    require(_clnyToken != 0x0 && _token != 0x0, "colony-auction-cannot-use-ether");
+    require(_clnyToken != 0x0 && _token != 0x0, "colony-auction-invalid-token");
     assert(_token != _clnyToken);
     clnyToken = ERC20Extended(_clnyToken);
     token = ERC20Extended(_token);

--- a/contracts/ColonyNetworkAuction.sol
+++ b/contracts/ColonyNetworkAuction.sol
@@ -202,7 +202,7 @@ contract DutchAuction is DSMath {
     return true;
   }
 
-  function close() public
+  function destruct() public
   auctionFinalized
   allBidsClaimed
   {

--- a/contracts/ColonyNetworkMining.sol
+++ b/contracts/ColonyNetworkMining.sol
@@ -27,7 +27,7 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
   // TODO: Can we handle a dispute regarding the very first hash that should be set?
 
   modifier onlyReputationMiningCycle () {
-    require(msg.sender == activeReputationMiningCycle);
+    require(msg.sender == activeReputationMiningCycle, "colony-reputation-mining-sender-not-active-reputation-cycle");
     _;
   }
 
@@ -43,17 +43,17 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
   }
 
   function initialiseReputationMining() public {
-    require(inactiveReputationMiningCycle == 0x0);
+    require(inactiveReputationMiningCycle == 0x0, "colony-reputation-mining-already-initialised");
     address clnyToken = IColony(metaColony).getToken();
-    require(clnyToken != 0x0);
+    require(clnyToken != 0x0, "colony-reputation-mining-clny-token-invalid-address");
     inactiveReputationMiningCycle = new ReputationMiningCycle(tokenLocking, clnyToken);
   }
 
   function startNextCycle() public {
     address clnyToken = IColony(metaColony).getToken();
-    require(clnyToken != 0x0);
-    require(activeReputationMiningCycle == 0x0);
-    require(inactiveReputationMiningCycle != 0x0);
+    require(clnyToken != 0x0, "colony-reputation-mining-clny-token-invalid-address");
+    require(activeReputationMiningCycle == 0x0, "colony-reputation-mining-still-active");
+    require(inactiveReputationMiningCycle != 0x0, "colony-reputation-mining-not-initialised");
     // Inactive now becomes active
     activeReputationMiningCycle = inactiveReputationMiningCycle;
     ReputationMiningCycle(activeReputationMiningCycle).resetWindow();

--- a/contracts/ColonyNetworkRegistrar.sol
+++ b/contracts/ColonyNetworkRegistrar.sol
@@ -32,7 +32,7 @@ contract ColonyNetworkRegistrar is ColonyNetworkStorage {
 
   modifier unowned(bytes32 node, bytes32 subnode) {
     address currentOwner = ENS(ens).owner(keccak256(abi.encodePacked(node, subnode)));
-    require(currentOwner == 0);
+    require(currentOwner == 0, "colony-label-already-in-use");
     _;
   }
 
@@ -52,7 +52,7 @@ contract ColonyNetworkRegistrar is ColonyNetworkStorage {
   public
   unowned(userNode, subnode)
   {
-    require(userLabels[msg.sender] == 0, "user-already-labeled");
+    require(userLabels[msg.sender] == 0, "colony-user-already-labeled");
     userLabels[msg.sender] = subnode;
 
     ENS(ens).setSubnodeOwner(userNode, subnode, msg.sender);

--- a/contracts/ColonyNetworkRegistrar.sol
+++ b/contracts/ColonyNetworkRegistrar.sol
@@ -52,7 +52,7 @@ contract ColonyNetworkRegistrar is ColonyNetworkStorage {
   public
   unowned(userNode, subnode)
   {
-    require(userLabels[msg.sender] == 0, "colony-user-already-owned");
+    require(userLabels[msg.sender] == 0, "colony-user-label-already-owned");
     userLabels[msg.sender] = subnode;
 
     ENS(ens).setSubnodeOwner(userNode, subnode, msg.sender);

--- a/contracts/ColonyNetworkRegistrar.sol
+++ b/contracts/ColonyNetworkRegistrar.sol
@@ -32,7 +32,7 @@ contract ColonyNetworkRegistrar is ColonyNetworkStorage {
 
   modifier unowned(bytes32 node, bytes32 subnode) {
     address currentOwner = ENS(ens).owner(keccak256(abi.encodePacked(node, subnode)));
-    require(currentOwner == 0, "colony-label-already-in-use");
+    require(currentOwner == 0, "colony-label-already-owned");
     _;
   }
 
@@ -52,7 +52,7 @@ contract ColonyNetworkRegistrar is ColonyNetworkStorage {
   public
   unowned(userNode, subnode)
   {
-    require(userLabels[msg.sender] == 0, "colony-user-already-labeled");
+    require(userLabels[msg.sender] == 0, "colony-user-already-owned");
     userLabels[msg.sender] = subnode;
 
     ENS(ens).setSubnodeOwner(userNode, subnode, msg.sender);

--- a/contracts/ColonyNetworkStorage.sol
+++ b/contracts/ColonyNetworkStorage.sol
@@ -88,7 +88,7 @@ contract ColonyNetworkStorage is DSAuth, DSMath {
   mapping (address => bytes32) userLabels;
 
   modifier calledByColony() {
-    require(_isColony[msg.sender]);
+    require(_isColony[msg.sender], "colony-must-be-colony");
     _;
   }
 }

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -147,22 +147,22 @@ contract ColonyStorage is DSAuth, DSMath {
 
   modifier confirmTaskRoleIdentity(uint256 _id, uint8 _role) {
     Role storage role = tasks[_id].roles[_role];
-    require(msg.sender == role.user);
+    require(msg.sender == role.user, "colony-task-role-identity-mismatch");
     _;
   }
 
   modifier taskExists(uint256 _id) {
-    require(_id <= taskCount);
+    require(_id <= taskCount, "colony-task-does-not-exist");
     _;
   }
 
   modifier taskNotFinalized(uint256 _id) {
-    require(!tasks[_id].finalized);
+    require(!tasks[_id].finalized, "colony-task-already-finalized");
     _;
   }
 
   modifier taskFinalized(uint256 _id) {
-    require(tasks[_id].finalized);
+    require(tasks[_id].finalized, "colony-task-not-finalized");
     _;
   }
 
@@ -170,18 +170,18 @@ contract ColonyStorage is DSAuth, DSMath {
     IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
     bool isGlobalSkill;
     (, , isGlobalSkill) = colonyNetworkContract.getSkill(_skillId);
-    require(isGlobalSkill);
+    require(isGlobalSkill, "colony-not-global-skill");
     _;
   }
 
   modifier skillExists(uint256 _skillId) {
     IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
-    require(_skillId <= colonyNetworkContract.getSkillCount());
+    require(_skillId <= colonyNetworkContract.getSkillCount(), "colony-skill-does-not-exist");
     _;
   }
 
   modifier domainExists(uint256 _domainId) {
-    require(_domainId <= domainCount);
+    require(_domainId <= domainCount, "colony-domain-does-not-exist");
     _;
   }
 
@@ -191,7 +191,7 @@ contract ColonyStorage is DSAuth, DSMath {
   }
 
   modifier isAdmin(address _user) {
-    require(Authority(authority).hasUserRole(_user, ADMIN_ROLE));
+    require(Authority(authority).hasUserRole(_user, ADMIN_ROLE), "colony-not-admin");
     _;
   }
 
@@ -206,7 +206,7 @@ contract ColonyStorage is DSAuth, DSMath {
   }
 
   modifier self() {
-    require(address(this) == msg.sender);
+    require(address(this) == msg.sender, "colony-not-self");
     _;
   }
 }

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -196,12 +196,12 @@ contract ColonyStorage is DSAuth, DSMath {
   }
 
   modifier recovery() {
-    require(recoveryMode, "not-in-recovery-mode");
+    require(recoveryMode, "colony-not-in-recovery-mode");
     _;
   }
 
   modifier stoppable() {
-    require(!recoveryMode, "in-recovery-mode");
+    require(!recoveryMode, "colony-in-recovery-mode");
     _;
   }
 

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -226,7 +226,7 @@ contract ColonyTask is ColonyStorage {
     } else {
       nSignaturesRequired = 2;
     }
-    require(_sigR.length == nSignaturesRequired, "colony-task-role-assignment-does-not-meet-signatures-required");
+    require(_sigR.length == nSignaturesRequired, "colony-task-role-assignment-does-not-meet-required-signatures");
 
     bytes32 msgHash = keccak256(abi.encodePacked(address(this), address(this), _value, _data, taskChangeNonces[taskId]));
     address[] memory reviewerAddresses = getReviewerAddresses(
@@ -248,7 +248,7 @@ contract ColonyTask is ColonyStorage {
         "colony-task-role-assignment-not-signed-by-manager"
       );
       // One of the signers must be an address we want to set here
-      require(userAddress == reviewerAddresses[0] || userAddress == reviewerAddresses[1], "colony-task-role-assignment-not-signed-by-new-role-user");
+      require(userAddress == reviewerAddresses[0] || userAddress == reviewerAddresses[1], "colony-task-role-assignment-not-signed-by-new-user-for-role");
       // Require that signatures are not from the same address
       // This will never throw, because we require that manager is one of the signers,
       // and if manager is both signers, then `userAddress` must also be a manager, and if
@@ -279,7 +279,7 @@ contract ColonyTask is ColonyStorage {
   {
     // MAYBE: we should hash these the other way around, i.e. generateSecret(_rating, _salt)
     bytes32 ratingSecret = generateSecret(_salt, _rating);
-    require(ratingSecret == taskWorkRatings[_id].secret[_role], "colony-task-rating-secret-not-match");
+    require(ratingSecret == taskWorkRatings[_id].secret[_role], "colony-task-rating-secret-mismatch");
 
     TaskRatings rating = TaskRatings(_rating);
     require(rating != TaskRatings.None, "colony-task-rating-missing");

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -89,7 +89,7 @@ contract ColonyTask is ColonyStorage {
       require(sub(now, ratingSecrets.timestamp) <= RATING_REVEAL_TIMEOUT, "colony-task-rating-secret-reveal-period-closed");
     } else if (ratingSecrets.count < 2) {
       uint taskCompletionTime = tasks[_id].deliverableTimestamp != 0 ? tasks[_id].deliverableTimestamp : tasks[_id].dueDate;
-      require(sub(now, taskCompletionTime) > RATING_COMMIT_TIMEOUT, "colony-task-rating-secret-reveal-period-closed");
+      require(sub(now, taskCompletionTime) > RATING_COMMIT_TIMEOUT, "colony-task-rating-secret-reveal-period-not-open");
       require(sub(now, taskCompletionTime) <= add(RATING_COMMIT_TIMEOUT, RATING_REVEAL_TIMEOUT), "colony-task-rating-secret-reveal-period-closed");
     }
     _;
@@ -98,7 +98,7 @@ contract ColonyTask is ColonyStorage {
   modifier taskWorkRatingsClosed(uint256 _id) {
     uint taskCompletionTime = tasks[_id].deliverableTimestamp != 0 ? tasks[_id].deliverableTimestamp : tasks[_id].dueDate;
     // More than 10 days from work submission have passed
-    require(sub(now, taskCompletionTime) > add(RATING_COMMIT_TIMEOUT, RATING_REVEAL_TIMEOUT), "colony-task-rating-period-open");
+    require(sub(now, taskCompletionTime) > add(RATING_COMMIT_TIMEOUT, RATING_REVEAL_TIMEOUT), "colony-task-rating-period-still-open");
     _;
   }
 

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -344,10 +344,10 @@ contract ColonyTask is ColonyStorage {
 
   function setTaskDomain(uint256 _id, uint256 _domainId) public
   stoppable
-  confirmTaskRoleIdentity(_id, MANAGER)
   taskExists(_id)
   taskNotFinalized(_id)
   domainExists(_domainId)
+  confirmTaskRoleIdentity(_id, MANAGER)
   {
     tasks[_id].domainId = _domainId;
 
@@ -356,11 +356,11 @@ contract ColonyTask is ColonyStorage {
 
   function setTaskSkill(uint256 _id, uint256 _skillId) public
   stoppable
-  self()
   taskExists(_id)
   taskNotFinalized(_id)
   skillExists(_skillId)
   globalSkill(_skillId)
+  self()
   {
     tasks[_id].skills[0] = _skillId;
 
@@ -369,9 +369,9 @@ contract ColonyTask is ColonyStorage {
 
   function setTaskBrief(uint256 _id, bytes32 _specificationHash) public
   stoppable
-  self()
   taskExists(_id)
   taskNotFinalized(_id)
+  self()
   {
     tasks[_id].specificationHash = _specificationHash;
 
@@ -380,9 +380,9 @@ contract ColonyTask is ColonyStorage {
 
   function setTaskDueDate(uint256 _id, uint256 _dueDate) public
   stoppable
-  self()
   taskExists(_id)
   taskNotFinalized(_id)
+  self()
   {
     tasks[_id].dueDate = _dueDate;
 

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -41,56 +41,56 @@ contract ColonyTask is ColonyStorage {
     // Manager rated by worker
     // Worker rated by evaluator
     if (_role == MANAGER) {
-      require(tasks[_id].roles[WORKER].user == msg.sender);
+      require(tasks[_id].roles[WORKER].user == msg.sender, "colony-user-cannot-rate-task-manager");
     } else if (_role == WORKER) {
-      require(tasks[_id].roles[EVALUATOR].user == msg.sender);
+      require(tasks[_id].roles[EVALUATOR].user == msg.sender, "colony-user-cannot-rate-task-worker");
     } else {
-      revert();
+      revert("colony-unsupported-role-to-rate");
     }
     _;
   }
 
   modifier ratingSecretDoesNotExist(uint256 _id, uint8 _role) {
-    require(taskWorkRatings[_id].secret[_role] == "");
+    require(taskWorkRatings[_id].secret[_role] == "", "colony-task-rating-secret-already-exists");
     _;
   }
 
   modifier workNotSubmitted(uint256 _id) {
-    require(tasks[_id].deliverableTimestamp == 0);
+    require(tasks[_id].deliverableTimestamp == 0, "colony-task-deliverable-already-submitted");
     _;
   }
 
   modifier beforeDueDate(uint256 _id) {
-    require(tasks[_id].dueDate >= now);
+    require(tasks[_id].dueDate >= now, "colony-task-due-date-passed");
     _;
   }
 
   modifier taskWorkRatingCommitOpen(uint256 _id) {
     RatingSecrets storage ratingSecrets = taskWorkRatings[_id];
-    require(ratingSecrets.count < 2);
+    require(ratingSecrets.count < 2, "colony-task-rating-all-secrets-submitted");
 
     // Check we are either past the due date or work has already been submitted
     uint taskCompletionTime = tasks[_id].deliverableTimestamp != 0 ? tasks[_id].deliverableTimestamp : tasks[_id].dueDate;
-    require(taskCompletionTime > 0 && taskCompletionTime <= now);
+    require(taskCompletionTime > 0 && taskCompletionTime <= now, "colony-task-not-complete");
 
     // Check we are within 5 days of the work submission time
-    require(sub(now, taskCompletionTime) <= RATING_COMMIT_TIMEOUT);
+    require(sub(now, taskCompletionTime) <= RATING_COMMIT_TIMEOUT, "colony-task-rating-secret-submit-period-closed");
     _;
   }
 
   modifier taskWorkRatingRevealOpen(uint256 _id) {
     RatingSecrets storage ratingSecrets = taskWorkRatings[_id];
-    require(ratingSecrets.count <= 2);
+    require(ratingSecrets.count <= 2, "colony-task-rating-more-secrets-submitted-than-expected");
 
     // If both ratings have been received, start the reveal period from the time of the last rating commit
     // Otherwise start the reveal period after the commit period has expired
     // In both cases, keep reveal period open for 5 days
     if (ratingSecrets.count == 2) {
-      require(sub(now, ratingSecrets.timestamp) <= RATING_REVEAL_TIMEOUT);
+      require(sub(now, ratingSecrets.timestamp) <= RATING_REVEAL_TIMEOUT, "colony-task-rating-secret-reveal-period-closed");
     } else if (ratingSecrets.count < 2) {
       uint taskCompletionTime = tasks[_id].deliverableTimestamp != 0 ? tasks[_id].deliverableTimestamp : tasks[_id].dueDate;
-      require(sub(now, taskCompletionTime) > RATING_COMMIT_TIMEOUT);
-      require(sub(now, taskCompletionTime) <= add(RATING_COMMIT_TIMEOUT, RATING_REVEAL_TIMEOUT));
+      require(sub(now, taskCompletionTime) > RATING_COMMIT_TIMEOUT, "colony-task-rating-secret-reveal-period-closed");
+      require(sub(now, taskCompletionTime) <= add(RATING_COMMIT_TIMEOUT, RATING_REVEAL_TIMEOUT), "colony-task-rating-secret-reveal-period-closed");
     }
     _;
   }
@@ -98,13 +98,13 @@ contract ColonyTask is ColonyStorage {
   modifier taskWorkRatingsClosed(uint256 _id) {
     uint taskCompletionTime = tasks[_id].deliverableTimestamp != 0 ? tasks[_id].deliverableTimestamp : tasks[_id].dueDate;
     // More than 10 days from work submission have passed
-    require(sub(now, taskCompletionTime) > add(RATING_COMMIT_TIMEOUT, RATING_REVEAL_TIMEOUT));
+    require(sub(now, taskCompletionTime) > add(RATING_COMMIT_TIMEOUT, RATING_REVEAL_TIMEOUT), "colony-task-rating-period-open");
     _;
   }
 
   modifier taskWorkRatingsAssigned(uint256 _id) {
-    require(tasks[_id].roles[WORKER].rating != TaskRatings.None);
-    require(tasks[_id].roles[MANAGER].rating != TaskRatings.None);
+    require(tasks[_id].roles[WORKER].rating != TaskRatings.None, "colony-task-worker-rating-missing");
+    require(tasks[_id].roles[MANAGER].rating != TaskRatings.None, "colony-task-manager-rating-missing");
     _;
   }
 
@@ -150,14 +150,15 @@ contract ColonyTask is ColonyStorage {
     uint256 _value,
     bytes _data) public stoppable
   {
-    require(_value == 0);
-    require(_sigR.length == _sigS.length && _sigR.length == _sigV.length);
+    require(_value == 0, "colony-task-change-non-zero-value");
+    require(_sigR.length == _sigS.length && _sigR.length == _sigV.length, "colony-task-change-signatures-count-do-not-match");
 
     bytes4 sig;
     uint256 taskId;
     (sig, taskId) = deconstructCall(_data);
-    require(!tasks[taskId].finalized);
-    require(!roleAssignmentSigs[sig]);
+    require(taskId <= taskCount, "colony-task-does-not-exist");
+    require(!tasks[taskId].finalized, "colony-task-finalized");
+    require(!roleAssignmentSigs[sig], "colony-task-change-is-role-assignement");
 
     uint8 nSignaturesRequired;
     if (tasks[taskId].roles[reviewers[sig][0]].user == address(0) || tasks[taskId].roles[reviewers[sig][1]].user == address(0)) {
@@ -170,7 +171,7 @@ contract ColonyTask is ColonyStorage {
       nSignaturesRequired = 2;
     }
 
-    require(_sigR.length == nSignaturesRequired);
+    require(_sigR.length == nSignaturesRequired, "colony-task-change-does-not-meet-signatures-required");
 
     bytes32 msgHash = keccak256(abi.encodePacked(address(this), address(this), _value, _data, taskChangeNonces[taskId]));
     address[] memory reviewerAddresses = getReviewerAddresses(
@@ -183,19 +184,21 @@ contract ColonyTask is ColonyStorage {
 
     require(
       reviewerAddresses[0] == tasks[taskId].roles[reviewers[sig][0]].user ||
-      reviewerAddresses[0] == tasks[taskId].roles[reviewers[sig][1]].user
+      reviewerAddresses[0] == tasks[taskId].roles[reviewers[sig][1]].user,
+      "colony-task-signatures-do-not-match-reviewer-1"
     );
 
     if (nSignaturesRequired == 2) {
-      require(reviewerAddresses[0] != reviewerAddresses[1]);
+      require(reviewerAddresses[0] != reviewerAddresses[1], "colony-task-duplicate-reviewers");
       require(
         reviewerAddresses[1] == tasks[taskId].roles[reviewers[sig][0]].user ||
-        reviewerAddresses[1] == tasks[taskId].roles[reviewers[sig][1]].user
+        reviewerAddresses[1] == tasks[taskId].roles[reviewers[sig][1]].user,
+        "colony-task-signatures-do-not-match-reviewer-2"
       );
     }
 
     taskChangeNonces[taskId]++;
-    require(executeCall(address(this), _value, _data));
+    require(executeCall(address(this), _value, _data), "colony-task-change-execution-failed");
   }
 
   function executeTaskRoleAssignment(
@@ -206,15 +209,15 @@ contract ColonyTask is ColonyStorage {
     uint256 _value,
     bytes _data) public stoppable
   {
-    require(_value == 0);
-    require(_sigR.length == _sigS.length && _sigR.length == _sigV.length);
+    require(_value == 0, "colony-task-role-assignment-non-zero-value");
+    require(_sigR.length == _sigS.length && _sigR.length == _sigV.length, "colony-task-role-assignment-signatures-count-do-not-match");
 
     bytes4 sig;
     uint256 taskId;
     address userAddress;
     (sig, taskId, userAddress) = deconstructRoleChangeCall(_data);
 
-    require(roleAssignmentSigs[sig]);
+    require(roleAssignmentSigs[sig], "colony-task-change-is-not-role-assignement");
 
     uint8 nSignaturesRequired;
     // If manager wants to set himself to a role
@@ -223,7 +226,7 @@ contract ColonyTask is ColonyStorage {
     } else {
       nSignaturesRequired = 2;
     }
-    require(_sigR.length == nSignaturesRequired);
+    require(_sigR.length == nSignaturesRequired, "colony-task-role-assignment-does-not-meet-signatures-required");
 
     bytes32 msgHash = keccak256(abi.encodePacked(address(this), address(this), _value, _data, taskChangeNonces[taskId]));
     address[] memory reviewerAddresses = getReviewerAddresses(
@@ -236,25 +239,30 @@ contract ColonyTask is ColonyStorage {
 
     if (nSignaturesRequired == 1) {
       // Since we want to set a manager as an evaluator, require just manager's signature
-      require(reviewerAddresses[0] == tasks[taskId].roles[MANAGER].user);
+      require(reviewerAddresses[0] == tasks[taskId].roles[MANAGER].user, "colony-task-role-assignment-not-signed-by-manager");
     } else {
       // One of signers must be a manager
-      require(reviewerAddresses[0] == tasks[taskId].roles[MANAGER].user || reviewerAddresses[1] == tasks[taskId].roles[MANAGER].user);
+      require(
+        reviewerAddresses[0] == tasks[taskId].roles[MANAGER].user ||
+        reviewerAddresses[1] == tasks[taskId].roles[MANAGER].user,
+        "colony-task-role-assignment-not-signed-by-manager"
+      );
       // One of the signers must be an address we want to set here
-      require(userAddress == reviewerAddresses[0] || userAddress == reviewerAddresses[1]);
+      require(userAddress == reviewerAddresses[0] || userAddress == reviewerAddresses[1], "colony-task-role-assignment-not-signed-by-new-role-user");
       // Require that signatures are not from the same address
       // This will never throw, because we require that manager is one of the signers,
       // and if manager is both signers, then `userAddress` must also be a manager, and if
       // `userAddress` is a manager, then we require 1 signature (will be kept for possible future changes)
-      require(reviewerAddresses[0] != reviewerAddresses[1]);
+      require(reviewerAddresses[0] != reviewerAddresses[1], "colony-task-role-assignment-duplicate-signatures");
     }
 
     taskChangeNonces[taskId]++;
-    require(executeCall(address(this), _value, _data));
+    require(executeCall(address(this), _value, _data), "colony-task-role-assignment-execution-failed");
   }
 
   function submitTaskWorkRating(uint256 _id, uint8 _role, bytes32 _ratingSecret) public
   stoppable
+  taskExists(_id)
   userCanRateRole(_id, _role)
   ratingSecretDoesNotExist(_id, _role)
   taskWorkRatingCommitOpen(_id)
@@ -271,10 +279,10 @@ contract ColonyTask is ColonyStorage {
   {
     // MAYBE: we should hash these the other way around, i.e. generateSecret(_rating, _salt)
     bytes32 ratingSecret = generateSecret(_salt, _rating);
-    require(ratingSecret == taskWorkRatings[_id].secret[_role]);
+    require(ratingSecret == taskWorkRatings[_id].secret[_role], "colony-task-rating-secret-not-match");
 
     TaskRatings rating = TaskRatings(_rating);
-    require(rating != TaskRatings.None, "Cannot rate None!");
+    require(rating != TaskRatings.None, "colony-task-rating-missing");
     tasks[_id].roles[_role].rating = rating;
 
     emit TaskWorkRatingRevealed(_id, _role, _rating);
@@ -324,13 +332,13 @@ contract ColonyTask is ColonyStorage {
 
   function setTaskEvaluatorRole(uint256 _id, address _user) public stoppable self {
     // Can only assign role if no one is currently assigned to it
-    require(tasks[_id].roles[EVALUATOR].user == 0x0);
+    require(tasks[_id].roles[EVALUATOR].user == 0x0, "colony-task-evaluator-role-already-assigned");
     setTaskRoleUser(_id, EVALUATOR, _user);
   }
 
   function setTaskWorkerRole(uint256 _id, address _user) public stoppable self {
     // Can only assign role if no one is currently assigned to it
-    require(tasks[_id].roles[WORKER].user == 0x0);
+    require(tasks[_id].roles[WORKER].user == 0x0, "colony-task-worker-role-already-assigned");
     setTaskRoleUser(_id, WORKER, _user);
   }
 
@@ -405,6 +413,7 @@ contract ColonyTask is ColonyStorage {
 
   function finalizeTask(uint256 _id) public
   stoppable
+  taskExists(_id)
   taskWorkRatingsAssigned(_id)
   taskNotFinalized(_id)
   {
@@ -468,7 +477,7 @@ contract ColonyTask is ColonyStorage {
   }
 
   function getReputation(int payout, uint8 rating, bool rateFail) internal pure returns(int reputation) {
-    require(rating > 0 && rating <= 3, "Invalid rating");
+    require(rating > 0 && rating <= 3, "colony-task-rating-invalid");
 
     // -1, 1, 1.5 multipliers, -0.5 penalty
     int8[3] memory ratingMultipliers = [-2, 2, 3];

--- a/contracts/PatriciaTree/Bits.sol
+++ b/contracts/PatriciaTree/Bits.sol
@@ -16,7 +16,7 @@ library Bits {
   /// @param self The `uint256` to find the highest bit set in
   /// @dev Requires that `self != 0`.
   function highestBitSet(uint self) internal pure returns (uint8 highest) {
-    require(self != 0);
+    require(self != 0, "colony-patricia-tree-zero-self");
     uint val = self;
     for (uint8 i = 128; i >= 1; i >>= 1) {
       if (val & (ONE << i) - 1 << i != 0) {
@@ -31,7 +31,7 @@ library Bits {
   /// @param self The `uint256` to find the lowest bit set in
   /// @dev Requires that `self != 0`.
   function lowestBitSet(uint self) internal pure returns (uint8 lowest) {
-    require(self != 0);
+    require(self != 0, "colony-patricia-tree-zero-self");
     uint val = self;
     for (uint8 i = 128; i >= 1; i >>= 1) {
       if (val & (ONE << i) - 1 == 0) {

--- a/contracts/PatriciaTree/Data.sol
+++ b/contracts/PatriciaTree/Data.sol
@@ -57,7 +57,7 @@ library Data {
   // Removes the first bit from a label and returns the bit and a
   // label containing the rest of the label (shifted to the left).
   function chopFirstBit(Label memory self) internal pure returns (uint firstBit, Label memory tail) {
-    require(self.length > 0);
+    require(self.length > 0, "colony-patricia-tree-zero-self-length");
     return (uint(self.data >> 255), Label(self.data << 1, self.length - 1));
   }
 
@@ -126,7 +126,7 @@ library Data {
   // Returns the result of removing a prefix of length `prefix` bits from the
   // given label (shifting its data to the left).
   function removePrefix(Label memory self, uint prefix) private pure returns (Label memory r) {
-    require(prefix <= self.length);
+    require(prefix <= self.length, "colony-patricia-tree-prefix-longer-than-self");
     r.length = self.length - prefix;
     r.data = self.data << prefix;
   }

--- a/contracts/PatriciaTree/PatriciaTree.sol
+++ b/contracts/PatriciaTree/PatriciaTree.sol
@@ -32,7 +32,7 @@ contract PatriciaTree is IPatriciaTree, PatriciaTreeProofs {
   }
 
   function getProof(bytes key) public view returns (uint branchMask, bytes32[] _siblings) {
-    require(tree.root != 0);
+    require(tree.root != 0, "colony-patricia-tree-zero-tree-root");
     Data.Label memory k = Data.Label(keccak256(key), 256);
     Data.Edge memory e = tree.rootEdge;
     bytes32[256] memory siblings;

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -122,7 +122,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     uint256 balance;
     (, balance) = ITokenLocking(tokenLockingAddress).getUserLock(clnyTokenAddress, msg.sender);
     require(entryIndex <= balance / 10**15, "colony-reputation-mining-stake-minimum-not-met");
-    require(entryIndex > 0);
+    require(entryIndex > 0, "colony-reputation-mining-zero-entry-index-passed");
     // If this user has submitted before during this round...
     if (reputationHashSubmissions[msg.sender].proposedNewRootHash != 0x0) {
       // ...require that they are submitting the same hash ...
@@ -648,7 +648,9 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
 
     // Check that the supplied log entry corresponds to this update number
     require(updateNumber >= logEntry.nPreviousUpdates, "colony-reputation-mining-update-number-part-of-previous-log-entry-updates");
-    require(updateNumber < logEntry.nUpdates + logEntry.nPreviousUpdates, "colony-reputation-mining-update-number-part-of-following-log-entry-updates");
+    require(
+      updateNumber < logEntry.nUpdates + logEntry.nPreviousUpdates,
+      "colony-reputation-mining-update-number-part-of-following-log-entry-updates");
     uint expectedSkillId;
     address expectedAddress;
     (expectedSkillId, expectedAddress) = getExpectedSkillIdAndAddress(logEntry, updateNumber);
@@ -901,7 +903,8 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     // TODO: we're calling this twice during submitJRH. Should only need to call once.
     uint256 reputationRootHashNNodes = IColonyNetwork(colonyNetworkAddress).getReputationRootHashNNodes();
 
-    uint256 nUpdates = reputationUpdateLog[nLogEntries-1].nUpdates + reputationUpdateLog[nLogEntries-1].nPreviousUpdates + reputationRootHashNNodes;
+    uint256 nUpdates = reputationUpdateLog[nLogEntries-1].nUpdates +
+    reputationUpdateLog[nLogEntries-1].nPreviousUpdates + reputationRootHashNNodes;
     bytes memory nUpdatesBytes = new bytes(32);
     disputeRounds[round][index].jrhNnodes = nUpdates + 1;
     bytes32 submittedHash = disputeRounds[round][index].proposedNewRootHash;

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -832,7 +832,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
       } else {
         // TODO: Is this safe? I think so, because even if there's over/underflows, they should
         // still be the same number.
-        require(int(agreeStateReputationValue)+logEntry.amount == int(disagreeStateReputationValue));
+        require(int(agreeStateReputationValue)+logEntry.amount == int(disagreeStateReputationValue), "colony-invalid-newest-reputation-proof");
       }
     }
   }

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -90,8 +90,8 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   /// @notice A modifier that checks that the supplied `roundNumber` is the final round
   /// @param roundNumber The `roundNumber` to check if it is the final round
   modifier finalDisputeRoundCompleted(uint256 roundNumber) {
-    require (nSubmittedHashes - nInvalidatedHashes == 1);
-    require (disputeRounds[roundNumber].length == 1); //i.e. this is the final round
+    require(nSubmittedHashes - nInvalidatedHashes == 1, "colony-reputation-mining-final-round-not-completed");
+    require(disputeRounds[roundNumber].length == 1, "colony-reputation-mining-final-round-not-completed"); //i.e. this is the final round
     // Note that even if we are passed the penultimate round, which had a length of two, and had one eliminated,
     // and therefore 'delete' called in `invalidateHash`, the array still has a length of '2' - it's just that one
     // element is zeroed. If this functionality of 'delete' is ever changed, this will have to change too.
@@ -103,7 +103,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   /// @param idx The index in the round of the hash under consideration
   modifier challengeOpen(uint256 round, uint256 idx) {
     // TODO: More checks that this is an appropriate time to respondToChallenge
-    require(disputeRounds[round][idx].lowerBound == disputeRounds[round][idx].upperBound);
+    require(disputeRounds[round][idx].lowerBound == disputeRounds[round][idx].upperBound, "colony-reputation-mining-challenge-closed");
     _;
   }
 
@@ -121,15 +121,15 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     // Here, the minimum stake is 10**15.
     uint256 balance;
     (, balance) = ITokenLocking(tokenLockingAddress).getUserLock(clnyTokenAddress, msg.sender);
-    require(entryIndex <= balance / 10**15);
+    require(entryIndex <= balance / 10**15, "colony-reputation-mining-stake-minimum-not-met");
     require(entryIndex > 0);
     // If this user has submitted before during this round...
     if (reputationHashSubmissions[msg.sender].proposedNewRootHash != 0x0) {
       // ...require that they are submitting the same hash ...
-      require(newHash == reputationHashSubmissions[msg.sender].proposedNewRootHash);
+      require(newHash == reputationHashSubmissions[msg.sender].proposedNewRootHash, "colony-reputation-mining-submitting-different-hash");
       // ...require that they are submitting the same number of nodes for that hash ...
-      require(nNodes == reputationHashSubmissions[msg.sender].nNodes);
-      require (submittedEntries[newHash][msg.sender][entryIndex] == false); // ... but not this exact entry
+      require(nNodes == reputationHashSubmissions[msg.sender].nNodes, "colony-reputation-mining-submitting-different-nnodes");
+      require(submittedEntries[newHash][msg.sender][entryIndex] == false, "colony-reputation-mining-submitting-same-entry-index"); // ... but not this exact entry
     }
     _;
   }
@@ -138,7 +138,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   /// @dev A submission will only be accepted from a reputation miner if `keccak256(address, N, hash) < target`
   /// At the beginning of the submission window, the target is set to 0 and slowly increases to 2^256 - 1 after an hour
   modifier withinTarget(bytes32 newHash, uint256 entryIndex) {
-    require(reputationMiningWindowOpenTimestamp > 0);
+    require(reputationMiningWindowOpenTimestamp > 0, "colony-reputation-mining-cycle-not-open");
     // Check the ticket is a winning one.
     // TODO Figure out how to uncomment the next line, but not break tests sporadically.
     // require((now-reputationMiningWindowOpenTimestamp) <= 3600);
@@ -146,7 +146,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     if (now - reputationMiningWindowOpenTimestamp <= 3600) {
       uint256 x = 32164469232587832062103051391302196625908329073789045566515995557753647122;
       uint256 target = (now - reputationMiningWindowOpenTimestamp ) * x;
-      require(uint256(getEntryHash(msg.sender, entryIndex, newHash)) < target);
+      require(uint256(getEntryHash(msg.sender, entryIndex, newHash)) < target, "colony-reputation-mining-cycle-closed");
     }
     _;
   }
@@ -163,7 +163,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   }
 
   function resetWindow() public {
-    require(msg.sender == colonyNetworkAddress);
+    require(msg.sender == colonyNetworkAddress, "colony-reputation-mining-sender-not-network");
     reputationMiningWindowOpenTimestamp = now;
   }
 
@@ -172,7 +172,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   withinTarget(newHash, entryIndex)
   {
     // Limit the total number of miners allowed to submit a specific hash to 12
-    require (submittedHashes[newHash][nNodes].length < 12);
+    require(submittedHashes[newHash][nNodes].length < 12, "colony-reputation-mining-max-number-miners-reached");
 
     // If this is a new hash, increment nSubmittedHashes as such.
     if (submittedHashes[newHash][nNodes].length == 0) {
@@ -247,10 +247,10 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
       // We just move the opponent on, and nothing else happens.
 
       // Ensure that the previous round is complete, and this entry wouldn't possibly get an opponent later on.
-      require(nHashesCompletedChallengeRound[round-1] == disputeRounds[round-1].length);
+      require(nHashesCompletedChallengeRound[round-1] == disputeRounds[round-1].length, "colony-reputation-mining-previous-dispute-round-not-complete");
 
       // Prevent us invalidating the final hash
-      require(disputeRounds[round].length > 1);
+      require(disputeRounds[round].length > 1, "colony-reputation-mining-cannot-invalidate-final-hash");
       // Move opponent on to next round
       disputeRounds[round+1].push(disputeRounds[round][opponentIdx]);
       delete disputeRounds[round][opponentIdx];
@@ -264,15 +264,15 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
         startPairingInRound(round+1);
       }
     } else {
-      require(disputeRounds[round].length > opponentIdx);
-      require(disputeRounds[round][opponentIdx].proposedNewRootHash != "");
+      require(disputeRounds[round].length > opponentIdx, "colony-reputation-mining-dispute-id-not-in-range");
+      require(disputeRounds[round][opponentIdx].proposedNewRootHash != "", "colony-reputation-mining-proposed-hash-empty");
 
       // Require that this is not better than its opponent.
-      require(disputeRounds[round][opponentIdx].challengeStepCompleted >= disputeRounds[round][idx].challengeStepCompleted);
-      require(disputeRounds[round][opponentIdx].provedPreviousReputationUID >= disputeRounds[round][idx].provedPreviousReputationUID);
+      require(disputeRounds[round][opponentIdx].challengeStepCompleted >= disputeRounds[round][idx].challengeStepCompleted, "colony-reputation-mining-less-challenge-rounds-completed");
+      require(disputeRounds[round][opponentIdx].provedPreviousReputationUID >= disputeRounds[round][idx].provedPreviousReputationUID, "colony-reputation-mining-less-reputation-uids-proven");
 
       // Require that it has failed a challenge (i.e. failed to respond in time)
-      require(now - disputeRounds[round][idx].lastResponseTimestamp >= 600); //'In time' is ten minutes here.
+      require(now - disputeRounds[round][idx].lastResponseTimestamp >= 600, "colony-reputation-mining-failed-to-respond-in-time"); //'In time' is ten minutes here.
 
       // Work out whether we are invalidating just the supplied idx or its opponent too.
       bool eliminateOpponent = false;
@@ -323,7 +323,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   {
     // TODO: Check this challenge is active.
     // This require is necessary, but not a sufficient check (need to check we have an opponent, at least).
-    require(disputeRounds[round][idx].lowerBound!=disputeRounds[round][idx].upperBound);
+    require(disputeRounds[round][idx].lowerBound != disputeRounds[round][idx].upperBound, "colony-reputation-mining-challenge-not-active");
 
     uint256 targetNode = add(
       disputeRounds[round][idx].lowerBound,
@@ -337,7 +337,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     }
 
     bytes32 impliedRoot = getImpliedRoot(targetNodeBytes, jhIntermediateValue, branchMask, siblings);
-    require(impliedRoot==jrh, "colony-invalid-binary-search-response");
+    require(impliedRoot==jrh, "colony-reputation-mining-invalid-binary-search-response");
     // If require hasn't thrown, proof is correct.
     // Process the consequences
     processBinaryChallengeSearchResponse(round, idx, jhIntermediateValue, targetNode);
@@ -431,7 +431,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   ) public
   {
     // Require we've not submitted already.
-    require(disputeRounds[round][index].jrh == 0x0);
+    require(disputeRounds[round][index].jrh == 0x0, "colony-reputation-mining-hash-already-submitted");
 
     // Check the proofs for the JRH
     checkJRHProof1(jrh, branchMask1, siblings1);
@@ -455,7 +455,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     uint256 _nChildren
   ) public
   {
-    require(colonyNetworkAddress == msg.sender);
+    require(colonyNetworkAddress == msg.sender, "colony-reputation-mining-sender-not-network");
     uint reputationUpdateLogLength = reputationUpdateLog.length;
     uint nPreviousUpdates = 0;
     if (reputationUpdateLogLength > 0) {
@@ -545,8 +545,8 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
   }
 
   function rewardStakersWithReputation(address[] stakers, address commonColonyAddress, uint256 reward, uint256 miningSkillId) public {
-    require(reputationUpdateLog.length==0);
-    require(msg.sender == colonyNetworkAddress);
+    require(msg.sender == colonyNetworkAddress, "colony-reputation-mining-sender-not-network");
+    require(reputationUpdateLog.length == 0, "colony-reputation-mining-log-length-non-zero");
     for (uint256 i = 0; i < stakers.length; i++) {
       // We *know* we're the first entries in this reputation update log, so we don't need all the bookkeeping in
       // the AppendReputationUpdateLog function
@@ -638,7 +638,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     // We check that the reputation UID is right for the decay transition being disputed.
     // The key is then implicitly checked when they prove that the key+value they supplied is in the
     // right intermediate state in their justification tree.
-    require(uid-1 == _updateNumber);
+    require(uid-1 == _updateNumber, "colony-reputation-mining-uid-not-decay");
   }
 
   function checkKeyLogEntry(uint256 round, uint256 idx, uint256 logEntryNumber, bytes memory _reputationKey) internal {
@@ -647,8 +647,8 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     ReputationLogEntry storage logEntry = reputationUpdateLog[logEntryNumber];
 
     // Check that the supplied log entry corresponds to this update number
-    require(updateNumber >= logEntry.nPreviousUpdates);
-    require(updateNumber < logEntry.nUpdates + logEntry.nPreviousUpdates);
+    require(updateNumber >= logEntry.nPreviousUpdates, "colony-reputation-mining-update-number-part-of-previous-log-entry-updates");
+    require(updateNumber < logEntry.nUpdates + logEntry.nPreviousUpdates, "colony-reputation-mining-update-number-part-of-following-log-entry-updates");
     uint expectedSkillId;
     address expectedAddress;
     (expectedSkillId, expectedAddress) = getExpectedSkillIdAndAddress(logEntry, updateNumber);
@@ -666,9 +666,9 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
                                               // any unintended side effects here, but I'm not quite confortable enough with EVM's stack to be sure.
                                               // Not sure what the alternative would be anyway.
     }
-    require(expectedAddress == userAddress);
-    require(logEntry.colony == colonyAddress);
-    require(expectedSkillId == skillId);
+    require(expectedAddress == userAddress, "colony-reputation-mining-user-address-mismatch");
+    require(logEntry.colony == colonyAddress, "colony-reputation-mining-colony-address-mismatch");
+    require(expectedSkillId == skillId, "colony-reputation-mining-skill-id-mismatch");
   }
 
   function getExpectedSkillIdAndAddress(ReputationLogEntry storage logEntry, uint256 updateNumber) internal view
@@ -739,7 +739,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
       // This implies they are claiming that this is a new hash.
       return;
     }
-    require(impliedRoot == jrh);
+    require(impliedRoot == jrh, "colony-reputation-mining-invalid-before-reputation-proof");
     // They've actually verified whatever they claimed. We increment their challengeStepCompleted by one to indicate this.
     // In the event that our opponent lied about this reputation not existing yet in the tree, they will both complete
     // a call to respondToChallenge, but we will have a higher challengeStepCompleted value, and so they will be the ones
@@ -774,7 +774,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     }
 
     bytes32 impliedRoot = getImpliedRoot(firstDisagreeIdxBytes, jhLeafValue, u[U_DISAGREE_STATE_BRANCH_MASK], disagreeStateSiblings);
-    require(jrh==impliedRoot, "colony-invalid-after-reputation-proof");
+    require(jrh==impliedRoot, "colony-reputation-mining-invalid-after-reputation-proof");
   }
 
   function performReputationCalculation(
@@ -801,13 +801,13 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     if (agreeStateReputationUID != 0) {
       // i.e. if this was an existing reputation, then require that the ID hasn't changed.
       // TODO: Situation where it is not an existing reputation
-      require(agreeStateReputationUID==disagreeStateReputationUID);
+      require(agreeStateReputationUID==disagreeStateReputationUID, "colony-reputation-mining-uid-changed-for-existing-reputation");
     } else {
       uint256 previousNewReputationUID;
       assembly {
         previousNewReputationUID := mload(add(previousNewReputationValueBytes, 64))
       }
-      require(previousNewReputationUID+1 == disagreeStateReputationUID);
+      require(previousNewReputationUID + 1 == disagreeStateReputationUID, "colony-reputation-mining-new-uid-incorrect");
       // Flag that we need to check that the reputation they supplied is in the 'agree' state.
       // This feels like it might be being a bit clever, using this array to pass a 'return' value out of
       // this function, without adding a new variable to the stack in the parent function...
@@ -816,23 +816,23 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
 
     // We don't care about underflows for the purposes of comparison, but for the calculation we deem 'correct'.
     // i.e. a reputation can't be negative.
-    if (u[U_DECAY_TRANSITION]==1) {
+    if (u[U_DECAY_TRANSITION] == 1) {
       // Very large reputation decays are calculated the 'other way around' to avoid overflows.
       if (agreeStateReputationValue > uint256(2**256 - 1)/uint256(10**15)) {
-        require(disagreeStateReputationValue == (agreeStateReputationValue/1000000000000000)*999679150010888);
+        require(disagreeStateReputationValue == (agreeStateReputationValue/1000000000000000)*999679150010888, "colony-reputation-mining-decay-incorrect");
       } else {
-        require(disagreeStateReputationValue == (agreeStateReputationValue*999679150010888)/1000000000000000);
+        require(disagreeStateReputationValue == (agreeStateReputationValue*999679150010888)/1000000000000000, "colony-reputation-mining-decay-incorrect");
       }
     } else {
       if (logEntry.amount < 0 && uint(logEntry.amount * -1) > agreeStateReputationValue ) {
-        require(disagreeStateReputationValue == 0);
+        require(disagreeStateReputationValue == 0, "colony-reputation-mining-reputation-value-non-zero");
       } else if (uint(logEntry.amount) + agreeStateReputationValue < agreeStateReputationValue) {
         // We also don't allow reputation to overflow
-        require(disagreeStateReputationValue == 2**256 - 1);
+        require(disagreeStateReputationValue == 2**256 - 1, "colony-reputation-mining-reputation-not-max-uint");
       } else {
         // TODO: Is this safe? I think so, because even if there's over/underflows, they should
         // still be the same number.
-        require(int(agreeStateReputationValue)+logEntry.amount == int(disagreeStateReputationValue), "colony-invalid-newest-reputation-proof");
+        require(int(agreeStateReputationValue)+logEntry.amount == int(disagreeStateReputationValue), "colony-reputation-mining-invalid-newest-reputation-proof");
       }
     }
   }
@@ -864,7 +864,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
     }
     // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
     bytes32 impliedRoot = getImpliedRoot(lastAgreeIdxBytes, jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
-    require(impliedRoot == disputeRounds[u[U_ROUND]][u[U_IDX]].jrh);
+    require(impliedRoot == disputeRounds[u[U_ROUND]][u[U_IDX]].jrh, "colony-reputation-mining-last-state-disagreement");
   }
 
   function saveProvedReputation(uint256[11] u, bytes previousNewReputationValue) internal {
@@ -887,7 +887,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
       mstore(add(jhLeafValue, 0x40), reputationRootHashNNodes)
     }
     bytes32 impliedRoot = getImpliedRoot(zero, jhLeafValue, branchMask1, siblings1);
-    require(jrh==impliedRoot, "colony-invalid-jrh-proof-1");
+    require(jrh==impliedRoot, "colony-reputation-mining-invalid-jrh-proof-1");
   }
 
   function checkJRHProof2(uint256 round, uint256 index, bytes32 jrh, uint256 branchMask2, bytes32[] siblings2) internal {
@@ -913,7 +913,7 @@ contract ReputationMiningCycle is PatriciaTreeProofs, DSMath {
       mstore(add(nUpdatesBytes, 0x20), nUpdates)
     }
     bytes32 impliedRoot = getImpliedRoot(nUpdatesBytes, jhLeafValue, branchMask2, siblings2);
-    require(jrh==impliedRoot, "colony-invalid-jrh-proof-2");
+    require(jrh==impliedRoot, "colony-reputation-mining-invalid-jrh-proof-2");
 
   }
 

--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -33,17 +33,17 @@ library SafeMath {
   }
 
   function addInt(int a, int b) public pure returns (int) {
-    require(safeToAddInt(a, b));
+    require(safeToAddInt(a, b), "colony-math-unsafe-int-add");
     return a + b;
   }
 
   function subInt(int a, int b) public pure returns (int) {
-    require(safeToSubInt(a, b));
+    require(safeToSubInt(a, b), "colony-math-unsafe-int-sub");
     return a - b;
   }
 
   function mulInt(int a, int b) public pure returns (int) {
-    require(safeToMulInt(a, b));
+    require(safeToMulInt(a, b), "colony-math-unsafe-int-mul");
     return a * b;
   }
 }

--- a/contracts/TokenLocking.sol
+++ b/contracts/TokenLocking.sol
@@ -31,7 +31,7 @@ contract TokenLocking is TokenLockingStorage, DSMath {
     if (_token == clnyToken) {
       bytes32 submittedHash;
       (submittedHash,,,,,,,,,,) = IReputationMiningCycle(IColonyNetwork(colonyNetwork).getReputationMiningCycle(true)).getReputationHashSubmissions(msg.sender);
-      require(submittedHash == 0x0, "colony-token-locking-hash-already-submitted");
+      require(submittedHash == 0x0, "colony-token-locking-hash-submitted");
     }
     _;
   }

--- a/contracts/TokenLocking.sol
+++ b/contracts/TokenLocking.sol
@@ -51,8 +51,12 @@ contract TokenLocking is TokenLockingStorage, DSMath {
     return totalLockCount[_token];
   }
 
-  function unlockTokenForUser(address _token, address _user, uint256 _lockId) public onlyColony {
-    require(sub(_lockId, userLocks[_token][_user].lockCount) == 1, "colony-token-locking-invalid-lock-id");
+  function unlockTokenForUser(address _token, address _user, uint256 _lockId) public 
+  onlyColony 
+  {
+    uint256 lockCountDelta = sub(_lockId, userLocks[_token][_user].lockCount);
+    require(lockCountDelta != 0, "colony-token-already-unlocked");
+    require(lockCountDelta == 1, "colony-token-locking-has-previous-active-locks");
     // If we want to unlock tokens at id greater than total lock count, we are doing something wrong
     assert(_lockId <= totalLockCount[_token]);
     userLocks[_token][_user].lockCount = _lockId;

--- a/contracts/TokenLocking.sol
+++ b/contracts/TokenLocking.sol
@@ -21,7 +21,7 @@ contract TokenLocking is TokenLockingStorage, DSMath {
 
   modifier tokenNotLocked(address _token) {
     if (userLocks[_token][msg.sender].balance > 0) {
-      require(userLocks[_token][msg.sender].lockCount == totalLockCount[_token], "token-locking-token-locked");
+      require(userLocks[_token][msg.sender].lockCount == totalLockCount[_token], "colony-token-locking-token-locked");
     }
     _;
   }
@@ -50,23 +50,23 @@ contract TokenLocking is TokenLockingStorage, DSMath {
   }
 
   function unlockTokenForUser(address _token, address _user, uint256 _lockId) public onlyColony {
-    require(sub(_lockId, userLocks[_token][_user].lockCount) == 1, "token-locking-invalid-lock-id");
+    require(sub(_lockId, userLocks[_token][_user].lockCount) == 1, "colony-token-locking-invalid-lock-id");
     // If we want to unlock tokens at id greater than total lock count, we are doing something wrong
     assert(_lockId <= totalLockCount[_token]);
     userLocks[_token][_user].lockCount = _lockId;
   }
 
   function incrementLockCounterTo(address _token, uint256 _lockId) public {
-    require(_lockId <= totalLockCount[_token] && _lockId > userLocks[_token][msg.sender].lockCount, "token-locking-invalid-lock-id");
+    require(_lockId <= totalLockCount[_token] && _lockId > userLocks[_token][msg.sender].lockCount, "colony-token-locking-invalid-lock-id");
     userLocks[_token][msg.sender].lockCount = _lockId;
   }
 
   function deposit(address _token, uint256 _amount) public
   tokenNotLocked(_token)
   {
-    require(_amount > 0, "token-locking-invalid-amount");
+    require(_amount > 0, "colony-token-locking-invalid-amount");
 
-    require(ERC20Extended(_token).transferFrom(msg.sender, address(this), _amount), "token-locking-transfer-failed");
+    require(ERC20Extended(_token).transferFrom(msg.sender, address(this), _amount), "colony-token-locking-transfer-failed");
 
     userLocks[_token][msg.sender] = Lock(totalLockCount[_token], add(userLocks[_token][msg.sender].balance, _amount));
   }

--- a/contracts/TokenLocking.sol
+++ b/contracts/TokenLocking.sol
@@ -15,7 +15,9 @@ contract TokenLocking is TokenLockingStorage, DSMath {
   }
 
   modifier onlyReputationMiningCycle() {
-    require(msg.sender == IColonyNetwork(colonyNetwork).getReputationMiningCycle(true), "colony-token-locking-sender-not-reputation-mining-cycle");
+    require(
+      msg.sender == IColonyNetwork(colonyNetwork).getReputationMiningCycle(true),
+      "colony-token-locking-sender-not-reputation-mining-cycle");
     _;
   }
 

--- a/contracts/TokenLocking.sol
+++ b/contracts/TokenLocking.sol
@@ -10,12 +10,12 @@ import "../lib/dappsys/math.sol";
 
 contract TokenLocking is TokenLockingStorage, DSMath {
   modifier onlyColony() {
-    require(IColonyNetwork(colonyNetwork).isColony(msg.sender), "token-locking-sender-not-colony");
+    require(IColonyNetwork(colonyNetwork).isColony(msg.sender), "colony-token-locking-sender-not-colony");
     _;
   }
 
   modifier onlyReputationMiningCycle() {
-    require(msg.sender == IColonyNetwork(colonyNetwork).getReputationMiningCycle(true), "token-locking-sender-not-reputation-mining-cycle");
+    require(msg.sender == IColonyNetwork(colonyNetwork).getReputationMiningCycle(true), "colony-token-locking-sender-not-reputation-mining-cycle");
     _;
   }
 
@@ -31,7 +31,7 @@ contract TokenLocking is TokenLockingStorage, DSMath {
     if (_token == clnyToken) {
       bytes32 submittedHash;
       (submittedHash,,,,,,,,,,) = IReputationMiningCycle(IColonyNetwork(colonyNetwork).getReputationMiningCycle(true)).getReputationHashSubmissions(msg.sender);
-      require(submittedHash == 0x0);
+      require(submittedHash == 0x0, "colony-token-locking-hash-already-submitted");
     }
     _;
   }
@@ -75,11 +75,11 @@ contract TokenLocking is TokenLockingStorage, DSMath {
   tokenNotLocked(_token)
   hashNotSubmitted(_token)
   {
-    require(_amount > 0, "token-locking-invalid-amount");
+    require(_amount > 0, "colony-token-locking-invalid-amount");
 
     userLocks[_token][msg.sender].balance = sub(userLocks[_token][msg.sender].balance, _amount);
 
-    require(ERC20Extended(_token).transfer(msg.sender, _amount), "token-locking-transfer-failed");
+    require(ERC20Extended(_token).transfer(msg.sender, _amount), "colony-token-locking-transfer-failed");
   }
 
   // This function is only used in context of reputation mining

--- a/contracts/ens/ENSRegistry.sol
+++ b/contracts/ens/ENSRegistry.sol
@@ -17,7 +17,7 @@ contract ENSRegistry is ENS {
   // Permits modifications only by the owner of the specified node, or if unowned.
   modifier onlyOwner(bytes32 node) {
     address currentOwner = records[node].owner;
-    require(currentOwner == 0 || currentOwner == msg.sender);
+    require(currentOwner == 0 || currentOwner == msg.sender, "colony-ens-non-owner-access");
     _;
   }
 

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -87,7 +87,6 @@ export function web3GetAccounts() {
   });
 }
 
-// eslint-disable-next-line no-unused-vars
 export async function checkErrorRevert(promise, errorMessage) {
   // There is a discrepancy between how ganache-cli handles errors
   // (throwing an exception all the way up to these tests) and how geth/parity handle them
@@ -98,7 +97,7 @@ export async function checkErrorRevert(promise, errorMessage) {
   // We have to have this special function that we use to catch the error.
   let tx;
   let receipt;
-  let reason; // eslint-disable-line no-unused-vars
+  let reason;
   try {
     tx = await promise;
     receipt = await web3GetTransactionReceipt(tx);

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -104,8 +104,7 @@ export async function checkErrorRevert(promise, errorMessage) {
     receipt = await web3GetTransactionReceipt(tx);
   } catch (err) {
     ({ tx, receipt, reason } = err);
-    // TODO: address as part of https://github.com/JoinColony/colonyNetwork/issues/201#issuecomment-407634292
-    // assert.equal(reason, errorMessage);
+    assert.equal(reason, errorMessage);
   }
   // Check the receipt `status` to ensure transaction failed.
   assert.equal(receipt.status, 0x00);

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -92,7 +92,7 @@ contract("Colony Funding", accounts => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await makeTask({ colony });
 
-      await checkErrorRevert(colony.moveFundsBetweenPots(0, 2, 1, otherToken.address), "colony-funding-cannot-move-funds-from-pot-0");
+      await checkErrorRevert(colony.moveFundsBetweenPots(0, 2, 1, otherToken.address), "colony-funding-cannot-move-funds-from-pot");
       const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
       const colonyRewardPotBalance = await colony.getPotBalance(0, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -797,7 +797,7 @@ contract("Colony Funding", accounts => {
         colony.claimRewardPayout(payoutId.toString(), initialSquareRoots, userReputation.toString(), totalReputation.toString(), {
           from: userAddress1
         }),
-        "colony-token-locking-invalid-lock-id"
+        "colony-token-already-unlocked"
       );
     });
 
@@ -815,7 +815,7 @@ contract("Colony Funding", accounts => {
         colony.claimRewardPayout(payoutId2, initialSquareRoots, userReputation.toString(), totalReputation.toString(), {
           from: userAddress1
         }),
-        "colony-token-locking-invalid-lock-id"
+        "colony-token-locking-has-previous-active-locks"
       );
     });
 
@@ -902,7 +902,7 @@ contract("Colony Funding", accounts => {
         colony.claimRewardPayout(payoutId, initialSquareRoots, userReputation.toString(), totalReputation.toString(), {
           from: userAddress1
         }),
-        "colony-token-locking-invalid-lock-id"
+        "colony-token-already-unlocked"
       );
     });
 

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -802,16 +802,20 @@ contract("Colony Funding", accounts => {
     });
 
     it("should not be able to claim funds if previous payout is not claimed", async () => {
+      const tokenArgs = getTokenArgs();
+      const newToken = await Token.new(...tokenArgs);
+      await fundColonyWithTokens(colony, newToken, initialFunding.toString());
+
       await colony.startNextRewardPayout(otherToken.address);
 
-      const { logs } = await colony.startNextRewardPayout(token.address);
+      const { logs } = await colony.startNextRewardPayout(newToken.address);
       const payoutId2 = logs[0].args.id;
 
       await checkErrorRevert(
         colony.claimRewardPayout(payoutId2, initialSquareRoots, userReputation.toString(), totalReputation.toString(), {
           from: userAddress1
         }),
-        "colony-reward-payout-invalid-parameter-amount"
+        "colony-token-locking-invalid-lock-id"
       );
     });
 

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -92,7 +92,7 @@ contract("Colony Funding", accounts => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await makeTask({ colony });
 
-      await checkErrorRevert(colony.moveFundsBetweenPots(0, 2, 1, otherToken.address), "colony-funding-cannot-move-funds-from-pot");
+      await checkErrorRevert(colony.moveFundsBetweenPots(0, 2, 1, otherToken.address), "colony-funding-cannot-move-funds-from-rewards-pot");
       const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
       const colonyRewardPotBalance = await colony.getPotBalance(0, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -92,7 +92,7 @@ contract("Colony Funding", accounts => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await makeTask({ colony });
 
-      await checkErrorRevert(colony.moveFundsBetweenPots(0, 2, 1, otherToken.address), "colonyFunding-cannot-move-funds-from-pot-0");
+      await checkErrorRevert(colony.moveFundsBetweenPots(0, 2, 1, otherToken.address), "colony-funding-cannot-move-funds-from-pot-0");
       const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
       const colonyRewardPotBalance = await colony.getPotBalance(0, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
@@ -121,7 +121,7 @@ contract("Colony Funding", accounts => {
       await makeTask({ colony });
       await colony.moveFundsBetweenPots(1, 2, 40, otherToken.address);
 
-      await checkErrorRevert(colony.moveFundsBetweenPots(2, 3, 50, otherToken.address));
+      await checkErrorRevert(colony.moveFundsBetweenPots(2, 3, 50, otherToken.address), "colony-funding-task-bad-state");
       const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
       const pot2Balance = await colony.getPotBalance(2, otherToken.address);
@@ -401,7 +401,7 @@ contract("Colony Funding", accounts => {
 
     it("should not allow contributions to nonexistent pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 5, 40, otherToken.address));
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, 5, 40, otherToken.address), "colony-funding-nonexistent-pot");
       const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
       assert.equal(colonyPotBalance.toNumber(), 99);
     });
@@ -492,7 +492,7 @@ contract("Colony Funding", accounts => {
       await makeTask({ colony });
       await colony.moveFundsBetweenPots(1, 2, 40, 0x0);
 
-      await checkErrorRevert(colony.moveFundsBetweenPots(2, 3, 50, 0x0));
+      await checkErrorRevert(colony.moveFundsBetweenPots(2, 3, 50, 0x0), "colony-funding-task-bad-state");
       const colonyEtherBalance = await web3GetBalance(colony.address);
       const colonyPotBalance = await colony.getPotBalance(1, 0x0);
       const pot2Balance = await colony.getPotBalance(2, 0x0);
@@ -797,7 +797,7 @@ contract("Colony Funding", accounts => {
         colony.claimRewardPayout(payoutId.toString(), initialSquareRoots, userReputation.toString(), totalReputation.toString(), {
           from: userAddress1
         }),
-        "colony-reward-payout-already-claimed-or-waived"
+        "colony-token-locking-invalid-lock-id"
       );
     });
 
@@ -811,7 +811,7 @@ contract("Colony Funding", accounts => {
         colony.claimRewardPayout(payoutId2, initialSquareRoots, userReputation.toString(), totalReputation.toString(), {
           from: userAddress1
         }),
-        "colony-reward-payout-bad-id"
+        "colony-reward-payout-invalid-parameter-amount"
       );
     });
 
@@ -826,7 +826,7 @@ contract("Colony Funding", accounts => {
         "colony-reward-payout-invalid-parameter-total-tokens",
         "colony-reward-payout-invalid-parameter-numerator",
         "colony-reward-payout-invalid-parameter-denominator",
-        "colony-reward-payout-invalid-parameter-amountAvailableForPayout"
+        "colony-reward-payout-invalid-parameter-amount"
       ];
 
       const promises = initialSquareRoots.map((param, i) => {
@@ -883,7 +883,7 @@ contract("Colony Funding", accounts => {
     it("should not be able to finalize payout if payoutId does not exist", async () => {
       await colony.startNextRewardPayout(otherToken.address);
 
-      await checkErrorRevert(colony.finalizeRewardPayout(10), "colony-reward-payout-not-found");
+      await checkErrorRevert(colony.finalizeRewardPayout(10), "colony-reward-payout-token-not-active");
     });
 
     it("should not be able to claim the same payout twice", async () => {
@@ -898,7 +898,7 @@ contract("Colony Funding", accounts => {
         colony.claimRewardPayout(payoutId, initialSquareRoots, userReputation.toString(), totalReputation.toString(), {
           from: userAddress1
         }),
-        "token-locking-invalid-lock-id"
+        "colony-token-locking-invalid-lock-id"
       );
     });
 

--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -63,7 +63,7 @@ contract("ColonyNetworkAuction", accounts => {
     });
 
     it("should fail with 0x0 token", async () => {
-      await checkErrorRevert(colonyNetwork.startTokenAuction("0x0"), "colony-auction-cannot-use-ether");
+      await checkErrorRevert(colonyNetwork.startTokenAuction("0x0"), "colony-auction-invalid-token");
     });
 
     it("should fail if auction is initialised for the CLNY token", async () => {

--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -112,13 +112,13 @@ contract("ColonyNetworkAuction", accounts => {
     });
 
     it("should fail starting the auction twice", async () => {
-      await checkErrorRevert(colonyNetwork.startTokenAuction(token.address));
+      await checkErrorRevert(colonyNetwork.startTokenAuction(token.address), "colony-auction-start-too-soon");
     });
 
     it("should fail if the last auction for the same token started less than 30 days", async () => {
       await token.mint(quantity.toString());
       await token.transfer(colonyNetwork.address, quantity.toString());
-      await checkErrorRevert(colonyNetwork.startTokenAuction(token.address));
+      await checkErrorRevert(colonyNetwork.startTokenAuction(token.address), "colony-auction-start-too-soon");
     });
 
     const auctionProps = [

--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -412,28 +412,28 @@ contract("ColonyNetworkAuction", accounts => {
     });
   });
 
-  describe("when closing the auction", async () => {
+  describe("when destructing the auction", async () => {
     beforeEach(async () => {
       await giveUserCLNYTokens(colonyNetwork, BIDDER_1, clnyNeededForMaxPriceAuctionSellout.toString());
       await clny.approve(tokenAuction.address, clnyNeededForMaxPriceAuctionSellout.toString(), { from: BIDDER_1 });
       await tokenAuction.bid(clnyNeededForMaxPriceAuctionSellout.toString(), { from: BIDDER_1 });
     });
 
-    it("should be able to close the auction and kill the auction contract", async () => {
+    it("should be able to destruct the auction and kill the auction contract", async () => {
       await tokenAuction.finalize();
       await tokenAuction.claim({ from: BIDDER_1 });
-      await tokenAuction.close();
+      await tokenAuction.destruct();
       const code = await web3GetCode(tokenAuction.address);
       assert.equal(code, 0);
     });
 
     it("should fail if auction not finalized", async () => {
-      await checkErrorRevert(tokenAuction.close(), "colony-auction-not-finalized");
+      await checkErrorRevert(tokenAuction.destruct(), "colony-auction-not-finalized");
     });
 
     it("should fail if not all bids have been claimed", async () => {
       await tokenAuction.finalize();
-      await checkErrorRevert(tokenAuction.close(), "colony-auction-not-all-bids-claimed");
+      await checkErrorRevert(tokenAuction.destruct(), "colony-auction-not-all-bids-claimed");
     });
 
     it("should fail if there are CLNY tokens left owned by the auction", async () => {
@@ -442,7 +442,7 @@ contract("ColonyNetworkAuction", accounts => {
       await metaColony.mintTokens(100);
       await giveUserCLNYTokens(colonyNetwork, BIDDER_1, 100);
       await clny.transfer(tokenAuction.address, 100, { from: BIDDER_1 });
-      await checkErrorRevert(tokenAuction.close());
+      await checkErrorRevert(tokenAuction.destruct());
     });
   });
 });

--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -63,7 +63,7 @@ contract("ColonyNetworkAuction", accounts => {
     });
 
     it("should fail with 0x0 token", async () => {
-      await checkErrorRevert(colonyNetwork.startTokenAuction("0x0"));
+      await checkErrorRevert(colonyNetwork.startTokenAuction("0x0"), "colony-auction-cannot-use-ether");
     });
 
     it("should fail if auction is initialised for the CLNY token", async () => {
@@ -275,18 +275,18 @@ contract("ColonyNetworkAuction", accounts => {
       await giveUserCLNYTokens(colonyNetwork, BIDDER_1, clnyNeededForMaxPriceAuctionSellout.addn(1).toString());
       await clny.approve(tokenAuction.address, clnyNeededForMaxPriceAuctionSellout.addn(1).toString(), { from: BIDDER_1 });
       await tokenAuction.bid(clnyNeededForMaxPriceAuctionSellout.toString(), { from: BIDDER_1 });
-      await checkErrorRevert(tokenAuction.bid(1, { from: BIDDER_1 }));
+      await checkErrorRevert(tokenAuction.bid(1, { from: BIDDER_1 }), "colony-auction-closed");
     });
 
     it("cannot finalize when target not reached", async () => {
       await giveUserCLNYTokens(colonyNetwork, BIDDER_1, "3000");
       await clny.approve(tokenAuction.address, "3000", { from: BIDDER_1 });
       await tokenAuction.bid("3000", { from: BIDDER_1 });
-      await checkErrorRevert(tokenAuction.finalize());
+      await checkErrorRevert(tokenAuction.finalize(), "colony-auction-not-closed");
     });
 
     it("cannot bid with 0 tokens", async () => {
-      await checkErrorRevert(tokenAuction.bid(0));
+      await checkErrorRevert(tokenAuction.bid(0), "colony-auction-invalid-bid");
     });
   });
 
@@ -328,16 +328,16 @@ contract("ColonyNetworkAuction", accounts => {
       await tokenAuction.finalize();
       await giveUserCLNYTokens(colonyNetwork, BIDDER_1, 1000);
       await clny.approve(tokenAuction.address, 1000, { from: BIDDER_1 });
-      await checkErrorRevert(tokenAuction.bid(1000, { from: BIDDER_1 }));
+      await checkErrorRevert(tokenAuction.bid(1000, { from: BIDDER_1 }), "colony-auction-closed");
     });
 
     it("cannot finalize after finalized once", async () => {
       await tokenAuction.finalize();
-      await checkErrorRevert(tokenAuction.finalize());
+      await checkErrorRevert(tokenAuction.finalize(), "colony-auction-already-finalized");
     });
 
     it("cannot claim if not finalized", async () => {
-      await checkErrorRevert(tokenAuction.claim({ from: BIDDER_1 }));
+      await checkErrorRevert(tokenAuction.claim({ from: BIDDER_1 }), "colony-auction-not-finalized");
     });
   });
 
@@ -428,12 +428,12 @@ contract("ColonyNetworkAuction", accounts => {
     });
 
     it("should fail if auction not finalized", async () => {
-      await checkErrorRevert(tokenAuction.close());
+      await checkErrorRevert(tokenAuction.close(), "colony-auction-not-finalized");
     });
 
     it("should fail if not all bids have been claimed", async () => {
       await tokenAuction.finalize();
-      await checkErrorRevert(tokenAuction.close());
+      await checkErrorRevert(tokenAuction.close(), "colony-auction-not-all-bids-claimed");
     });
 
     it("should fail if there are CLNY tokens left owned by the auction", async () => {

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -780,14 +780,17 @@ contract("ColonyNetworkMining", accounts => {
 
   describe("Function permissions", () => {
     it('should not allow "setReputationRootHash" to be called from an account that is not not reputationMiningCycle', async () => {
-      await checkErrorRevert(colonyNetwork.setReputationRootHash("0x000001", 10, [accounts[0], accounts[1]]));
+      await checkErrorRevert(
+        colonyNetwork.setReputationRootHash("0x000001", 10, [accounts[0], accounts[1]]),
+        "colony-reputation-mining-sender-not-active-reputation-cycle"
+      );
     });
 
     it('should not allow "startNextCycle" to be called if a cycle is in progress', async () => {
       const addr = await colonyNetwork.getReputationMiningCycle(true);
       await forwardTime(3600, this);
       assert(parseInt(addr, 16) !== 0);
-      await checkErrorRevert(colonyNetwork.startNextCycle());
+      await checkErrorRevert(colonyNetwork.startNextCycle(), "colony-reputation-mining-still-active");
     });
 
     it('should not allow "rewardStakersWithReputation" to be called by someone not the colonyNetwork', async () => {

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -264,7 +264,7 @@ contract("ColonyNetworkMining", accounts => {
       const addr = await colonyNetwork.getReputationMiningCycle(true);
       await forwardTime(3600);
       const repCycle = await ReputationMiningCycle.at(addr);
-      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 0));
+      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 0), "colony-reputation-mining-zero-entry-index-passed");
       const nSubmittedHashes = await repCycle.nSubmittedHashes();
       assert(nSubmittedHashes.isZero());
     });

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -276,7 +276,10 @@ contract("ColonyNetworkMining", accounts => {
       const repCycle = await ReputationMiningCycle.at(addr);
       await repCycle.submitRootHash("0x12345678", 10, 10);
       let userLock = await tokenLocking.getUserLock(clny.address, MAIN_ACCOUNT);
-      await checkErrorRevert(tokenLocking.withdraw(clny.address, userLock[1].toString(), { from: MAIN_ACCOUNT }));
+      await checkErrorRevert(
+        tokenLocking.withdraw(clny.address, userLock[1].toString(), { from: MAIN_ACCOUNT }),
+        "colony-token-locking-hash-submitted"
+      );
       userLock = await tokenLocking.getUserLock(clny.address, MAIN_ACCOUNT);
       assert(userLock[1].eq(new BN("1000000000000000000")));
     });
@@ -305,7 +308,10 @@ contract("ColonyNetworkMining", accounts => {
       const addr = await colonyNetwork.getReputationMiningCycle(false);
       const repCycle = await ReputationMiningCycle.at(addr);
       const nLogEntriesBefore = await repCycle.getReputationUpdateLogLength();
-      await checkErrorRevert(repCycle.appendReputationUpdateLog(MAIN_ACCOUNT, 100, 0, metaColony.address, 0, 1));
+      await checkErrorRevert(
+        repCycle.appendReputationUpdateLog(MAIN_ACCOUNT, 100, 0, metaColony.address, 0, 1),
+        "colony-reputation-mining-sender-not-network"
+      );
       const nLogEntriesAfter = await repCycle.getReputationUpdateLogLength();
       assert.equal(nLogEntriesBefore.toString(), nLogEntriesAfter.toString());
     });
@@ -316,7 +322,7 @@ contract("ColonyNetworkMining", accounts => {
       const addr = await colonyNetwork.getReputationMiningCycle(true);
       const repCycle = await ReputationMiningCycle.at(addr);
       const windowOpenTimestampBefore = await repCycle.reputationMiningWindowOpenTimestamp();
-      await checkErrorRevert(repCycle.resetWindow());
+      await checkErrorRevert(repCycle.resetWindow(), "colony-reputation-mining-sender-not-network");
       const windowOpenTimestampAfter = await repCycle.reputationMiningWindowOpenTimestamp();
       assert.equal(windowOpenTimestampBefore.toString(), windowOpenTimestampAfter.toString());
     });
@@ -395,7 +401,7 @@ contract("ColonyNetworkMining", accounts => {
       await goodClient.submitRootHash();
       await badClient.submitRootHash();
 
-      await checkErrorRevert(repCycle.confirmNewHash(0));
+      await checkErrorRevert(repCycle.confirmNewHash(0), "colony-reputation-mining-final-round-not-completed");
       const newAddr = await colonyNetwork.getReputationMiningCycle(true);
       assert(newAddr !== 0x0);
       assert(addr !== 0x0);
@@ -417,7 +423,7 @@ contract("ColonyNetworkMining", accounts => {
       await badClient.submitRootHash();
 
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
-      await checkErrorRevert(accommodateChallengeAndInvalidateHash(this, goodClient));
+      await checkErrorRevert(accommodateChallengeAndInvalidateHash(this, goodClient), "colony-reputation-mining-cannot-invalidate-final-hash");
     });
 
     it("should fail if one tries to invalidate a hash that does not exist", async () => {
@@ -440,7 +446,7 @@ contract("ColonyNetworkMining", accounts => {
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
       await accommodateChallengeAndInvalidateHash(this, badClient2);
       await forwardTime(600, this);
-      await checkErrorRevert(repCycle.invalidateHash(1, 2));
+      await checkErrorRevert(repCycle.invalidateHash(1, 2), "colony-reputation-mining-dispute-id-not-in-range");
       // Cleanup after test
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient2);
       await repCycle.confirmNewHash(2);
@@ -463,7 +469,7 @@ contract("ColonyNetworkMining", accounts => {
       await goodClient.submitJustificationRootHash();
       await forwardTime(600, this);
 
-      await checkErrorRevert(repCycle.invalidateHash(0, 0));
+      await checkErrorRevert(repCycle.invalidateHash(0, 0), "colony-reputation-mining-less-challenge-rounds-completed");
       // Cleanup after test
       await repCycle.invalidateHash(0, 1);
       await repCycle.confirmNewHash(1);
@@ -484,7 +490,7 @@ contract("ColonyNetworkMining", accounts => {
       await badClient.submitRootHash();
 
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
-      await checkErrorRevert(repCycle.invalidateHash(0, 1));
+      await checkErrorRevert(repCycle.invalidateHash(0, 1), "colony-reputation-mining-proposed-hash-empty");
     });
 
     it("should invalidate a hash and its partner if both have timed out", async () => {
@@ -524,8 +530,8 @@ contract("ColonyNetworkMining", accounts => {
       await goodClient.submitRootHash();
       await badClient.submitRootHash();
 
-      await checkErrorRevert(repCycle.invalidateHash(0, 1));
-      await checkErrorRevert(repCycle.confirmNewHash(1));
+      await checkErrorRevert(repCycle.invalidateHash(0, 1), "colony-reputation-mining-failed-to-respond-in-time");
+      await checkErrorRevert(repCycle.confirmNewHash(1), "colony-reputation-mining-final-round-not-completed");
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
       await repCycle.confirmNewHash(1);
     });
@@ -537,7 +543,7 @@ contract("ColonyNetworkMining", accounts => {
 
       const addr = await colonyNetwork.getReputationMiningCycle(true);
       const repCycle = await ReputationMiningCycle.at(addr);
-      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 10));
+      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 10), "colony-reputation-mining-cycle-closed");
       const nSubmittedHashes = await repCycle.nSubmittedHashes();
       assert(nSubmittedHashes.isZero());
     });
@@ -547,7 +553,7 @@ contract("ColonyNetworkMining", accounts => {
 
       const addr = await colonyNetwork.getReputationMiningCycle(false);
       const repCycle = await ReputationMiningCycle.at(addr);
-      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 10));
+      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 10), "colony-reputation-mining-cycle-not-open");
       const nSubmittedHashes = await repCycle.nSubmittedHashes();
       assert.equal(nSubmittedHashes.toString(), "0");
     });
@@ -581,7 +587,7 @@ contract("ColonyNetworkMining", accounts => {
       const repCycle = await ReputationMiningCycle.at(addr);
       await forwardTime(3600, this);
       await repCycle.submitRootHash("0x12345678", 10, 10);
-      await checkErrorRevert(repCycle.submitRootHash("0x87654321", 10, 10));
+      await checkErrorRevert(repCycle.submitRootHash("0x87654321", 10, 10), "colony-reputation-mining-submitting-different-hash");
       const nSubmittedHashes = await repCycle.nSubmittedHashes();
       assert(nSubmittedHashes.eq(new BN(1)));
     });
@@ -594,7 +600,7 @@ contract("ColonyNetworkMining", accounts => {
       await forwardTime(3600, this);
       await repCycle.submitRootHash("0x12345678", 10, 10);
 
-      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 11, 9));
+      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 11, 9), "colony-reputation-mining-submitting-different-nnodes");
       const nSubmittedHashes = await repCycle.nSubmittedHashes();
       assert(nSubmittedHashes.eq(new BN(1)));
     });
@@ -606,7 +612,7 @@ contract("ColonyNetworkMining", accounts => {
       const repCycle = await ReputationMiningCycle.at(addr);
       await forwardTime(3600, this);
       await repCycle.submitRootHash("0x12345678", 10, 10);
-      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 10));
+      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 10), "colony-reputation-mining-submitting-same-entry-index");
       const nSubmittedHashes = await repCycle.nSubmittedHashes();
       assert(nSubmittedHashes.eq(new BN(1)));
     });
@@ -669,7 +675,7 @@ contract("ColonyNetworkMining", accounts => {
       await repCycle.submitRootHash("0x12345678", 10, 10);
       await repCycle.submitRootHash("0x12345678", 10, 11);
       await repCycle.submitRootHash("0x12345678", 10, 12);
-      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 13));
+      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 13), "colony-reputation-mining-max-number-miners-reached");
     });
 
     it("should prevent submission of hashes with an invalid entry for the balance of a user", async () => {
@@ -679,7 +685,7 @@ contract("ColonyNetworkMining", accounts => {
       const addr = await colonyNetwork.getReputationMiningCycle(true);
       await forwardTime(3600, this);
       const repCycle = await ReputationMiningCycle.at(addr);
-      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 1000000000000));
+      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 1000000000000), "colony-reputation-mining-stake-minimum-not-met");
       await repCycle.submitRootHash("0x87654321", 10, 10, { from: OTHER_ACCOUNT });
     });
 
@@ -688,7 +694,7 @@ contract("ColonyNetworkMining", accounts => {
 
       const addr = await colonyNetwork.getReputationMiningCycle(true);
       const repCycle = await ReputationMiningCycle.at(addr);
-      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 1));
+      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 1), "colony-reputation-mining-cycle-closed");
     });
   });
 
@@ -787,12 +793,12 @@ contract("ColonyNetworkMining", accounts => {
     it('should not allow "rewardStakersWithReputation" to be called by someone not the colonyNetwork', async () => {
       const addr = await colonyNetwork.getReputationMiningCycle(true);
       const repCycle = await ReputationMiningCycle.at(addr);
-      await checkErrorRevert(repCycle.rewardStakersWithReputation([MAIN_ACCOUNT], 0x0, 10000, 3));
+      await checkErrorRevert(repCycle.rewardStakersWithReputation([MAIN_ACCOUNT], 0x0, 10000, 3), "colony-reputation-mining-sender-not-network");
     });
   });
 
   describe("Types of disagreement", () => {
-    it("In the event of a disagreement, allows a user to submit a JRH with proofs for a submission", async () => {
+    it("in the event of a disagreement, allows a user to submit a JRH with proofs for a submission", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
@@ -947,7 +953,7 @@ contract("ColonyNetworkMining", accounts => {
       });
     });
 
-    it("In the event of a disagreement, allows a binary search between opponents to take place to find their first disagreement", async () => {
+    it("in the event of a disagreement, allows a binary search between opponents to take place to find their first disagreement", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
@@ -1084,7 +1090,7 @@ contract("ColonyNetworkMining", accounts => {
       await repCycle.invalidateHash(0, 1);
     });
 
-    it("If an existing reputation's uniqueID is changed, that disagreement should be handled correctly", async () => {
+    it("if an existing reputation's uniqueID is changed, that disagreement should be handled correctly", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
@@ -1164,7 +1170,7 @@ contract("ColonyNetworkMining", accounts => {
       await repCycle.invalidateHash(0, 1);
     });
 
-    it("If a new reputation's uniqueID is wrong, that disagreement should be handled correctly", async () => {
+    it("if a new reputation's uniqueID is wrong, that disagreement should be handled correctly", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
@@ -1241,7 +1247,7 @@ contract("ColonyNetworkMining", accounts => {
 
       await forwardTime(600, this);
       // Check that we can't invalidate the one that proved a higher reputation already existed
-      await checkErrorRevert(repCycle.invalidateHash(0, 0));
+      await checkErrorRevert(repCycle.invalidateHash(0, 0), "colony-reputation-mining-less-reputation-uids-proven");
 
       await repCycle.invalidateHash(0, 1);
       await repCycle.confirmNewHash(1);
@@ -1249,7 +1255,7 @@ contract("ColonyNetworkMining", accounts => {
       assert.equal(confirmedHash, righthash);
     });
 
-    it("If a new reputation's UID is not proved right because a too-old previous ID is proved, it should be handled correctly", async () => {
+    it("if a new reputation's UID is not proved right because a too-old previous ID is proved, it should be handled correctly", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
@@ -1312,13 +1318,13 @@ contract("ColonyNetworkMining", accounts => {
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
 
-      await checkErrorRevert(badClient2.respondToChallenge(), "colony-inadequate-newest-reputation-proof");
+      await checkErrorRevert(badClient2.respondToChallenge(), "colony-reputation-mining-less-challenge-rounds-completed");
       // Cleanup
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
       await repCycle.confirmNewHash(1);
     });
 
-    it(`If a reputation decay calculation is wrong, it should be handled correctly`, async () => {
+    it(`if a reputation decay calculation is wrong, it should be handled correctly`, async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
@@ -1430,14 +1436,14 @@ contract("ColonyNetworkMining", accounts => {
         repCycle.submitJustificationRootHash(round.toString(), index.toString(), jrh, "0", siblings1, branchMask2.toString(), siblings2, {
           gasLimit: 6000000
         }),
-        "colony-invalid-jrh-proof-1"
+        "colony-reputation-mining-invalid-jrh-proof-1"
       );
 
       await checkErrorRevert(
         repCycle.submitJustificationRootHash(round.toString(), index.toString(), jrh, branchMask1.toString(), siblings1, "0", siblings2, {
           gasLimit: 6000000
         }),
-        "colony-invalid-jrh-proof-2"
+        "colony-reputation-mining-invalid-jrh-proof-2"
       );
 
       // Cleanup
@@ -1445,11 +1451,11 @@ contract("ColonyNetworkMining", accounts => {
       await badClient.submitJustificationRootHash();
 
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
-      await checkErrorRevert(repCycle.confirmNewHash(0));
+      await checkErrorRevert(repCycle.confirmNewHash(0), "colony-reputation-mining-final-round-not-completed");
       await repCycle.confirmNewHash(1);
     });
 
-    it("should correctly check the proof of the previously newest reputation, if necessary.", async () => {
+    it("should correctly check the proof of the previously newest reputation, if necessary", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
@@ -1513,9 +1519,9 @@ contract("ColonyNetworkMining", accounts => {
             index.toString(),
             goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.branchMask.toString(),
             goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].nextUpdateProof.nNodes.toString(),
-            `0x${agreeStateBranchMask.toString(16)}`,
+            agreeStateBranchMask.toString(),
             goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.nNodes.toString(),
-            `0x${disagreeStateBranchMask.toString(16)}`,
+            disagreeStateBranchMask.toString(),
             // This is the wrong line
             0,
             // This is the correct line, for future reference
@@ -1535,7 +1541,7 @@ contract("ColonyNetworkMining", accounts => {
           goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.siblings,
           { gasLimit: 4000000 }
         ),
-        "colony-invalid-newest-reputation-proof"
+        "colony-reputation-mining-last-state-disagreement"
       );
 
       // Cleanup
@@ -1626,9 +1632,9 @@ contract("ColonyNetworkMining", accounts => {
             index.toString(),
             goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.branchMask.toString(),
             goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].nextUpdateProof.nNodes.toString(),
-            `0x${agreeStateBranchMask.toString(16)}`,
+            agreeStateBranchMask.toString(),
             goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.nNodes.toString(),
-            `0x${disagreeStateBranchMask.toString(16)}`,
+            disagreeStateBranchMask.toString(),
             goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.branchMask,
             0,
             logEntryNumber.toString(),
@@ -1647,7 +1653,7 @@ contract("ColonyNetworkMining", accounts => {
           goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.siblings,
           { gasLimit: 4000000 }
         ),
-        "colony-invalid-newest-reputation-proof"
+        "colony-reputation-mining-uid-not-decay"
       );
       // Cleanup
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
@@ -1721,11 +1727,11 @@ contract("ColonyNetworkMining", accounts => {
             goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.branchMask.toString(),
             goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].nextUpdateProof.nNodes.toString(),
             // This is the right line
-            // `0x${agreeStateBranchMask.toString(16)}`,
+            // agreeStateBranchMask.toString(),
             // This is the wrong line
             0,
             goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.nNodes.toString(),
-            `0x${disagreeStateBranchMask.toString(16)}`,
+            disagreeStateBranchMask.toString(),
             // This is the correct line, for future reference
             goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.branchMask,
             0,
@@ -1743,7 +1749,7 @@ contract("ColonyNetworkMining", accounts => {
           goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.siblings,
           { gasLimit: 4000000 }
         ),
-        "colony-invalid-before-reputation-proof"
+        "colony-reputation-mining-invalid-before-reputation-proof"
       );
       await checkErrorRevert(
         repCycle.respondToChallenge(
@@ -1752,12 +1758,12 @@ contract("ColonyNetworkMining", accounts => {
             index.toString(),
             goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.branchMask.toString(),
             goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].nextUpdateProof.nNodes.toString(),
-            `0x${agreeStateBranchMask.toString(16)}`,
+            agreeStateBranchMask.toString(),
             goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.nNodes.toString(),
             // This is the wrong line
             0,
             // This is the right line
-            // `0x${disagreeStateBranchMask.toString(16)}`,
+            // disagreeStateBranchMask.toString(),
             // This is the correct line, for future reference
             goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.branchMask,
             0,
@@ -1775,7 +1781,7 @@ contract("ColonyNetworkMining", accounts => {
           goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.siblings,
           { gasLimit: 4000000 }
         ),
-        "colony-invalid-after-reputation-proof"
+        "colony-reputation-mining-invalid-after-reputation-proof"
       );
 
       // Cleanup
@@ -1831,7 +1837,7 @@ contract("ColonyNetworkMining", accounts => {
       await accommodateChallengeAndInvalidateHash(this, clients[2], clients[3]);
       await accommodateChallengeAndInvalidateHash(this, clients[4], clients[5]);
       await accommodateChallengeAndInvalidateHash(this, clients[0], clients[2]); // This is the first pairing in round 2
-      await checkErrorRevert(accommodateChallengeAndInvalidateHash(this, clients[4]));
+      await checkErrorRevert(accommodateChallengeAndInvalidateHash(this, clients[4]), "colony-reputation-mining-previous-dispute-round-not-complete");
       // Now clean up
       await accommodateChallengeAndInvalidateHash(this, clients[6], clients[7]);
       await accommodateChallengeAndInvalidateHash(this, clients[4], clients[6]);
@@ -1857,7 +1863,7 @@ contract("ColonyNetworkMining", accounts => {
       await badClient.submitJustificationRootHash();
 
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
-      await checkErrorRevert(repCycle.confirmNewHash(0));
+      await checkErrorRevert(repCycle.confirmNewHash(0), "colony-reputation-mining-final-round-not-completed");
       await repCycle.confirmNewHash(1);
     });
 
@@ -1876,7 +1882,10 @@ contract("ColonyNetworkMining", accounts => {
       await goodClient.submitJustificationRootHash();
       await badClient.submitJustificationRootHash();
 
-      await checkErrorRevert(repCycle.respondToBinarySearchForChallenge(0, 0, "0x00", 0x0, []), "colony-invalid-binary-search-response");
+      await checkErrorRevert(
+        repCycle.respondToBinarySearchForChallenge(0, 0, "0x00", 0x0, []),
+        "colony-reputation-mining-invalid-binary-search-response"
+      );
 
       // Cleanup
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
@@ -1936,13 +1945,16 @@ contract("ColonyNetworkMining", accounts => {
       )}`;
 
       await checkErrorRevert(
-        repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], wrongColonyKey, [], "0x00", [], "0x00", [], "0x00", "0x00", [])
+        repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], wrongColonyKey, [], "0x00", [], "0x00", [], "0x00", "0x00", []),
+        "colony-reputation-mining-colony-address-mismatch"
       );
       await checkErrorRevert(
-        repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], wrongReputationKey, [], "0x00", [], "0x00", [], "0x00", "0x00", [])
+        repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], wrongReputationKey, [], "0x00", [], "0x00", [], "0x00", "0x00", []),
+        "colony-reputation-mining-skill-id-mismatch"
       );
       await checkErrorRevert(
-        repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], wrongUserKey, [], "0x00", [], "0x00", [], "0x00", "0x00", [])
+        repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], wrongUserKey, [], "0x00", [], "0x00", [], "0x00", "0x00", []),
+        "colony-reputation-mining-user-address-mismatch"
       );
 
       await forwardTime(600, this);
@@ -1971,7 +1983,10 @@ contract("ColonyNetworkMining", accounts => {
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
 
-      await checkErrorRevert(repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "0x00", [], "0x00", [], "0x00", [], "0x00", "0x00", []));
+      await checkErrorRevert(
+        repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "0x00", [], "0x00", [], "0x00", [], "0x00", "0x00", []),
+        "colony-reputation-mining-challenge-closed"
+      );
 
       // Cleanup
       await badClient.respondToBinarySearchForChallenge();
@@ -1993,6 +2008,7 @@ contract("ColonyNetworkMining", accounts => {
           let addr = await colonyNetwork.getReputationMiningCycle(true);
           let repCycle = await ReputationMiningCycle.at(addr);
           await forwardTime(3600, this);
+
           await repCycle.submitRootHash("0x00", 0, 10);
           await repCycle.confirmNewHash(0);
 

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -332,7 +332,7 @@ contract("ColonyNetwork", accounts => {
 
       // Can't register two labels for a user
       const newLabel = web3utils.soliditySha3("test2");
-      await checkErrorRevert(colonyNetwork.registerUserLabel(newLabel, { from: accounts[1] }), "colony-user-already-owned");
+      await checkErrorRevert(colonyNetwork.registerUserLabel(newLabel, { from: accounts[1] }), "colony-user-label-already-owned");
     });
 
     it("should be able to register one unique label per colony, if owner", async () => {

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -332,7 +332,7 @@ contract("ColonyNetwork", accounts => {
 
       // Can't register two labels for a user
       const newLabel = web3utils.soliditySha3("test2");
-      await checkErrorRevert(colonyNetwork.registerUserLabel(newLabel, { from: accounts[1] }));
+      await checkErrorRevert(colonyNetwork.registerUserLabel(newLabel, { from: accounts[1] }), "user-already-labeled");
     });
 
     it("should be able to register one unique label per colony, if owner", async () => {
@@ -355,7 +355,7 @@ contract("ColonyNetwork", accounts => {
 
       // Can't register two labels for a colony
       const newLabel = web3utils.soliditySha3("test2");
-      await checkErrorRevert(colony.registerColonyLabel(newLabel, { from: accounts[0] }));
+      await checkErrorRevert(colony.registerColonyLabel(newLabel, { from: accounts[0] }), "colony-already-labeled");
     });
   });
 });

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -134,7 +134,7 @@ contract("ColonyNetwork", accounts => {
       await colonyNetwork.createMetaColony(token.address);
       const metaColonyAddress1 = await colonyNetwork.getMetaColony();
 
-      await checkErrorRevert(colonyNetwork.createMetaColony(token.address));
+      await checkErrorRevert(colonyNetwork.createMetaColony(token.address), "colony-meta-colony-exists-already");
       const metaColonyAddress2 = await colonyNetwork.getMetaColony();
       assert.equal(metaColonyAddress1, metaColonyAddress2);
     });
@@ -240,7 +240,7 @@ contract("ColonyNetwork", accounts => {
       const newVersion = currentColonyVersion.subn(1).toNumber();
       await colonyNetwork.addColonyVersion(newVersion, sampleResolver);
 
-      await checkErrorRevert(colony.upgrade(newVersion));
+      await checkErrorRevert(colony.upgrade(newVersion), "colony-version-must-be-newer");
       assert.equal(version.toNumber(), currentColonyVersion.toNumber());
     });
 
@@ -252,7 +252,7 @@ contract("ColonyNetwork", accounts => {
       const newVersion = currentColonyVersion.addn(1).toNumber();
       const colony = await Colony.at(colonyAddress);
 
-      await checkErrorRevert(colony.upgrade(newVersion));
+      await checkErrorRevert(colony.upgrade(newVersion), "colony-version-must-be-registered");
       assert.equal(version.toNumber(), currentColonyVersion.toNumber());
     });
 
@@ -283,13 +283,13 @@ contract("ColonyNetwork", accounts => {
     });
 
     it("should not be able to add a global skill, by an address that is not the meta colony ", async () => {
-      await checkErrorRevert(colonyNetwork.addSkill(1, true));
+      await checkErrorRevert(colonyNetwork.addSkill(1, true), "colony-must-be-meta-colony");
       const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 1);
     });
 
     it("should NOT be able to add a local skill, by an address that is not a Colony", async () => {
-      await checkErrorRevert(colonyNetwork.addSkill(2, false));
+      await checkErrorRevert(colonyNetwork.addSkill(1, false), "colony-must-be-colony");
 
       const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 1);
@@ -328,11 +328,11 @@ contract("ColonyNetwork", accounts => {
       assert.equal(owner, accounts[1]);
 
       // Label already in use
-      await checkErrorRevert(colonyNetwork.registerUserLabel(label, { from: accounts[2] }));
+      await checkErrorRevert(colonyNetwork.registerUserLabel(label, { from: accounts[2] }), "colony-label-already-in-use");
 
       // Can't register two labels for a user
       const newLabel = web3utils.soliditySha3("test2");
-      await checkErrorRevert(colonyNetwork.registerUserLabel(newLabel, { from: accounts[1] }), "user-already-labeled");
+      await checkErrorRevert(colonyNetwork.registerUserLabel(newLabel, { from: accounts[1] }), "colony-user-already-labeled");
     });
 
     it("should be able to register one unique label per colony, if owner", async () => {

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -328,11 +328,11 @@ contract("ColonyNetwork", accounts => {
       assert.equal(owner, accounts[1]);
 
       // Label already in use
-      await checkErrorRevert(colonyNetwork.registerUserLabel(label, { from: accounts[2] }), "colony-label-already-in-use");
+      await checkErrorRevert(colonyNetwork.registerUserLabel(label, { from: accounts[2] }), "colony-label-already-owned");
 
       // Can't register two labels for a user
       const newLabel = web3utils.soliditySha3("test2");
-      await checkErrorRevert(colonyNetwork.registerUserLabel(newLabel, { from: accounts[1] }), "colony-user-already-labeled");
+      await checkErrorRevert(colonyNetwork.registerUserLabel(newLabel, { from: accounts[1] }), "colony-user-already-owned");
     });
 
     it("should be able to register one unique label per colony, if owner", async () => {

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -85,21 +85,27 @@ contract("Colony Task Work Rating", accounts => {
       let dueDate = await currentBlockTime();
       dueDate += SECONDS_PER_DAY * 7;
       const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
-      await checkErrorRevert(colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR }));
+      await checkErrorRevert(colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR }), "colony-task-not-complete");
       const ratingSecrets = await colony.getTaskWorkRatings(taskId);
       assert.equal(ratingSecrets[0].toNumber(), 0);
     });
 
     it("should fail if I try to rate work on behalf of a worker", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
-      await checkErrorRevert(colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: OTHER }));
+      await checkErrorRevert(
+        colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: OTHER }),
+        "colony-user-cannot-rate-task-manager"
+      );
       const ratingSecrets = await colony.getTaskWorkRatings(taskId);
       assert.equal(ratingSecrets[0], 0);
     });
 
     it("should fail if I try to rate work for a role that's not setup to be rated", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
-      await checkErrorRevert(colony.submitTaskWorkRating(taskId, EVALUATOR_ROLE, RATING_2_SECRET, { from: EVALUATOR }));
+      await checkErrorRevert(
+        colony.submitTaskWorkRating(taskId, EVALUATOR_ROLE, RATING_2_SECRET, { from: EVALUATOR }),
+        "colony-unsupported-role-to-rate"
+      );
       const ratingSecrets = await colony.getTaskWorkRatings(taskId);
       assert.equal(ratingSecrets[0].toNumber(), 0);
     });
@@ -108,7 +114,10 @@ contract("Colony Task Work Rating", accounts => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
 
-      await checkErrorRevert(colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_1_SECRET, { from: EVALUATOR }));
+      await checkErrorRevert(
+        colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_1_SECRET, { from: EVALUATOR }),
+        "colony-task-rating-secret-already-exists"
+      );
       const ratingSecrets = await colony.getTaskWorkRatings(taskId);
       assert.equal(ratingSecrets[0], 1);
       const ratingSecret = await colony.getTaskWorkRatingSecret(taskId, WORKER_ROLE);
@@ -119,7 +128,10 @@ contract("Colony Task Work Rating", accounts => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
 
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
-      await checkErrorRevert(colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR }));
+      await checkErrorRevert(
+        colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR }),
+        "colony-task-rating-secret-submit-period-closed"
+      );
       const ratingSecrets = await colony.getTaskWorkRatings(taskId);
       assert.equal(ratingSecrets[0].toNumber(), 0);
     });
@@ -127,7 +139,7 @@ contract("Colony Task Work Rating", accounts => {
     it("should fail if I try to submit work for a task using an invalid id", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
 
-      await checkErrorRevert(colony.submitTaskWorkRating(10, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR }));
+      await checkErrorRevert(colony.submitTaskWorkRating(10, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR }), "colony-task-does-not-exist");
       const ratingSecrets = await colony.getTaskWorkRatings(taskId);
       assert.equal(ratingSecrets[0], 0);
     });
@@ -170,7 +182,10 @@ contract("Colony Task Work Rating", accounts => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
-      await checkErrorRevert(colony.revealTaskWorkRating(taskId, MANAGER_ROLE, MANAGER_RATING, RATING_2_SALT, { from: WORKER }));
+      await checkErrorRevert(
+        colony.revealTaskWorkRating(taskId, MANAGER_ROLE, MANAGER_RATING, RATING_2_SALT, { from: WORKER }),
+        "colony-task-rating-secret-not-match"
+      );
 
       const roleManager = await colony.getTaskRole(taskId, MANAGER_ROLE);
       assert.equal(roleManager[2].toNumber(), 0);
@@ -182,7 +197,10 @@ contract("Colony Task Work Rating", accounts => {
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
 
       await forwardTime(SECONDS_PER_DAY * 5 + 2, this);
-      await checkErrorRevert(colony.revealTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR }));
+      await checkErrorRevert(
+        colony.revealTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR }),
+        "colony-task-rating-secret-reveal-period-closed"
+      );
 
       const roleWorker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(roleWorker[2].toNumber(), 0);
@@ -194,7 +212,10 @@ contract("Colony Task Work Rating", accounts => {
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
 
       await forwardTime(SECONDS_PER_DAY * 5 + 2, this);
-      await checkErrorRevert(colony.revealTaskWorkRating(taskId, MANAGER_ROLE, MANAGER_RATING, RATING_1_SALT, { from: WORKER }));
+      await checkErrorRevert(
+        colony.revealTaskWorkRating(taskId, MANAGER_ROLE, MANAGER_RATING, RATING_1_SALT, { from: WORKER }),
+        "colony-task-rating-secret-reveal-period-closed"
+      );
 
       const roleManager = await colony.getTaskRole(1, MANAGER_ROLE);
       assert.equal(roleManager[2].toNumber(), 0);
@@ -204,7 +225,10 @@ contract("Colony Task Work Rating", accounts => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
       await forwardTime(SECONDS_PER_DAY * 4, this);
-      await checkErrorRevert(colony.revealTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR }));
+      await checkErrorRevert(
+        colony.revealTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR }),
+        "colony-task-rating-secret-reveal-period-closed"
+      );
 
       const roleWorker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(roleWorker[2].toNumber(), 0);
@@ -215,7 +239,10 @@ contract("Colony Task Work Rating", accounts => {
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
 
       await forwardTime(SECONDS_PER_DAY * 10 + 1, this);
-      await checkErrorRevert(colony.revealTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR }));
+      await checkErrorRevert(
+        colony.revealTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR }),
+        "colony-task-rating-secret-reveal-period-closed"
+      );
 
       const roleWorker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(roleWorker[2].toNumber(), 0);
@@ -301,7 +328,7 @@ contract("Colony Task Work Rating", accounts => {
     it("should revert if I try to assign ratings before the reveal period is over", async () => {
       await setupAssignedTask({ colonyNetwork, colony });
       await forwardTime(SECONDS_PER_DAY * 6, this);
-      await checkErrorRevert(colony.assignWorkRating(1));
+      await checkErrorRevert(colony.assignWorkRating(1), "colony-task-rating-period-open");
       const roleWorker = await colony.getTaskRole(1, WORKER_ROLE);
       assert.isFalse(roleWorker[1]);
     });

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -184,7 +184,7 @@ contract("Colony Task Work Rating", accounts => {
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
       await checkErrorRevert(
         colony.revealTaskWorkRating(taskId, MANAGER_ROLE, MANAGER_RATING, RATING_2_SALT, { from: WORKER }),
-        "colony-task-rating-secret-not-match"
+        "colony-task-rating-secret-mismatch"
       );
 
       const roleManager = await colony.getTaskRole(taskId, MANAGER_ROLE);

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -227,7 +227,7 @@ contract("Colony Task Work Rating", accounts => {
       await forwardTime(SECONDS_PER_DAY * 4, this);
       await checkErrorRevert(
         colony.revealTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR }),
-        "colony-task-rating-secret-reveal-period-closed"
+        "colony-task-rating-secret-reveal-period-not-open"
       );
 
       const roleWorker = await colony.getTaskRole(taskId, WORKER_ROLE);
@@ -328,7 +328,7 @@ contract("Colony Task Work Rating", accounts => {
     it("should revert if I try to assign ratings before the reveal period is over", async () => {
       await setupAssignedTask({ colonyNetwork, colony });
       await forwardTime(SECONDS_PER_DAY * 6, this);
-      await checkErrorRevert(colony.assignWorkRating(1), "colony-task-rating-period-open");
+      await checkErrorRevert(colony.assignWorkRating(1), "colony-task-rating-period-still-open");
       const roleWorker = await colony.getTaskRole(1, WORKER_ROLE);
       assert.isFalse(roleWorker[1]);
     });

--- a/test/colony.js
+++ b/test/colony.js
@@ -1089,7 +1089,7 @@ contract("Colony", accounts => {
 
     it("should fail if a non-colony call is made to the task update functions", async () => {
       await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskBrief(1, SPECIFICATION_HASH_UPDATED, { from: OTHER }));
+      await checkErrorRevert(colony.setTaskBrief(1, SPECIFICATION_HASH_UPDATED, { from: OTHER }), "colony-not-self");
     });
 
     it("should fail update of task brief signed by a non-registered role", async () => {
@@ -1296,7 +1296,7 @@ contract("Colony", accounts => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony, token });
       await colony.finalizeTask(taskId);
-      await checkErrorRevert(colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH));
+      await checkErrorRevert(colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH), "colony-task-already-finalized");
     });
 
     it("should fail if I try to submit work for a task that is past its due date", async () => {
@@ -1307,7 +1307,7 @@ contract("Colony", accounts => {
     });
 
     it("should fail if I try to submit work for a task using an invalid id", async () => {
-      await checkErrorRevert(colony.submitTaskDeliverable(10, DELIVERABLE_HASH));
+      await checkErrorRevert(colony.submitTaskDeliverable(10, DELIVERABLE_HASH), "colony-task-does-not-exist");
     });
 
     it("should fail if I try to submit work twice", async () => {
@@ -1326,7 +1326,7 @@ contract("Colony", accounts => {
       dueDate += SECONDS_PER_DAY * 4;
       await setupAssignedTask({ colonyNetwork, colony, dueDate });
 
-      await checkErrorRevert(colony.submitTaskDeliverable(1, SPECIFICATION_HASH, { from: OTHER }));
+      await checkErrorRevert(colony.submitTaskDeliverable(1, SPECIFICATION_HASH, { from: OTHER }), "colony-task-role-identity-mismatch");
       const task = await colony.getTask(1);
       assert.notEqual(task[1], DELIVERABLE_HASH);
     });
@@ -1364,7 +1364,7 @@ contract("Colony", accounts => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony, token });
       await colony.finalizeTask(taskId);
-      await checkErrorRevert(colony.finalizeTask(taskId));
+      await checkErrorRevert(colony.finalizeTask(taskId), "colony-task-already-finalized");
     });
 
     it("should fail if I try to accept a task using an invalid id", async () => {
@@ -1451,11 +1451,11 @@ contract("Colony", accounts => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony, token });
       await colony.finalizeTask(taskId);
-      await checkErrorRevert(colony.cancelTask(taskId));
+      await checkErrorRevert(colony.cancelTask(taskId), "colony-task-already-finalized");
     });
 
     it("should fail if manager tries to cancel a task with invalid id", async () => {
-      await checkErrorRevert(colony.cancelTask(10));
+      await checkErrorRevert(colony.cancelTask(10), "colony-task-does-not-exist");
     });
 
     it("should log a TaskCanceled event", async () => {
@@ -1722,7 +1722,7 @@ contract("Colony", accounts => {
     it("should return error when task is not finalized", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony, token });
-      await checkErrorRevert(colony.claimPayout(taskId, MANAGER_ROLE, token.address));
+      await checkErrorRevert(colony.claimPayout(taskId, MANAGER_ROLE, token.address), "colony-task-not-finalized");
     });
 
     it("should return error when called by account that doesn't match the role", async () => {

--- a/test/colony.js
+++ b/test/colony.js
@@ -476,7 +476,7 @@ contract("Colony", accounts => {
           sigTypes: [0],
           args: [taskId, EVALUATOR]
         }),
-        "colony-task-role-assignment-does-not-meet-signatures-required"
+        "colony-task-role-assignment-does-not-meet-required-signatures"
       );
 
       const evaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
@@ -491,7 +491,7 @@ contract("Colony", accounts => {
           sigTypes: [0],
           args: [taskId, WORKER]
         }),
-        "colony-task-role-assignment-does-not-meet-signatures-required"
+        "colony-task-role-assignment-does-not-meet-required-signatures"
       );
 
       const worker = await colony.getTaskRole(taskId, WORKER_ROLE);
@@ -593,7 +593,7 @@ contract("Colony", accounts => {
           sigTypes: [0, 0],
           args: [taskId, 0x0]
         }),
-        "colony-task-role-assignment-not-signed-by-new-role-user"
+        "colony-task-role-assignment-not-signed-by-new-user-for-role"
       );
 
       const workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
@@ -612,7 +612,7 @@ contract("Colony", accounts => {
           sigTypes: [0, 0],
           args: [taskId, EVALUATOR]
         }),
-        "colony-task-role-assignment-not-signed-by-new-role-user"
+        "colony-task-role-assignment-not-signed-by-new-user-for-role"
       );
 
       const workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
@@ -659,7 +659,7 @@ contract("Colony", accounts => {
           sigTypes: [0],
           args: [taskId, EVALUATOR]
         }),
-        "colony-task-role-assignment-does-not-meet-signatures-required"
+        "colony-task-role-assignment-does-not-meet-required-signatures"
       );
 
       await checkErrorRevert(
@@ -671,7 +671,7 @@ contract("Colony", accounts => {
           sigTypes: [0],
           args: [taskId, WORKER]
         }),
-        "colony-task-role-assignment-does-not-meet-signatures-required"
+        "colony-task-role-assignment-does-not-meet-required-signatures"
       );
 
       const evaluatorInfo = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
@@ -797,7 +797,7 @@ contract("Colony", accounts => {
           sigTypes: [0, 0],
           args: [taskId, OTHER]
         }),
-        "colony-task-role-assignment-not-signed-by-new-role-user"
+        "colony-task-role-assignment-not-signed-by-new-user-for-role"
       );
 
       const managerInfo = await colony.getTaskRole(taskId, MANAGER_ROLE);
@@ -837,7 +837,7 @@ contract("Colony", accounts => {
           sigTypes: [0, 0],
           args: [taskId, 0x0]
         }),
-        "colony-task-role-assignment-not-signed-by-new-role-user"
+        "colony-task-role-assignment-not-signed-by-new-user-for-role"
       );
 
       const managerInfo = await colony.getTaskRole(taskId, MANAGER_ROLE);

--- a/test/colony.js
+++ b/test/colony.js
@@ -416,7 +416,8 @@ contract("Colony", accounts => {
           signers: [MANAGER, WORKER],
           sigTypes: [0, 0],
           args: [taskId, WORKER]
-        })
+        }),
+        "colony-task-change-is-not-role-assignement"
       );
     });
 
@@ -432,7 +433,7 @@ contract("Colony", accounts => {
       const sigR = sigs.map(sig => sig.sigR[0]);
       const sigS = sigs.map(sig => sig.sigS[0]);
 
-      await checkErrorRevert(colony.executeTaskRoleAssignment(sigV, sigR, sigS, sigTypes, 10, txData));
+      await checkErrorRevert(colony.executeTaskRoleAssignment(sigV, sigR, sigS, sigTypes, 10, txData), "colony-task-role-assignment-non-zero-value");
     });
 
     it("should allow the worker and evaluator roles to be assigned", async () => {
@@ -474,7 +475,8 @@ contract("Colony", accounts => {
           signers: [MANAGER],
           sigTypes: [0],
           args: [taskId, EVALUATOR]
-        })
+        }),
+        "colony-task-role-assignment-does-not-meet-signatures-required"
       );
 
       const evaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
@@ -488,7 +490,8 @@ contract("Colony", accounts => {
           signers: [MANAGER],
           sigTypes: [0],
           args: [taskId, WORKER]
-        })
+        }),
+        "colony-task-role-assignment-does-not-meet-signatures-required"
       );
 
       const worker = await colony.getTaskRole(taskId, WORKER_ROLE);
@@ -515,7 +518,8 @@ contract("Colony", accounts => {
           signers: [MANAGER, OTHER],
           sigTypes: [0, 0],
           args: [taskId, OTHER]
-        })
+        }),
+        "colony-task-role-assignment-execution-failed"
       );
 
       await executeSignedRoleAssignment({
@@ -535,7 +539,8 @@ contract("Colony", accounts => {
           signers: [MANAGER, OTHER],
           sigTypes: [0, 0],
           args: [taskId, OTHER]
-        })
+        }),
+        "colony-task-role-assignment-execution-failed"
       );
     });
 
@@ -587,7 +592,8 @@ contract("Colony", accounts => {
           signers: [MANAGER, OTHER],
           sigTypes: [0, 0],
           args: [taskId, 0x0]
-        })
+        }),
+        "colony-task-role-assignment-not-signed-by-new-role-user"
       );
 
       const workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
@@ -605,7 +611,8 @@ contract("Colony", accounts => {
           signers: [MANAGER, WORKER],
           sigTypes: [0, 0],
           args: [taskId, EVALUATOR]
-        })
+        }),
+        "colony-task-role-assignment-not-signed-by-new-role-user"
       );
 
       const workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
@@ -651,7 +658,8 @@ contract("Colony", accounts => {
           signers: [EVALUATOR],
           sigTypes: [0],
           args: [taskId, EVALUATOR]
-        })
+        }),
+        "colony-task-role-assignment-does-not-meet-signatures-required"
       );
 
       await checkErrorRevert(
@@ -662,7 +670,8 @@ contract("Colony", accounts => {
           signers: [WORKER],
           sigTypes: [0],
           args: [taskId, WORKER]
-        })
+        }),
+        "colony-task-role-assignment-does-not-meet-signatures-required"
       );
 
       const evaluatorInfo = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
@@ -716,7 +725,7 @@ contract("Colony", accounts => {
       assert.equal(worker[0], WORKER);
     });
 
-    it("should not allow role assignment if non of the signers is manager", async () => {
+    it("should not allow role assignment if none of the signers is manager", async () => {
       const taskId = await makeTask({ colony });
 
       await checkErrorRevert(
@@ -727,7 +736,8 @@ contract("Colony", accounts => {
           signers: [WORKER, OTHER],
           sigTypes: [0, 0],
           args: [taskId, WORKER]
-        })
+        }),
+        "colony-task-role-assignment-not-signed-by-manager"
       );
 
       const worker = await colony.getTaskRole(taskId, WORKER_ROLE);
@@ -765,7 +775,8 @@ contract("Colony", accounts => {
           signers: [OTHER],
           sigTypes: [0],
           args: [taskId, MANAGER]
-        })
+        }),
+        "colony-task-role-assignment-not-signed-by-manager"
       );
 
       const managerInfo = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
@@ -785,7 +796,8 @@ contract("Colony", accounts => {
           signers: [MANAGER, EVALUATOR],
           sigTypes: [0, 0],
           args: [taskId, OTHER]
-        })
+        }),
+        "colony-task-role-assignment-not-signed-by-new-role-user"
       );
 
       const managerInfo = await colony.getTaskRole(taskId, MANAGER_ROLE);
@@ -803,7 +815,8 @@ contract("Colony", accounts => {
           signers: [MANAGER, OTHER],
           sigTypes: [0, 0],
           args: [taskId, OTHER]
-        })
+        }),
+        "colony-task-role-assignment-execution-failed"
       );
 
       const managerInfo = await colony.getTaskRole(taskId, MANAGER_ROLE);
@@ -823,7 +836,8 @@ contract("Colony", accounts => {
           signers: [MANAGER, OTHER],
           sigTypes: [0, 0],
           args: [taskId, 0x0]
-        })
+        }),
+        "colony-task-role-assignment-not-signed-by-new-role-user"
       );
 
       const managerInfo = await colony.getTaskRole(taskId, MANAGER_ROLE);
@@ -845,7 +859,7 @@ contract("Colony", accounts => {
         args: [taskId, WORKER]
       });
 
-      // Setting the manager
+      // Setting the evaluator
       await executeSignedRoleAssignment({
         colony,
         taskId,
@@ -864,7 +878,8 @@ contract("Colony", accounts => {
           signers: [EVALUATOR, WORKER],
           sigTypes: [0, 0],
           args: [taskId, WORKER]
-        })
+        }),
+        "colony-task-role-assignment-not-signed-by-manager"
       );
 
       const managerInfo = await colony.getTaskRole(taskId, MANAGER_ROLE);
@@ -1054,7 +1069,8 @@ contract("Colony", accounts => {
           signers: [MANAGER, MANAGER],
           sigTypes: [0, 1],
           args: [taskId, SPECIFICATION_HASH_UPDATED]
-        })
+        }),
+        "colony-task-duplicate-reviewers"
       );
       const task = await colony.getTask(taskId);
       assert.equal(task[0], SPECIFICATION_HASH);
@@ -1112,7 +1128,8 @@ contract("Colony", accounts => {
           signers: [MANAGER, OTHER],
           sigTypes: [0, 0],
           args: [taskId, SPECIFICATION_HASH_UPDATED]
-        })
+        }),
+        "colony-task-change-does-not-meet-signatures-required"
       );
     });
 
@@ -1145,7 +1162,8 @@ contract("Colony", accounts => {
           signers: [MANAGER, EVALUATOR],
           sigTypes: [0, 0],
           args: [taskId, SPECIFICATION_HASH_UPDATED]
-        })
+        }),
+        "colony-task-signatures-do-not-match-reviewer-2"
       );
     });
 
@@ -1160,7 +1178,8 @@ contract("Colony", accounts => {
           signers: [MANAGER, EVALUATOR],
           sigTypes: [0, 0],
           args: [taskId, 0]
-        })
+        }),
+        "colony-task-change-does-not-meet-signatures-required"
       );
     });
 
@@ -1175,7 +1194,8 @@ contract("Colony", accounts => {
           signers: [MANAGER],
           sigTypes: [0],
           args: [10, SPECIFICATION_HASH_UPDATED]
-        })
+        }),
+        "colony-task-does-not-exist"
       );
     });
 
@@ -1192,7 +1212,8 @@ contract("Colony", accounts => {
           signers: [MANAGER, EVALUATOR],
           sigTypes: [0, 0],
           args: [taskId, SPECIFICATION_HASH_UPDATED]
-        })
+        }),
+        "colony-task-finalized"
       );
     });
 
@@ -1303,7 +1324,7 @@ contract("Colony", accounts => {
       let dueDate = await currentBlockTime();
       dueDate -= 1;
       await setupAssignedTask({ colonyNetwork, colony, dueDate });
-      await checkErrorRevert(colony.submitTaskDeliverable(1, DELIVERABLE_HASH));
+      await checkErrorRevert(colony.submitTaskDeliverable(1, DELIVERABLE_HASH), "colony-task-due-date-passed");
     });
 
     it("should fail if I try to submit work for a task using an invalid id", async () => {
@@ -1316,7 +1337,7 @@ contract("Colony", accounts => {
       await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.submitTaskDeliverable(1, DELIVERABLE_HASH, { from: WORKER });
 
-      await checkErrorRevert(colony.submitTaskDeliverable(1, SPECIFICATION_HASH, { from: WORKER }));
+      await checkErrorRevert(colony.submitTaskDeliverable(1, SPECIFICATION_HASH, { from: WORKER }), "colony-task-deliverable-already-submitted");
       const task = await colony.getTask(1);
       assert.equal(task[1], DELIVERABLE_HASH);
     });
@@ -1357,7 +1378,7 @@ contract("Colony", accounts => {
     it("should fail if the task work ratings have not been assigned", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupFundedTask({ colonyNetwork, colony, token });
-      await checkErrorRevert(colony.finalizeTask(taskId));
+      await checkErrorRevert(colony.finalizeTask(taskId), "colony-task-worker-rating-missing");
     });
 
     it("should fail if I try to accept a task that was finalized before", async () => {
@@ -1370,7 +1391,7 @@ contract("Colony", accounts => {
     it("should fail if I try to accept a task using an invalid id", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await setupRatedTask({ colonyNetwork, colony, token });
-      await checkErrorRevert(colony.finalizeTask(10));
+      await checkErrorRevert(colony.finalizeTask(10), "colony-task-does-not-exist");
     });
 
     it("should log a TaskFinalized event", async () => {

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -293,7 +293,7 @@ contract("Meta Colony", accounts => {
 
     it("should NOT be able to add a child domain more than one level away from the root domain", async () => {
       await metaColony.addDomain(1);
-      await checkErrorRevert(metaColony.addDomain(2));
+      await checkErrorRevert(metaColony.addDomain(2), "colony-parent-skill-not-root");
 
       const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 4);

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -392,18 +392,18 @@ contract("Meta Colony", accounts => {
     it("should NOT allow a non-manager to set domain on task", async () => {
       await colony.addDomain(1);
       await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskDomain(1, 2, { from: OTHER_ACCOUNT }));
+      await checkErrorRevert(colony.setTaskDomain(1, 2, { from: OTHER_ACCOUNT }), "colony-task-role-identity-mismatch");
       const task = await colony.getTask(1);
       assert.equal(task[8].toNumber(), 1);
     });
 
     it("should NOT be able to set a domain on nonexistent task", async () => {
-      await checkErrorRevert(colony.setTaskDomain(10, 3));
+      await checkErrorRevert(colony.setTaskDomain(10, 3), "colony-task-does-not-exist");
     });
 
     it("should NOT be able to set a nonexistent domain on task", async () => {
       await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskDomain(1, 20));
+      await checkErrorRevert(colony.setTaskDomain(1, 20), "colony-domain-does-not-exist");
 
       const task = await colony.getTask(1);
       assert.equal(task[8].toNumber(), 1);
@@ -413,7 +413,7 @@ contract("Meta Colony", accounts => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony });
       await colony.finalizeTask(taskId);
-      await checkErrorRevert(colony.setTaskDomain(taskId, 1));
+      await checkErrorRevert(colony.setTaskDomain(taskId, 1), "colony-task-already-finalized");
     });
 
     it("should be able to set global skill on task", async () => {
@@ -440,13 +440,13 @@ contract("Meta Colony", accounts => {
       await metaColony.addGlobalSkill(5);
 
       await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskSkill(1, 5, { from: OTHER_ACCOUNT }));
+      await checkErrorRevert(colony.setTaskSkill(1, 5, { from: OTHER_ACCOUNT }), "colony-not-self");
       const task = await colony.getTask(1);
       assert.equal(task[9][0].toNumber(), 0);
     });
 
     it("should NOT be able to set global skill on nonexistent task", async () => {
-      await checkErrorRevert(colony.setTaskSkill(10, 1));
+      await checkErrorRevert(colony.setTaskSkill(10, 1), "colony-task-does-not-exist");
     });
 
     it("should NOT be able to set global skill on finalized task", async () => {
@@ -455,7 +455,7 @@ contract("Meta Colony", accounts => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony });
       await colony.finalizeTask(taskId);
-      await checkErrorRevert(colony.setTaskSkill(taskId, 6));
+      await checkErrorRevert(colony.setTaskSkill(taskId, 6), "colony-task-already-finalized");
 
       const task = await colony.getTask(taskId);
       assert.equal(task[9][0].toNumber(), 1);
@@ -463,12 +463,12 @@ contract("Meta Colony", accounts => {
 
     it("should NOT be able to set nonexistent skill on task", async () => {
       await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskSkill(1, 5));
+      await checkErrorRevert(colony.setTaskSkill(1, 5), "colony-skill-does-not-exist");
     });
 
     it("should NOT be able to set local skill on task", async () => {
       await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskSkill(1, 3));
+      await checkErrorRevert(colony.setTaskSkill(1, 3), "colony-not-global-skill");
     });
   });
 

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -134,7 +134,7 @@ contract("Meta Colony", accounts => {
     });
 
     it("should NOT be able to add a child skill to a local skill parent", async () => {
-      await checkErrorRevert(metaColony.addGlobalSkill(2), "colony-global-skill-id-does-not-match");
+      await checkErrorRevert(metaColony.addGlobalSkill(2), "colony-global-and-local-skill-trees-are-separate");
       const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 3);
     });
@@ -293,7 +293,7 @@ contract("Meta Colony", accounts => {
 
     it("should NOT be able to add a child domain more than one level away from the root domain", async () => {
       await metaColony.addDomain(1);
-      await checkErrorRevert(metaColony.addDomain(2), "colony-parent-skill-not-root");
+      await checkErrorRevert(metaColony.addDomain(2), "colony-parent-domain-not-root");
 
       const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 4);
@@ -435,7 +435,7 @@ contract("Meta Colony", accounts => {
       assert.equal(task[9][0].toNumber(), 6);
     });
 
-    it("should not allow a non-manager to set global skill on task", async () => {
+    it("should not allow anyone but the colony to set global skill on task", async () => {
       await metaColony.addGlobalSkill(1);
       await metaColony.addGlobalSkill(5);
 

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -128,13 +128,13 @@ contract("Meta Colony", accounts => {
       await metaColony.addGlobalSkill(1);
       await metaColony.addGlobalSkill(1);
 
-      await checkErrorRevert(metaColony.addGlobalSkill(6));
+      await checkErrorRevert(metaColony.addGlobalSkill(6), "colony-invalid-skill-id");
       const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 5);
     });
 
     it("should NOT be able to add a child skill to a local skill parent", async () => {
-      await checkErrorRevert(metaColony.addGlobalSkill(2));
+      await checkErrorRevert(metaColony.addGlobalSkill(2), "colony-global-skill-id-does-not-match");
       const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 3);
     });
@@ -261,7 +261,7 @@ contract("Meta Colony", accounts => {
     });
 
     it("should NOT be able to add a new root global skill", async () => {
-      await checkErrorRevert(metaColony.addGlobalSkill(0));
+      await checkErrorRevert(metaColony.addGlobalSkill(0), "colony-invalid-parent-skill-id");
 
       const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 3);
@@ -352,7 +352,7 @@ contract("Meta Colony", accounts => {
     });
 
     it("should NOT be able to add a new local skill by anyone but a Colony", async () => {
-      await checkErrorRevert(colonyNetwork.addSkill(2, false));
+      await checkErrorRevert(colonyNetwork.addSkill(2, false), "colony-must-be-colony");
 
       const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 4);
@@ -362,7 +362,7 @@ contract("Meta Colony", accounts => {
       const skillCountBefore = await colonyNetwork.getSkillCount();
       const rootDomain = await colony.getDomain(1);
       const rootLocalSkillId = rootDomain[0].toNumber();
-      await checkErrorRevert(colonyNetwork.addSkill(rootLocalSkillId, false));
+      await checkErrorRevert(colonyNetwork.addSkill(rootLocalSkillId, false), "colony-must-be-colony");
       const skillCountAfter = await colonyNetwork.getSkillCount();
 
       assert.equal(skillCountBefore.toNumber(), skillCountAfter.toNumber());

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -164,7 +164,7 @@ contract("Colony Reputation Updates", accounts => {
 
     it("should not be able to be appended by an account that is not a colony", async () => {
       const lengthBefore = await inactiveReputationMiningCycle.getReputationUpdateLogLength();
-      await checkErrorRevert(colonyNetwork.appendReputationUpdateLog(OTHER, 1, 2));
+      await checkErrorRevert(colonyNetwork.appendReputationUpdateLog(OTHER, 1, 2), "colony-must-be-colony");
       const lengthAfter = await inactiveReputationMiningCycle.getReputationUpdateLogLength();
       assert.equal(lengthBefore.toNumber(), lengthAfter.toNumber());
     });

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -236,7 +236,7 @@ contract("Colony Reputation Updates", accounts => {
       const taskPotBalance = await metaColony.getPotBalance(2, colonyToken.address);
       expect(taskPotBalance).to.eq.BN(maxUIntNumber);
 
-      await checkErrorRevert(metaColony.finalizeTask(taskId));
+      await checkErrorRevert(metaColony.finalizeTask(taskId), "colony-math-unsafe-int-mul");
     });
   });
 });

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -141,7 +141,7 @@ contract("TokenLocking", accounts => {
         tokenLocking.withdraw(token.address, 0, {
           from: userAddress
         }),
-        "token-locking-invalid-amount"
+        "colony-token-locking-invalid-amount"
       );
 
       const info = await tokenLocking.getUserLock(token.address, userAddress);
@@ -197,7 +197,7 @@ contract("TokenLocking", accounts => {
       await tokenLocking.deposit(token.address, usersTokens, {
         from: userAddress
       });
-      await checkErrorRevert(tokenLocking.lockToken(token.address), "token-locking-sender-not-colony");
+      await checkErrorRevert(tokenLocking.lockToken(token.address), "colony-token-locking-sender-not-colony");
     });
 
     it("should not be able to unlock users tokens if sender is not colony", async () => {
@@ -209,7 +209,7 @@ contract("TokenLocking", accounts => {
       });
       const { logs } = await colony.startNextRewardPayout(otherToken.address);
       const payoutId = logs[0].args.id;
-      await checkErrorRevert(tokenLocking.unlockTokenForUser(token.address, userAddress, payoutId), "token-locking-sender-not-colony");
+      await checkErrorRevert(tokenLocking.unlockTokenForUser(token.address, userAddress, payoutId), "colony-token-locking-sender-not-colony");
     });
 
     it("should be able to deposit tokens multiple times if they are unlocked", async () => {
@@ -314,7 +314,7 @@ contract("TokenLocking", accounts => {
     });
 
     it('should not allow "punishStakers" to be called from an account that is not not reputationMiningCycle', async () => {
-      await checkErrorRevert(tokenLocking.punishStakers([accounts[0], accounts[1]]), "token-locking-sender-not-reputation-mining-cycle");
+      await checkErrorRevert(tokenLocking.punishStakers([accounts[0], accounts[1]]), "colony-token-locking-sender-not-reputation-mining-cycle");
     });
   });
 });

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -68,8 +68,7 @@ contract("TokenLocking", accounts => {
       await checkErrorRevert(
         tokenLocking.deposit(token.address, usersTokens, {
           from: userAddress
-        }),
-        "token-locking-transfer-failed"
+        })
       );
       const info = await tokenLocking.getUserLock(token.address, userAddress);
       const userDepositedBalance = info[1];
@@ -125,7 +124,8 @@ contract("TokenLocking", accounts => {
       await checkErrorRevert(
         tokenLocking.deposit(token.address, 0, {
           from: userAddress
-        })
+        }),
+        "colony-token-locking-invalid-amount"
       );
     });
 
@@ -140,7 +140,8 @@ contract("TokenLocking", accounts => {
       await checkErrorRevert(
         tokenLocking.withdraw(token.address, 0, {
           from: userAddress
-        })
+        }),
+        "token-locking-invalid-amount"
       );
 
       const info = await tokenLocking.getUserLock(token.address, userAddress);
@@ -185,7 +186,7 @@ contract("TokenLocking", accounts => {
         tokenLocking.incrementLockCounterTo(token.address, 10, {
           from: userAddress
         }),
-        "token-locking-invalid-lock-id"
+        "colony-token-locking-invalid-lock-id"
       );
     });
 
@@ -238,7 +239,7 @@ contract("TokenLocking", accounts => {
         tokenLocking.deposit(token.address, usersTokens, {
           from: userAddress
         }),
-        "token-locking-token-locked"
+        "colony-token-locking-token-locked"
       );
     });
 
@@ -254,7 +255,7 @@ contract("TokenLocking", accounts => {
         tokenLocking.withdraw(token.address, usersTokens, {
           from: userAddress
         }),
-        "token-locking-token-locked"
+        "colony-token-locking-token-locked"
       );
     });
 


### PR DESCRIPTION
Closes #201 

Error messages are prefixed with `colony-`, `colony-reputation-mining` and `colony-task` to identify better the error source. 

`solium` rules for missing error messages as well as long lines are switched to errors to force us to use revert errors going forward. It helps avoid false positives in tests and makes debugging much easier.