### PR TITLE
Updated contract loader to exact version 1.5.4

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -1,0 +1,11 @@
+{
+  "groups": {
+    "default": {
+      "packages": [
+        "package.json",
+        "packages/reputation-miner/package.json",
+        "packages/colony-js-contract-loader-network/package.json"
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "web3-utils": "^1.0.0-beta.34"
   },
   "dependencies": {
-    "@colony/colony-js-contract-loader-fs": "^1.3.0"
+    "@colony/colony-js-contract-loader-fs": "1.5.4"
   },
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "homepage": "https://github.com/JoinColony/colonyNetwork#readme",
   "devDependencies": {
+    "@colony/colony-js-contract-loader-fs": "1.5.4",
     "@colony/eslint-config-colony": "5.0.0",
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.2.3",
@@ -81,9 +82,6 @@
     "solium": "^1.1.8",
     "truffle": "^5.0.0-next.7",
     "web3-utils": "^1.0.0-beta.34"
-  },
-  "dependencies": {
-    "@colony/colony-js-contract-loader-fs": "1.5.4"
   },
   "private": true,
   "workspaces": [

--- a/packages/colony-js-contract-loader-network/package.json
+++ b/packages/colony-js-contract-loader-network/package.json
@@ -12,7 +12,7 @@
   "author": "Christian Maniewski <chris@colony.io>",
   "license": "GPL-3.0",
   "dependencies": {
-    "@colony/colony-js-contract-loader": "^1.4.1",
+    "@colony/colony-js-contract-loader": "1.5.4",
     "assert": "^1.4.1",
     "babel-runtime": "^6.26.0"
   },

--- a/packages/reputation-miner/package.json
+++ b/packages/reputation-miner/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@colony/colony-js-contract-loader-fs": "^1.3.0",
+    "@colony/colony-js-contract-loader-fs": "1.5.4",
     "bn.js": "^4.11.8",
     "ethers": "^3.0.15",
     "express": "^4.16.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,6 +92,13 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@colony/colony-js-contract-loader-fs@1.5.4":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-loader-fs/-/colony-js-contract-loader-fs-1.5.4.tgz#db4d38180561ccb51cbbe3c887e123873750d222"
+  dependencies:
+    "@colony/colony-js-contract-loader" "^1.5.4"
+    jsonfile "^4.0.0"
+
 "@colony/colony-js-contract-loader-fs@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-loader-fs/-/colony-js-contract-loader-fs-1.3.0.tgz#dc32f03b9bd3501b3f67db89537a7fe542c09121"
@@ -109,6 +116,13 @@
 "@colony/colony-js-contract-loader@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-loader/-/colony-js-contract-loader-1.4.1.tgz#0427b24d1fc06e3482895c4ebbea94832016a719"
+  dependencies:
+    assert "^1.4.1"
+    babel-runtime "^6.26.0"
+
+"@colony/colony-js-contract-loader@^1.5.4":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-loader/-/colony-js-contract-loader-1.5.4.tgz#4b43cf66671f2ea419490cc676b08619b28002f8"
   dependencies:
     assert "^1.4.1"
     babel-runtime "^6.26.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -99,28 +99,7 @@
     "@colony/colony-js-contract-loader" "^1.5.4"
     jsonfile "^4.0.0"
 
-"@colony/colony-js-contract-loader-fs@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-loader-fs/-/colony-js-contract-loader-fs-1.3.0.tgz#dc32f03b9bd3501b3f67db89537a7fe542c09121"
-  dependencies:
-    "@colony/colony-js-contract-loader" "^1.3.0"
-    jsonfile "^4.0.0"
-
-"@colony/colony-js-contract-loader@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-loader/-/colony-js-contract-loader-1.3.0.tgz#280b406fd9da9232b0281e95672ce08deef5fc68"
-  dependencies:
-    assert "^1.4.1"
-    babel-runtime "^6.26.0"
-
-"@colony/colony-js-contract-loader@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-loader/-/colony-js-contract-loader-1.4.1.tgz#0427b24d1fc06e3482895c4ebbea94832016a719"
-  dependencies:
-    assert "^1.4.1"
-    babel-runtime "^6.26.0"
-
-"@colony/colony-js-contract-loader@^1.5.4":
+"@colony/colony-js-contract-loader@1.5.4", "@colony/colony-js-contract-loader@^1.5.4":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-loader/-/colony-js-contract-loader-1.5.4.tgz#4b43cf66671f2ea419490cc676b08619b28002f8"
   dependencies:


### PR DESCRIPTION
The reason why greenkeeper wasn't updating `@colony/colony-js-contract-loader-fs` is because we set a version `^1.3.0` which would cover everything to version `2.0.0`.
I set the version to be exact, so we will get PR from greenkeeper on every patch update.

Question: Is there any reason why `@colony/colony-js-contract-loader-fs` is not in `devDependencies`?