### PR TITLE
Refactoring task update calls

### DIFF
--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -114,12 +114,8 @@ contract ColonyTask is ColonyStorage {
     task.domainId = _domainId;
     task.skills = new uint256[](1);
     tasks[taskCount] = task;
-    tasks[taskCount].roles[MANAGER] = Role({
-      user: msg.sender,
-      rateFail: false,
-      rating: TaskRatings.None
-    });
-
+    tasks[taskCount].roles[MANAGER].user = msg.sender;
+    tasks[taskCount].roles[EVALUATOR].user = msg.sender;
     pots[potCount].taskId = taskCount;
 
     emit PotAdded(potCount);

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -395,6 +395,7 @@ contract ColonyTask is ColonyStorage {
 
   function finalizeTask(uint256 _id) public
   stoppable
+  taskExists(_id)
   canFinalizeTask(_id)
   taskNotFinalized(_id)
   {

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -95,16 +95,8 @@ contract ColonyTask is ColonyStorage {
     _;
   }
 
-  modifier taskWorkRatingsClosed(uint256 _id) {
-    uint taskCompletionTime = tasks[_id].deliverableTimestamp != 0 ? tasks[_id].deliverableTimestamp : tasks[_id].dueDate;
-    // More than 10 days from work submission have passed
-    require(sub(now, taskCompletionTime) > add(RATING_COMMIT_TIMEOUT, RATING_REVEAL_TIMEOUT), "colony-task-rating-period-still-open");
-    _;
-  }
-
-  modifier taskWorkRatingsAssigned(uint256 _id) {
-    require(tasks[_id].roles[WORKER].rating != TaskRatings.None, "colony-task-worker-rating-missing");
-    require(tasks[_id].roles[MANAGER].rating != TaskRatings.None, "colony-task-manager-rating-missing");
+  modifier canFinalizeTask(uint256 _id) {
+    require(taskWorkRatingsAssigned(_id) || taskWorkRatingsClosed(_id), "colony-task-cannot-finalize");
     _;
   }
 
@@ -297,28 +289,6 @@ contract ColonyTask is ColonyStorage {
     emit TaskWorkRatingRevealed(_id, _role, _rating);
   }
 
-  // In the event of a user not committing or revealing within the 10 day rating window,
-  // their rating of their counterpart is assumed to be the highest possible
-  // and they will receive a reputation penalty
-  function assignWorkRating(uint256 _id) public
-  stoppable
-  taskWorkRatingsClosed(_id)
-  {
-    Role storage managerRole = tasks[_id].roles[MANAGER];
-    Role storage workerRole = tasks[_id].roles[WORKER];
-    Role storage evaluatorRole = tasks[_id].roles[EVALUATOR];
-
-    if (workerRole.rating == TaskRatings.None) {
-      evaluatorRole.rateFail = true;
-      workerRole.rating = TaskRatings.Excellent;
-    }
-
-    if (managerRole.rating == TaskRatings.None) {
-      workerRole.rateFail = true;
-      managerRole.rating = TaskRatings.Excellent;
-    }
-  }
-
   function generateSecret(bytes32 _salt, uint256 _value) public pure returns (bytes32) {
     return keccak256(abi.encodePacked(_salt, _value));
   }
@@ -429,10 +399,13 @@ contract ColonyTask is ColonyStorage {
 
   function finalizeTask(uint256 _id) public
   stoppable
-  taskExists(_id)
-  taskWorkRatingsAssigned(_id)
+  canFinalizeTask(_id)
   taskNotFinalized(_id)
   {
+    if (!taskWorkRatingsAssigned(_id)) {
+      assignWorkRating(_id);
+    }
+
     Task storage task = tasks[_id];
     task.finalized = true;
 
@@ -551,6 +524,37 @@ contract ColonyTask is ColonyStorage {
       sig := mload(add(_data, 0x20))
       taskId := mload(add(_data, 0x24)) // same as calldataload(72)
       userAddress := mload(add(_data, 0x44))
+    }
+  }
+
+  function taskWorkRatingsAssigned(uint256 _id) internal view returns (bool) {
+    return (tasks[_id].roles[WORKER].rating != TaskRatings.None) && (tasks[_id].roles[MANAGER].rating != TaskRatings.None);
+  }
+
+  function taskWorkRatingsClosed(uint256 _id) internal view returns (bool) {
+    uint taskCompletionTime = tasks[_id].deliverableTimestamp != 0 ? tasks[_id].deliverableTimestamp : tasks[_id].dueDate;
+    // More than 10 days from work submission have passed
+    return sub(now, taskCompletionTime) > add(RATING_COMMIT_TIMEOUT, RATING_REVEAL_TIMEOUT);
+  }
+
+  // In the event of a user not committing or revealing within the 10 day rating window,
+  // their rating of their counterpart is assumed to be the highest possible
+  // and they will receive a reputation penalty
+  function assignWorkRating(uint256 _id) internal {
+    require(taskWorkRatingsClosed(_id), "colony-task-ratings-not-closed");
+
+    Role storage managerRole = tasks[_id].roles[MANAGER];
+    Role storage workerRole = tasks[_id].roles[WORKER];
+    Role storage evaluatorRole = tasks[_id].roles[EVALUATOR];
+
+    if (workerRole.rating == TaskRatings.None) {
+      evaluatorRole.rateFail = true;
+      workerRole.rating = TaskRatings.Excellent;
+    }
+
+    if (managerRole.rating == TaskRatings.None) {
+      workerRole.rateFail = true;
+      managerRole.rating = TaskRatings.Excellent;
     }
   }
 

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -95,8 +95,8 @@ contract ColonyTask is ColonyStorage {
     _;
   }
 
-  modifier canFinalizeTask(uint256 _id) {
-    require(taskWorkRatingsAssigned(_id) || taskWorkRatingsClosed(_id), "colony-task-cannot-finalize");
+  modifier taskWorkRatingsComplete(uint256 _id) {
+    require(taskWorkRatingsAssigned(_id) || taskWorkRatingsClosed(_id), "colony-task-ratings-incomplete");
     _;
   }
 
@@ -396,7 +396,7 @@ contract ColonyTask is ColonyStorage {
   function finalizeTask(uint256 _id) public
   stoppable
   taskExists(_id)
-  canFinalizeTask(_id)
+  taskWorkRatingsComplete(_id)
   taskNotFinalized(_id)
   {
     if (!taskWorkRatingsAssigned(_id)) {

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -420,6 +420,13 @@ contract ColonyTask is ColonyStorage {
     emit TaskDeliverableSubmitted(_id, _deliverableHash);
   }
 
+  function submitTaskDeliverableAndRating(uint256 _id, bytes32 _deliverableHash, bytes32 _ratingSecret) public
+  stoppable
+  {
+    submitTaskDeliverable(_id, _deliverableHash);
+    submitTaskWorkRating(_id, 0, _ratingSecret);
+  }
+
   function finalizeTask(uint256 _id) public
   stoppable
   taskExists(_id)

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -307,10 +307,6 @@ contract IColony {
   /// @param _salt Salt value used to generate the rating secret
   function revealTaskWorkRating(uint256 _id, uint8 _role, uint8 _rating, bytes32 _salt) public;
 
-  /// @notice Assign missing ratings penalising users where needed for missing the rating window
-  /// @param _id Id of the task
-  function assignWorkRating(uint256 _id) public;
-
   /// @notice Helper function used to generage consistently the rating secret using salt value `_salt` and value to hide `_value`
   /// @param _salt Salt value
   /// @param _value Value to hide

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -394,6 +394,13 @@ contract IColony {
   /// @param _deliverableHash Unique hash of the task deliverable content in ddb
   function submitTaskDeliverable(uint256 _id, bytes32 _deliverableHash) public;
 
+  /// @notice Submit the task deliverable for Worker and rating for Manager
+  /// @dev Internally call `submitTaskDeliverable` and `submitTaskWorkRating` in sequence
+  /// @param _id Id of the task
+  /// @param _deliverableHash Unique hash of the task deliverable content in ddb
+  /// @param _ratingSecret Rating secret for manager
+  function submitTaskDeliverableAndRating(uint256 _id, bytes32 _deliverableHash, bytes32 _ratingSecret) public;
+
   /// @notice Called after task work rating is complete which closes the task and logs the respective reputation log updates
   /// Allowed to be called once per task. Secured function to authorised members
   /// @dev Set the `task.finalized` property to true

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -54,7 +54,7 @@ contract("All", accounts => {
   const gasPrice = 20e9;
 
   const MANAGER = accounts[0];
-  const EVALUATOR = accounts[1];
+  const EVALUATOR = MANAGER;
   const WORKER = accounts[2];
 
   let colony;
@@ -187,15 +187,6 @@ contract("All", accounts => {
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, tokenAddress, 100]
-      });
-
-      await executeSignedRoleAssignment({
-        colony,
-        taskId,
-        functionName: "setTaskEvaluatorRole",
-        signers: [MANAGER, EVALUATOR],
-        sigTypes: [0, 0],
-        args: [taskId, EVALUATOR]
       });
 
       await executeSignedRoleAssignment({

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -26,7 +26,7 @@ export async function makeTask({ colony, hash = SPECIFICATION_HASH, domainId = 1
   return logs.filter(log => log.event === "TaskAdded")[0].args.id;
 }
 
-async function getSigsAndTransactionData({ colony, functionName, taskId, signers, sigTypes, args }) {
+async function getSigsAndTransactionData({ colony, taskId, functionName, signers, sigTypes, args }) {
   const txData = await colony.contract.methods[functionName](...args).encodeABI();
   const sigsPromises = sigTypes.map((type, i) => {
     if (type === 0) {
@@ -41,13 +41,13 @@ async function getSigsAndTransactionData({ colony, functionName, taskId, signers
   return { sigV, sigR, sigS, txData };
 }
 
-export async function executeSignedTaskChange({ colony, functionName, taskId, signers, sigTypes, args }) {
-  const { sigV, sigR, sigS, txData } = await getSigsAndTransactionData({ colony, functionName, taskId, signers, sigTypes, args });
+export async function executeSignedTaskChange({ colony, taskId, functionName, signers, sigTypes, args }) {
+  const { sigV, sigR, sigS, txData } = await getSigsAndTransactionData({ colony, taskId, functionName, signers, sigTypes, args });
   return colony.executeTaskChange(sigV, sigR, sigS, sigTypes, 0, txData);
 }
 
-export async function executeSignedRoleAssignment({ colony, functionName, taskId, signers, sigTypes, args }) {
-  const { sigV, sigR, sigS, txData } = await getSigsAndTransactionData({ colony, functionName, taskId, signers, sigTypes, args });
+export async function executeSignedRoleAssignment({ colony, taskId, functionName, signers, sigTypes, args }) {
+  const { sigV, sigR, sigS, txData } = await getSigsAndTransactionData({ colony, taskId, functionName, signers, sigTypes, args });
   return colony.executeTaskRoleAssignment(sigV, sigR, sigS, sigTypes, 0, txData);
 }
 
@@ -65,8 +65,8 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
 
     await executeSignedTaskChange({
       colony,
-      functionName: "setTaskSkill",
       taskId,
+      functionName: "setTaskSkill",
       signers: [manager],
       sigTypes: [0],
       args: [taskId, rootGlobalSkill.toNumber()]
@@ -74,8 +74,8 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
   } else {
     await executeSignedTaskChange({
       colony,
-      functionName: "setTaskSkill",
       taskId,
+      functionName: "setTaskSkill",
       signers: [manager],
       sigTypes: [0],
       args: [taskId, skill]
@@ -85,8 +85,8 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
   if (manager !== evaluator) {
     await executeSignedTaskChange({
       colony,
-      functionName: "removeTaskEvaluatorRole",
       taskId,
+      functionName: "removeTaskEvaluatorRole",
       signers: [manager],
       sigTypes: [0],
       args: [taskId]
@@ -94,8 +94,8 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
 
     await executeSignedRoleAssignment({
       colony,
-      functionName: "setTaskEvaluatorRole",
       taskId,
+      functionName: "setTaskEvaluatorRole",
       signers: [manager, evaluator],
       sigTypes: [0, 0],
       args: [taskId, evaluator]
@@ -121,8 +121,8 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
 
   await executeSignedTaskChange({
     colony,
-    functionName: "setTaskDueDate",
     taskId,
+    functionName: "setTaskDueDate",
     signers,
     sigTypes,
     args: [taskId, dueDateTimestamp]
@@ -165,8 +165,8 @@ export async function setupFundedTask({
 
   await executeSignedTaskChange({
     colony,
-    functionName: "setTaskManagerPayout",
     taskId,
+    functionName: "setTaskManagerPayout",
     signers: [manager],
     sigTypes: [0],
     args: [taskId, tokenAddress, managerPayout.toString()]
@@ -177,8 +177,8 @@ export async function setupFundedTask({
 
   await executeSignedTaskChange({
     colony,
-    functionName: "setTaskEvaluatorPayout",
     taskId,
+    functionName: "setTaskEvaluatorPayout",
     signers,
     sigTypes,
     args: [taskId, tokenAddress, evaluatorPayout.toString()]
@@ -189,8 +189,8 @@ export async function setupFundedTask({
 
   await executeSignedTaskChange({
     colony,
-    functionName: "setTaskWorkerPayout",
     taskId,
+    functionName: "setTaskWorkerPayout",
     signers,
     sigTypes,
     args: [taskId, tokenAddress, workerPayout.toString()]

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -167,8 +167,8 @@ contract("Colony Funding", accounts => {
       // Pot was equal to payout, transition to pot being equal by changing payout (18)
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, otherToken.address, 0]
@@ -186,8 +186,8 @@ contract("Colony Funding", accounts => {
       // Pot was equal to payout, transition to pot being lower by increasing payout (8)
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, otherToken.address, 40]
@@ -211,8 +211,8 @@ contract("Colony Funding", accounts => {
       // Pot was above payout, transition to being equal by increasing payout (12)
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, otherToken.address, 80]
@@ -224,8 +224,8 @@ contract("Colony Funding", accounts => {
       // Pot was equal to payout, transition to being above by decreasing payout (6)
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, otherToken.address, 40]
@@ -246,8 +246,8 @@ contract("Colony Funding", accounts => {
       // Remove 20 from pot
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, otherToken.address, 20]
@@ -255,8 +255,8 @@ contract("Colony Funding", accounts => {
       await colony.moveFundsBetweenPots(2, 1, 20, otherToken.address);
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, otherToken.address, 40]
@@ -275,8 +275,8 @@ contract("Colony Funding", accounts => {
       // Remove 60 from pot
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, otherToken.address, 20]
@@ -284,8 +284,8 @@ contract("Colony Funding", accounts => {
       await colony.moveFundsBetweenPots(2, 1, 60, otherToken.address);
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, otherToken.address, 40]
@@ -295,8 +295,8 @@ contract("Colony Funding", accounts => {
       // Pot was below payout, change to being above by changing payout (4)
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, otherToken.address, 10]
@@ -308,8 +308,8 @@ contract("Colony Funding", accounts => {
       // Pot was above, change to being above by changing payout (16)
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, otherToken.address, 5]
@@ -327,8 +327,8 @@ contract("Colony Funding", accounts => {
       // Pot was above payout, change to being below by changing payout (10)
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, otherToken.address, 40]
@@ -340,8 +340,8 @@ contract("Colony Funding", accounts => {
       // Pot was below payout, change to being below by changing payout (14)
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, otherToken.address, 30]
@@ -356,8 +356,8 @@ contract("Colony Funding", accounts => {
       // Remove 5 from pot
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, otherToken.address, 5]
@@ -365,8 +365,8 @@ contract("Colony Funding", accounts => {
       await colony.moveFundsBetweenPots(2, 1, 5, otherToken.address);
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, otherToken.address, 30]
@@ -376,8 +376,8 @@ contract("Colony Funding", accounts => {
       // Pot was below payout, change to being equal by changing payout (2)
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, otherToken.address, 5]
@@ -519,8 +519,8 @@ contract("Colony Funding", accounts => {
       // Set manager payout above pot value 40 > 0
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, 0x0, 40]
@@ -539,8 +539,8 @@ contract("Colony Funding", accounts => {
       // Set manager payout above pot value 50 > 40
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, 0x0, 50]

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -19,7 +19,7 @@ const DSRoles = artifacts.require("DSRoles");
 
 contract("Colony Funding", accounts => {
   const MANAGER = accounts[0];
-  const EVALUATOR = accounts[1];
+  const EVALUATOR = MANAGER;
   const WORKER = accounts[2];
 
   let colony;
@@ -106,7 +106,7 @@ contract("Colony Funding", accounts => {
     it("should not let tokens be moved by non-admins", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await makeTask({ colony });
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 2, 51, otherToken.address, { from: EVALUATOR }));
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, 2, 51, otherToken.address, { from: WORKER }));
       const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
       const pot2Balance = await colony.getPotBalance(2, otherToken.address);

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -2492,27 +2492,27 @@ contract("ColonyNetworkMining", accounts => {
       const client = new ReputationMiner({ loader: contractLoader, minerAddress: MAIN_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree });
       await client.initialise(colonyNetwork.address);
       await client.addLogContentsToReputationTree();
-      // Check the client's tree has eight entries. In order these were added (and therefore in order of reputation UID),
+      // Check the client's tree has seven entries. In order these were added (and therefore in order of reputation UID),
       // these are:
       // 1. Colony-wide total reputation for metaColony's root skill
       // 2. Colony-wide total reputation for mining skill
       // 3. Miner's reputation for metaColony's root skill
       // 4. Miner's reputation for mining skill
       // x. Colony-wide total reputation for metacolony's root skill (same as 1)
-      // x. Manager reputation for metaColony's root skill (same as 3, by virtue of Manage and miner being MAIN_ACCOUNT)
+      // x. Manager reputation for metaColony's root skill (same as 3, by virtue of manager and miner being MAIN_ACCOUNT)
       // x. Colony-wide total reputation for metacolony's root skill (same as 1)
-      // 5. Evaluator reputation for metaColony's root skill
+      // x. Evaluator reputation for metaColony's root skill (same as 3, by virtue of evaluator and manager being MAIN_ACCOUNT)
       // x. Colony-wide total reputation for metacolony's root skill (same as 1)
-      // 6. Worker reputation for metacolony's root skill
-      // 7. Colony-wide total reputation for global skill task was in
-      // 8. Worker reputation for global skill task was in
+      // 5. Worker reputation for metacolony's root skill
+      // 6. Colony-wide total reputation for global skill task was in
+      // 7. Worker reputation for global skill task was in
       //
 
       const GLOBAL_SKILL = 1;
       const META_ROOT_SKILL = 2;
       const MINING_SKILL = 3;
 
-      assert.equal(Object.keys(client.reputations).length, 8);
+      assert.equal(Object.keys(client.reputations).length, 7);
       let key;
       let value;
       // These should be:
@@ -2536,25 +2536,20 @@ contract("ColonyNetworkMining", accounts => {
       value = makeReputationValue(1000000000000000000, 4);
       assert.equal(client.reputations[key], value);
 
-      // 5. Reputation reward for OTHER_ACCOUNT for being the evaluator for the tasks created by giveUserCLNYTokens
-      key = makeReputationKey(metaColony.address, META_ROOT_SKILL, OTHER_ACCOUNT);
+      // 5. Reputation reward for accounts[2] for being the worker for the tasks created by giveUserCLNYTokens
+      // NB at the moment, the reputation reward for the worker is 0.
+      key = makeReputationKey(metaColony.address, META_ROOT_SKILL, accounts[2]);
       value = makeReputationValue(0, 5);
       assert.equal(client.reputations[key], value);
 
-      // 6. Reputation reward for accounts[2] for being the worker for the tasks created by giveUserCLNYTokens
-      // NB at the moment, the reputation reward for the worker is 0.
-      key = makeReputationKey(metaColony.address, META_ROOT_SKILL, accounts[2]);
+      // 6. Colony-wide total reputation for global skill task was in
+      key = makeReputationKey(metaColony.address, GLOBAL_SKILL);
       value = makeReputationValue(0, 6);
       assert.equal(client.reputations[key], value);
 
-      // 7. Colony-wide total reputation for global skill task was in
-      key = makeReputationKey(metaColony.address, GLOBAL_SKILL);
-      value = makeReputationValue(0, 7);
-      assert.equal(client.reputations[key], value);
-
-      // 8. Worker reputation for global skill task was in
+      // 7. Worker reputation for global skill task was in
       key = makeReputationKey(metaColony.address, GLOBAL_SKILL, accounts[2]);
-      value = makeReputationValue(0, 8);
+      value = makeReputationValue(0, 7);
       assert.equal(client.reputations[key], value);
     });
 
@@ -2606,16 +2601,15 @@ contract("ColonyNetworkMining", accounts => {
       const META_ROOT_SKILL = 2;
       const MINING_SKILL = 3;
 
-      assert.equal(Object.keys(goodClient.reputations).length, 23);
       const reputationProps = [
         { id: 1, skill: META_ROOT_SKILL, account: undefined, value: 3000003000000000000 },
         { id: 2, skill: MINING_SKILL, account: undefined, value: 1000000000000000000 },
         { id: 3, skill: META_ROOT_SKILL, account: MAIN_ACCOUNT, value: 3000001000000000000 },
         { id: 4, skill: MINING_SKILL, account: MAIN_ACCOUNT, value: 1000000000000000000 },
-        { id: 5, skill: META_ROOT_SKILL, account: OTHER_ACCOUNT, value: 1000000000000 },
-        { id: 6, skill: META_ROOT_SKILL, account: accounts[2], value: 1000000000000 },
-        { id: 7, skill: 1, account: undefined, value: 1000000000000 },
-        { id: 8, skill: 1, account: accounts[2], value: 0 },
+        { id: 5, skill: META_ROOT_SKILL, account: accounts[2], value: 1000000000000 },
+        { id: 6, skill: 1, account: undefined, value: 1000000000000 },
+        { id: 7, skill: 1, account: accounts[2], value: 0 },
+        { id: 8, skill: META_ROOT_SKILL, account: OTHER_ACCOUNT, value: 1000000000000 },
 
         { id: 9, skill: 9, account: undefined, value: 1000000000000 },
         { id: 10, skill: 8, account: undefined, value: 1000000000000 },
@@ -2634,6 +2628,8 @@ contract("ColonyNetworkMining", accounts => {
         { id: 22, skill: 1, account: OTHER_ACCOUNT, value: 1000000000000 },
         { id: 23, skill: 10, account: OTHER_ACCOUNT, value: 1000000000000 }
       ];
+
+      assert.equal(Object.keys(goodClient.reputations).length, reputationProps.length);
 
       reputationProps.forEach(reputationProp => {
         const key = makeReputationKey(metaColony.address, reputationProp.skill, reputationProp.account);

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -70,6 +70,19 @@ contract("Colony Task Work Rating", accounts => {
       assert.equal(ratingSecret2, RATING_1_SECRET);
     });
 
+    it("should allow combined submission and rating, before the due date", async () => {
+      const currentTime = await currentBlockTime();
+      const dueDate = currentTime + SECONDS_PER_DAY * 7;
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
+
+      await colony.submitTaskDeliverableAndRating(taskId, DELIVERABLE_HASH, RATING_1_SECRET, { from: WORKER });
+      const ratings = await colony.getTaskWorkRatings(taskId);
+      assert.equal(ratings[0].toNumber(), 1);
+      assert.closeTo(ratings[1].toNumber(), currentTime, 2);
+      const ratingSecret = await colony.getTaskWorkRatingSecret(taskId, MANAGER_ROLE);
+      assert.equal(ratingSecret, RATING_1_SECRET);
+    });
+
     it("should allow rating, after the due date has passed, when no work has been submitted", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -284,7 +284,7 @@ contract("Colony Task Work Rating", accounts => {
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
       await colony.revealTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR });
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
-      await colony.assignWorkRating(taskId);
+      await colony.finalizeTask(taskId);
 
       const roleWorker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.isTrue(roleWorker[1]);
@@ -303,7 +303,7 @@ contract("Colony Task Work Rating", accounts => {
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
       await colony.revealTaskWorkRating(taskId, MANAGER_ROLE, MANAGER_RATING, RATING_1_SALT, { from: WORKER });
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
-      await colony.assignWorkRating(taskId);
+      await colony.finalizeTask(taskId);
 
       const roleWorker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.isFalse(roleWorker[1]);
@@ -313,7 +313,6 @@ contract("Colony Task Work Rating", accounts => {
       assert.isFalse(roleManager[1]);
       assert.equal(roleManager[2].toNumber(), MANAGER_RATING);
 
-      await colony.finalizeTask(taskId);
       const roleEvaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
       assert.isTrue(roleEvaluator[1]);
       assert.equal(roleEvaluator[2].toNumber(), 1);
@@ -322,7 +321,7 @@ contract("Colony Task Work Rating", accounts => {
     it("should assign rating 3 to manager and 3 to worker, with penalties, when no one has submitted any ratings", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
       await forwardTime(SECONDS_PER_DAY * 10 + 1, this);
-      await colony.assignWorkRating(taskId);
+      await colony.finalizeTask(taskId);
 
       const roleWorker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.isTrue(roleWorker[1]);
@@ -332,7 +331,6 @@ contract("Colony Task Work Rating", accounts => {
       assert.isFalse(roleManager[1]);
       assert.equal(roleManager[2].toNumber(), 3);
 
-      await colony.finalizeTask(taskId);
       const roleEvaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
       assert.isTrue(roleEvaluator[1]);
       assert.equal(roleEvaluator[2].toNumber(), 1);
@@ -341,7 +339,7 @@ contract("Colony Task Work Rating", accounts => {
     it("should revert if I try to assign ratings before the reveal period is over", async () => {
       await setupAssignedTask({ colonyNetwork, colony });
       await forwardTime(SECONDS_PER_DAY * 6, this);
-      await checkErrorRevert(colony.assignWorkRating(1), "colony-task-rating-period-still-open");
+      await checkErrorRevert(colony.finalizeTask(1), "colony-task-cannot-finalize");
       const roleWorker = await colony.getTaskRole(1, WORKER_ROLE);
       assert.isFalse(roleWorker[1]);
     });

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -23,7 +23,8 @@ const EtherRouter = artifacts.require("EtherRouter");
 const Token = artifacts.require("Token");
 
 contract("Colony Task Work Rating", accounts => {
-  const EVALUATOR = accounts[1];
+  const MANAGER = accounts[0];
+  const EVALUATOR = MANAGER;
   const WORKER = accounts[2];
   const OTHER = accounts[3];
 

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -340,7 +340,7 @@ contract("Colony Task Work Rating", accounts => {
     it("should revert if I try to assign ratings before the reveal period is over", async () => {
       await setupAssignedTask({ colonyNetwork, colony });
       await forwardTime(SECONDS_PER_DAY * 6, this);
-      await checkErrorRevert(colony.finalizeTask(1), "colony-task-cannot-finalize");
+      await checkErrorRevert(colony.finalizeTask(1), "colony-task-ratings-incomplete");
       const roleWorker = await colony.getTaskRole(1, WORKER_ROLE);
       assert.isFalse(roleWorker[1]);
     });

--- a/test/colony.js
+++ b/test/colony.js
@@ -63,7 +63,7 @@ const ReputationMiningCycle = artifacts.require("ReputationMiningCycle");
 
 contract("Colony", accounts => {
   const MANAGER = accounts[0];
-  const EVALUATOR = accounts[1];
+  const EVALUATOR = MANAGER;
   const WORKER = accounts[2];
   const OTHER = accounts[3];
 
@@ -291,12 +291,51 @@ contract("Colony", accounts => {
       assert.equal(taskCount.toNumber(), 0);
     });
 
-    it("should set the task manager as the creator", async () => {
-      await makeTask({ colony });
+    it("should set the task manager as the creator and evaluator", async () => {
+      const taskId = await makeTask({ colony });
+
       const taskCount = await colony.getTaskCount();
       assert.equal(taskCount.toNumber(), 1);
-      const taskManager = await colony.getTaskRole(1, MANAGER_ROLE);
+
+      const taskManager = await colony.getTaskRole(taskId, MANAGER_ROLE);
       assert.equal(taskManager[0], MANAGER);
+
+      const taskEvaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
+      assert.equal(taskEvaluator[0], MANAGER);
+    });
+
+    it("should allow the reassignment of evaluator", async () => {
+      const newEvaluator = accounts[1];
+      assert.notEqual(MANAGER, newEvaluator);
+
+      const taskId = await makeTask({ colony });
+
+      let taskEvaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
+      assert.equal(taskEvaluator[0], EVALUATOR);
+
+      await executeSignedTaskChange({
+        colony,
+        functionName: "removeTaskEvaluatorRole",
+        taskId,
+        signers: [MANAGER], // NOTE: only one signature because manager === evaluator
+        sigTypes: [0],
+        args: [taskId]
+      });
+
+      taskEvaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
+      assert.equal(taskEvaluator[0], "0x0000000000000000000000000000000000000000");
+
+      await executeSignedRoleAssignment({
+        colony,
+        functionName: "setTaskEvaluatorRole",
+        taskId,
+        signers: [MANAGER, newEvaluator],
+        sigTypes: [0, 0],
+        args: [taskId, newEvaluator]
+      });
+
+      taskEvaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
+      assert.equal(taskEvaluator[0], newEvaluator);
     });
 
     it("should return the correct number of tasks", async () => {
@@ -448,6 +487,9 @@ contract("Colony", accounts => {
     });
 
     it("should allow the worker and evaluator roles to be assigned", async () => {
+      const newEvaluator = accounts[1];
+      assert.notEqual(MANAGER, newEvaluator);
+
       const taskId = await makeTask({ colony });
 
       await executeSignedRoleAssignment({
@@ -459,24 +501,45 @@ contract("Colony", accounts => {
         args: [taskId, WORKER]
       });
 
+      await executeSignedTaskChange({
+        colony,
+        taskId,
+        functionName: "removeTaskEvaluatorRole",
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId]
+      });
+
       await executeSignedRoleAssignment({
         colony,
         taskId,
         functionName: "setTaskEvaluatorRole",
-        signers: [MANAGER, EVALUATOR],
+        signers: [MANAGER, newEvaluator],
         sigTypes: [0, 0],
-        args: [taskId, EVALUATOR]
+        args: [taskId, newEvaluator]
       });
 
       const worker = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(worker[0], WORKER);
 
       const evaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
-      assert.equal(evaluator[0], EVALUATOR);
+      assert.equal(evaluator[0], newEvaluator);
     });
 
     it("should not allow the worker or evaluator roles to be assigned only by manager", async () => {
+      const newEvaluator = accounts[1];
+      assert.notEqual(MANAGER, newEvaluator);
+
       const taskId = await makeTask({ colony });
+
+      await executeSignedTaskChange({
+        colony,
+        taskId,
+        functionName: "removeTaskEvaluatorRole",
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId]
+      });
 
       await checkErrorRevert(
         executeSignedRoleAssignment({
@@ -485,7 +548,7 @@ contract("Colony", accounts => {
           functionName: "setTaskEvaluatorRole",
           signers: [MANAGER],
           sigTypes: [0],
-          args: [taskId, EVALUATOR]
+          args: [taskId, newEvaluator]
         }),
         "colony-task-role-assignment-does-not-meet-required-signatures"
       );
@@ -532,15 +595,6 @@ contract("Colony", accounts => {
         }),
         "colony-task-role-assignment-execution-failed"
       );
-
-      await executeSignedRoleAssignment({
-        colony,
-        taskId,
-        functionName: "setTaskEvaluatorRole",
-        signers: [MANAGER, EVALUATOR],
-        sigTypes: [0, 0],
-        args: [taskId, EVALUATOR]
-      });
 
       await checkErrorRevert(
         executeSignedRoleAssignment({
@@ -612,6 +666,9 @@ contract("Colony", accounts => {
     });
 
     it("should not allow role to be assigned if passed address is not equal to one of the signers", async () => {
+      const newEvaluator = accounts[1];
+      assert.notEqual(MANAGER, newEvaluator);
+
       const taskId = await makeTask({ colony });
 
       await checkErrorRevert(
@@ -621,7 +678,7 @@ contract("Colony", accounts => {
           functionName: "setTaskWorkerRole",
           signers: [MANAGER, WORKER],
           sigTypes: [0, 0],
-          args: [taskId, EVALUATOR]
+          args: [taskId, newEvaluator]
         }),
         "colony-task-role-assignment-not-signed-by-new-user-for-role"
       );
@@ -636,23 +693,11 @@ contract("Colony", accounts => {
       await executeSignedRoleAssignment({
         colony,
         taskId,
-        functionName: "setTaskEvaluatorRole",
-        signers: [MANAGER],
-        sigTypes: [0],
-        args: [taskId, MANAGER]
-      });
-
-      await executeSignedRoleAssignment({
-        colony,
-        taskId,
         functionName: "setTaskWorkerRole",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, MANAGER]
       });
-
-      const evaluatorInfo = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
-      assert.equal(evaluatorInfo[0], MANAGER);
 
       const workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(workerInfo[0], MANAGER);
@@ -660,18 +705,6 @@ contract("Colony", accounts => {
 
     it("should not allow anyone to assign himself to a role with one signature except manager", async () => {
       const taskId = await makeTask({ colony });
-
-      await checkErrorRevert(
-        executeSignedRoleAssignment({
-          colony,
-          taskId,
-          functionName: "setTaskEvaluatorRole",
-          signers: [EVALUATOR],
-          sigTypes: [0],
-          args: [taskId, EVALUATOR]
-        }),
-        "colony-task-role-assignment-does-not-meet-required-signatures"
-      );
 
       await checkErrorRevert(
         executeSignedRoleAssignment({
@@ -685,39 +718,8 @@ contract("Colony", accounts => {
         "colony-task-role-assignment-does-not-meet-required-signatures"
       );
 
-      const evaluatorInfo = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
-      assert.equal(evaluatorInfo[0], "0x0000000000000000000000000000000000000000");
-
       const workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(workerInfo[0], "0x0000000000000000000000000000000000000000");
-    });
-
-    it("should be able to remove evaluator role", async () => {
-      const taskId = await makeTask({ colony });
-
-      await executeSignedRoleAssignment({
-        colony,
-        taskId,
-        functionName: "setTaskEvaluatorRole",
-        signers: [MANAGER, EVALUATOR],
-        sigTypes: [0, 0],
-        args: [taskId, EVALUATOR]
-      });
-
-      let evaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
-      assert.equal(evaluator[0], EVALUATOR);
-
-      await executeSignedTaskChange({
-        colony,
-        taskId,
-        functionName: "removeTaskEvaluatorRole",
-        signers: [MANAGER, EVALUATOR],
-        sigTypes: [0, 0],
-        args: [taskId]
-      });
-
-      evaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
-      assert.equal(evaluator[0], "0x0000000000000000000000000000000000000000");
     });
 
     it("should allow different modes of signing when assigning roles", async () => {
@@ -782,7 +784,7 @@ contract("Colony", accounts => {
         executeSignedRoleAssignment({
           colony,
           taskId,
-          functionName: "setTaskEvaluatorRole",
+          functionName: "setTaskWorkerRole",
           signers: [OTHER],
           sigTypes: [0],
           args: [taskId, MANAGER]
@@ -790,7 +792,7 @@ contract("Colony", accounts => {
         "colony-task-role-assignment-not-signed-by-manager"
       );
 
-      const managerInfo = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
+      const managerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
       assert.equal(managerInfo[0], "0x0000000000000000000000000000000000000000");
     });
 
@@ -804,7 +806,7 @@ contract("Colony", accounts => {
           colony,
           taskId,
           functionName: "setTaskManagerRole",
-          signers: [MANAGER, EVALUATOR],
+          signers: [MANAGER, WORKER],
           sigTypes: [0, 0],
           args: [taskId, OTHER]
         }),
@@ -856,8 +858,10 @@ contract("Colony", accounts => {
     });
 
     it("should not allow assignment of manager role if current manager is not one of the signers", async () => {
-      const taskId = await makeTask({ colony });
+      const newEvaluator = accounts[1];
+      assert.notEqual(MANAGER, newEvaluator);
 
+      const taskId = await makeTask({ colony });
       await colony.setAdminRole(WORKER);
 
       // Setting the worker
@@ -871,13 +875,22 @@ contract("Colony", accounts => {
       });
 
       // Setting the evaluator
+      await executeSignedTaskChange({
+        colony,
+        taskId,
+        functionName: "removeTaskEvaluatorRole",
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId]
+      });
+
       await executeSignedRoleAssignment({
         colony,
         taskId,
         functionName: "setTaskEvaluatorRole",
-        signers: [MANAGER, EVALUATOR],
+        signers: [MANAGER, newEvaluator],
         sigTypes: [0, 0],
-        args: [taskId, EVALUATOR]
+        args: [taskId, newEvaluator]
       });
 
       await checkErrorRevert(
@@ -886,7 +899,7 @@ contract("Colony", accounts => {
           colony,
           taskId,
           functionName: "setTaskManagerRole",
-          signers: [EVALUATOR, WORKER],
+          signers: [newEvaluator, WORKER],
           sigTypes: [0, 0],
           args: [taskId, WORKER]
         }),
@@ -1122,15 +1135,6 @@ contract("Colony", accounts => {
     it("should fail update of task brief signed by a non-registered role", async () => {
       const taskId = await makeTask({ colony });
 
-      await executeSignedRoleAssignment({
-        colony,
-        taskId,
-        functionName: "setTaskEvaluatorRole",
-        signers: [MANAGER, EVALUATOR],
-        sigTypes: [0, 0],
-        args: [taskId, EVALUATOR]
-      });
-
       await checkErrorRevert(
         executeSignedTaskChange({
           colony,
@@ -1150,15 +1154,6 @@ contract("Colony", accounts => {
       await executeSignedRoleAssignment({
         colony,
         taskId,
-        functionName: "setTaskEvaluatorRole",
-        signers: [MANAGER, EVALUATOR],
-        sigTypes: [0, 0],
-        args: [taskId, EVALUATOR]
-      });
-
-      await executeSignedRoleAssignment({
-        colony,
-        taskId,
         functionName: "setTaskWorkerRole",
         signers: [MANAGER, WORKER],
         sigTypes: [0, 0],
@@ -1170,8 +1165,8 @@ contract("Colony", accounts => {
           colony,
           functionName: "setTaskBrief",
           taskId,
-          signers: [MANAGER, EVALUATOR],
-          sigTypes: [0, 0],
+          signers: [MANAGER],
+          sigTypes: [0],
           args: [taskId, SPECIFICATION_HASH_UPDATED]
         }),
         "colony-task-signatures-do-not-match-reviewer-2"
@@ -1220,8 +1215,8 @@ contract("Colony", accounts => {
           colony,
           functionName: "setTaskBrief",
           taskId,
-          signers: [MANAGER, EVALUATOR],
-          sigTypes: [0, 0],
+          signers: [MANAGER],
+          sigTypes: [0],
           args: [taskId, SPECIFICATION_HASH_UPDATED]
         }),
         "colony-task-finalized"
@@ -1521,14 +1516,6 @@ contract("Colony", accounts => {
         sigTypes: [0, 0],
         args: [taskId, WORKER]
       });
-      await executeSignedRoleAssignment({
-        colony,
-        taskId,
-        functionName: "setTaskEvaluatorRole",
-        signers: [MANAGER, EVALUATOR],
-        sigTypes: [0, 0],
-        args: [taskId, EVALUATOR]
-      });
       await colony.mintTokens(100);
 
       // Set the manager payout as 5000 wei and 100 colony tokens
@@ -1555,8 +1542,8 @@ contract("Colony", accounts => {
         colony,
         functionName: "setTaskEvaluatorPayout",
         taskId,
-        signers: [MANAGER, EVALUATOR],
-        sigTypes: [0, 0],
+        signers: [MANAGER],
+        sigTypes: [0],
         args: [taskId, 0x0, 1000]
       });
 
@@ -1565,8 +1552,8 @@ contract("Colony", accounts => {
         colony,
         functionName: "setTaskEvaluatorPayout",
         taskId,
-        signers: [MANAGER, EVALUATOR],
-        sigTypes: [0, 0],
+        signers: [MANAGER],
+        sigTypes: [0],
         args: [taskId, token.address, 40]
       });
 
@@ -1749,11 +1736,14 @@ contract("Colony", accounts => {
     });
 
     it("should disburse nothing for unsatisfactory work, for manager and worker", async () => {
+      const evaluator = accounts[1];
+
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({
         colonyNetwork,
         colony,
         token,
+        evaluator,
         managerRating: 1,
         workerRating: 1
       });
@@ -1761,7 +1751,7 @@ contract("Colony", accounts => {
 
       await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
       await colony.claimPayout(taskId, WORKER_ROLE, token.address, { from: WORKER });
-      await colony.claimPayout(taskId, EVALUATOR_ROLE, token.address, { from: EVALUATOR });
+      await colony.claimPayout(taskId, EVALUATOR_ROLE, token.address, { from: evaluator });
 
       const managerBalance = await token.balanceOf(MANAGER);
       assert.equal(managerBalance.toNumber(), 0);
@@ -1769,20 +1759,22 @@ contract("Colony", accounts => {
       const workerBalance = await token.balanceOf(WORKER);
       assert.equal(workerBalance.toNumber(), 0);
 
-      const evaluatorBalance = await token.balanceOf(EVALUATOR);
+      const evaluatorBalance = await token.balanceOf(evaluator);
       const evaluatorPayout = EVALUATOR_PAYOUT.divn(100).muln(99); // "Subtract" 1% fee
       assert.equal(evaluatorBalance.toString(), evaluatorPayout.toString());
     });
 
     it("should disburse nothing for unsatisfactory work, for evaluator", async () => {
+      const evaluator = accounts[1];
+
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await setupFundedTask({ colonyNetwork, colony, token });
+      const taskId = await setupFundedTask({ colonyNetwork, colony, token, evaluator });
       await forwardTime(SECONDS_PER_DAY * 10 + 1, this);
       await colony.finalizeTask(taskId);
 
       await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
       await colony.claimPayout(taskId, WORKER_ROLE, token.address, { from: WORKER });
-      await colony.claimPayout(taskId, EVALUATOR_ROLE, token.address, { from: EVALUATOR });
+      await colony.claimPayout(taskId, EVALUATOR_ROLE, token.address, { from: evaluator });
 
       const managerBalance = await token.balanceOf(MANAGER);
       const managerPayout = MANAGER_PAYOUT.divn(100).muln(99); // "Subtract" 1% fee
@@ -1792,7 +1784,7 @@ contract("Colony", accounts => {
       const workerPayout = WORKER_PAYOUT.divn(100).muln(99); // "Subtract" 1% fee
       assert.equal(workerBalance.toString(), workerPayout.toString());
 
-      const evaluatorBalance = await token.balanceOf(EVALUATOR);
+      const evaluatorBalance = await token.balanceOf(evaluator);
       assert.equal(evaluatorBalance.toNumber(), 0);
     });
 

--- a/test/colony.js
+++ b/test/colony.js
@@ -1384,7 +1384,7 @@ contract("Colony", accounts => {
     it("should fail if the task work ratings have not been assigned", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupFundedTask({ colonyNetwork, colony, token });
-      await checkErrorRevert(colony.finalizeTask(taskId), "colony-task-cannot-finalize");
+      await checkErrorRevert(colony.finalizeTask(taskId), "colony-task-ratings-incomplete");
     });
 
     it("should fail if I try to accept a task that was finalized before", async () => {

--- a/test/colony.js
+++ b/test/colony.js
@@ -315,8 +315,8 @@ contract("Colony", accounts => {
 
       await executeSignedTaskChange({
         colony,
-        functionName: "removeTaskEvaluatorRole",
         taskId,
+        functionName: "removeTaskEvaluatorRole",
         signers: [MANAGER], // NOTE: only one signature because manager === evaluator
         sigTypes: [0],
         args: [taskId]
@@ -327,8 +327,8 @@ contract("Colony", accounts => {
 
       await executeSignedRoleAssignment({
         colony,
-        functionName: "setTaskEvaluatorRole",
         taskId,
+        functionName: "setTaskEvaluatorRole",
         signers: [MANAGER, newEvaluator],
         sigTypes: [0, 0],
         args: [taskId, newEvaluator]
@@ -916,8 +916,8 @@ contract("Colony", accounts => {
       // Change the task brief
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskBrief",
         taskId,
+        functionName: "setTaskBrief",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, SPECIFICATION_HASH_UPDATED]
@@ -931,8 +931,8 @@ contract("Colony", accounts => {
 
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskDueDate",
         taskId,
+        functionName: "setTaskDueDate",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, dueDate]
@@ -949,8 +949,8 @@ contract("Colony", accounts => {
       // Change the task1 brief
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskBrief",
         taskId: taskId1,
+        functionName: "setTaskBrief",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId1, SPECIFICATION_HASH_UPDATED]
@@ -960,8 +960,8 @@ contract("Colony", accounts => {
 
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskBrief",
         taskId: taskId2,
+        functionName: "setTaskBrief",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId2, SPECIFICATION_HASH_UPDATED]
@@ -975,8 +975,8 @@ contract("Colony", accounts => {
 
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskDueDate",
         taskId: taskId2,
+        functionName: "setTaskDueDate",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId2, dueDate]
@@ -991,8 +991,8 @@ contract("Colony", accounts => {
 
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskBrief",
         taskId,
+        functionName: "setTaskBrief",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, SPECIFICATION_HASH_UPDATED]
@@ -1015,8 +1015,8 @@ contract("Colony", accounts => {
 
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskBrief",
         taskId,
+        functionName: "setTaskBrief",
         signers: [MANAGER, WORKER],
         sigTypes: [0, 0],
         args: [taskId, SPECIFICATION_HASH_UPDATED]
@@ -1039,8 +1039,8 @@ contract("Colony", accounts => {
 
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskBrief",
         taskId,
+        functionName: "setTaskBrief",
         signers: [MANAGER, WORKER],
         sigTypes: [1, 1],
         args: [taskId, SPECIFICATION_HASH_UPDATED]
@@ -1063,8 +1063,8 @@ contract("Colony", accounts => {
 
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskBrief",
         taskId,
+        functionName: "setTaskBrief",
         signers: [MANAGER, WORKER],
         sigTypes: [0, 1],
         args: [taskId, SPECIFICATION_HASH_UPDATED]
@@ -1088,8 +1088,8 @@ contract("Colony", accounts => {
       await checkErrorRevert(
         executeSignedTaskChange({
           colony,
-          functionName: "setTaskBrief",
           taskId,
+          functionName: "setTaskBrief",
           signers: [MANAGER, MANAGER],
           sigTypes: [0, 1],
           args: [taskId, SPECIFICATION_HASH_UPDATED]
@@ -1116,8 +1116,8 @@ contract("Colony", accounts => {
 
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskDueDate",
         taskId,
+        functionName: "setTaskDueDate",
         signers: [MANAGER, WORKER],
         sigTypes: [0, 0],
         args: [taskId, dueDate]
@@ -1138,8 +1138,8 @@ contract("Colony", accounts => {
       await checkErrorRevert(
         executeSignedTaskChange({
           colony,
-          functionName: "setTaskBrief",
           taskId,
+          functionName: "setTaskBrief",
           signers: [MANAGER, OTHER],
           sigTypes: [0, 0],
           args: [taskId, SPECIFICATION_HASH_UPDATED]
@@ -1163,8 +1163,8 @@ contract("Colony", accounts => {
       await checkErrorRevert(
         executeSignedTaskChange({
           colony,
-          functionName: "setTaskBrief",
           taskId,
+          functionName: "setTaskBrief",
           signers: [MANAGER],
           sigTypes: [0],
           args: [taskId, SPECIFICATION_HASH_UPDATED]
@@ -1179,8 +1179,8 @@ contract("Colony", accounts => {
       await checkErrorRevert(
         executeSignedTaskChange({
           colony,
-          functionName: "getTaskRole",
           taskId,
+          functionName: "getTaskRole",
           signers: [MANAGER, EVALUATOR],
           sigTypes: [0, 0],
           args: [taskId, 0]
@@ -1195,8 +1195,8 @@ contract("Colony", accounts => {
       await checkErrorRevert(
         executeSignedTaskChange({
           colony,
-          functionName: "setTaskBrief",
           taskId,
+          functionName: "setTaskBrief",
           signers: [MANAGER],
           sigTypes: [0],
           args: [10, SPECIFICATION_HASH_UPDATED]
@@ -1213,8 +1213,8 @@ contract("Colony", accounts => {
       await checkErrorRevert(
         executeSignedTaskChange({
           colony,
-          functionName: "setTaskBrief",
           taskId,
+          functionName: "setTaskBrief",
           signers: [MANAGER],
           sigTypes: [0],
           args: [taskId, SPECIFICATION_HASH_UPDATED]
@@ -1229,8 +1229,8 @@ contract("Colony", accounts => {
       await expectEvent(
         executeSignedTaskChange({
           colony,
-          functionName: "setTaskBrief",
           taskId,
+          functionName: "setTaskBrief",
           signers: [MANAGER],
           sigTypes: [0],
           args: [taskId, SPECIFICATION_HASH_UPDATED]
@@ -1246,8 +1246,8 @@ contract("Colony", accounts => {
       await expectEvent(
         executeSignedTaskChange({
           colony,
-          functionName: "setTaskDueDate",
           taskId,
+          functionName: "setTaskDueDate",
           signers: [MANAGER],
           sigTypes: [0],
           args: [taskId, dueDate]
@@ -1269,8 +1269,8 @@ contract("Colony", accounts => {
       await expectEvent(
         executeSignedTaskChange({
           colony,
-          functionName: "setTaskSkill",
           taskId,
+          functionName: "setTaskSkill",
           signers: [MANAGER],
           sigTypes: [0],
           args: [taskId, skillCount.toNumber()]
@@ -1501,8 +1501,8 @@ contract("Colony", accounts => {
 
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskDueDate",
         taskId,
+        functionName: "setTaskDueDate",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, dueDate]
@@ -1521,8 +1521,8 @@ contract("Colony", accounts => {
       // Set the manager payout as 5000 wei and 100 colony tokens
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, 0x0, 5000]
@@ -1530,8 +1530,8 @@ contract("Colony", accounts => {
 
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskManagerPayout",
         taskId,
+        functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, token.address, 100]
@@ -1540,8 +1540,8 @@ contract("Colony", accounts => {
       // Set the evaluator payout as 1000 ethers
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskEvaluatorPayout",
         taskId,
+        functionName: "setTaskEvaluatorPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, 0x0, 1000]
@@ -1550,8 +1550,8 @@ contract("Colony", accounts => {
       // Set the evaluator payout as 40 colony tokens
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskEvaluatorPayout",
         taskId,
+        functionName: "setTaskEvaluatorPayout",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, token.address, 40]
@@ -1560,8 +1560,8 @@ contract("Colony", accounts => {
       // Set the worker payout as 98000 wei and 200 colony tokens
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskWorkerPayout",
         taskId,
+        functionName: "setTaskWorkerPayout",
         signers: [MANAGER, WORKER],
         sigTypes: [0, 0],
         args: [taskId, 0x0, 98000]
@@ -1569,8 +1569,8 @@ contract("Colony", accounts => {
 
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskWorkerPayout",
         taskId,
+        functionName: "setTaskWorkerPayout",
         signers: [MANAGER, WORKER],
         sigTypes: [0, 0],
         args: [taskId, token.address, 200]
@@ -1663,8 +1663,8 @@ contract("Colony", accounts => {
       await expectEvent(
         executeSignedTaskChange({
           colony,
-          functionName: "setTaskWorkerPayout",
           taskId,
+          functionName: "setTaskWorkerPayout",
           signers: [MANAGER, WORKER],
           sigTypes: [0, 0],
           args: [taskId, 0x0, 98000]

--- a/test/colony.js
+++ b/test/colony.js
@@ -1169,7 +1169,7 @@ contract("Colony", accounts => {
           sigTypes: [0],
           args: [taskId, SPECIFICATION_HASH_UPDATED]
         }),
-        "colony-task-signatures-do-not-match-reviewer-2"
+        "colony-task-change-does-not-meet-signatures-required"
       );
     });
 
@@ -1384,7 +1384,7 @@ contract("Colony", accounts => {
     it("should fail if the task work ratings have not been assigned", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupFundedTask({ colonyNetwork, colony, token });
-      await checkErrorRevert(colony.finalizeTask(taskId), "colony-task-worker-rating-missing");
+      await checkErrorRevert(colony.finalizeTask(taskId), "colony-task-cannot-finalize");
     });
 
     it("should fail if I try to accept a task that was finalized before", async () => {
@@ -1599,24 +1599,6 @@ contract("Colony", accounts => {
 
       const taskPayoutWorker = await colony.getTaskPayout(taskId, WORKER_ROLE, 0x0);
       assert.equal(taskPayoutWorker.toNumber(), 98000);
-    });
-
-    it("should not be able to set all payments at once if evaluator is assigned and not manager", async () => {
-      let dueDate = await currentBlockTime();
-      dueDate += SECONDS_PER_DAY * 7;
-
-      const taskId = await makeTask({ colony, dueDate });
-
-      await executeSignedRoleAssignment({
-        colony,
-        taskId,
-        functionName: "setTaskEvaluatorRole",
-        signers: [MANAGER, EVALUATOR],
-        sigTypes: [0, 0],
-        args: [taskId, EVALUATOR]
-      });
-
-      await checkErrorRevert(colony.setAllTaskPayouts(taskId, 0x0, 5000, 1000, 98000), "colony-funding-evaluator-already-set");
     });
 
     it("should not be able to set all payments at once if worker is assigned and not manager", async () => {

--- a/test/colony.js
+++ b/test/colony.js
@@ -1494,19 +1494,10 @@ contract("Colony", accounts => {
 
   describe("when funding tasks", () => {
     it("should be able to set the task payouts for different roles", async () => {
-      const taskId = await makeTask({ colony });
-
       let dueDate = await currentBlockTime();
       dueDate += SECONDS_PER_DAY * 7;
 
-      await executeSignedTaskChange({
-        colony,
-        taskId,
-        functionName: "setTaskDueDate",
-        signers: [MANAGER],
-        sigTypes: [0],
-        args: [taskId, dueDate]
-      });
+      const taskId = await makeTask({ colony, dueDate });
 
       await executeSignedRoleAssignment({
         colony,

--- a/test/colony.js
+++ b/test/colony.js
@@ -1778,7 +1778,6 @@ contract("Colony", accounts => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupFundedTask({ colonyNetwork, colony, token });
       await forwardTime(SECONDS_PER_DAY * 10 + 1, this);
-      await colony.assignWorkRating(taskId);
       await colony.finalizeTask(taskId);
 
       await colony.claimPayout(taskId, MANAGER_ROLE, token.address);

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -424,8 +424,8 @@ contract("Meta Colony", accounts => {
 
       await executeSignedTaskChange({
         colony,
-        functionName: "setTaskSkill",
         taskId,
+        functionName: "setTaskSkill",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, 6]

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -25,7 +25,7 @@ const ReputationMiningCycle = artifacts.require("ReputationMiningCycle");
 
 contract("Colony Reputation Updates", accounts => {
   const MANAGER = accounts[0];
-  const EVALUATOR = accounts[1];
+  const EVALUATOR = MANAGER;
   const WORKER = accounts[2];
   const OTHER = accounts[3];
 


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #296

<!--- Summary of changes including design decisions -->

- [x] Setting the evaluator to the task creator (similarly to how the manager is assigned) as for the Colony Contribute these 2 roles will be fulfilled by the same person. We'll still allow for the role to be reassigned later
- [x] Submitting the deliverable and rating for the task manager. If they are submitting the task, the immediate next thing they need to do is rate the manager
- [x] Public functions assignWorkRating + finalizeTask?
- [ ] Changing task role assignments currently requires removeTaskXRole followed by setTaskXRole, perhaps these can be part of the same call?

SO:

- Automatically assign task creator as both manager and evaluator
- Create `submitTaskDeliverableAndRating` function which wraps `submitTaskDeliverable` and `submitTaskWorkRating`
- Make `assignWorkRating` an internal function and bundle it into a more general `finalizeTask`.

Will not create a combined `reassignTaskXRole` function now since it involves doing something fancy with signatures.