### PR TITLE
Upgrade truffle to next.9

### DIFF
--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -164,9 +164,7 @@ export async function expectAllEvents(tx, eventNames) {
 }
 
 export async function forwardTime(seconds, test) {
-  // TODO: Get the client via web3GetClient() which requires web3 beta34 for `getNodeInfo`.
-  // Current version of truffle 5.0.0-next.6
-  const client = "TestRPC";
+  const client = await web3GetClient();
   const p = new Promise((resolve, reject) => {
     if (client.indexOf("TestRPC") === -1) {
       resolve(test.skip());

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "solidity-coverage": "0.5.7",
     "solidity-parser-antlr": "^0.3.0",
     "solium": "^1.1.8",
-    "truffle": "^5.0.0-next.7",
+    "truffle": "^5.0.0-next.9",
     "web3-utils": "^1.0.0-beta.34"
   },
   "private": true,

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -138,12 +138,12 @@ contract("ColonyNetworkMining", accounts => {
       while (noError) {
         let txHash = await client1.respondToBinarySearchForChallenge(); // eslint-disable-line no-await-in-loop
         let tx = await web3GetTransactionReceipt(txHash); // eslint-disable-line no-await-in-loop
-        if (parseInt(tx.status, 16) === 0) {
+        if (!tx.status) {
           noError = false;
         }
         txHash = await client2.respondToBinarySearchForChallenge(); // eslint-disable-line no-await-in-loop
         tx = await web3GetTransactionReceipt(txHash); // eslint-disable-line no-await-in-loop
-        if (parseInt(tx.status, 16) === 0) {
+        if (!tx.status) {
           noError = false;
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2041,6 +2041,12 @@ decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decamelize@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-2.0.0.tgz#656d7bbc8094c4c788ea53c5840908c9c7d063c7"
+  dependencies:
+    xregexp "4.0.0"
+
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
@@ -7464,9 +7470,9 @@ trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
 
-truffle@^5.0.0-next.7:
-  version "5.0.0-next.7"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.0-next.7.tgz#f6d6a4a82a1efc520a46a19d5467c9e7bb0def8a"
+truffle@^5.0.0-next.9:
+  version "5.0.0-next.9"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.0-next.9.tgz#47141465a08cf44925cbb4a864f1dbab0ce8a1e2"
   dependencies:
     mocha "^4.1.0"
     original-require "1.0.1"
@@ -8168,6 +8174,10 @@ xmlhttprequest@*, xmlhttprequest@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
 
+xregexp@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020"
+
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
@@ -8186,6 +8196,10 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
+"y18n@^3.2.1 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+
 yaeti@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
@@ -8197,6 +8211,12 @@ yallist@^2.1.2:
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
+
+yargs-parser@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs-parser@^2.4.1:
   version "2.4.1"
@@ -8262,6 +8282,23 @@ yargs@^11.0.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
+
+yargs@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.1.tgz#6432e56123bb4e7c3562115401e98374060261c2"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^2.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1 || ^4.0.0"
+    yargs-parser "^10.1.0"
 
 yargs@^4.6.0, yargs@^4.7.1:
   version "4.8.1"


### PR DESCRIPTION
`next.9` upgrades web3 to `beta.35`. They changed the way the `status` field on the receipt is formatted from hex number to boolean. Just couple places in one of the test helpers where this value is checked directly - have updated those.

And `getNodeInfo` is available so have re-enabled the client check for `forwardTime`.



