### PR TITLE
chore(package): update ganache-cli to version 6.1.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,8 @@ step_setup_global_packages: &step_setup_global_packages
     name: "Set up global packages"
     command: |
       yarn --pure-lockfile
+      # Trigger husky install manually due to https://github.com/typicode/husky/issues/227
+      node node_modules/husky/lib/installer/bin install
       git submodule update --init
 step_setup_greenkeeper: &step_setup_greenkeeper
   run:

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eth-ens-namehash": "^2.0.8",
     "eth-gas-reporter": "^0.1.2",
     "ethereumjs-util": "^5.2.0",
-    "ganache-cli": "6.1.6",
+    "ganache-cli": "6.1.8",
     "ganache-core": "^2.0.2",
     "husky": "^1.0.0-rc.13",
     "istanbul": "^0.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3273,9 +3273,9 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-ganache-cli@6.1.6:
-  version "6.1.6"
-  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.1.6.tgz#99b500a25f571271a6978ef3f9c9c53e1a3854f0"
+ganache-cli@6.1.8:
+  version "6.1.8"
+  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.1.8.tgz#49a8a331683a9652183f82ef1378d17e1814fcd3"
   dependencies:
     source-map-support "^0.5.3"
 


### PR DESCRIPTION
Closes #310

Also trigger husky install manually due to https://github.com/typicode/husky/issues/227