### PR TITLE
Split `startNextCycle` into two functions

### DIFF
--- a/contracts/ColonyNetworkMining.sol
+++ b/contracts/ColonyNetworkMining.sol
@@ -42,15 +42,20 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
     rewardStakers(stakers);
   }
 
+  function initialiseReputationMining() public {
+    require(inactiveReputationMiningCycle == 0x0);
+    address clnyToken = IColony(metaColony).getToken();
+    require(clnyToken != 0x0);
+    inactiveReputationMiningCycle = new ReputationMiningCycle(tokenLocking, clnyToken);
+  }
+
   function startNextCycle() public {
     address clnyToken = IColony(metaColony).getToken();
     require(clnyToken != 0x0);
     require(activeReputationMiningCycle == 0x0);
+    require(inactiveReputationMiningCycle != 0x0);
+    // Inactive now becomes active
     activeReputationMiningCycle = inactiveReputationMiningCycle;
-    if (activeReputationMiningCycle == 0x0) {
-      // This will only be true the very first time that this is run, to kick off the whole reputation mining process
-      activeReputationMiningCycle = new ReputationMiningCycle(tokenLocking, clnyToken);
-    }
     ReputationMiningCycle(activeReputationMiningCycle).resetWindow();
     inactiveReputationMiningCycle = new ReputationMiningCycle(tokenLocking, clnyToken);
   }

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -156,6 +156,9 @@ contract IColonyNetwork {
   /// subsequently called from within `setReputationRootHash`
   function startNextCycle() public;
 
+  /// @notice Creates initial inactive reputation mining cycle
+  function initialiseReputationMining() public;
+
   /// @notice Get the root hash of the current reputation state tree
   /// @return rootHash bytes32 The current Reputation Root Hash
   function getReputationRootHash() public view returns (bytes32 rootHash);

--- a/migrations/6_setup_meta_colony.js
+++ b/migrations/6_setup_meta_colony.js
@@ -34,6 +34,7 @@ module.exports = deployer => {
     })
     .then(() => ITokenLocking.at(tokenLocking))
     .then(iTokenLocking => iTokenLocking.deposit(token.address, "10000000000000000"))
+    .then(() => colonyNetwork.initialiseReputationMining())
     .then(() => colonyNetwork.startNextCycle())
     .then(() => colonyNetwork.getSkillCount())
     .then(skillCount => {

--- a/test/colony.js
+++ b/test/colony.js
@@ -87,6 +87,7 @@ contract("Colony", accounts => {
     const clnyToken = await Token.new("Colony Network Token", "CLNY", 18);
     await colonyNetwork.createMetaColony(clnyToken.address);
 
+    await colonyNetwork.initialiseReputationMining();
     await colonyNetwork.startNextCycle();
   });
 

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -45,6 +45,7 @@ contract("Meta Colony", accounts => {
     const metaColonyAddress = await colonyNetwork.getMetaColony();
     metaColony = await IColony.at(metaColonyAddress);
 
+    await colonyNetwork.initialiseReputationMining();
     await colonyNetwork.startNextCycle();
   });
 

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -59,6 +59,7 @@ contract("Colony Reputation Updates", accounts => {
       .mul(new BN(1000))
       .toString();
     await fundColonyWithTokens(metaColony, colonyToken, amount);
+    await colonyNetwork.initialiseReputationMining();
     await colonyNetwork.startNextCycle();
     const inactiveReputationMiningCycleAddress = await colonyNetwork.getReputationMiningCycle(false);
     inactiveReputationMiningCycle = await ReputationMiningCycle.at(inactiveReputationMiningCycleAddress);


### PR DESCRIPTION
Due to this function starting to run out of block gas limit we've had to split it in two. More details on where the issue was identified first:
https://github.com/JoinColony/colonyNetwork/pull/295#discussion_r208863960