### PR TITLE
Convenience methods for setting task properities

### DIFF
--- a/contracts/Authority.sol
+++ b/contracts/Authority.sol
@@ -55,8 +55,8 @@ contract Authority is DSRoles {
     setAdminRoleCapability(colony, "addDomain(uint256)");
     setOwnerRoleCapability(colony, "addDomain(uint256)");
     // Add task
-    setAdminRoleCapability(colony, "makeTask(bytes32,uint256)");
-    setOwnerRoleCapability(colony, "makeTask(bytes32,uint256)");
+    setAdminRoleCapability(colony, "makeTask(bytes32,uint256,uint256,uint256)");
+    setOwnerRoleCapability(colony, "makeTask(bytes32,uint256,uint256,uint256)");
     // Start next reward payout
     setAdminRoleCapability(colony, "startNextRewardPayout(address)");
     setOwnerRoleCapability(colony, "startNextRewardPayout(address)");

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -51,6 +51,27 @@ contract ColonyFunding is ColonyStorage {
     emit TaskWorkerPayoutChanged(_id, _token, _amount);
   }
 
+  function setAllTaskPayouts(
+    uint256 _id,
+    address _token,
+    uint256 _managerAmount,
+    uint256 _evaluatorAmount,
+    uint256 _workerAmount
+  )
+  public
+  stoppable
+  {
+    Task storage task = tasks[_id];
+
+    require(task.roles[MANAGER].user == msg.sender, "colony-funding-must-be-manager");
+    require(task.roles[EVALUATOR].user == task.roles[MANAGER].user || task.roles[EVALUATOR].user == 0x0, "colony-funding-evaluator-already-set");
+    require(task.roles[WORKER].user == task.roles[MANAGER].user || task.roles[WORKER].user == 0x0, "colony-funding-worker-already-set");
+
+    this.setTaskManagerPayout(_id, _token, _managerAmount);
+    this.setTaskEvaluatorPayout(_id, _token, _evaluatorAmount);
+    this.setTaskWorkerPayout(_id, _token, _workerAmount);
+  }
+
   // To get all payouts for a task iterate over roles.length
   function getTaskPayout(uint256 _id, uint256 _role, address _token) public view returns (uint256) {
     Task storage task = tasks[_id];

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -108,7 +108,7 @@ contract ColonyTask is ColonyStorage {
     _;
   }
 
-  function makeTask(bytes32 _specificationHash, uint256 _domainId) public
+  function makeTask(bytes32 _specificationHash, uint256 _domainId, uint256 _skillId, uint256 _dueDate) public
   stoppable
   auth
   domainExists(_domainId)
@@ -132,6 +132,15 @@ contract ColonyTask is ColonyStorage {
 
     emit PotAdded(potCount);
     emit TaskAdded(taskCount);
+
+    if (_skillId > 0) {
+      this.setTaskSkill(taskCount, _skillId);
+    }
+
+    if (_dueDate > 0) {
+      this.setTaskDueDate(taskCount, _dueDate);
+    }
+
   }
 
   function getTaskCount() public view returns (uint256) {

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -479,6 +479,15 @@ contract IColony {
   /// @param _amount Payout amount
   function setTaskWorkerPayout(uint256 _id, address _token, uint256 _amount) public;
 
+  /// @notice Set `_token` payout for all roles in task `_id` to the respective amounts
+  /// @dev Can only call if evaluator and worker are unassigned or manager, otherwise need signature
+  /// @param _id Id of the task
+  /// @param _token Address of the token, `0x0` value indicates Ether
+  /// @param _managerAmount Payout amount for manager
+  /// @param _evaluatorAmount Payout amount for evaluator
+  /// @param _workerAmount Payout amount for worker
+  function setAllTaskPayouts(uint256 _id,address _token,uint256 _managerAmount,uint256 _evaluatorAmount,uint256 _workerAmount) public;
+
   /// @notice Claim the payout in `_token` denomination for work completed in task `_id` by contributor with role `_role`
   /// Allowed only by the contributors themselves after task is finalized. Here the network receives its fee from each payout.
   /// Ether fees go straight to the Meta Colony whereas Token fees go to the Network to be auctioned off.

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -234,7 +234,9 @@ contract IColony {
   /// @notice Make a new task in the colony. Secured function to authorised members
   /// @param _specificationHash Database identifier where the task specification is stored
   /// @param _domainId The domain where the task belongs
-  function makeTask(bytes32 _specificationHash, uint256 _domainId) public;
+  /// @param _skillId The skill associated with the task, can set to 0 for no-op
+  /// @param _dueDate The due date of the task, can set to 0 for no-op
+  function makeTask(bytes32 _specificationHash, uint256 _domainId, uint256 _skillId, uint256 _dueDate) public;
 
   /// @notice Get the number of tasks in the colony
   /// @return count The task count

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -20,8 +20,8 @@ const IColony = artifacts.require("IColony");
 const ITokenLocking = artifacts.require("ITokenLocking");
 const Token = artifacts.require("Token");
 
-export async function makeTask({ colony, hash = SPECIFICATION_HASH, domainId = 1 }) {
-  const { logs } = await colony.makeTask(hash, domainId);
+export async function makeTask({ colony, hash = SPECIFICATION_HASH, domainId = 1, skillId = 0, dueDate = 0 }) {
+  const { logs } = await colony.makeTask(hash, domainId, skillId, dueDate);
   // Reading the ID out of the event triggered by our transaction will allow us to make multiple tasks in parallel in the future.
   return logs.filter(log => log.event === "TaskAdded")[0].args.id;
 }


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #251 

<!--- Summary of changes including design decisions -->

- Extend `makeTask` to take optional `_skillId` and `_dueDate` arguments. Passing 0 results in a no-op.
- Add `setAllTaskPayouts` to allow manager to set payouts before new evaluator or worker is assigned.

Initial issue asked for all functionality to be available in one go, but there were some limitations:

- Task funding logic lives separately from task creation logic, so you cannot call `setXPayout` functions from within `ColonyTask.sol`.
- Funding can be denominated in many tokens, so may need to call `setAllTaskPayouts` multiple times.

Having a bulk payout setting function alongside an extended `makeTask` seemed like a reasonable way to go.