### PR TITLE
Add 'task completion' to task workflow; make due date optional

### DIFF
--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -151,7 +151,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
       Task storage task = tasks[fromTaskId];
       uint totalPayout = getTotalTaskPayout(fromTaskId, _token);
       uint surplus = (fromPotPreviousAmount > totalPayout) ? sub(fromPotPreviousAmount, totalPayout) : 0;
-      require(task.cancelled || surplus >= _amount, "colony-funding-task-bad-state");
+      require(task.status == CANCELLED || surplus >= _amount, "colony-funding-task-bad-state");
     }
 
     pots[_fromPot].balance[_token] = sub(fromPotPreviousAmount, _amount);

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -96,7 +96,7 @@ contract ColonyStorage is DSAuth, DSMath {
   uint8 constant EVALUATOR = 1;
   uint8 constant WORKER = 2;
 
-  // Task Sates
+  // Task States
   uint8 constant ACTIVE = 0;
   uint8 constant CANCELLED = 1;
   uint8 constant FINALIZED = 2;

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -86,12 +86,20 @@ contract ColonyStorage is DSAuth, DSMath {
   uint256 potCount;
   uint256 domainCount;
 
+  // Colony-wide roles
   uint8 constant OWNER_ROLE = 0;
   uint8 constant ADMIN_ROLE = 1;
   uint8 constant RECOVERY_ROLE = 2;
+
+  // Task Roles
   uint8 constant MANAGER = 0;
   uint8 constant EVALUATOR = 1;
   uint8 constant WORKER = 2;
+
+  // Task Sates
+  uint8 constant ACTIVE = 0;
+  uint8 constant CANCELLED = 1;
+  uint8 constant FINALIZED = 2;
 
   // Variables for recovery mode
   bool recoveryMode;
@@ -106,12 +114,11 @@ contract ColonyStorage is DSAuth, DSMath {
   struct Task {
     bytes32 specificationHash;
     bytes32 deliverableHash;
-    bool finalized;
-    bool cancelled;
+    uint8 status;
     uint256 dueDate;
     uint256 payoutsWeCannotMake;
     uint256 potId;
-    uint256 deliverableTimestamp;
+    uint256 completionTimestamp;
     uint256 domainId;
     uint256[] skills;
 
@@ -160,12 +167,12 @@ contract ColonyStorage is DSAuth, DSMath {
   }
 
   modifier taskNotFinalized(uint256 _id) {
-    require(!tasks[_id].finalized, "colony-task-already-finalized");
+    require(tasks[_id].status != FINALIZED, "colony-task-already-finalized");
     _;
   }
 
   modifier taskFinalized(uint256 _id) {
-    require(tasks[_id].finalized, "colony-task-not-finalized");
+    require(tasks[_id].status == FINALIZED, "colony-task-not-finalized");
     _;
   }
 

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -73,7 +73,8 @@ contract ColonyTask is ColonyStorage {
 
   modifier afterDueDate(uint256 _id) {
     uint dueDate = tasks[_id].dueDate;
-    require(dueDate > 0 && now >= dueDate, "colony-task-due-date-in-future");
+    require(dueDate > 0, "colony-task-due-date-not-set");
+    require(now >= dueDate, "colony-task-due-date-in-future");
     _;
   }
 

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -390,7 +390,7 @@ contract IColony {
 
   /// @notice Submit the task deliverable, i.e. the output of the work performed for task `_id`
   /// Submission is allowed only to the assigned worker before the task due date. Submissions cannot be overwritten
-  /// @dev Set the `task.deliverableHash` and `task.deliverableTimestamp` properties
+  /// @dev Set the `task.deliverableHash` and `task.completionTimestamp` properties
   /// @param _id Id of the task
   /// @param _deliverableHash Unique hash of the task deliverable content in ddb
   function submitTaskDeliverable(uint256 _id, bytes32 _deliverableHash) public;
@@ -428,7 +428,7 @@ contract IColony {
   /// @return dueDate Due date
   /// @return payoutsWeCannotMake Number of payouts that cannot be completed with the current task funding
   /// @return potId Id of funding pot for task
-  /// @return deliverableTimestamp Deliverable submission timestamp
+  /// @return completionTimestamp Task completion timestamp
   /// @return domainId Task domain id, default is root colony domain with id 1
   /// @return skillIds Array of global skill ids assigned to task
   function getTask(uint256 _id) public view returns (

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -64,6 +64,11 @@ contract IColony {
   /// @param deliverableHash Hash of the work performed
   event TaskDeliverableSubmitted(uint256 indexed id, bytes32 deliverableHash);
 
+  /// @notice Event logged when a task has been completed. This is either because the dueDate has passed
+  /// and the manager has become tired of waiting, or the worker has submitted the deliverable. In the
+  /// latter case, TaskDeliverableSubmitted will also be emitted.
+  event TaskCompleted(uint256 indexed id);
+
   /// @notice Event logged when the rating of a role was revealed
   /// @param id Id of the task
   /// @param role Role that got rated
@@ -405,16 +410,21 @@ contract IColony {
 
   /// @notice Cancel a task at any point before it is finalized. Secured function to authorised members
   /// Any funds assigned to its funding pot can be moved back to the domain via `IColony.moveFundsBetweenPots`
-  /// @dev Set the `task.cancelled` property to true
+  /// @dev Set the `task.status` property to 1
   /// @param _id Id of the task
   function cancelTask(uint256 _id) public;
+
+  /// @notice Mark a task as complete after the due date has passed.
+  /// This allows the task to be rated and finalized (and funds recovered) even in the presence of a work who has disappeared.
+  /// Note that if the due date was not set, then this function will throw.
+  /// @param _id Id of the task
+  function completeTask(uint256 _id) public;
 
   /// @notice Get a task with id `_id`
   /// @param _id Id of the task
   /// @return specificationHash Task brief hash
   /// @return deliverableHash Task deliverable hash
-  /// @return finalized Finalised property
-  /// @return cancelled Cancelled property
+  /// @return status Status property. 0 - Active. 1 - Cancelled. 2 - Finalized
   /// @return dueDate Due date
   /// @return payoutsWeCannotMake Number of payouts that cannot be completed with the current task funding
   /// @return potId Id of funding pot for task
@@ -424,12 +434,11 @@ contract IColony {
   function getTask(uint256 _id) public view returns (
     bytes32 specificationHash,
     bytes32 deliverableHash,
-    bool finalized,
-    bool cancelled,
+    uint8 status,
     uint256 dueDate,
     uint256 payoutsWeCannotMake,
     uint256 potId,
-    uint256 deliverableTimestamp,
+    uint256 completionTimestamp,
     uint256 domainId,
     uint256[] skillIds
     );

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -65,7 +65,7 @@ contract IColony {
   event TaskDeliverableSubmitted(uint256 indexed id, bytes32 deliverableHash);
 
   /// @notice Event logged when a task has been completed. This is either because the dueDate has passed
-  /// and the manager has become tired of waiting, or the worker has submitted the deliverable. In the
+  /// and the manager closed the task, or the worker has submitted the deliverable. In the
   /// latter case, TaskDeliverableSubmitted will also be emitted.
   event TaskCompleted(uint256 indexed id);
 
@@ -415,7 +415,7 @@ contract IColony {
   function cancelTask(uint256 _id) public;
 
   /// @notice Mark a task as complete after the due date has passed.
-  /// This allows the task to be rated and finalized (and funds recovered) even in the presence of a work who has disappeared.
+  /// This allows the task to be rated and finalized (and funds recovered) even in the presence of a worker who has disappeared.
   /// Note that if the due date was not set, then this function will throw.
   /// @param _id Id of the task
   function completeTask(uint256 _id) public;

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -23,6 +23,10 @@ const RATING_2_SALT = web3Utils.soliditySha3(getRandomString(10));
 const RATING_1_SECRET = web3Utils.soliditySha3(RATING_1_SALT, MANAGER_RATING);
 const RATING_2_SECRET = web3Utils.soliditySha3(RATING_2_SALT, WORKER_RATING);
 
+const ACTIVE_TASK_STATE = 0;
+const CANCELLED_TASK_STATE = 1;
+const FINALIZED_TASK_STATE = 2;
+
 module.exports = {
   MANAGER_ROLE,
   EVALUATOR_ROLE,
@@ -41,5 +45,8 @@ module.exports = {
   RATING_1_SALT,
   RATING_2_SALT,
   RATING_1_SECRET,
-  RATING_2_SECRET
+  RATING_2_SECRET,
+  ACTIVE_TASK_STATE,
+  CANCELLED_TASK_STATE,
+  FINALIZED_TASK_STATE
 };

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -116,7 +116,7 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
   });
 
   let dueDateTimestamp = dueDate;
-  if (!dueDateTimestamp) {
+  if (dueDateTimestamp !== 0 && !dueDateTimestamp) {
     dueDateTimestamp = await currentBlockTime();
   }
 

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -12,7 +12,8 @@ import {
   RATING_2_SALT,
   MANAGER_ROLE,
   WORKER_ROLE,
-  SPECIFICATION_HASH
+  SPECIFICATION_HASH,
+  DELIVERABLE_HASH
 } from "./constants";
 import { currentBlockTime, createSignatures, createSignaturesTrezor, web3GetAccounts } from "./test-helper";
 
@@ -156,7 +157,7 @@ export async function setupFundedTask({
   }
   const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate, domain, skill, evaluator, worker });
   const task = await colony.getTask(taskId);
-  const potId = task[6].toNumber();
+  const potId = task[5].toNumber();
   const managerPayoutBN = new BN(managerPayout);
   const evaluatorPayoutBN = new BN(evaluatorPayout);
   const workerPayoutBN = new BN(workerPayout);
@@ -233,6 +234,9 @@ export async function setupRatedTask({
     evaluatorPayout,
     workerPayout
   });
+
+  await colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH, { from: worker });
+
   const WORKER_RATING_SECRET = web3Utils.soliditySha3(workerRatingSalt, workerRating);
   const MANAGER_RATING_SECRET = web3Utils.soliditySha3(managerRatingSalt, managerRating);
   await colony.submitTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING_SECRET, { from: evaluator });

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -15,7 +15,7 @@ import {
   SPECIFICATION_HASH,
   DELIVERABLE_HASH
 } from "./constants";
-import { currentBlockTime, createSignatures, createSignaturesTrezor, web3GetAccounts } from "./test-helper";
+import { createSignatures, createSignaturesTrezor, web3GetAccounts } from "./test-helper";
 
 const IColony = artifacts.require("IColony");
 const ITokenLocking = artifacts.require("ITokenLocking");
@@ -115,19 +115,17 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
     args: [taskId, worker]
   });
 
-  let dueDateTimestamp = dueDate;
-  if (dueDateTimestamp !== 0 && !dueDateTimestamp) {
-    dueDateTimestamp = await currentBlockTime();
+  const dueDateTimestamp = dueDate;
+  if (dueDateTimestamp) {
+    await executeSignedTaskChange({
+      colony,
+      taskId,
+      functionName: "setTaskDueDate",
+      signers,
+      sigTypes,
+      args: [taskId, dueDateTimestamp]
+    });
   }
-
-  await executeSignedTaskChange({
-    colony,
-    taskId,
-    functionName: "setTaskDueDate",
-    signers,
-    sigTypes,
-    args: [taskId, dueDateTimestamp]
-  });
   return taskId;
 }
 

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -193,13 +193,13 @@ contract("Colony Funding", accounts => {
         args: [taskId, otherToken.address, 0]
       });
       let task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 0);
+      assert.equal(task[4].toNumber(), 0);
 
       // Pot 0, Payout 0
       // Pot was equal to payout, transition to pot being equal by changing pot (17)
       await colony.moveFundsBetweenPots(1, 2, 0, otherToken.address);
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 0);
+      assert.equal(task[4].toNumber(), 0);
 
       // Pot 0, Payout 0
       // Pot was equal to payout, transition to pot being lower by increasing payout (8)
@@ -212,19 +212,19 @@ contract("Colony Funding", accounts => {
         args: [taskId, otherToken.address, 40]
       });
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 1);
+      assert.equal(task[4].toNumber(), 1);
 
       // Pot 0, Payout 40
       // Pot was below payout, transition to being equal by increasing pot (1)
       await colony.moveFundsBetweenPots(1, 2, 40, otherToken.address);
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 0);
+      assert.equal(task[4].toNumber(), 0);
 
       // Pot 40, Payout 40
       // Pot was equal to payout, transition to being above by increasing pot (5)
       await colony.moveFundsBetweenPots(1, 2, 40, otherToken.address);
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 0);
+      assert.equal(task[4].toNumber(), 0);
 
       // Pot 80, Payout 40
       // Pot was above payout, transition to being equal by increasing payout (12)
@@ -237,7 +237,7 @@ contract("Colony Funding", accounts => {
         args: [taskId, otherToken.address, 80]
       });
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 0);
+      assert.equal(task[4].toNumber(), 0);
 
       // Pot 80, Payout 80
       // Pot was equal to payout, transition to being above by decreasing payout (6)
@@ -250,13 +250,13 @@ contract("Colony Funding", accounts => {
         args: [taskId, otherToken.address, 40]
       });
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 0);
+      assert.equal(task[4].toNumber(), 0);
 
       // Pot 80, Payout 40
       // Pot was above payout, transition to being equal by decreasing pot (11)
       await colony.moveFundsBetweenPots(2, 1, 40, otherToken.address);
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 0);
+      assert.equal(task[4].toNumber(), 0);
 
       // Pot 40, Payout 40
       // Pot was equal to payout, transition to pot being below payout by changing pot (7)
@@ -285,7 +285,7 @@ contract("Colony Funding", accounts => {
       // Pot was below payout, change to being above by changing pot (3)
       await colony.moveFundsBetweenPots(1, 2, 60, otherToken.address);
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 0);
+      assert.equal(task[4].toNumber(), 0);
 
       // Pot 80, Payout 40
       // Pot was above payout, change to being below by changing pot (9)
@@ -321,7 +321,7 @@ contract("Colony Funding", accounts => {
         args: [taskId, otherToken.address, 10]
       });
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 0);
+      assert.equal(task[4].toNumber(), 0);
 
       // Pot 20, Payout 10
       // Pot was above, change to being above by changing payout (16)
@@ -334,13 +334,13 @@ contract("Colony Funding", accounts => {
         args: [taskId, otherToken.address, 5]
       });
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 0);
+      assert.equal(task[4].toNumber(), 0);
 
       // Pot 20, Payout 5
       // Pot was above, change to being above by changing pot (15)
       await colony.moveFundsBetweenPots(2, 1, 10, otherToken.address);
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 0);
+      assert.equal(task[4].toNumber(), 0);
 
       // Pot 10, Payout 5
       // Pot was above payout, change to being below by changing payout (10)
@@ -353,7 +353,7 @@ contract("Colony Funding", accounts => {
         args: [taskId, otherToken.address, 40]
       });
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 1);
+      assert.equal(task[4].toNumber(), 1);
 
       // Pot 10, Payout 40
       // Pot was below payout, change to being below by changing payout (14)
@@ -366,7 +366,7 @@ contract("Colony Funding", accounts => {
         args: [taskId, otherToken.address, 30]
       });
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 1);
+      assert.equal(task[4].toNumber(), 1);
 
       // Pot 10, Payout 30
       // Pot was below payout, change to being below by changing pot (13)
@@ -402,7 +402,7 @@ contract("Colony Funding", accounts => {
         args: [taskId, otherToken.address, 5]
       });
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 0);
+      assert.equal(task[4].toNumber(), 0);
 
       // Pot 5, Payout 5
     });
@@ -463,7 +463,7 @@ contract("Colony Funding", accounts => {
       await colony.claimPayout(taskId, WORKER_ROLE, token.address, { from: WORKER });
 
       const taskInfo = await colony.getTask(taskId);
-      const taskPotId = taskInfo[6].toNumber();
+      const taskPotId = taskInfo[5].toNumber();
       const remainingPotBalance = await colony.getPotBalance(taskPotId, token.address);
       assert.equal(remainingPotBalance.toString(), WORKER_PAYOUT.toString(), "should have remaining pot balance equal to worker payout");
 
@@ -545,12 +545,12 @@ contract("Colony Funding", accounts => {
         args: [taskId, 0x0, 40]
       });
       let task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 1);
+      assert.equal(task[4].toNumber(), 1);
 
       // Fund the pot equal to manager payout 40 = 40
       await colony.moveFundsBetweenPots(1, 2, 40, 0x0);
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 0);
+      assert.equal(task[4].toNumber(), 0);
 
       // Cannot bring pot balance below current payout
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 30, 0x0), "colony-funding-task-bad-state");
@@ -565,12 +565,12 @@ contract("Colony Funding", accounts => {
         args: [taskId, 0x0, 50]
       });
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 1);
+      assert.equal(task[4].toNumber(), 1);
 
       // Fund the pot equal to manager payout, plus 10, 50 < 60
       await colony.moveFundsBetweenPots(1, 2, 20, 0x0);
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 0);
+      assert.equal(task[4].toNumber(), 0);
 
       // Cannot bring pot balance below current payout
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 30, 0x0), "colony-funding-task-bad-state");
@@ -578,7 +578,7 @@ contract("Colony Funding", accounts => {
       // Can remove surplus 50 = 50
       await colony.moveFundsBetweenPots(2, 1, 10, 0x0);
       task = await colony.getTask(taskId);
-      assert.equal(task[5].toNumber(), 0);
+      assert.equal(task[4].toNumber(), 0);
     });
 
     it("should pay fees on revenue correctly", async () => {

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -84,8 +84,9 @@ contract("Colony Task Work Rating", accounts => {
       assert.equal(ratingSecret, RATING_1_SECRET);
     });
 
-    it("should allow rating, after the due date has passed, when no work has been submitted", async () => {
+    it("should allow rating after the due date has passed when no work has been submitted and the manager has marked the task complete", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
 
@@ -104,8 +105,14 @@ contract("Colony Task Work Rating", accounts => {
       assert.equal(ratingSecrets[0].toNumber(), 0);
     });
 
+    it("should not allow the manager to mark a task as complete if no due date is set");
+    it("should not allow the manager to mark a task as complete if before the due date and work has not been submitted");
+    it("should not allow the manager to (re-)mark a task as complete if work has already been submitted");
+    it("should allow the manager to mark a task as complete if after the due date and no work has been submitted");
+
     it("should fail if I try to rate work on behalf of a worker", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      await colony.completeTask(taskId);
       await checkErrorRevert(
         colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: OTHER }),
         "colony-user-cannot-rate-task-manager"
@@ -116,6 +123,7 @@ contract("Colony Task Work Rating", accounts => {
 
     it("should fail if I try to rate work for a role that's not setup to be rated", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      await colony.completeTask(taskId);
       await checkErrorRevert(
         colony.submitTaskWorkRating(taskId, EVALUATOR_ROLE, RATING_2_SECRET, { from: EVALUATOR }),
         "colony-unsupported-role-to-rate"
@@ -126,6 +134,7 @@ contract("Colony Task Work Rating", accounts => {
 
     it("should fail, if I try to rate work twice", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
 
       await checkErrorRevert(
@@ -140,6 +149,7 @@ contract("Colony Task Work Rating", accounts => {
 
     it("should fail if I try to rate a task too late", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      await colony.completeTask(taskId);
 
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
       await checkErrorRevert(
@@ -194,6 +204,7 @@ contract("Colony Task Work Rating", accounts => {
 
     it("should fail if I try to reveal rating with an incorrect secret", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
       await checkErrorRevert(
@@ -207,6 +218,7 @@ contract("Colony Task Work Rating", accounts => {
 
     it("should fail if there are two rating secrets and I try to reveal the one from the evaluator late", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
 
@@ -222,6 +234,7 @@ contract("Colony Task Work Rating", accounts => {
 
     it("should fail if there are two rating secrets and I try to reveal the one from the worker late", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
 
@@ -237,6 +250,7 @@ contract("Colony Task Work Rating", accounts => {
 
     it("should fail if evaluator tries to reveal rating before the 5 days wait for rating commits expires", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
       await forwardTime(SECONDS_PER_DAY * 4, this);
       await checkErrorRevert(
@@ -250,6 +264,7 @@ contract("Colony Task Work Rating", accounts => {
 
     it("should fail if evaluator tries to reveal rating after 5 days wait for rating reveal expires", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
 
       await forwardTime(SECONDS_PER_DAY * 10 + 1, this);
@@ -281,6 +296,7 @@ contract("Colony Task Work Rating", accounts => {
   describe("when assigning work ratings after the user not commiting or revealing on time", () => {
     it("should assign rating 3 to manager and penalise worker, when they haven't submitted rating on time", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
       await colony.revealTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR });
@@ -300,6 +316,7 @@ contract("Colony Task Work Rating", accounts => {
 
     it("should assign rating 3 to worker and 1 to evaluator if evaluator hasn't submitted rating on time", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
       await colony.revealTaskWorkRating(taskId, MANAGER_ROLE, MANAGER_RATING, RATING_1_SALT, { from: WORKER });
@@ -321,6 +338,7 @@ contract("Colony Task Work Rating", accounts => {
 
     it("should assign rating 3 to manager and 3 to worker, with penalties, when no one has submitted any ratings", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      await colony.completeTask(taskId);
       await forwardTime(SECONDS_PER_DAY * 10 + 1, this);
       await colony.finalizeTask(taskId);
 
@@ -338,7 +356,8 @@ contract("Colony Task Work Rating", accounts => {
     });
 
     it("should revert if I try to assign ratings before the reveal period is over", async () => {
-      await setupAssignedTask({ colonyNetwork, colony });
+      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      await colony.completeTask(taskId);
       await forwardTime(SECONDS_PER_DAY * 6, this);
       await checkErrorRevert(colony.finalizeTask(1), "colony-task-ratings-incomplete");
       const roleWorker = await colony.getTaskRole(1, WORKER_ROLE);

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -85,7 +85,8 @@ contract("Colony Task Work Rating", accounts => {
     });
 
     it("should allow rating after the due date has passed when no work has been submitted and the manager has marked the task complete", async () => {
-      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
@@ -124,7 +125,8 @@ contract("Colony Task Work Rating", accounts => {
     });
 
     it("should allow the manager to mark a task as complete if after the due date and no work has been submitted", async () => {
-      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.completeTask(taskId);
     });
 
@@ -135,7 +137,8 @@ contract("Colony Task Work Rating", accounts => {
     });
 
     it("should fail if I try to rate work on behalf of a worker", async () => {
-      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.completeTask(taskId);
       await checkErrorRevert(
         colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: OTHER }),
@@ -146,7 +149,8 @@ contract("Colony Task Work Rating", accounts => {
     });
 
     it("should fail if I try to rate work for a role that's not setup to be rated", async () => {
-      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.completeTask(taskId);
       await checkErrorRevert(
         colony.submitTaskWorkRating(taskId, EVALUATOR_ROLE, RATING_2_SECRET, { from: EVALUATOR }),
@@ -157,7 +161,8 @@ contract("Colony Task Work Rating", accounts => {
     });
 
     it("should fail, if I try to rate work twice", async () => {
-      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
 
@@ -172,7 +177,8 @@ contract("Colony Task Work Rating", accounts => {
     });
 
     it("should fail if I try to rate a task too late", async () => {
-      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.completeTask(taskId);
 
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
@@ -227,7 +233,8 @@ contract("Colony Task Work Rating", accounts => {
     });
 
     it("should fail if I try to reveal rating with an incorrect secret", async () => {
-      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
@@ -241,7 +248,8 @@ contract("Colony Task Work Rating", accounts => {
     });
 
     it("should fail if there are two rating secrets and I try to reveal the one from the evaluator late", async () => {
-      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
@@ -257,7 +265,8 @@ contract("Colony Task Work Rating", accounts => {
     });
 
     it("should fail if there are two rating secrets and I try to reveal the one from the worker late", async () => {
-      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
@@ -273,7 +282,8 @@ contract("Colony Task Work Rating", accounts => {
     });
 
     it("should fail if evaluator tries to reveal rating before the 5 days wait for rating commits expires", async () => {
-      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
       await forwardTime(SECONDS_PER_DAY * 4, this);
@@ -287,7 +297,8 @@ contract("Colony Task Work Rating", accounts => {
     });
 
     it("should fail if evaluator tries to reveal rating after 5 days wait for rating reveal expires", async () => {
-      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
 
@@ -319,7 +330,8 @@ contract("Colony Task Work Rating", accounts => {
 
   describe("when assigning work ratings after the user not commiting or revealing on time", () => {
     it("should assign rating 3 to manager and penalise worker, when they haven't submitted rating on time", async () => {
-      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
@@ -339,7 +351,8 @@ contract("Colony Task Work Rating", accounts => {
     });
 
     it("should assign rating 3 to worker and 1 to evaluator if evaluator hasn't submitted rating on time", async () => {
-      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.completeTask(taskId);
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
       await forwardTime(SECONDS_PER_DAY * 5 + 1, this);
@@ -361,7 +374,8 @@ contract("Colony Task Work Rating", accounts => {
     });
 
     it("should assign rating 3 to manager and 3 to worker, with penalties, when no one has submitted any ratings", async () => {
-      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.completeTask(taskId);
       await forwardTime(SECONDS_PER_DAY * 10 + 1, this);
       await colony.finalizeTask(taskId);
@@ -380,7 +394,8 @@ contract("Colony Task Work Rating", accounts => {
     });
 
     it("should revert if I try to assign ratings before the reveal period is over", async () => {
-      const taskId = await setupAssignedTask({ colonyNetwork, colony });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.completeTask(taskId);
       await forwardTime(SECONDS_PER_DAY * 6, this);
       await checkErrorRevert(colony.finalizeTask(1), "colony-task-ratings-incomplete");

--- a/test/colony.js
+++ b/test/colony.js
@@ -21,7 +21,10 @@ import {
   RATING_2_SECRET,
   MANAGER_PAYOUT,
   WORKER_PAYOUT,
-  EVALUATOR_PAYOUT
+  EVALUATOR_PAYOUT,
+  ACTIVE_TASK_STATE,
+  CANCELLED_TASK_STATE,
+  FINALIZED_TASK_STATE
 } from "../helpers/constants";
 import {
   getTokenArgs,
@@ -284,7 +287,7 @@ contract("Colony", accounts => {
       const task = await colony.getTask(1);
       assert.equal(task[0], SPECIFICATION_HASH);
       assert.equal(task[1], "0x0000000000000000000000000000000000000000000000000000000000000000");
-      assert.equal(task[2].toNumber(), 0);
+      assert.equal(task[2].toNumber(), ACTIVE_TASK_STATE);
       assert.equal(task[3].toNumber(), 0);
       assert.equal(task[4].toNumber(), 0);
     });
@@ -1386,12 +1389,12 @@ contract("Colony", accounts => {
   });
 
   describe("when finalizing a task", () => {
-    it('should set the task "status" property to "finalized" (2)', async () => {
+    it('should set the task "status" property to "finalized"', async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony, token });
       await colony.finalizeTask(taskId);
       const task = await colony.getTask(taskId);
-      assert.equal(task[2].toNumber(), 2);
+      assert.equal(task[2].toNumber(), FINALIZED_TASK_STATE);
     });
 
     it("should fail if the task work ratings have not been assigned and they still have time to be", async () => {
@@ -1422,13 +1425,13 @@ contract("Colony", accounts => {
   });
 
   describe("when cancelling a task", () => {
-    it('should set the task "status" property to "cancelled" (1)', async () => {
+    it('should set the task "status" property to "cancelled"', async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony, token });
 
       await colony.cancelTask(taskId);
       const task = await colony.getTask(taskId);
-      assert.equal(task[2].toNumber(), 1);
+      assert.equal(task[2].toNumber(), CANCELLED_TASK_STATE);
     });
 
     it("should be possible to return funds back to the domain", async () => {

--- a/test/colony.js
+++ b/test/colony.js
@@ -1328,14 +1328,16 @@ contract("Colony", accounts => {
 
     it("should fail if I try to submit work for a task that is complete", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await setupAssignedTask({ colonyNetwork, colony, token });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, token, dueDate });
       await colony.completeTask(taskId);
       await checkErrorRevert(colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH), "colony-task-complete");
     });
 
     it("should fail if I try to submit work for a task that is finalized", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await setupRatedTask({ colonyNetwork, colony, token });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupRatedTask({ colonyNetwork, colony, dueDate, token });
       await colony.finalizeTask(taskId);
       await checkErrorRevert(colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH), "colony-task-complete");
     });
@@ -1399,7 +1401,8 @@ contract("Colony", accounts => {
 
     it("should fail if the task work ratings have not been assigned and they still have time to be", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await setupFundedTask({ colonyNetwork, colony, token });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate, token });
       await colony.completeTask(taskId);
       await checkErrorRevert(colony.finalizeTask(taskId), "colony-task-ratings-incomplete");
     });
@@ -1758,7 +1761,9 @@ contract("Colony", accounts => {
       const evaluator = accounts[1];
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await setupFundedTask({ colonyNetwork, colony, token, evaluator });
+      const dueDate = await currentBlockTime();
+      const taskId = await setupFundedTask({ colonyNetwork, colony, dueDate, token, evaluator });
+
       await colony.completeTask(taskId);
 
       await forwardTime(SECONDS_PER_DAY * 10 + 1, this);

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -391,7 +391,7 @@ contract("Meta Colony", accounts => {
       await colony.setTaskDomain(taskId, 2);
 
       const task = await colony.getTask(taskId);
-      assert.equal(task[8].toNumber(), 2);
+      assert.equal(task[7].toNumber(), 2);
     });
 
     it("should NOT allow a non-manager to set domain on task", async () => {
@@ -399,7 +399,7 @@ contract("Meta Colony", accounts => {
       await makeTask({ colony });
       await checkErrorRevert(colony.setTaskDomain(1, 2, { from: OTHER_ACCOUNT }), "colony-task-role-identity-mismatch");
       const task = await colony.getTask(1);
-      assert.equal(task[8].toNumber(), 1);
+      assert.equal(task[7].toNumber(), 1);
     });
 
     it("should NOT be able to set a domain on nonexistent task", async () => {
@@ -411,7 +411,7 @@ contract("Meta Colony", accounts => {
       await checkErrorRevert(colony.setTaskDomain(1, 20), "colony-domain-does-not-exist");
 
       const task = await colony.getTask(1);
-      assert.equal(task[8].toNumber(), 1);
+      assert.equal(task[7].toNumber(), 1);
     });
 
     it("should NOT be able to set a domain on finalized task", async () => {
@@ -437,7 +437,7 @@ contract("Meta Colony", accounts => {
       });
 
       const task = await colony.getTask(taskId);
-      assert.equal(task[9][0].toNumber(), 6);
+      assert.equal(task[8][0].toNumber(), 6);
     });
 
     it("should not allow anyone but the colony to set global skill on task", async () => {
@@ -447,7 +447,7 @@ contract("Meta Colony", accounts => {
       await makeTask({ colony });
       await checkErrorRevert(colony.setTaskSkill(1, 5, { from: OTHER_ACCOUNT }), "colony-not-self");
       const task = await colony.getTask(1);
-      assert.equal(task[9][0].toNumber(), 0);
+      assert.equal(task[8][0].toNumber(), 0);
     });
 
     it("should NOT be able to set global skill on nonexistent task", async () => {
@@ -463,7 +463,7 @@ contract("Meta Colony", accounts => {
       await checkErrorRevert(colony.setTaskSkill(taskId, 6), "colony-task-already-finalized");
 
       const task = await colony.getTask(taskId);
-      assert.equal(task[9][0].toNumber(), 1);
+      assert.equal(task[8][0].toNumber(), 1);
     });
 
     it("should NOT be able to set nonexistent skill on task", async () => {

--- a/upgrade-test/colony-upgrade.js
+++ b/upgrade-test/colony-upgrade.js
@@ -77,17 +77,15 @@ contract("Colony contract upgrade", accounts => {
     it("should return correct tasks", async () => {
       const task1 = await updatedColony.getTask(1);
       assert.equal(task1[0], SPECIFICATION_HASH);
-      assert.isFalse(task1[2]);
-      assert.isFalse(task1[3]);
+      assert.equal(task1[2].toNumber(), 0);
+      assert.equal(task1[3].toNumber(), 0);
       assert.equal(task1[4].toNumber(), 0);
-      assert.equal(task1[5].toNumber(), 0);
 
       const task2 = await updatedColony.getTask(2);
       assert.equal(task2[0], SPECIFICATION_HASH_UPDATED);
-      assert.isFalse(task2[2]);
-      assert.isFalse(task2[3]);
+      assert.equal(task2[2].toNumber(), 0);
+      assert.equal(task2[3].toNumber(), 0);
       assert.equal(task2[4].toNumber(), 0);
-      assert.equal(task2[5].toNumber(), 0);
     });
 
     it("should return correct permissions", async () => {


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #316.

## Implementational notes

Instead of adding yet another `bool` to the task property, I have renamed `deliverableTimestamp` to `completionTimestamp`, and if the `completionTimestamp` is zero, then the task is not complete. This timestamp is set to `now` when the task deliverable is submitted or the task is explicitly marked as completed by the manager. The manager is only allowed to do this once the due date is passed. These are the only two ways this timestamp can be set.

A `TaskCompleted(uint256 taskId)` event is fired when a task is completed via either method. Note that when it is completed via the submission of the deliverable, the `TaskDeliverableSubmitted` event is fired also.

Repeating the issue here, but worth reiterating: if the due date is not set, the only way for a task to complete is for the deliverable to be submitted.

I had originally hoped to remove the `finalized` boolean in a similar way, but realised we cannot infer whether a task is finalized or not because it has to write to the reputation update log. `cancelled` and `finalized` bools have been removed from the task struct and replaced with a `uint8` called `status`. This was partially done because 'completed' was originally going to be another state until we realised it could be inferred from the timestamp. I left this change in, however, because it will make introducing new states much easier in the future (which I strongly suspect we will want to do based on user feedback, despite my personal view).

The valid statuses are:

```
0 - Active
1 - Cancelled
2 - Finalized
```

## Unrelated changes

* I have modified `checkErrorRevert` so that it doesn't try to check a property on an `undefined` item in the event the passed transaction succeeds. This gives you a more meaningful error message when writing tests that have transactions pass when they shouldn't.

* I have modified `setupAssignedTask` so that passing `0` as the `dueDate` parameter does not set a due date, rather than setting the `dueDate` to the current block time. Not defining the `dueDate` still follows the old behaviour.
