### PR TITLE
Give miner ability to persist reputation states

### DIFF
--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -775,9 +775,7 @@ class ReputationMiner {
     const db = await sqlite.open(this.dbPath, { Promise });
 
     const currentRootHash = await this.getRootHash();
-    let res = await db.all(`SELECT rowid, root_hash FROM reputation_states WHERE root_hash='${currentRootHash}' AND n_nodes='${this.nReputations}'`);
-
-    res = await db.run(`INSERT OR IGNORE INTO reputation_states (root_hash, n_nodes) VALUES ('${currentRootHash}', ${this.nReputations})`);
+    let res = await db.run(`INSERT OR IGNORE INTO reputation_states (root_hash, n_nodes) VALUES ('${currentRootHash}', ${this.nReputations})`);
 
     for (let i = 0; i < Object.keys(this.reputations).length; i += 1) {
       const key = Object.keys(this.reputations)[i];

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -866,7 +866,11 @@ class ReputationMiner {
 
   async resetDB() {
     const db = await sqlite.open(this.dbPath, { Promise });
-    await db.run(`DROP TABLE users, colonies, skills, reputations, reputation_states`);
+    await db.run(`DROP TABLE IF EXISTS users`);
+    await db.run(`DROP TABLE IF EXISTS colonies`);
+    await db.run(`DROP TABLE IF EXISTS skills`);
+    await db.run(`DROP TABLE IF EXISTS reputations`);
+    await db.run(`DROP TABLE IF EXISTS reputation_states`);
     await db.run("CREATE TABLE users ( address text NOT NULL UNIQUE )");
     await db.run("CREATE TABLE reputation_states ( root_hash text NOT NULL UNIQUE, n_nodes INTEGER NOT NULL )");
     await db.run("CREATE TABLE colonies ( address text NOT NULL UNIQUE )");

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -777,18 +777,18 @@ class ReputationMiner {
     const currentRootHash = await this.getRootHash();
     let res = await db.all(`SELECT rowid, root_hash FROM reputation_states WHERE root_hash='${currentRootHash}' AND n_nodes='${this.nReputations}'`);
 
-    let rootHashDBId;
+    let rootHashRowId;
     if (res.length === 0) {
       res = await db.run(`INSERT INTO reputation_states (root_hash, n_nodes) VALUES ('${currentRootHash}', ${this.nReputations})`);
-      rootHashDBId = res.lastID;
+      rootHashRowId = res.lastID;
     } else {
-      rootHashDBId = res[0].rowid;
+      rootHashRowId = res[0].rowid;
     }
 
     for (let i = 0; i < Object.keys(this.reputations).length; i += 1) {
-      let colonyDBId;
-      let userDBId;
-      let skillDBId;
+      let colonyRowId;
+      let userRowId;
+      let skillRowId;
       const key = Object.keys(this.reputations)[i];
       const value = this.reputations[key];
       let [colonyAddress, skillId, userAddress] = await ReputationMiner.breakKeyInToElements(key); // eslint-disable-line no-await-in-loop
@@ -799,42 +799,42 @@ class ReputationMiner {
       res = await db.all(`SELECT rowid FROM colonies WHERE address='${colonyAddress}'`); // eslint-disable-line no-await-in-loop
       if (res.length === 0) {
         res = await db.run(`INSERT INTO colonies (address) VALUES ('${colonyAddress}')`); // eslint-disable-line no-await-in-loop
-        colonyDBId = res.lastID;
+        colonyRowId = res.lastID;
       } else {
-        colonyDBId = res[0].rowid;
+        colonyRowId = res[0].rowid;
       }
 
       res = await db.all(`SELECT rowid FROM users WHERE address='${userAddress}'`); // eslint-disable-line no-await-in-loop
       if (res.length === 0) {
         res = await db.run(`INSERT INTO users (address) VALUES ('${userAddress}')`); // eslint-disable-line no-await-in-loop
-        userDBId = res.lastID;
+        userRowId = res.lastID;
       } else {
-        userDBId = res[0].rowid;
+        userRowId = res[0].rowid;
       }
 
       res = await db.all(`SELECT skill_id FROM skills WHERE skill_id='${skillId}'`); // eslint-disable-line no-await-in-loop
       if (res.length === 0) {
         res = await db.run(`INSERT INTO skills (skill_id) VALUES ('${skillId}')`); // eslint-disable-line no-await-in-loop
-        skillDBId = res.lastID;
+        skillRowId = res.lastID;
       } else {
-        skillDBId = res[0].skill_id;
+        skillRowId = res[0].skill_id;
       }
 
       // eslint-disable-next-line no-await-in-loop
       res = await db.get(
         `SELECT COUNT ( * ) AS "n"
         FROM reputations
-        WHERE root_hash=${rootHashDBId}
-        AND colony_address=${colonyDBId}
-        AND skill_id=${skillDBId}
-        AND user_address=${userDBId}`
+        WHERE root_hash_rowid=${rootHashRowId}
+        AND colony_address_rowid=${colonyRowId}
+        AND skill_id=${skillRowId}
+        AND user_address_rowid=${userRowId}`
       );
 
       if (res.n === 0) {
         // eslint-disable-next-line no-await-in-loop
         await db.run(
-          `INSERT INTO reputations (root_hash, colony_address, skill_id, user_address, value)
-          VALUES (${rootHashDBId}, ${colonyDBId}, ${skillDBId}, ${userDBId}, '${value}')`
+          `INSERT INTO reputations (root_hash_rowid, colony_address_rowid, skill_id, user_address_rowid, value)
+          VALUES (${rootHashRowId}, ${colonyRowId}, ${skillRowId}, ${userRowId}, '${value}')`
         );
       }
     }
@@ -849,9 +849,9 @@ class ReputationMiner {
     const res = await db.all(
       `SELECT reputations.skill_id, reputations.value, reputation_states.root_hash, colonies.address as colony_address, users.address as user_address
        FROM reputations
-       INNER JOIN colonies ON colonies.rowid=reputations.colony_address
-       INNER JOIN users ON users.rowid=reputations.user_address
-       INNER JOIN reputation_states ON reputation_states.rowid=reputations.root_hash
+       INNER JOIN colonies ON colonies.rowid=reputations.colony_address_rowid
+       INNER JOIN users ON users.rowid=reputations.user_address_rowid
+       INNER JOIN reputation_states ON reputation_states.rowid=reputations.root_hash_rowid
        WHERE reputation_states.root_hash="${reputationRootHash}"`
     );
     this.nReputations = ethers.utils.bigNumberify(res.length);
@@ -877,10 +877,10 @@ class ReputationMiner {
     await db.run("CREATE TABLE skills ( skill_id INTEGER PRIMARY KEY )");
     await db.run(
       `CREATE TABLE reputations (
-        root_hash text NOT NULL,
-        colony_address INTEGER NOT NULL,
+        root_hash_rowid text NOT NULL,
+        colony_address_rowid INTEGER NOT NULL,
         skill_id INTEGER NOT NULL,
-        user_address INTEGER NOT NULL,
+        user_address_rowid INTEGER NOT NULL,
         value text NOT NULL
       )`
     );

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -65,7 +65,7 @@ class ReputationMinerClient {
         await this._miner.insert(ADDRESS3, 1, ADDRESS2, new BN("100000000"));
         await this._miner.insert(ADDRESS3, 1, ADDRESS4, new BN("100000000"));
         await this._miner.insert(ADDRESS3, 1, ADDRESS0, new BN("200000000"));
-        console.log("💾 Writing initialised state with dummy data to JSON file");
+        console.log("💾 Writing initialised state with dummy data to database");
 
         await this._miner.saveCurrentState();
       }

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -1,5 +1,3 @@
-const path = require("path");
-const jsonfile = require("jsonfile");
 const ethers = require("ethers");
 const express = require("express");
 const BN = require("bn.js");
@@ -12,11 +10,10 @@ class ReputationMinerClient {
    * @param {string} minerAddress            The address that is staking CLNY that will allow the miner to submit reputation hashes
    * @param {Number} [realProviderPort=8545] The port that the RPC node with the ability to sign transactions from `minerAddress` is responding on. The address is assumed to be `localhost`.
    */
-  constructor({ file, minerAddress, loader, realProviderPort, seed, privateKey, provider }) {
+  constructor({ file, minerAddress, loader, realProviderPort, seed, privateKey, provider, useJSTree }) {
     this._loader = loader;
-    this._miner = new ReputationMiner({ minerAddress, loader, provider, privateKey, realProviderPort });
+    this._miner = new ReputationMiner({ minerAddress, loader, provider, privateKey, realProviderPort, dbPath: file, useJSTree });
     this._seed = seed;
-    this._file = path.resolve(process.cwd(), file);
 
     this._app = express();
     this._app.get("/:colonyAddress/:skillId/:userAddress", async (req, res) => {
@@ -47,39 +44,30 @@ class ReputationMinerClient {
 
     this.repCycleContractDef = await this._loader.load({ contractName: "IReputationMiningCycle" }, { abi: true, address: false });
 
-    try {
-      // TODO: I don't really like writing properties like that. We might need a setReputations() method on the miner
-      // It can also then set the nReputations
-      this._miner.reputations = jsonfile.readFileSync(this._file);
-      console.log("💾 Restored from JSON file");
-    } catch (err) {
-      this._miner.reputations = {};
+    // TODO: Get latest state from database, then sync to current state on-chain.
+    // However, for now, we're the only miner, so we can just load the current saved state and go from there.
+    const latestReputationHash = await this._miner.colonyNetwork.getReputationRootHash();
+    await this._miner.createDB();
+    await this._miner.loadState(latestReputationHash);
+    if (this._miner.nReputations.eq(0)) {
       console.log("No existing reputations found - starting from scratch");
-    }
-    this._miner.nReputations = Object.keys(this._miner.reputations).length;
+      if (this._seed) {
+        // Temporary data if --seed is set and there's nothing to restore from.
+        const ADDRESS1 = "0x309e642dbf573119ca75153b25f5b8462ff1b90b";
+        const ADDRESS2 = "0xbc13dbc1a954b3443d6f75297a232faa513774b3";
+        const ADDRESS3 = "0x2b183746bd1403cdec8e4fe45139339da20bcf3d";
+        const ADDRESS4 = "0xcd0751d4181acda4f8edb2f3b33b915f91abeef0";
+        const ADDRESS0 = "0x0000000000000000000000000000000000000000";
+        await this._miner.insert(ADDRESS1, 1, ADDRESS2, new BN("999999999"));
+        await this._miner.insert(ADDRESS1, 1, ADDRESS0, new BN("999999999"));
+        await this._miner.insert(ADDRESS1, 2, ADDRESS2, new BN("888888888888888"));
+        await this._miner.insert(ADDRESS1, 2, ADDRESS0, new BN("888888888888888"));
+        await this._miner.insert(ADDRESS3, 1, ADDRESS2, new BN("100000000"));
+        await this._miner.insert(ADDRESS3, 1, ADDRESS4, new BN("100000000"));
+        await this._miner.insert(ADDRESS3, 1, ADDRESS0, new BN("200000000"));
+        console.log("💾 Writing initialised state with dummy data to JSON file");
 
-    if (this._miner.nReputations === 0 && this._seed) {
-      // Temporary data if --seed is set and there's nothing to restore from.
-      const ADDRESS1 = "0x309e642dbf573119ca75153b25f5b8462ff1b90b";
-      const ADDRESS2 = "0xbc13dbc1a954b3443d6f75297a232faa513774b3";
-      const ADDRESS3 = "0x2b183746bd1403cdec8e4fe45139339da20bcf3d";
-      const ADDRESS4 = "0xcd0751d4181acda4f8edb2f3b33b915f91abeef0";
-      const ADDRESS0 = "0x0000000000000000000000000000000000000000";
-      await this._miner.insert(ADDRESS1, 1, ADDRESS2, new BN("999999999"));
-      await this._miner.insert(ADDRESS1, 1, ADDRESS0, new BN("999999999"));
-      await this._miner.insert(ADDRESS1, 2, ADDRESS2, new BN("888888888888888"));
-      await this._miner.insert(ADDRESS1, 2, ADDRESS0, new BN("888888888888888"));
-      await this._miner.insert(ADDRESS3, 1, ADDRESS2, new BN("100000000"));
-      await this._miner.insert(ADDRESS3, 1, ADDRESS4, new BN("100000000"));
-      await this._miner.insert(ADDRESS3, 1, ADDRESS0, new BN("200000000"));
-      console.log("💾 Writing initialised state with dummy data to JSON file");
-
-      jsonfile.writeFileSync(this._file, this._miner.reputations);
-    } else {
-      // TODO: It would be good to have an interface on the miner for that, I'm pretty sure this logic is already somewhere in there
-      for (let i = 0; i < Object.keys(this._miner.reputations).length; i += 1) {
-        const key = Object.keys(this._miner.reputations)[i];
-        await this._miner.reputationTree.insert(key, this._miner.reputations[key], { gasLimit: 4000000 }); // eslint-disable-line no-await-in-loop
+        await this._miner.saveCurrentState();
       }
     }
 
@@ -95,7 +83,8 @@ class ReputationMinerClient {
     const addr = await this._miner.colonyNetwork.getReputationMiningCycle(true);
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this._miner.realWallet);
 
-    const windowOpened = await repCycle.reputationMiningWindowOpenTimestamp();
+    let windowOpened = await repCycle.getReputationMiningWindowOpenTimestamp();
+    windowOpened = windowOpened.toNumber();
 
     const block = await this._miner.realProvider.getBlock("latest");
     const now = block.timestamp;
@@ -104,8 +93,8 @@ class ReputationMinerClient {
       // If so, process the log
       await this._miner.addLogContentsToReputationTree();
 
-      console.log("💾 Writing new reputation state to JSON file");
-      jsonfile.writeFileSync(this._file, this._miner.reputations);
+      console.log("💾 Writing new reputation state to database");
+      await this._miner.saveCurrentState();
 
       console.log("#️⃣ Submitting new reputation hash");
 

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -21,5 +21,5 @@ if (rinkeby) {
   provider = new ethers.providers.InfuraProvider("rinkeby");
 }
 
-const client = new ReputationMinerClient({ file, loader, minerAddress, privateKey, provider, seed });
+const client = new ReputationMinerClient({ file, loader, minerAddress, privateKey, provider, seed, useJSTree: true });
 client.initialise(colonyNetworkAddress);

--- a/packages/reputation-miner/package.json
+++ b/packages/reputation-miner/package.json
@@ -20,6 +20,7 @@
     "express": "^4.16.3",
     "ganache-core": "^2.1.6",
     "jsonfile": "^4.0.0",
+    "sqlite": "^3.0.0",
     "web3-utils": "^1.0.0-beta.34",
     "yargs": "^12.0.1"
   }

--- a/packages/reputation-miner/package.json
+++ b/packages/reputation-miner/package.json
@@ -19,7 +19,6 @@
     "ethers": "https://github.com/area/ethers.js#typescript",
     "express": "^4.16.3",
     "ganache-core": "^2.1.6",
-    "jsonfile": "^4.0.0",
     "sqlite": "^3.0.0",
     "web3-utils": "^1.0.0-beta.34",
     "yargs": "^12.0.1"

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -2979,8 +2979,9 @@ contract("ColonyNetworkMining", accounts => {
 
     process.env.SOLIDITY_COVERAGE // eslint-disable-line no-unused-expressions
       ? it.skip
-      : it.only("The client should be able to correctly sync to the current state from an old, correct state loaded from the database", async () => {
+      : it("The client should be able to correctly sync to the current state from an old, correct state loaded from the database", async () => {
           // Save to the database
+          await goodClient.resetDB();
           await goodClient.saveCurrentState();
           const savedHash = await goodClient.reputationTree.getRootHash();
 
@@ -3004,6 +3005,7 @@ contract("ColonyNetworkMining", accounts => {
         });
 
     it("should be able to successfully save the current state to the database and then load it", async () => {
+      await goodClient.resetDB();
       await goodClient.saveCurrentState();
       const client1Hash = await goodClient.reputationTree.getRootHash();
       await goodClient2.loadState(client1Hash);

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -2976,5 +2976,13 @@ contract("ColonyNetworkMining", accounts => {
           const client2Hash = await goodClient2.reputationTree.getRootHash();
           assert.equal(client1Hash, client2Hash);
         });
+
+    it("should be able to successfully save the current state to the database and then load it", async () => {
+      await goodClient.saveCurrentState();
+      const client1Hash = await goodClient.reputationTree.getRootHash();
+      await goodClient2.loadState(client1Hash);
+      const client2Hash = await goodClient2.reputationTree.getRootHash();
+      assert.equal(client1Hash, client2Hash);
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5103,7 +5103,7 @@ mz@^2.6.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@2.10.0, nan@^2.0.8, nan@^2.2.1, nan@^2.3.3, nan@^2.9.2:
+nan@2.10.0, nan@^2.0.8, nan@^2.2.1, nan@^2.3.3, nan@^2.9.2, nan@~2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
@@ -5175,7 +5175,7 @@ node-notifier@^5.2.1:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@^0.10.0:
+node-pre-gyp@^0.10.0, node-pre-gyp@^0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
   dependencies:
@@ -6711,6 +6711,26 @@ split-string@^3.0.1, split-string@^3.0.2:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+sql-template-strings@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/sql-template-strings/-/sql-template-strings-2.2.2.tgz#3f11508a25addfce217a3042a9d300c3193b96ff"
+
+sqlite3@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.0.2.tgz#1bbeb68b03ead5d499e42a3a1b140064791c5a64"
+  dependencies:
+    nan "~2.10.0"
+    node-pre-gyp "^0.10.3"
+    request "^2.87.0"
+
+sqlite@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/sqlite/-/sqlite-3.0.0.tgz#94b70b6d1e837b1dff6881d393776ff609383c5c"
+  dependencies:
+    sqlite3 "^4.0.0"
+  optionalDependencies:
+    sql-template-strings "^2.2.2"
 
 sshpk@^1.7.0:
   version "1.14.2"


### PR DESCRIPTION
Closes #302 

## Implementation details

I have introduced an [SQLite](https://www.sqlite.org/) database to the miner for persisting state. This is an internal SQL instance (i.e. not a separate server) that persists to disk invisibly (i.e. no need to explicitly call a 'save' function on the database instance created. The schema of the database I have used is defined by

```
CREATE TABLE users ( address text NOT NULL UNIQUE );
CREATE TABLE reputation_states ( root_hash text NOT NULL UNIQUE, n_nodes INTEGER NOT NULL );
CREATE TABLE colonies ( address text NOT NULL UNIQUE );
CREATE TABLE skills ( skill_id INTEGER PRIMARY KEY );
CREATE TABLE reputations ( root_hash text NOT NULL, colony_address INTEGER NOT NULL, skill_id INTEGER NOT NULL, user_address INTEGER NOT NULL, value text NOT NULL);
```
Note that each table (apart from `skills`, which is defined with `PRIMARY KEY`) also has a [`rowid`](https://www.sqlite.org/lang_createtable.html#rowid) column, which acts as the primary key for each table. Note that while `address` would be a good natural key for `users`, if it appeared repeatedly as a foreign key in `reputations`, there would be a great deal of wasted disk space. By using surrogate keys, the drive requirements for a reputation miner are vastly reduced.

Individual reputations are stored in the `reputations` table. By storing these, we are able to recreate any past reputation state that the miner has stored, and in turn any reputation proof for a past state. This will be a requirement in the future when miners are acting as oracles, and must provide users proofs for their historical reputations, not only the current one (e.g. when a reward payout is occurring). I believe this is a reasonable tradeoff between storage space required, ease of development, and computation required to respond. For example, the same would be possible if we just stored all logs (which would require much less space), but having to replay all history to recreate an old state would be interminably slow going forward.

Going forward, old states that are stored that no longer have a use (e.g. no reward payouts or disputes relying on a particular state) can be purged to recover disk space.

It has been many years since I had to think about optimising SQL, and I'm sure what I have here could be a lot better. In particular, I have completely ignored having to deal with race conditions by having each query implement sequentially (leading to a lot of `//eslint-disable-line no-await-in-loop`). I don't particularly want to waste a lot of time improving those now, but if someone more knowledgeable than me could spot something easy, I'd cheerfully do it.

## Other changes

I have added the ability to call `sync` with a new parameter; if set to true, then all (valid) states that are encountered are saved to the database. This will be useful for a new miner coming online that wishes to act as a reputation oracle.