### PR TITLE
Make the due date default to 90 days in future

### DIFF
--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -73,7 +73,7 @@ contract ColonyTask is ColonyStorage {
 
   modifier afterDueDate(uint256 _id) {
     uint dueDate = tasks[_id].dueDate;
-    require(dueDate > 0, "colony-task-due-date-not-set");
+    /* require(dueDate > 0, "colony-task-due-date-not-set"); */
     require(now >= dueDate, "colony-task-due-date-in-future");
     _;
   }
@@ -138,6 +138,8 @@ contract ColonyTask is ColonyStorage {
 
     uint256 dueDate = _dueDate;
     if (dueDate == 0) {
+      // If / When restoring due date to optional status in the future, be sure to go uncomment the relevant line in `afterDueDate` that checks the
+      // due date has been set.
       dueDate = now + 90 days;
     }
     this.setTaskDueDate(taskCount, dueDate);

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -136,9 +136,11 @@ contract ColonyTask is ColonyStorage {
       this.setTaskSkill(taskCount, _skillId);
     }
 
-    if (_dueDate > 0) {
-      this.setTaskDueDate(taskCount, _dueDate);
+    uint256 dueDate = _dueDate;
+    if (dueDate == 0) {
+      dueDate = now + 90 days;
     }
+    this.setTaskDueDate(taskCount, dueDate);
 
   }
 
@@ -379,6 +381,7 @@ contract ColonyTask is ColonyStorage {
   taskNotFinalized(_id)
   self()
   {
+    require (_dueDate > 0, "colony-task-due-date-cannot-be-zero");
     tasks[_id].dueDate = _dueDate;
 
     emit TaskDueDateChanged(_id, _dueDate);

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -106,7 +106,7 @@ contract("Colony Task Work Rating", accounts => {
       assert.equal(ratingSecrets[0].toNumber(), 0);
     });
 
-    it("should not allow the manager to mark a task as complete if no due date is set", async () => {
+    it.skip("should not allow the manager to mark a task as complete if no due date is set", async () => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate: 0 });
       await checkErrorRevert(colony.completeTask(taskId), "colony-task-due-date-not-set");
     });

--- a/upgrade-test/colony-upgrade.js
+++ b/upgrade-test/colony-upgrade.js
@@ -1,5 +1,5 @@
 /* globals artifacts */
-import { getTokenArgs } from "../helpers/test-helper";
+import { currentBlockTime, getTokenArgs } from "../helpers/test-helper";
 import { setupColonyVersionResolver } from "../helpers/upgradable-contracts";
 import { SPECIFICATION_HASH, SPECIFICATION_HASH_UPDATED } from "../helpers/constants";
 import { makeTask } from "../helpers/test-data-generator";
@@ -27,11 +27,13 @@ contract("Colony contract upgrade", accounts => {
   let updatedColony;
   let updatedColonyVersion;
 
-  const dueDate = 112233445566;
+  let dueDate;
 
   before(async () => {
     const etherRouterColonyNetwork = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouterColonyNetwork.address);
+
+    dueDate = await currentBlockTime();
 
     const tokenArgs = getTokenArgs();
     const colonyToken = await Token.new(...tokenArgs);

--- a/upgrade-test/colony-upgrade.js
+++ b/upgrade-test/colony-upgrade.js
@@ -27,6 +27,8 @@ contract("Colony contract upgrade", accounts => {
   let updatedColony;
   let updatedColonyVersion;
 
+  const dueDate = 112233445566;
+
   before(async () => {
     const etherRouterColonyNetwork = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouterColonyNetwork.address);
@@ -43,8 +45,8 @@ contract("Colony contract upgrade", accounts => {
     const tokenAddress = await colony.getToken();
     token = await Token.at(tokenAddress);
 
-    await makeTask({ colony });
-    await makeTask({ colony, hash: SPECIFICATION_HASH_UPDATED });
+    await makeTask({ colony, dueDate });
+    await makeTask({ colony, dueDate: dueDate + 1, hash: SPECIFICATION_HASH_UPDATED });
     // Setup new Colony contract version on the Network
     const updatedColonyContract = await UpdatedColony.new();
     const resolver = await Resolver.new();
@@ -78,13 +80,13 @@ contract("Colony contract upgrade", accounts => {
       const task1 = await updatedColony.getTask(1);
       assert.equal(task1[0], SPECIFICATION_HASH);
       assert.equal(task1[2].toNumber(), 0);
-      assert.equal(task1[3].toNumber(), 0);
+      assert.equal(task1[3].toNumber(), dueDate);
       assert.equal(task1[4].toNumber(), 0);
 
       const task2 = await updatedColony.getTask(2);
       assert.equal(task2[0], SPECIFICATION_HASH_UPDATED);
       assert.equal(task2[2].toNumber(), 0);
-      assert.equal(task2[3].toNumber(), 0);
+      assert.equal(task2[3].toNumber(), dueDate + 1);
       assert.equal(task2[4].toNumber(), 0);
     });
 


### PR DESCRIPTION
Closes #329 

I am not anticipating this to be a permanent solution; I feel like once disputes are fully fleshed out and begin to be implemented, we can apply them here as one of the first testbeds for them. This is why I have left the 'unset due date' test in, but `skip`ed it. I don't really have much to say here; I was pretty surprised at how straightforward this change ultimately turned out to be.