### PR TITLE
Update solidity coverage to 0.5.11 and changes for lockfile update issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ jobs:
     steps:
       - checkout
       - <<: *step_restore_cache
+      - run:
+          name: "Remove .git/hooks/pre-commit"
+          command: rm .git/hooks/pre-commit
       - <<: *step_setup_global_packages
       - <<: *step_setup_greenkeeper
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,10 @@ jobs:
     steps:
       - checkout
       - <<: *step_restore_cache
+      - <<: *step_setup_global_packages
       - run:
           name: "Remove .git/hooks/pre-commit"
           command: rm .git/hooks/pre-commit
-      - <<: *step_setup_global_packages
       - <<: *step_setup_greenkeeper
       - run:
           name: "Run Greenkeeper lockfile update"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ step_restore_cache: &step_restore_cache
   restore_cache:
     keys:
       - node-modules-{{ checksum "package.json" }}
-      - node-modules-
 step_setup_global_packages: &step_setup_global_packages
   run:
     name: "Set up global packages"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "prettier": "^1.12.1",
     "rimraf": "^2.6.2",
     "shortid": "^2.2.8",
-    "solidity-coverage": "0.5.8",
+    "solidity-coverage": "0.5.11",
     "solidity-parser-antlr": "^0.3.0",
     "solium": "^1.1.8",
     "truffle": "^5.0.0-next.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6566,9 +6566,9 @@ solc@0.4.24, solc@^0.4.2:
     semver "^5.3.0"
     yargs "^4.7.1"
 
-solidity-coverage@0.5.8:
-  version "0.5.8"
-  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.5.8.tgz#e5518b22e28ece47a28fb9ca1e4f3a8a64877752"
+solidity-coverage@0.5.11:
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.5.11.tgz#1ee45f6d98b75a615aadb8f9aa7db4a2b32258e7"
   dependencies:
     death "^1.1.0"
     ethereumjs-testrpc-sc "6.1.6"


### PR DESCRIPTION
Closes #326 
Closes #328 

Updates solidity coverage to 0.5.11 and continue fighting the good fight against `greenkeeper-lockfile-update` errors on uploading yarn lockfiles. Here the idea is to remove the `node_modules` cache for anything but a `package.json` that matches the checksum, meaning cache is not restored for GK PRs which I think is the right behaviour to expect. In addition although `husky` is definitely **not** installing the git pre-commit hooks those are attempted to be run when GK tries to commits the update `yarn.lockfile` so we explicitly remove the git hooks folder in case this is additionally been cached somewhere.
