### PR TITLE
Use correct Rinkeby colonyNetwork address

### DIFF
--- a/packages/colony-js-contract-loader-network/contracts/static/EtherRouter.json
+++ b/packages/colony-js-contract-loader-network/contracts/static/EtherRouter.json
@@ -121,7 +121,7 @@
   },
   "networks": {
     "rinkeby": {
-      "address": "0x6B110832B5673F62B841ee24E60e2b032090D0de"
+      "address": "0xDF0F615d9548a5edc2377BB9CD88b81a846DfBC5"
     }
   },
   "schemaVersion": "2.0.0",

--- a/packages/colony-js-contract-loader-network/package.json
+++ b/packages/colony-js-contract-loader-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/colony-js-contract-loader-network",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Load the Colony contract ABIs directly from this package",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This is a small fix to use the correct deployed Rinkeby ColonyNetwork address for the network loader package.