### PR TITLE
Update Rinkeby ABIs

### DIFF
--- a/packages/colony-js-contract-loader-network/contracts/versioned/rinkeby-v2/Authority.json
+++ b/packages/colony-js-contract-loader-network/contracts/versioned/rinkeby-v2/Authority.json
@@ -317,9 +317,9 @@
   ],
   "compiler": {
     "name": "solc",
-    "version": "0.4.23+commit.124ca40d.Emscripten.clang"
+    "version": "0.4.23+commit.124ca40d.Linux.g++"
   },
   "networks": {},
   "schemaVersion": "2.0.1",
-  "updatedAt": "2018-08-21T15:01:00.355Z"
+  "updatedAt": "2018-09-08T13:06:59.558Z"
 }

--- a/packages/colony-js-contract-loader-network/contracts/versioned/rinkeby-v2/IColony.json
+++ b/packages/colony-js-contract-loader-network/contracts/versioned/rinkeby-v2/IColony.json
@@ -149,6 +149,18 @@
           "indexed": true,
           "name": "id",
           "type": "uint256"
+        }
+      ],
+      "name": "TaskCompleted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "id",
+          "type": "uint256"
         },
         {
           "indexed": false,
@@ -1084,6 +1096,20 @@
       "type": "function"
     },
     {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_id",
+          "type": "uint256"
+        }
+      ],
+      "name": "completeTask",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
       "constant": true,
       "inputs": [
         {
@@ -1102,12 +1128,8 @@
           "type": "bytes32"
         },
         {
-          "name": "finalized",
-          "type": "bool"
-        },
-        {
-          "name": "cancelled",
-          "type": "bool"
+          "name": "status",
+          "type": "uint8"
         },
         {
           "name": "dueDate",
@@ -1122,7 +1144,7 @@
           "type": "uint256"
         },
         {
-          "name": "deliverableTimestamp",
+          "name": "completionTimestamp",
           "type": "uint256"
         },
         {
@@ -1371,6 +1393,22 @@
         {
           "name": "_token",
           "type": "address"
+        },
+        {
+          "name": "key",
+          "type": "bytes"
+        },
+        {
+          "name": "value",
+          "type": "bytes"
+        },
+        {
+          "name": "branchMask",
+          "type": "uint256"
+        },
+        {
+          "name": "siblings",
+          "type": "bytes32[]"
         }
       ],
       "name": "startNextRewardPayout",
@@ -1391,12 +1429,20 @@
           "type": "uint256[7]"
         },
         {
-          "name": "_userReputation",
+          "name": "key",
+          "type": "bytes"
+        },
+        {
+          "name": "value",
+          "type": "bytes"
+        },
+        {
+          "name": "branchMask",
           "type": "uint256"
         },
         {
-          "name": "_totalReputation",
-          "type": "uint256"
+          "name": "siblings",
+          "type": "bytes32[]"
         }
       ],
       "name": "claimRewardPayout",
@@ -1418,6 +1464,10 @@
         {
           "name": "reputationState",
           "type": "bytes32"
+        },
+        {
+          "name": "colonyWideReputation",
+          "type": "uint256"
         },
         {
           "name": "totalTokens",
@@ -1539,9 +1589,9 @@
   ],
   "compiler": {
     "name": "solc",
-    "version": "0.4.23+commit.124ca40d.Emscripten.clang"
+    "version": "0.4.23+commit.124ca40d.Linux.g++"
   },
   "networks": {},
   "schemaVersion": "2.0.1",
-  "updatedAt": "2018-08-21T15:01:00.401Z"
+  "updatedAt": "2018-09-08T13:06:59.638Z"
 }

--- a/packages/colony-js-contract-loader-network/contracts/versioned/rinkeby-v2/IColonyNetwork.json
+++ b/packages/colony-js-contract-loader-network/contracts/versioned/rinkeby-v2/IColonyNetwork.json
@@ -16,7 +16,8 @@
         }
       ],
       "name": "ColonyAdded",
-      "type": "event"
+      "type": "event",
+      "signature": "0x6747f57524d6303c6e3d698d8b6ab540620b0455ccde2e5aa047d8a179787d74"
     },
     {
       "anonymous": false,
@@ -33,7 +34,8 @@
         }
       ],
       "name": "SkillAdded",
-      "type": "event"
+      "type": "event",
+      "signature": "0xafe765b392910efb92e8447f3571f7d46c9046cf149b438ccd40b473f4fb332e"
     },
     {
       "anonymous": false,
@@ -55,7 +57,26 @@
         }
       ],
       "name": "AuctionCreated",
-      "type": "event"
+      "type": "event",
+      "signature": "0x261f6e6830ed857876d5aa4eca876ccf116d09b91a6675e3e1a1920d53ef585e"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "hash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "name": "nNodes",
+          "type": "uint256"
+        }
+      ],
+      "name": "ReputationMiningCycleComplete",
+      "type": "event",
+      "signature": "0x752ef39e1c821a8c89637d42bd3a0126ea4839ad4ce6f6a10bea30141c117260"
     },
     {
       "constant": true,
@@ -69,7 +90,8 @@
       ],
       "payable": false,
       "stateMutability": "view",
-      "type": "function"
+      "type": "function",
+      "signature": "0x731bc22f"
     },
     {
       "constant": true,
@@ -83,7 +105,8 @@
       ],
       "payable": false,
       "stateMutability": "view",
-      "type": "function"
+      "type": "function",
+      "signature": "0x711a39be"
     },
     {
       "constant": true,
@@ -102,7 +125,8 @@
       ],
       "payable": false,
       "stateMutability": "view",
-      "type": "function"
+      "type": "function",
+      "signature": "0xdb0dd7ff"
     },
     {
       "constant": false,
@@ -125,7 +149,8 @@
       ],
       "payable": false,
       "stateMutability": "nonpayable",
-      "type": "function"
+      "type": "function",
+      "signature": "0x32b9cf33"
     },
     {
       "constant": true,
@@ -152,7 +177,8 @@
       ],
       "payable": false,
       "stateMutability": "view",
-      "type": "function"
+      "type": "function",
+      "signature": "0xbd880fae"
     },
     {
       "constant": false,
@@ -174,7 +200,8 @@
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
-      "type": "function"
+      "type": "function",
+      "signature": "0x5a8adafa"
     },
     {
       "constant": true,
@@ -188,7 +215,8 @@
       ],
       "payable": false,
       "stateMutability": "view",
-      "type": "function"
+      "type": "function",
+      "signature": "0x05f53b29"
     },
     {
       "constant": true,
@@ -202,7 +230,8 @@
       ],
       "payable": false,
       "stateMutability": "view",
-      "type": "function"
+      "type": "function",
+      "signature": "0xfd139958"
     },
     {
       "constant": false,
@@ -216,7 +245,8 @@
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
-      "type": "function"
+      "type": "function",
+      "signature": "0x8fb6839a"
     },
     {
       "constant": true,
@@ -230,7 +260,8 @@
       ],
       "payable": false,
       "stateMutability": "view",
-      "type": "function"
+      "type": "function",
+      "signature": "0xb319902a"
     },
     {
       "constant": false,
@@ -244,7 +275,8 @@
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
-      "type": "function"
+      "type": "function",
+      "signature": "0xa2f99b86"
     },
     {
       "constant": false,
@@ -263,7 +295,8 @@
       ],
       "payable": false,
       "stateMutability": "nonpayable",
-      "type": "function"
+      "type": "function",
+      "signature": "0x08eb0d2c"
     },
     {
       "constant": false,
@@ -281,7 +314,8 @@
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
-      "type": "function"
+      "type": "function",
+      "signature": "0xf07eb921"
     },
     {
       "constant": true,
@@ -300,7 +334,8 @@
       ],
       "payable": false,
       "stateMutability": "view",
-      "type": "function"
+      "type": "function",
+      "signature": "0x6f92650d"
     },
     {
       "constant": true,
@@ -314,7 +349,8 @@
       ],
       "payable": false,
       "stateMutability": "view",
-      "type": "function"
+      "type": "function",
+      "signature": "0xbca1e4df"
     },
     {
       "constant": true,
@@ -337,7 +373,8 @@
       ],
       "payable": false,
       "stateMutability": "view",
-      "type": "function"
+      "type": "function",
+      "signature": "0xd987fc16"
     },
     {
       "constant": true,
@@ -360,7 +397,8 @@
       ],
       "payable": false,
       "stateMutability": "view",
-      "type": "function"
+      "type": "function",
+      "signature": "0x09d10a5e"
     },
     {
       "constant": true,
@@ -379,7 +417,8 @@
       ],
       "payable": false,
       "stateMutability": "view",
-      "type": "function"
+      "type": "function",
+      "signature": "0xf2c8599c"
     },
     {
       "constant": true,
@@ -398,7 +437,8 @@
       ],
       "payable": false,
       "stateMutability": "view",
-      "type": "function"
+      "type": "function",
+      "signature": "0x8f14c886"
     },
     {
       "constant": false,
@@ -420,7 +460,8 @@
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
-      "type": "function"
+      "type": "function",
+      "signature": "0x743ed431"
     },
     {
       "constant": false,
@@ -429,7 +470,8 @@
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
-      "type": "function"
+      "type": "function",
+      "signature": "0x450e2ed3"
     },
     {
       "constant": false,
@@ -438,7 +480,8 @@
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
-      "type": "function"
+      "type": "function",
+      "signature": "0xee65786a"
     },
     {
       "constant": true,
@@ -452,7 +495,8 @@
       ],
       "payable": false,
       "stateMutability": "view",
-      "type": "function"
+      "type": "function",
+      "signature": "0x97824c3f"
     },
     {
       "constant": true,
@@ -466,7 +510,8 @@
       ],
       "payable": false,
       "stateMutability": "view",
-      "type": "function"
+      "type": "function",
+      "signature": "0x7680150d"
     },
     {
       "constant": false,
@@ -480,7 +525,8 @@
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
-      "type": "function"
+      "type": "function",
+      "signature": "0x55a8495a"
     },
     {
       "constant": false,
@@ -498,7 +544,8 @@
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
-      "type": "function"
+      "type": "function",
+      "signature": "0x6060c4aa"
     },
     {
       "constant": false,
@@ -512,7 +559,8 @@
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
-      "type": "function"
+      "type": "function",
+      "signature": "0x2c9f527e"
     },
     {
       "constant": false,
@@ -526,14 +574,45 @@
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
-      "type": "function"
+      "type": "function",
+      "signature": "0x2c0d05e6"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "miningResolverAddress",
+          "type": "address"
+        }
+      ],
+      "name": "setMiningResolver",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "signature": "0xe1636882"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getMiningResolver",
+      "outputs": [
+        {
+          "name": "miningResolverAddress",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function",
+      "signature": "0x749f15cd"
     }
   ],
   "compiler": {
     "name": "solc",
-    "version": "0.4.23+commit.124ca40d.Emscripten.clang"
+    "version": "0.4.23+commit.124ca40d.Linux.g++"
   },
   "networks": {},
   "schemaVersion": "2.0.1",
-  "updatedAt": "2018-08-21T15:01:00.415Z"
+  "updatedAt": "2018-09-08T13:07:22.394Z"
 }

--- a/packages/colony-js-contract-loader-network/package.json
+++ b/packages/colony-js-contract-loader-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/colony-js-contract-loader-network",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Load the Colony contract ABIs directly from this package",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This PR updates the contract ABIs in the `@colony/colony-js-network-loader` package so that all of the changes in the contracts are reflected (and that the ABIs match the Rinkeby deployed versions).