### PR TITLE
Deal with base issues in mining client cleanly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ lib/dappsys
 ganache-accounts.json
 .vscode/
 yarn-error.log
+reputationStates.sqlite

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -257,9 +257,7 @@ class ReputationMiner {
     // We update colonywide sums first (children, parents, skill)
     // Then the user-specifc sums in the order children, parents, skill.
 
-    // Converting to decimal, since its going to be converted to hex inside `insert`
-    const skillIdDecimal = new BN(skillId, 16).toString();
-    await this.insert(colonyAddress, skillIdDecimal, userAddress, score, updateNumber);
+    await this.insert(colonyAddress, skillId, userAddress, score, updateNumber);
   }
 
   /**
@@ -288,6 +286,14 @@ class ReputationMiner {
     let colonyAddress = _colonyAddress;
     let userAddress = _userAddress;
 
+    let base = 10;
+    let skillId = _skillId.toString();
+    if (skillId.slice(0, 2) === "0x") {
+      // We've been passed a hex string
+      skillId = skillId.slice(2);
+      base = 16;
+    }
+
     let isAddress = web3Utils.isAddress(colonyAddress);
     // TODO should we return errors here?
     if (!isAddress) {
@@ -305,10 +311,10 @@ class ReputationMiner {
     }
     colonyAddress = colonyAddress.toLowerCase();
     userAddress = userAddress.toLowerCase();
-    const key = `0x${new BN(colonyAddress, 16).toString(16, 40)}${new BN(_skillId.toString()).toString(16, 64)}${new BN(userAddress, 16).toString(
-      16,
-      40
-    )}`;
+    const key = `0x${new BN(colonyAddress, 16).toString(16, 40)}${new BN(skillId.toString(), base).toString(16, 64)}${new BN(
+      userAddress,
+      16
+    ).toString(16, 40)}`;
     return key;
   }
 
@@ -375,7 +381,7 @@ class ReputationMiner {
     const colonyAddress = key.slice(2, 42);
     const skillId = key.slice(42, 106);
     const userAddress = key.slice(106);
-    return [colonyAddress, skillId, userAddress];
+    return [`0x${colonyAddress}`, `0x${skillId}`, `0x${userAddress}`];
   }
 
   /**

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -705,8 +705,8 @@ contract("Colony Funding", accounts => {
 
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
-
-      await miningClient.insert(newColony.address, rootDomainSkill, "0x0000000000000000000000000000000000000000", toBN(10), 0);
+      const globalKey = await ReputationMiner.getKey(newColony.address, rootDomainSkill, "0x0000000000000000000000000000000000000000");
+      await miningClient.insert(globalKey, toBN(10), 0);
 
       await forwardTime(3600, this);
       await miningClient.submitRootHash();
@@ -950,7 +950,8 @@ contract("Colony Funding", accounts => {
       const result = await newColony.getDomain(1);
       const rootDomainSkill = result.skillId;
 
-      await miningClient.insert(newColony.address, rootDomainSkill, "0x0000000000000000000000000000000000000000", toBN(0), 0);
+      const globalKey = await ReputationMiner.getKey(newColony.address, rootDomainSkill, "0x0000000000000000000000000000000000000000");
+      await miningClient.insert(globalKey, toBN(0), 0);
 
       await forwardTime(3600, this);
       await miningClient.submitRootHash();
@@ -1038,7 +1039,9 @@ contract("Colony Funding", accounts => {
       const rootDomainSkill = result.skillId;
 
       await colony.bootstrapColony([userAddress1], [userTokens3]);
-      await miningClient.insert(colony.address, rootDomainSkill, userAddress3, toBN(0), 0);
+
+      const userKey = await ReputationMiner.getKey(colony.address, rootDomainSkill, userAddress3);
+      await miningClient.insert(userKey, toBN(0), 0);
 
       await miningClient.addLogContentsToReputationTree();
       await forwardTime(3600, this);

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -1394,13 +1394,10 @@ contract("ColonyNetworkMining", accounts => {
       const keys = Object.keys(goodClient.reputations);
       for (let i = 0; i < keys.length; i += 1) {
         const key = keys[i];
-        const colonyAddress = key.slice(0, 42);
-        const skillId = key.slice(42, 106);
-        const userAddress = key.slice(106);
         const value = goodClient.reputations[key];
         const score = new BN(value.slice(2, 66), 16);
 
-        await badClient.insert(colonyAddress, skillId, userAddress, score, 0); // eslint-disable-line no-await-in-loop
+        await badClient.insert(key, score, 0); // eslint-disable-line no-await-in-loop
       }
 
       righthash = await goodClient.getRootHash();
@@ -2329,23 +2326,14 @@ contract("ColonyNetworkMining", accounts => {
       let addr = await colonyNetwork.getReputationMiningCycle(true);
       let repCycle = await IReputationMiningCycle.at(addr);
       const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId();
+      const globalKey = await ReputationMiner.getKey(metaColony.address, rootGlobalSkill, "0x0000000000000000000000000000000000000000");
+      const userKey = await ReputationMiner.getKey(metaColony.address, rootGlobalSkill, MAIN_ACCOUNT);
 
-      await goodClient.insert(
-        metaColony.address,
-        rootGlobalSkill,
-        "0x0000000000000000000000000000000000000000",
-        new BN("2").pow(new BN("256")).subn(2),
-        0
-      );
-      await goodClient.insert(metaColony.address, rootGlobalSkill, MAIN_ACCOUNT, new BN("2").pow(new BN("256")).subn(2), 0);
-      await badClient.insert(
-        metaColony.address,
-        rootGlobalSkill,
-        "0x0000000000000000000000000000000000000000",
-        new BN("2").pow(new BN("256")).subn(2),
-        0
-      );
-      await badClient.insert(metaColony.address, rootGlobalSkill, MAIN_ACCOUNT, new BN("2").pow(new BN("256")).subn(2), 0);
+      await goodClient.insert(globalKey, new BN("2").pow(new BN("256")).subn(2), 0);
+      await goodClient.insert(userKey, new BN("2").pow(new BN("256")).subn(2), 0);
+      await badClient.insert(globalKey, new BN("2").pow(new BN("256")).subn(2), 0);
+      await badClient.insert(userKey, new BN("2").pow(new BN("256")).subn(2), 0);
+
       const rootHash = await goodClient.getRootHash();
       await fundColonyWithTokens(metaColony, clny, new BN("4").mul(new BN("10").pow(new BN("75"))).toString());
       const taskId = await setupRatedTask({
@@ -2394,23 +2382,14 @@ contract("ColonyNetworkMining", accounts => {
       let addr = await colonyNetwork.getReputationMiningCycle(true);
       let repCycle = await IReputationMiningCycle.at(addr);
       const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId();
+      const globalKey = await ReputationMiner.getKey(metaColony.address, rootGlobalSkill, "0x0000000000000000000000000000000000000000");
+      const userKey = await ReputationMiner.getKey(metaColony.address, rootGlobalSkill, MAIN_ACCOUNT);
 
-      await goodClient.insert(
-        metaColony.address,
-        rootGlobalSkill,
-        "0x0000000000000000000000000000000000000000",
-        new BN("2").pow(new BN("256")).subn(2),
-        0
-      );
-      await goodClient.insert(metaColony.address, rootGlobalSkill, MAIN_ACCOUNT, new BN("2").pow(new BN("256")).subn(2), 0);
-      await badClient.insert(
-        metaColony.address,
-        rootGlobalSkill,
-        "0x0000000000000000000000000000000000000000",
-        new BN("2").pow(new BN("256")).subn(2),
-        0
-      );
-      await badClient.insert(metaColony.address, rootGlobalSkill, MAIN_ACCOUNT, new BN("2").pow(new BN("256")).subn(2), 0);
+      await goodClient.insert(globalKey, new BN("2").pow(new BN("256")).subn(2), 0);
+      await goodClient.insert(userKey, new BN("2").pow(new BN("256")).subn(2), 0);
+      await badClient.insert(globalKey, new BN("2").pow(new BN("256")).subn(2), 0);
+      await badClient.insert(userKey, new BN("2").pow(new BN("256")).subn(2), 0);
+
       const rootHash = await goodClient.getRootHash();
 
       await repCycle.submitRootHash(rootHash, 2, 10);
@@ -2768,11 +2747,14 @@ contract("ColonyNetworkMining", accounts => {
       let addr = await colonyNetwork.getReputationMiningCycle(true);
       let repCycle = await IReputationMiningCycle.at(addr);
       const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId();
+      const globalKey = await ReputationMiner.getKey(metaColony.address, rootGlobalSkill, "0x0000000000000000000000000000000000000000");
+      const userKey = await ReputationMiner.getKey(metaColony.address, rootGlobalSkill, MAIN_ACCOUNT);
 
-      await goodClient.insert(metaColony.address, rootGlobalSkill, "0x0000000000000000000000000000000000000000", new BN("1"), 0);
-      await goodClient.insert(metaColony.address, rootGlobalSkill, MAIN_ACCOUNT, new BN("1"), 0);
-      await badClient.insert(metaColony.address, rootGlobalSkill, "0x0000000000000000000000000000000000000000", new BN("1"), 0);
-      await badClient.insert(metaColony.address, rootGlobalSkill, MAIN_ACCOUNT, new BN("1"), 0);
+      await goodClient.insert(globalKey, new BN("1"), 0);
+      await goodClient.insert(userKey, new BN("1"), 0);
+      await badClient.insert(globalKey, new BN("1"), 0);
+      await badClient.insert(userKey, new BN("1"), 0);
+
       const rootHash = await goodClient.getRootHash();
 
       await repCycle.submitRootHash(rootHash, 2, 10);
@@ -2820,13 +2802,10 @@ contract("ColonyNetworkMining", accounts => {
       const keys = Object.keys(goodClient.reputations);
       for (let i = 0; i < keys.length; i += 1) {
         const key = keys[i];
-        const colonyAddress = key.slice(0, 42);
-        const skillId = key.slice(42, 106);
-        const userAddress = key.slice(106);
         const value = goodClient.reputations[key];
         const score = new BN(value.slice(2, 66), 16);
-
-        await badClient.insert(colonyAddress, skillId, userAddress, score, 0); // eslint-disable-line no-await-in-loop
+        console.log(key, score);
+        await badClient.insert(key, score, 0); // eslint-disable-line no-await-in-loop
       }
 
       await goodClient.addLogContentsToReputationTree();

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -2804,7 +2804,6 @@ contract("ColonyNetworkMining", accounts => {
         const key = keys[i];
         const value = goodClient.reputations[key];
         const score = new BN(value.slice(2, 66), 16);
-        console.log(key, score);
         await badClient.insert(key, score, 0); // eslint-disable-line no-await-in-loop
       }
 


### PR DESCRIPTION
Closes #318 

Everything returned by `breakKeyInToElements` is now prefixed by `0x` to make it clear that they are base16, and getKey can now deal with a base 16 string passed to it.