### PR TITLE
Remove obsolete todos

### DIFF
--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -116,7 +116,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
       metaColonyAddress.transfer(fee);
     } else {
       // Payout token
-      // TODO: If it's a whitelisted token, it goes straight to the metaColony
+      // TODO: (post CCv1) If it's a whitelisted token, it goes straight to the metaColony
       // If it's any other token, goes to the colonyNetwork contract first to be auctioned.
       ERC20Extended payoutToken = ERC20Extended(_token);
       payoutToken.transfer(task.roles[_role].user, remainder);

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -515,7 +515,6 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     // Proof 2 needs to prove that they finished with the reputation root hash they submitted, and the
     // key is the number of updates implied by the contents of the reputation update log (implemented)
     // plus the number of nodes in the last accepted update, each of which will have decayed once (not implemented)
-    // TODO: Account for decay calculations
     uint256 nLogEntries = reputationUpdateLog.length;
     // The total number of updates we expect is the nPreviousUpdates in the last entry of the log plus the number
     // of updates that log entry implies by itself, plus the number of decays (the number of nodes in current state)

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -25,9 +25,6 @@ import "./ITokenLocking.sol";
 import "./ReputationMiningCycleStorage.sol";
 
 
-// TODO: Can we handle all possible disputes regarding the very first hash that should be set?
-// Currently, at the very least, we can't handle a dispute if the very first entry is disputed.
-// A possible workaround would be to 'kick off' reputation mining with a known dummy state...
 contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProofs, DSMath {
 
   /// @notice A modifier that checks that the supplied `roundNumber` is the final round

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -114,7 +114,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       // Freeze the reputation mining system.
     } */
   }
-  
+
   /////////////////////////
   // Internal functions
   /////////////////////////
@@ -307,7 +307,6 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
     if (agreeStateReputationUID != 0) {
       // i.e. if this was an existing reputation, then require that the ID hasn't changed.
-      // TODO: Situation where it is not an existing reputation
       require(agreeStateReputationUID==disagreeStateReputationUID, "colony-reputation-mining-uid-changed-for-existing-reputation");
     } else {
       uint256 previousNewReputationUID;

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -25,9 +25,10 @@ import "./ITokenLocking.sol";
 import "./ReputationMiningCycleStorage.sol";
 
 
-// TODO: Can we handle all possible disputes regarding the very first hash that should be set?
+// TODO (post CCv1, possibly never): Can we handle all possible disputes regarding the very first hash that should be set?
 // Currently, at the very least, we can't handle a dispute if the very first entry is disputed.
 // A possible workaround would be to 'kick off' reputation mining with a known dummy state...
+// Given the approach we a taking for launch, we are able to guarantee that we are the only reputation miner for 100+ of the first cycles, even if we decided to lengthen a cycle length. As a result, maybe we just don't care about this special case?
 contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaTreeProofs, DSMath {
 
   /// @notice A modifier that checks if the challenge corresponding to the hash in the passed `round` and `id` is open

--- a/contracts/ReputationMiningCycleStorage.sol
+++ b/contracts/ReputationMiningCycleStorage.sol
@@ -41,7 +41,7 @@ contract ReputationMiningCycleStorage is DSAuth {
   address colonyNetworkAddress;
   address tokenLockingAddress;
   address clnyTokenAddress;
-  // TODO: Do we need both these mappings?
+  
   mapping (bytes32 => mapping( uint256 => address[])) submittedHashes;
   mapping (address => Submission) reputationHashSubmissions;
   uint256 reputationMiningWindowOpenTimestamp;

--- a/contracts/ReputationMiningCycleStorage.sol
+++ b/contracts/ReputationMiningCycleStorage.sol
@@ -20,10 +20,6 @@ pragma experimental "v0.5.0";
 
 import "../lib/dappsys/auth.sol";
 
-// TODO: Can we handle all possible disputes regarding the very first hash that should be set?
-// Currently, at the very least, we can't handle a dispute if the very first entry is disputed.
-// A possible workaround would be to 'kick off' reputation mining with a known dummy state...
-
 
 contract ReputationMiningCycleStorage is DSAuth {
   // Address of the Resolver contract used by EtherRouter for lookups and routing

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -214,7 +214,6 @@ contract("All", accounts => {
     });
 
     it("when working with staking", async () => {
-      // TODO: Should stakers be part of the constants?
       const STAKER1 = accounts[0];
       const STAKER2 = accounts[1];
       const STAKER3 = accounts[2];

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -229,7 +229,6 @@ class ReputationMiner {
       const currentRootHash = await this.colonyNetwork.getReputationRootHash({ blockNumber });
       if (!nNodes.eq(this.nReputations) || localRootHash !== currentRootHash) {
         console.log("Warning: client being initialized in bad state. Was the previous rootHash submitted correctly?");
-        // TODO If it's not already this value, then something has gone wrong, and we're working with the wrong state.
         interimHash = await this.colonyNetwork.getReputationRootHash(); // eslint-disable-line no-await-in-loop
         jhLeafValue = this.getJRHEntryValueAsBytes(interimHash, this.nReputations);
       }

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -332,10 +332,9 @@ contract("Meta Colony", accounts => {
       const domainCount = await colony.getDomainCount();
       assert.equal(domainCount.toNumber(), 4);
 
-      // TODO: I think newDomain1 is the root domain of the colony?
-      const newDomain1 = await colony.getDomain(1);
-      assert.equal(newDomain1[0].toNumber(), 4);
-      assert.equal(newDomain1[1].toNumber(), 1);
+      const rootDomain = await colony.getDomain(1);
+      assert.equal(rootDomain[0].toNumber(), 4);
+      assert.equal(rootDomain[1].toNumber(), 1);
 
       const newDomain2 = await colony.getDomain(2);
       assert.equal(newDomain2[0].toNumber(), 5);


### PR DESCRIPTION
Cleans up `todo`s in code and solves the _easy_ ones. Also adds a `(post CCv1)` note to ones that won't be done for the first version of Colony Contribute.

Closes #350 
Closes #343