### PR TITLE
Allow reputation oracle to return historical proofs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ step_setup_global_packages: &step_setup_global_packages
   run:
     name: "Set up global packages"
     command: |
-      yarn --pure-lockfile
+      yarn --pure-lockfile --network-concurrency 1
       # Trigger husky install manually due to https://github.com/typicode/husky/issues/227
       node node_modules/husky/lib/installer/bin install
       git submodule update --init

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@colony/colony-js-contract-loader-fs": "1.5.4",
     "@colony/eslint-config-colony": "5.0.0",
+    "async-request": "^1.2.0",
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.2.3",
     "babel-plugin-transform-runtime": "^6.23.0",

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -556,7 +556,7 @@ class ReputationMiner {
 
     const keyElements = ReputationMiner.breakKeyInToElements(key);
     const [colonyAddress, , userAddress] = keyElements;
-    const skillId = new BN(keyElements[1]).toString();
+    const skillId = parseInt(keyElements[1], 16);
     res = await db.all(
       `SELECT reputations.value
       FROM reputations
@@ -564,9 +564,9 @@ class ReputationMiner {
       INNER JOIN users ON users.rowid=reputations.user_rowid
       INNER JOIN reputation_states ON reputation_states.rowid=reputations.reputation_rowid
       WHERE reputation_states.root_hash="${rootHash}"
-      AND users.address="0x${userAddress}"
+      AND users.address="${userAddress}"
       AND reputations.skill_id="${skillId}"
-      AND colonies.address="0x${colonyAddress}"`
+      AND colonies.address="${colonyAddress}"`
     );
     await db.close();
 

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -568,12 +568,16 @@ class ReputationMiner {
       AND reputations.skill_id="${skillId}"
       AND colonies.address="0x${colonyAddress}"`
     );
+    await db.close();
 
     if (res.length === 0) {
       return new Error("No such reputation");
     }
 
-    await db.close();
+    if (res.length > 1) {
+      return new Error("Multiple such reputations found. Something is wrong!");
+    }
+
     const [branchMask, siblings] = await tree.getProof(key);
     const retBranchMask = ReputationMiner.getHexString(branchMask);
     return [retBranchMask, siblings, res[0].value];

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -545,7 +545,9 @@ class ReputationMiner {
        INNER JOIN reputation_states ON reputation_states.rowid=reputations.reputation_rowid
        WHERE reputation_states.root_hash="${rootHash}"`
     );
-
+    if (res.length === 0) {
+      return new Error("No such reputation state");
+    }
     for (let i = 0; i < res.length; i += 1) {
       const row = res[i];
       const rowKey = await ReputationMiner.getKey(row.colony_address, row.skill_id, row.user_address); // eslint-disable-line no-await-in-loop
@@ -566,6 +568,10 @@ class ReputationMiner {
       AND reputations.skill_id="${skillId}"
       AND colonies.address="0x${colonyAddress}"`
     );
+
+    if (res.length === 0) {
+      return new Error("No such reputation");
+    }
 
     await db.close();
     const [branchMask, siblings] = await tree.getProof(key);

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -3,6 +3,7 @@
 import path from "path";
 import BN from "bn.js";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
+import request from "async-request";
 
 import {
   forwardTime,
@@ -20,6 +21,8 @@ import MaliciousReputationMinerWrongUID from "../packages/reputation-miner/test/
 import MaliciousReputationMinerReuseUID from "../packages/reputation-miner/test/MaliciousReputationMinerReuseUID";
 import MaliciousReputationMinerWrongProofLogEntry from "../packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry";
 import MaliciousReputationMinerWrongNewestReputation from "../packages/reputation-miner/test/MaliciousReputationMinerWrongNewestReputation";
+
+import ReputationMinerClient from "../packages/reputation-miner/ReputationMinerClient";
 
 const EtherRouter = artifacts.require("EtherRouter");
 const IColony = artifacts.require("IColony");
@@ -2827,18 +2830,18 @@ contract("ColonyNetworkMining", accounts => {
     it.skip("should abort if a deposit did not complete correctly");
   });
 
+  async function advanceTimeSubmitAndConfirmHash(test) {
+    await forwardTime(3600, test);
+    await goodClient.addLogContentsToReputationTree();
+    await goodClient.submitRootHash();
+    const addr = await colonyNetwork.getReputationMiningCycle(true);
+    const repCycle = await IReputationMiningCycle.at(addr);
+    await repCycle.confirmNewHash(0);
+  }
+
   describe("Miner syncing functionality", () => {
     let startingBlockNumber;
     let goodClient2;
-
-    async function advanceTimeSubmitAndConfirmHash(test) {
-      await forwardTime(3600, test);
-      await goodClient.addLogContentsToReputationTree();
-      await goodClient.submitRootHash();
-      const addr = await colonyNetwork.getReputationMiningCycle(true);
-      const repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
-    }
 
     beforeEach(async () => {
       const startingBlock = await currentBlock();
@@ -3019,6 +3022,91 @@ contract("ColonyNetworkMining", accounts => {
 
       const clientHash3 = await goodClient.reputationTree.getRootHash();
       assert.equal(clientHash2, clientHash3);
+    });
+  });
+
+  describe("Reputation Mining Client", () => {
+    let client;
+    beforeEach(async () => {
+      await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
+      await advanceTimeSubmitAndConfirmHash();
+      await goodClient.saveCurrentState();
+
+      const loader = new TruffleLoader({
+        contractDir: path.resolve(process.cwd(), "build", "contracts")
+      });
+
+      client = new ReputationMinerClient({ loader, minerAddress: MAIN_ACCOUNT, useJSTree: true, auto: false });
+      await client.initialise(colonyNetwork.address);
+    });
+
+    afterEach(async () => {
+      client.close();
+    });
+
+    it("should correctly respond to a request for a reputation state in the current state", async () => {
+      const rootHash = await goodClient.getRootHash();
+      const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/${MAIN_ACCOUNT}`;
+      const res = await request(url);
+
+      assert.equal(res.statusCode, 200);
+      const oracleProofObject = JSON.parse(res.body);
+      const key = makeReputationKey(metaColony.address, 2, MAIN_ACCOUNT);
+
+      const [branchMask, siblings] = await goodClient.getProof(key);
+      const value = goodClient.reputations[key];
+
+      assert.equal(branchMask, oracleProofObject.branchMask);
+      assert.equal(siblings.length, oracleProofObject.siblings.length);
+      for (let i = 0; i < oracleProofObject.siblings.length; i += 1) {
+        assert.equal(siblings[i], oracleProofObject.siblings[i]);
+        assert.equal(siblings[i], oracleProofObject.siblings[i]);
+      }
+      assert.equal(key, oracleProofObject.key);
+      assert.equal(value, oracleProofObject.value);
+    });
+
+    it("should correctly respond to a request for a reputation state in a previous state", async () => {
+      const rootHash = await goodClient.getRootHash();
+      const key = makeReputationKey(metaColony.address, 2, MAIN_ACCOUNT);
+      const [branchMask, siblings] = await goodClient.getProof(key);
+      const value = goodClient.reputations[key];
+
+      await advanceTimeSubmitAndConfirmHash();
+
+      const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/${MAIN_ACCOUNT}`;
+      const res = await request(url);
+      assert.equal(res.statusCode, 200);
+      const oracleProofObject = JSON.parse(res.body);
+
+      assert.equal(branchMask, oracleProofObject.branchMask);
+      assert.equal(siblings.length, oracleProofObject.siblings.length);
+      for (let i = 0; i < oracleProofObject.siblings.length; i += 1) {
+        assert.equal(siblings[i], oracleProofObject.siblings[i]);
+        assert.equal(siblings[i], oracleProofObject.siblings[i]);
+      }
+      assert.equal(key, oracleProofObject.key);
+      assert.equal(value, oracleProofObject.value);
+    });
+
+    it("should correctly respond to a request for an invalid key in a valid past reputation state", async () => {
+      const rootHash = await goodClient.getRootHash();
+      const startingBlock = await currentBlock();
+      const startingBlockNumber = startingBlock.number;
+      await advanceTimeSubmitAndConfirmHash();
+      await client._miner.sync(startingBlockNumber); // eslint-disable-line no-underscore-dangle
+      const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/${accounts[4]}`;
+      const res = await request(url);
+      assert.equal(res.statusCode, 400);
+      assert.equal(JSON.parse(res.body).message, "Requested reputation does not exist or invalid request");
+    });
+
+    it("should correctly respond to a request for a valid key in an invalid reputation state", async () => {
+      const rootHash = await goodClient.getRootHash();
+      const url = `http://127.0.0.1:3000/${rootHash.slice(4)}0000/${metaColony.address}/2/${MAIN_ACCOUNT}`;
+      const res = await request(url);
+      assert.equal(res.statusCode, 400);
+      assert.equal(JSON.parse(res.body).message, "Requested reputation does not exist or invalid request");
     });
   });
 });

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -3032,11 +3032,13 @@ contract("ColonyNetworkMining", accounts => {
       await advanceTimeSubmitAndConfirmHash();
       await goodClient.saveCurrentState();
 
-      const loader = new TruffleLoader({
-        contractDir: path.resolve(process.cwd(), "build", "contracts")
+      client = new ReputationMinerClient({
+        loader: contractLoader,
+        realProviderPort: REAL_PROVIDER_PORT,
+        minerAddress: MAIN_ACCOUNT,
+        useJSTree: true,
+        auto: false
       });
-
-      client = new ReputationMinerClient({ loader, realProviderPort: REAL_PROVIDER_PORT, minerAddress: MAIN_ACCOUNT, useJSTree: true, auto: false });
       await client.initialise(colonyNetwork.address);
     });
 

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -3036,7 +3036,7 @@ contract("ColonyNetworkMining", accounts => {
         contractDir: path.resolve(process.cwd(), "build", "contracts")
       });
 
-      client = new ReputationMinerClient({ loader, minerAddress: MAIN_ACCOUNT, useJSTree: true, auto: false });
+      client = new ReputationMinerClient({ loader, realProviderPort: REAL_PROVIDER_PORT, minerAddress: MAIN_ACCOUNT, useJSTree: true, auto: false });
       await client.initialise(colonyNetwork.address);
     });
 
@@ -3048,7 +3048,6 @@ contract("ColonyNetworkMining", accounts => {
       const rootHash = await goodClient.getRootHash();
       const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/${MAIN_ACCOUNT}`;
       const res = await request(url);
-
       assert.equal(res.statusCode, 200);
       const oracleProofObject = JSON.parse(res.body);
       const key = makeReputationKey(metaColony.address, 2, MAIN_ACCOUNT);
@@ -3089,17 +3088,19 @@ contract("ColonyNetworkMining", accounts => {
       assert.equal(value, oracleProofObject.value);
     });
 
-    it("should correctly respond to a request for an invalid key in a valid past reputation state", async () => {
-      const rootHash = await goodClient.getRootHash();
-      const startingBlock = await currentBlock();
-      const startingBlockNumber = startingBlock.number;
-      await advanceTimeSubmitAndConfirmHash();
-      await client._miner.sync(startingBlockNumber); // eslint-disable-line no-underscore-dangle
-      const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/${accounts[4]}`;
-      const res = await request(url);
-      assert.equal(res.statusCode, 400);
-      assert.equal(JSON.parse(res.body).message, "Requested reputation does not exist or invalid request");
-    });
+    process.env.SOLIDITY_COVERAGE // eslint-disable-line no-unused-expressions
+      ? it.skip
+      : it("should correctly respond to a request for an invalid key in a valid past reputation state", async () => {
+          const rootHash = await goodClient.getRootHash();
+          const startingBlock = await currentBlock();
+          const startingBlockNumber = startingBlock.number;
+          await advanceTimeSubmitAndConfirmHash();
+          await client._miner.sync(startingBlockNumber); // eslint-disable-line no-underscore-dangle
+          const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/${accounts[4]}`;
+          const res = await request(url);
+          assert.equal(res.statusCode, 400);
+          assert.equal(JSON.parse(res.body).message, "Requested reputation does not exist or invalid request");
+        });
 
     it("should correctly respond to a request for a valid key in an invalid reputation state", async () => {
       const rootHash = await goodClient.getRootHash();

--- a/yarn.lock
+++ b/yarn.lock
@@ -430,6 +430,14 @@ async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
+async-request@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/async-request/-/async-request-1.2.0.tgz#b407af8b972d0292af659f190097f121dfa6ac9a"
+  dependencies:
+    lodash "^3.5.0"
+    request "^2.53.0"
+    tough-cookie "^0.12.1"
+
 async@1.x, async@^1.4.0, async@^1.4.2, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -4758,6 +4766,10 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
+lodash@^3.5.0:
+  version "3.10.1"
+  resolved "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
 lodash@^4.13.1, lodash@^4.14.2, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
@@ -5798,13 +5810,13 @@ punycode@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
+punycode@>=0.2.0, punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-
-punycode@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
 qs@6.5.1:
   version "6.5.1"
@@ -6084,7 +6096,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.67.0, request@^2.79.0, request@^2.83.0, request@^2.87.0:
+request@^2.53.0, request@^2.67.0, request@^2.79.0, request@^2.83.0, request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   dependencies:
@@ -7134,6 +7146,12 @@ tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
+
+tough-cookie@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-0.12.1.tgz#8220c7e21abd5b13d96804254bd5a81ebf2c7d62"
+  dependencies:
+    punycode ">=0.2.0"
 
 tr46@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Now that the history of all reputation states can be stored in the database, we needed to extend the reputation oracle to be able to return those historical states - showing a user their current reputation is great from a not-actually-doing-anything perspective, but if a reward payout is occurring (or, in the future, a dispute or a vote), the user needs to be able to prove their *historical* reputation to the contract.

This adds an extra parameter `rootHash` to the oracle route. If the root hash is the current root hash, then the reputation and proof is returned easily. If it is not the current root hash, the oracle attempts to  reconstruct that reputation state based on what it has in the database in a new (JS) patricia tree. Upon doing so, it calculates the proof for the requested reputation and returns it.

I have no idea how the response time scales with very large historical reputation states, but that's not really my concern right now.

I have also introduced an `auto` parameter to the `ReputationMiningClient`, which allows the autonomous submission to be toggled on and off (it is toggled off for the new tests to avoid race conditions).