### PR TITLE
Upgrade to truffle5 beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "solidity-coverage": "0.5.11",
     "solidity-parser-antlr": "^0.3.0",
     "solium": "^1.1.8",
-    "truffle": "^5.0.0-next.9",
+    "truffle": "5.0.0-beta.1",
     "web3-utils": "^1.0.0-beta.34"
   },
   "private": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6580,6 +6580,16 @@ solc@0.4.24, solc@^0.4.2:
     semver "^5.3.0"
     yargs "^4.7.1"
 
+solc@0.4.25:
+  version "0.4.25"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.25.tgz#06b8321f7112d95b4b903639b1138a4d292f5faa"
+  dependencies:
+    fs-extra "^0.30.0"
+    memorystream "^0.3.1"
+    require-from-string "^1.1.0"
+    semver "^5.3.0"
+    yargs "^4.7.1"
+
 solidity-coverage@0.5.11:
   version "0.5.11"
   resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.5.11.tgz#1ee45f6d98b75a615aadb8f9aa7db4a2b32258e7"
@@ -7177,13 +7187,13 @@ trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
 
-truffle@^5.0.0-next.9:
-  version "5.0.0-next.9"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.0-next.9.tgz#47141465a08cf44925cbb4a864f1dbab0ce8a1e2"
+truffle@5.0.0-beta.1:
+  version "5.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.0-beta.1.tgz#2ac40eb6128c1fa66b76c63567185e8fca17950b"
   dependencies:
     mocha "^4.1.0"
     original-require "1.0.1"
-    solc "0.4.24"
+    solc "0.4.25"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
This updates us to the newly released v5.beta1. Main improvement here is that before, `truffle` only showed events fired from contracts only when a test failed. With this version you can force it to show them always with `truffle test --show-events` (tested ok for gasCost tests)