### PR TITLE
CLNY goes to MetaColony, not ColonyNetwork

### DIFF
--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -315,12 +315,12 @@ contract("ColonyNetworkAuction", accounts => {
       assert.isTrue(finalized);
     });
 
-    it("Colony network gets all CLNY sent to the auction in bids", async () => {
-      const balanceBefore = await clny.balanceOf(colonyNetwork.address);
+    it("The metacolony gets all CLNY sent to the auction in bids", async () => {
+      const balanceBefore = await clny.balanceOf(metaColony.address);
       await tokenAuction.finalize();
       const receivedTotal = await tokenAuction.receivedTotal();
       assert.isFalse(receivedTotal.isZero());
-      const balanceAfter = await clny.balanceOf(colonyNetwork.address);
+      const balanceAfter = await clny.balanceOf(metaColony.address);
       assert.equal(balanceBefore.add(receivedTotal).toString(), balanceAfter.toString());
     });
 


### PR DESCRIPTION
Closes #368 

Pretty straightforward, I think. Only possible subtlety is that no explicit check required for the metacolony to exist, because CLNY address is looked up via the metacolony in `startTokenAuction`, so no auctions are able to be created if it doesn't exist.