### PR TITLE
Further mining cycle edge cases and checks

### DIFF
--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -92,6 +92,16 @@ contract IReputationMiningCycle {
   /// @param siblings The siblings of the Merkle proof that `jhIntermediateValue` is the value at key `targetNode`
   function respondToBinarySearchForChallenge(uint256 round, uint256 idx, bytes jhIntermediateValue, uint branchMask, bytes32[] siblings) public;
 
+
+  /// @notice Confirm the result of a binary search - depending on how exactly the binary search finished, the saved binary search intermediate state might be incorrect.
+  /// @notice This function ensures that the intermediate hashes saved are correct.
+  /// @param round The round number the hash we are responding on behalf of is in
+  /// @param idx The index in the round that the hash we are responding on behalf of is in
+  /// @param jhIntermediateValue The contents of the Justification Tree at the key given by `targetNode` (see function description). The value of `targetNode` is computed locally to establish what to submit to this function.
+  /// @param branchMask The branchMask of the Merkle proof that `jhIntermediateValue` is the value at key `targetNode`
+  /// @param siblings The siblings of the Merkle proof that `jhIntermediateValue` is the value at key `targetNode`
+  function confirmBinarySearchResult(uint256 round, uint256 idx, bytes jhIntermediateValue, uint256 branchMask, bytes32[] siblings) public;
+
   /// @notice Respond to challenge, to establish which (if either) of the two submissions facing off are correct.
   /// @param u A `uint256[10]` array. The elements of this array, in order are:
   /// * 1. The current round of the hash being responded on behalf of

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -282,10 +282,6 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
   ) public
   {
     require(disputeRounds[round][idx].lowerBound != disputeRounds[round][idx].upperBound, "colony-reputation-mining-challenge-not-active");
-    require(
-      2**(disputeRounds[round][idx].challengeStepCompleted - 1) < disputeRounds[round][idx].jrhNnodes,
-      "colony-reputation-mining-binary-search-already-complete"
-    );
 
     uint256 targetNode = add(
       disputeRounds[round][idx].lowerBound,

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -224,8 +224,9 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
       }
     } else {
       require(disputeRounds[round].length > opponentIdx, "colony-reputation-mining-dispute-id-not-in-range");
+      // If we are invalidating hash for idx then opponentIdx hash has to exist, so it is passed onto the next round
       require(disputeRounds[round][opponentIdx].proposedNewRootHash != "", "colony-reputation-mining-proposed-hash-empty");
-      require(disputeRounds[round][idx].proposedNewRootHash != "", "colony-reputation-mining-opponent-already-progressed");
+      require(disputeRounds[round][idx].proposedNewRootHash != "", "colony-reputation-mining-hash-already-progressed");
 
       // Require that this is not better than its opponent.
       require(disputeRounds[round][opponentIdx].challengeStepCompleted >= disputeRounds[round][idx].challengeStepCompleted, "colony-reputation-mining-less-challenge-rounds-completed");

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -225,6 +225,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     } else {
       require(disputeRounds[round].length > opponentIdx, "colony-reputation-mining-dispute-id-not-in-range");
       require(disputeRounds[round][opponentIdx].proposedNewRootHash != "", "colony-reputation-mining-proposed-hash-empty");
+      require(disputeRounds[round][idx].proposedNewRootHash != "", "colony-reputation-mining-opponent-already-progressed");
 
       // Require that this is not better than its opponent.
       require(disputeRounds[round][opponentIdx].challengeStepCompleted >= disputeRounds[round][idx].challengeStepCompleted, "colony-reputation-mining-less-challenge-rounds-completed");

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -372,7 +372,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     disputeRounds[round][index].challengeStepCompleted += 1;
 
     // Set bounds for first binary search if it's going to be needed
-    disputeRounds[round][index].upperBound = disputeRounds[round][index].jrhNnodes;
+    disputeRounds[round][index].upperBound = disputeRounds[round][index].jrhNnodes - 1;
   }
 
   function appendReputationUpdateLog(
@@ -612,7 +612,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
 
   function startMemberOfPair(uint256 roundNumber, uint256 index) internal {
     disputeRounds[roundNumber][index].lastResponseTimestamp = now;
-    disputeRounds[roundNumber][index].upperBound = disputeRounds[roundNumber][index].jrhNnodes;
+    disputeRounds[roundNumber][index].upperBound = disputeRounds[roundNumber][index].jrhNnodes - 1;
     disputeRounds[roundNumber][index].lowerBound = 0;
     disputeRounds[roundNumber][index].provedPreviousReputationUID = 0;
     if (disputeRounds[roundNumber][index].jrh != 0x0) {

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -270,6 +270,9 @@ contract("All", accounts => {
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
 
+      await goodClient.confirmBinarySearchResult();
+      await badClient.confirmBinarySearchResult();
+
       // We now know where they disagree
       await goodClient.respondToChallenge();
       // badClient will fail this if we try
@@ -291,6 +294,9 @@ contract("All", accounts => {
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient2.respondToBinarySearchForChallenge();
+
+      await goodClient.confirmBinarySearchResult();
+      await badClient.confirmBinarySearchResult();
 
       await goodClient.respondToChallenge();
       await oneHourLater();

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimNew.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimNew.js
@@ -1,0 +1,40 @@
+import ReputationMiner from "../ReputationMiner";
+
+class MaliciousReputationMinerClaimNew extends ReputationMiner {
+  // Only difference between this and the 'real' client should be that it claims a reputation update
+  // corresponds to a reputation that didn't previously exist in the tree.
+  constructor(opts, entryToFalsify) {
+    super(opts);
+    this.entryToFalsify = entryToFalsify.toString();
+  }
+
+  async addSingleReputationUpdate(updateNumber, repCycle, blockNumber) {
+    if (updateNumber.toString() === this.entryToFalsify) {
+      let key;
+      if (updateNumber.lt(this.nReputationsBeforeLatestLog)) {
+        key = await Object.keys(this.reputations)[updateNumber];
+      } else {
+        key = await this.getKeyForUpdateNumber(updateNumber, blockNumber);
+      }
+      delete this.reputations[key];
+      this.beWrongThisCycle = true;
+      // Note that this won't remove it from the PatriciaTree - which is what we want
+    }
+    await super.addSingleReputationUpdate(updateNumber, repCycle, blockNumber);
+    if (updateNumber.toString() === this.entryToFalsify) {
+      this.justificationHashes[ReputationMiner.getHexString(updateNumber.sub(1), 64)].nextUpdateProof = await this.getReputationProofObject("0");
+    }
+    this.beWrongThisCycle = false;
+  }
+
+  async getNewestReputationProofObject(i) {
+    // i is unused here, but is used in the Malicious3 mining client.
+    let key = Object.keys(this.reputations)[this.nReputations - 1];
+    if (i.gte(parseInt(this.entryToFalsify, 10))) {
+      key = Object.keys(this.reputations)[this.nReputations - 2];
+    }
+    return this.getReputationProofObject(key);
+  }
+}
+
+export default MaliciousReputationMinerClaimNew;

--- a/packages/reputation-miner/test/MaliciousReputationMinerUnsure.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerUnsure.js
@@ -1,0 +1,29 @@
+import ReputationMiner from "../ReputationMiner";
+
+class MaliciousReputationMinerClaimNew extends ReputationMiner {
+  // Not really sure how to describe this malicous mining client...
+  // It ends up proving a too-large newest reputation for the nNodes it claimed in the
+  // JRH (so in the test in question, the intermediate value had 6 nodes, but it proves
+  // a reputation with id 7 exists in that tree.
+  constructor(opts, entryToFalsify) {
+    super(opts);
+    this.entryToFalsify = entryToFalsify.toString();
+  }
+
+  async addSingleReputationUpdate(updateNumber, repCycle, blockNumber) {
+    if (updateNumber.toString() === this.entryToFalsify) {
+      let key;
+      if (updateNumber.lt(this.nReputationsBeforeLatestLog)) {
+        key = await Object.keys(this.reputations)[updateNumber];
+      } else {
+        key = await this.getKeyForUpdateNumber(updateNumber, blockNumber);
+      }
+      delete this.reputations[key];
+      this.nReputations = this.nReputations.sub(1);
+    }
+    // Note that this won't remove it from the PatriciaTree - which is what we want
+    await super.addSingleReputationUpdate(updateNumber, repCycle, blockNumber);
+  }
+}
+
+export default MaliciousReputationMinerClaimNew;

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -498,7 +498,7 @@ contract("ColonyNetworkMining", accounts => {
       const repCycle = await IReputationMiningCycle.at(addr);
 
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
-      await checkErrorRevert(repCycle.invalidateHash(0, 0), "colony-reputation-mining-opponent-already-progressed");
+      await checkErrorRevert(repCycle.invalidateHash(0, 0), "colony-reputation-mining-hash-already-progressed");
     });
 
     it("should invalidate a hash and its partner if both have timed out", async () => {

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -2009,7 +2009,7 @@ contract("ColonyNetworkMining", accounts => {
       await repCycle.confirmNewHash(1);
     });
 
-    it("should incorrectly confirming a binary search result should fail", async () => {
+    it("incorrectly confirming a binary search result should fail", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
@@ -2064,9 +2064,6 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, "1000000000000000000");
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, "1000000000000000000");
 
-      let addr = await colonyNetwork.getReputationMiningCycle(false);
-      let inactiveRepCycle = await IReputationMiningCycle.at(addr);
-
       badClient = new MaliciousReputationMinerExtraRep(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         5,
@@ -2089,8 +2086,8 @@ contract("ColonyNetworkMining", accounts => {
       await metaColony.finalizeTask(taskId);
       await advanceTimeSubmitAndConfirmHash(this);
       await advanceTimeSubmitAndConfirmHash(this);
-      addr = await colonyNetwork.getReputationMiningCycle(false);
-      inactiveRepCycle = await IReputationMiningCycle.at(addr);
+      let addr = await colonyNetwork.getReputationMiningCycle(false);
+      const inactiveRepCycle = await IReputationMiningCycle.at(addr);
 
       let powerTwoEntries = false;
       while (!powerTwoEntries) {

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -1003,20 +1003,20 @@ contract("ColonyNetworkMining", accounts => {
       let badSubmission = await repCycle.getDisputeRounds(0, 1);
       assert.equal(goodSubmission[3].toNumber(), 1); // Challenge steps completed
       assert.equal(goodSubmission[8].toNumber(), 0); // Lower bound for binary search
-      assert.equal(goodSubmission[9].toNumber(), 29); // Upper bound for binary search
+      assert.equal(goodSubmission[9].toNumber(), 28); // Upper bound for binary search
       assert.equal(badSubmission[3].toNumber(), 1);
       assert.equal(badSubmission[8].toNumber(), 0);
-      assert.equal(badSubmission[9].toNumber(), 29);
+      assert.equal(badSubmission[9].toNumber(), 28);
       await goodClient.respondToBinarySearchForChallenge();
 
       goodSubmission = await repCycle.getDisputeRounds(0, 0);
       badSubmission = await repCycle.getDisputeRounds(0, 1);
       assert.equal(goodSubmission[3].toNumber(), 2);
       assert.equal(goodSubmission[8].toNumber(), 0);
-      assert.equal(goodSubmission[9].toNumber(), 29);
+      assert.equal(goodSubmission[9].toNumber(), 28);
       assert.equal(badSubmission[3].toNumber(), 1);
       assert.equal(badSubmission[8].toNumber(), 0);
-      assert.equal(badSubmission[9].toNumber(), 29);
+      assert.equal(badSubmission[9].toNumber(), 28);
 
       await badClient.respondToBinarySearchForChallenge();
       goodSubmission = await repCycle.getDisputeRounds(0, 0);
@@ -1401,7 +1401,6 @@ contract("ColonyNetworkMining", accounts => {
       // Check badclient respondToChallenge failed
       const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 0);
       const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 1);
-
       assert.equal(goodSubmissionAfterResponseToChallenge[3].sub(badSubmissionAfterResponseToChallenge[3]).toNumber(), 2);
 
       await forwardTime(600, this);


### PR DESCRIPTION
Closes #348 and maybe some other issues I can't lay my hands on?

## Repeated calls of respondToChallenge
Until now, `respondToChallenge` was able to be called repeatedly; this would increase their `nChallengeStepsCompleted` to as high as necessary to 'win' the content.

Now, `nChallengeStepsCompleted` must be within a specific band for `respondToChallenge` to be called. The allowed value is based on jrhNnodes, which is the same for all submissions if they have managed to submit a JRH, which is a requirement for the binary search and all subsequent calls. Once respondToChallenge has been called once, `nChallengeStepsCompleted` moves out of this allowed band.

## Incorrect intermediateRootHash
When the binary search completed, there was no guarantee that the saved `intermediateReputationHash` / `intermediateReputationNNodes` for the hash that responded to the last challenge first would be correct. I have therefore introduced a new `confirmBinarySearchResult` call that is required to be made after the binary search has completed and before `respondToChallenge` can be called.

Note that at the end of this function, `nChallengeStepsCompleted` increases until `2**(nChallengeStepsCompleted-2)` is larger than `jrhNNodes`. This is a loop because we cannot guarantee the number of steps that have actually been taken (e.g. for eight nodes, it must be three steps, but if only seven nodes are present, it may take two or three, depending on where exactly the discrepancy is).

The calculation involving the `-2` will never underflow, as `nChallengeSteps` is increased when the JRH is submitted, and the fact that there is at least one binary search step as our trees are always greater than two leaves.

I am a little worried I'm trying to be too clever with these `nChallengeStepsCompleted` requirements, but on the plus side, because jrhNNodes is always odd, if I've gotten a <= where I should have a <, it shouldn't matter because we can never be an exact power of two. I've included a test that shows how I'd want to test against these constraints if it were possible, which at least serves to hit some of these requires for coverage purposes.