### PR TITLE
Economic tweaks

### DIFF
--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -241,9 +241,13 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     uint256 reward;
     (tokenAddress, reward) = calculateRewardForUser(_payoutId, _squareRoots, userReputation);
 
+    uint fee = calculateNetworkFeeForPayout(reward);
+    uint remainder = sub(reward, fee);
+
     pots[0].balance[tokenAddress] = sub(pots[0].balance[tokenAddress], reward);
 
-    ERC20Extended(tokenAddress).transfer(msg.sender, reward);
+    ERC20Extended(tokenAddress).transfer(msg.sender, remainder);
+    ERC20Extended(tokenAddress).transfer(colonyNetworkAddress, fee);
   }
 
   function finalizeRewardPayout(uint256 _payoutId) public stoppable {
@@ -269,9 +273,9 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     );
   }
 
-  function setRewardInverse(uint256 _rewardInverse) public 
+  function setRewardInverse(uint256 _rewardInverse) public
   stoppable
-  auth 
+  auth
   {
     require(_rewardInverse > 0, "colony-reward-inverse-cannot-be-zero");
     rewardInverse = _rewardInverse;
@@ -399,8 +403,8 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
     uint256 feeInverse = colonyNetworkContract.getFeeInverse();
 
-    if (_payout == 0 || feeInverse == 1) { 
-      fee = _payout; 
+    if (_payout == 0 || feeInverse == 1) {
+      fee = _payout;
     } else {
       fee = _payout/feeInverse + 1;
     }

--- a/contracts/ColonyNetworkAuction.sol
+++ b/contracts/ColonyNetworkAuction.sol
@@ -31,7 +31,7 @@ contract ColonyNetworkAuction is ColonyNetworkStorage {
     require(lastAuctionTimestamp == 0 || now - lastAuctionTimestamp >= 30 days, "colony-auction-start-too-soon");
 
     address clny = IColony(metaColony).getToken();
-    require(clny != 0x0, "colony-auction-invalid-token");
+    require(clny != 0x0, "colony-auction-invalid-clny-token");
 
     uint availableTokens = ERC20Extended(_token).balanceOf(this);
 


### PR DESCRIPTION
Closes #353

* CLNY used in auctions is burned, not sent to MetaColony
* If an auction of CLNY is attempted to be started, all CLNY held by ColonyNetwork is burned
* Rewards have the network fee applied to them, same as task payouts

My notes are unclear as to whether 'fees being the same on all tokens, including native ones' applies to `claimColonyFunds`, so I have left that unchanged for now but should check with Jack.