### PR TITLE
Miner variable rewards I

### DIFF
--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -321,7 +321,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
 
     uint256 userTokens;
     ITokenLocking tokenLocking = ITokenLocking(IColonyNetwork(colonyNetworkAddress).getTokenLocking());
-    (, userTokens) = tokenLocking.getUserLock(address(token), msg.sender);
+    (, userTokens,) = tokenLocking.getUserLock(address(token), msg.sender);
 
     require(userTokens > 0, "colony-reward-payout-invalid-user-tokens");
     require(userReputation > 0, "colony-reward-payout-invalid-user-reputation");

--- a/contracts/ColonyNetworkMining.sol
+++ b/contracts/ColonyNetworkMining.sol
@@ -21,6 +21,7 @@ pragma experimental "v0.5.0";
 import "./ColonyNetworkStorage.sol";
 import "./ERC20Extended.sol";
 import "./IReputationMiningCycle.sol";
+import "./ITokenLocking.sol";
 import "./EtherRouter.sol";
 
 
@@ -113,29 +114,58 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
     }
   }
 
+  // Constants for miner weight calculations, in WADs
+  uint256 constant T = 7776000 * WAD; // Seconds in 90 days
+  uint256 constant N = 24 * WAD; // 2x maximum number of miners
+  uint256 constant UINT32_MAX = 4294967295;
+
+  function calculateMinerWeight(uint256 timeStaked, uint256 submissonIndex) public view returns (uint256) {
+    require((submissonIndex >= 1) && (submissonIndex <= 12), "colony-reputation-mining-invalid-submission-index");
+    uint256 timeStakedMax = min(timeStaked, UINT32_MAX); // Maximum of ~136 years (uint32)
+
+    // (1 - exp{-t_n/T}) * (1 - (n-1)/N), 3rd degree Taylor expansion for exponential term
+    uint256 tnDivT = wdiv(timeStakedMax * WAD, T);
+    uint256 expTnDivT = add(add(add(WAD, tnDivT), wmul(tnDivT, tnDivT) / 2), wmul(wmul(tnDivT, tnDivT), tnDivT) / 6);
+    uint256 stakeTerm = sub(WAD, wdiv(WAD, expTnDivT));
+    uint256 submissionTerm = sub(WAD, wdiv((submissonIndex - 1) * WAD, N));
+    return wmul(stakeTerm, submissionTerm);
+  }
+
   function rewardStakers(address[] stakers) internal {
     // Internal unlike punish, because it's only ever called from setReputationRootHash
 
-    // TODO: Actually think about this function
     // Passing an array so that we don't incur the EtherRouter overhead for each staker if we looped over
     // it in ReputationMiningCycle.confirmNewHash;
-    uint256 reward = 10**18; //TODO: Actually work out how much reputation they earn, based on activity elsewhere in the colony.
-    if (reward >= uint256(int256(-1))/2) {
-      reward = uint256(int256(-1))/2;
-    }
-    // TODO: We need to be able to prove that the assert on the next line will never happen, otherwise we're locked out of reputation mining.
-    // Something like the above cap is an adequate short-term solution, but at the very least need to double check the limits
-    // (which I've fingered-in-the-air, but could easily have an OBOE hiding inside).
-    assert(reward < uint256(int256(-1))); // We do a cast later, so make sure we don't overflow.
 
+    uint256 i;
+    address clnyToken = IColony(metaColony).getToken();
+
+    // I. Calculate (normalized) miner weights
+    // uint256 timeStaked;
+    // uint256 minerWeightsTotal = 1;
+    // uint256[] memory minerWeights = new uint256[](stakers.length);
+
+    // for (i = 0; i < stakers.length; i++) {
+    //   (,,timeStaked) = ITokenLocking(tokenLocking).getUserLock(clnyToken, stakers[i]);
+    //   minerWeights[i] = calculateMinerWeight(now - timeStaked, i);
+    //   minerWeightsTotal = add(minerWeightsTotal, minerWeights[i]);
+    // }
+
+    // for (i = 0; i < stakers.length; i++) {
+    //   minerWeights[i] = wdiv(minerWeights[i], minerWeightsTotal);
+    // }
+
+    // II. Figure out total miner reward M
+    uint256 reward = 10**18; //TODO: Actually work out how much reputation they earn, based on activity elsewhere in the colony.
+
+    // III. Disburse reputation and tokens
     IMetaColony(metaColony).mintTokensForColonyNetwork(stakers.length * reward); // This should be the total amount of new tokens we're awarding.
 
     // This gives them reputation in the next update cycle.
     IReputationMiningCycle(inactiveReputationMiningCycle).rewardStakersWithReputation(stakers, metaColony, reward, rootGlobalSkillId + 2);
 
-    for (uint256 i = 0; i < stakers.length; i++) {
-      // Also give them some newly minted tokens.
-      ERC20Extended(IColony(metaColony).getToken()).transfer(stakers[i], reward);
+    for (i = 0; i < stakers.length; i++) {
+      ERC20Extended(clnyToken).transfer(stakers[i], reward);
     }
   }
 }

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -211,7 +211,8 @@ contract IColonyNetwork is IRecovery {
   /// @param newHash The reputation root hash
   /// @param newNNodes The updated nodes count value
   /// @param stakers Array of users who submitted or backed the hash, being accepted here as the new reputation root hash
-  function setReputationRootHash(bytes32 newHash, uint256 newNNodes, address[] stakers) public;
+  /// @param reward Amount of CLNY to be distributed as reward to miners
+  function setReputationRootHash(bytes32 newHash, uint256 newNNodes, address[] stakers, uint256 reward) public;
 
   /// @notice Starts a new Reputation Mining cycle. Explicitly called only the first time,
   /// subsequently called from within `setReputationRootHash`

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -198,9 +198,9 @@ contract IColonyNetwork is IRecovery {
 
   /// @notice Calculate raw miner weight in WADs
   /// @param _timeStaked Amount of time (in seconds) that the miner has staked their CLNY
-  /// @param _submissonIndex Index of reputation hash submission (between 1 and 12)
+  /// @param _submissonIndex Index of reputation hash submission (between 0 and 11)
   /// @return minerWeight The weight of miner reward
-  function calculateMinerWeight(uint256 _timeStaked, uint256 _submissonIndex) public view returns (uint256 minerWeight);
+  function calculateMinerWeight(uint256 _timeStaked, uint256 _submissonIndex) public pure returns (uint256 minerWeight);
 
   /// @notice Get the `Resolver` address for Colony contract version `_version`
   /// @param _version The Colony contract version

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -196,6 +196,12 @@ contract IColonyNetwork is IRecovery {
   /// @return repMiningCycleAddress address of active or inactive ReputationMiningCycle
   function getReputationMiningCycle(bool _active) public view returns (address repMiningCycleAddress);
 
+  /// @notice Calculate raw miner weight in WADs
+  /// @param _timeStaked Amount of time (in seconds) that the miner has staked their CLNY
+  /// @param _submissonIndex Index of reputation hash submission (between 1 and 12)
+  /// @return minerWeight The weight of miner reward
+  function calculateMinerWeight(uint256 _timeStaked, uint256 _submissonIndex) public view returns (uint256 minerWeight);
+
   /// @notice Get the `Resolver` address for Colony contract version `_version`
   /// @param _version The Colony contract version
   /// @return resolverAddress Address of the `Resolver` contract

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -199,12 +199,13 @@ contract IReputationMiningCycle {
 
   /// @notice Start the reputation log with the rewards for the stakers who backed the accepted new reputation root hash.
   /// @param stakers The array of stakers addresses to receive the reward.
-  /// @param commonColonyAddress The address of the common colony, which the special mining skill is earned in
+  /// @param weights The array of weights determining the proportion of reward to go to each staker
+  /// @param metaColonyAddress The address of the meta colony, which the special mining skill is earned in
   /// @param reward The amount of reputation to be rewarded to each staker
   /// @dev Only callable by colonyNetwork
   /// @dev Note that the same address might be present multiple times in `stakers` - this is acceptable, and indicates the
   /// same address backed the same hash multiple times with different entries.
-  function rewardStakersWithReputation(address[] stakers, address commonColonyAddress, uint reward, uint miningSkillId) public;
+  function rewardStakersWithReputation(address[] stakers, uint256[] weights, address metaColonyAddress, uint reward, uint miningSkillId) public;
 
   /// @notice Get the timestamp that the current reputation mining window opened
   function getReputationMiningWindowOpenTimestamp() public view returns (uint256 timestamp);

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -205,7 +205,13 @@ contract IReputationMiningCycle {
   /// @dev Only callable by colonyNetwork
   /// @dev Note that the same address might be present multiple times in `stakers` - this is acceptable, and indicates the
   /// same address backed the same hash multiple times with different entries.
-  function rewardStakersWithReputation(address[] stakers, uint256[] weights, address metaColonyAddress, uint reward, uint miningSkillId) public;
+  function rewardStakersWithReputation(
+    address[] stakers,
+    uint256[] weights,
+    address metaColonyAddress,
+    uint256 reward,
+    uint256 miningSkillId
+    ) public;
 
   /// @notice Get the timestamp that the current reputation mining window opened
   function getReputationMiningWindowOpenTimestamp() public view returns (uint256 timestamp);

--- a/contracts/ITokenLocking.sol
+++ b/contracts/ITokenLocking.sol
@@ -55,5 +55,6 @@ contract ITokenLocking {
   /// @param _user Address of the user
   /// @return lockCount User's token lock count
   /// @return amount User's deposited amount
-  function getUserLock(address _token, address _user) public view returns (uint256 lockCount, uint256 amount);
+  /// @return timestamp Timestamp of deposit
+  function getUserLock(address _token, address _user) public view returns (uint256 lockCount, uint256 amount, uint256 timestamp);
 }

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -54,16 +54,18 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
   /// @param entryIndex The number of the entry the submitter hash asked us to consider.
   modifier entryQualifies(bytes32 newHash, uint256 nNodes, uint256 entryIndex) {
     uint256 balance;
-    (, balance) = ITokenLocking(tokenLockingAddress).getUserLock(clnyTokenAddress, msg.sender);
+    (, balance,) = ITokenLocking(tokenLockingAddress).getUserLock(clnyTokenAddress, msg.sender);
     require(entryIndex <= balance / MIN_STAKE, "colony-reputation-mining-stake-minimum-not-met-for-index");
     require(entryIndex > 0, "colony-reputation-mining-zero-entry-index-passed");
+
     // If this user has submitted before during this round...
     if (reputationHashSubmissions[msg.sender].proposedNewRootHash != 0x0) {
       // ...require that they are submitting the same hash ...
       require(newHash == reputationHashSubmissions[msg.sender].proposedNewRootHash, "colony-reputation-mining-submitting-different-hash");
       // ...require that they are submitting the same number of nodes for that hash ...
       require(nNodes == reputationHashSubmissions[msg.sender].nNodes, "colony-reputation-mining-submitting-different-nnodes");
-      require(submittedEntries[newHash][msg.sender][entryIndex] == false, "colony-reputation-mining-submitting-same-entry-index"); // ... but not this exact entry
+      // ... but not this exact entry
+      require(submittedEntries[newHash][msg.sender][entryIndex] == false, "colony-reputation-mining-submitting-same-entry-index");
     }
     _;
   }

--- a/contracts/TokenLocking.sol
+++ b/contracts/TokenLocking.sol
@@ -86,9 +86,8 @@ contract TokenLocking is TokenLockingStorage, DSMath {
       currWeight /= 2;
     }
 
-    uint256 timestamp = add(mul(prevWeight, lock.timestamp), mul(currWeight, now)) / add(prevWeight, currWeight);
-
-    userLocks[_token][msg.sender] = Lock(totalLockCount[_token], add(lock.balance, _amount), timestamp);
+    uint256 newTimestamp = add(mul(prevWeight, lock.timestamp), mul(currWeight, now)) / add(prevWeight, currWeight);
+    userLocks[_token][msg.sender] = Lock(totalLockCount[_token], add(lock.balance, _amount), newTimestamp);
   }
 
   function withdraw(address _token, uint256 _amount) public

--- a/contracts/TokenLockingStorage.sol
+++ b/contracts/TokenLockingStorage.sol
@@ -14,6 +14,8 @@ contract TokenLockingStorage is DSAuth {
     uint256 lockCount;
     // Deposited balance
     uint256 balance;
+    // Timestamp of last deposit
+    uint256 timestamp;
   }
 
   // Maps token to user to Lock struct

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -366,6 +366,36 @@ contract("ColonyNetworkMining", accounts => {
       const windowOpenTimestampAfter = await repCycle.getReputationMiningWindowOpenTimestamp();
       assert.equal(windowOpenTimestampBefore.toString(), windowOpenTimestampAfter.toString());
     });
+
+    it("should correctly calculate the miner weight", async () => {
+      const UINT256_MAX = new BN(0).notn(256);
+      const UINT32_MAX = new BN(0).notn(32);
+      let weight;
+
+      // Large weight (staked for UINT256_MAX, first submission)
+      weight = await colonyNetwork.calculateMinerWeight(UINT256_MAX, 1);
+      assert.equal("999999964585636861", weight.toString());
+
+      // Large weight (staked for UINT32_MAX, first submission)
+      weight = await colonyNetwork.calculateMinerWeight(UINT32_MAX, 1);
+      assert.equal("999999964585636861", weight.toString());
+
+      // Middle weight (staked for UINT32_MAX, last submission)
+      weight = await colonyNetwork.calculateMinerWeight(UINT32_MAX, 12);
+      assert.equal("541666647483886633", weight.toString());
+
+      // Middle weight I (staked for T, first submission)
+      weight = await colonyNetwork.calculateMinerWeight(7776000, 1);
+      assert.equal("625000000000000000", weight.toString());
+
+      // Middle weight II (staked for T, last submission)
+      weight = await colonyNetwork.calculateMinerWeight(7776000, 12);
+      assert.equal("338541666666666667", weight.toString());
+
+      // Smallest weight (staked for 0, last submission)
+      weight = await colonyNetwork.calculateMinerWeight(0, 12);
+      assert.equal("0", weight.toString());
+    });
   });
 
   describe("Elimination of submissions", () => {

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -375,27 +375,27 @@ contract("ColonyNetworkMining", accounts => {
       let weight;
 
       // Large weight (staked for UINT256_MAX, first submission)
-      weight = await colonyNetwork.calculateMinerWeight(UINT256_MAX, 1);
+      weight = await colonyNetwork.calculateMinerWeight(UINT256_MAX, 0);
       assert.equal("999999964585636861", weight.toString());
 
       // Large weight (staked for UINT32_MAX, first submission)
-      weight = await colonyNetwork.calculateMinerWeight(UINT32_MAX, 1);
+      weight = await colonyNetwork.calculateMinerWeight(UINT32_MAX, 0);
       assert.equal("999999964585636861", weight.toString());
 
       // Middle weight (staked for UINT32_MAX, last submission)
-      weight = await colonyNetwork.calculateMinerWeight(UINT32_MAX, 12);
+      weight = await colonyNetwork.calculateMinerWeight(UINT32_MAX, 11);
       assert.equal("541666647483886633", weight.toString());
 
       // Middle weight I (staked for T, first submission)
-      weight = await colonyNetwork.calculateMinerWeight(7776000, 1);
+      weight = await colonyNetwork.calculateMinerWeight(7776000, 0);
       assert.equal("625000000000000000", weight.toString());
 
       // Middle weight II (staked for T, last submission)
-      weight = await colonyNetwork.calculateMinerWeight(7776000, 12);
+      weight = await colonyNetwork.calculateMinerWeight(7776000, 11);
       assert.equal("338541666666666667", weight.toString());
 
       // Smallest weight (staked for 0, last submission)
-      weight = await colonyNetwork.calculateMinerWeight(0, 12);
+      weight = await colonyNetwork.calculateMinerWeight(0, 11);
       assert.equal("0", weight.toString());
     });
   });

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -791,8 +791,8 @@ contract("ColonyNetworkMining", accounts => {
       assert.isTrue(balance1Updated.sub(REWARD.divn(2)).gtn(0), "Account was not rewarded properly");
       // Less than half of the reward
       assert.isTrue(balance2Updated.sub(REWARD.divn(2)).ltn(0), "Account was not rewarded properly");
-      // Sum is total reward within 100 wei of precision error
-      assert.closeTo(balance1Updated.add(balance2Updated).sub(REWARD).toNumber(), 0, 100); // eslint-disable-line prettier/prettier
+      // Sum is total reward within `stakers.length` wei of precision error
+      assert.closeTo(balance1Updated.add(balance2Updated).sub(REWARD).toNumber(), 0, 2); // eslint-disable-line prettier/prettier
 
       addr = await colonyNetwork.getReputationMiningCycle(false);
       repCycle = await IReputationMiningCycle.at(addr);


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Partially addresses #164 

<!--- Summary of changes including design decisions -->

- Variable miner rewards as per WP sec 7.8 equations 3 & 4
- Token staking timestamp updates as average of existing and new stake.
- Currently total reward is **fixed** at 1200 CLNY.
