### PR TITLE
Enable contract error messages on mining client

### DIFF
--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -144,7 +144,6 @@ export async function checkErrorRevert(promise, errorMessage) {
     // If the promise is from Truffle, then we have the receipt already.
     // If this tx has come from the mining client, the promise has just resolved to a tx hash and we need to do the following
     if (!receipt) {
-      console.log("no receipt returned");
       const txid = await promise;
       receipt = await web3GetTransactionReceipt(txid);
     }

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -92,6 +92,43 @@ export function web3GetAccounts() {
   });
 }
 
+export function web3GetRawCall(params) {
+  const packet = {
+    jsonrpc: "2.0",
+    method: "eth_call",
+    params: [params],
+    id: new Date().getTime()
+  };
+
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.send(packet, (err, res) => {
+      if (err !== null) return reject(err);
+      return resolve(res);
+    });
+  });
+}
+
+export function extractReasonString(res) {
+  if (!res || (!res.error && !res.result)) return "";
+
+  const errorStringHash = "0x08c379a0";
+
+  const isObject = res && typeof res === "object" && res.error && res.error.data;
+  const isString = res && typeof res === "object" && typeof res.result === "string";
+
+  if (isObject) {
+    const { data } = res.error;
+    const hash = Object.keys(data)[0];
+
+    if (data[hash].return && data[hash].return.includes(errorStringHash)) {
+      return web3.eth.abi.decodeParameter("string", data[hash].return.slice(10));
+    }
+  } else if (isString && res.result.includes(errorStringHash)) {
+    return web3.eth.abi.decodeParameter("string", res.result.slice(10));
+  }
+  return "";
+}
+
 export async function checkErrorRevert(promise, errorMessage) {
   // There is a discrepancy between how ganache-cli handles errors
   // (throwing an exception all the way up to these tests) and how geth/parity handle them
@@ -108,12 +145,7 @@ export async function checkErrorRevert(promise, errorMessage) {
     // If this tx has come from the mining client, the promise has just resolved to a tx hash and we need to do the following
     if (!receipt) {
       console.log("no receipt returned");
-      let txid;
-      txid = await promise;
-      // TODO: make this logic better. `ethers` returns a full transaction response from calls
-      if (txid.hash) {
-        txid = txid.hash;
-      }
+      const txid = await promise;
       receipt = await web3GetTransactionReceipt(txid);
     }
   } catch (err) {
@@ -122,6 +154,18 @@ export async function checkErrorRevert(promise, errorMessage) {
   }
   // Check the receipt `status` to ensure transaction failed.
   assert.equal(receipt.status, 0x00, `Transaction succeeded, but expected error ${errorMessage}`);
+}
+
+export async function checkErrorRevertEthers(promise, errorMessage) {
+  const tx = await promise;
+  const txid = tx.hash;
+
+  const receipt = await web3GetTransactionReceipt(txid);
+  assert.equal(receipt.status, 0x00, `Transaction succeeded, but expected to fail`);
+
+  const response = await web3GetRawCall({ from: tx.from, to: tx.to, data: tx.data, gas: tx.gasLimit.toNumber(), value: tx.value.toNumber() });
+  const reason = extractReasonString(response);
+  assert.equal(reason, errorMessage);
 }
 
 export function getRandomString(_length) {

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -107,7 +107,13 @@ export async function checkErrorRevert(promise, errorMessage) {
     // If the promise is from Truffle, then we have the receipt already.
     // If this tx has come from the mining client, the promise has just resolved to a tx hash and we need to do the following
     if (!receipt) {
-      const txid = await promise;
+      console.log("no receipt returned");
+      let txid;
+      txid = await promise;
+      // TODO: make this logic better. `ethers` returns a full transaction response from calls
+      if (txid.hash) {
+        txid = txid.hash;
+      }
       receipt = await web3GetTransactionReceipt(txid);
     }
   } catch (err) {

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -108,6 +108,7 @@ export function web3GetRawCall(params) {
   });
 }
 
+// Borrowed from `truffle` https://github.com/trufflesuite/truffle/blob/next/packages/truffle-contract/lib/reason.js
 export function extractReasonString(res) {
   if (!res || (!res.error && !res.result)) return "";
 

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -77,9 +77,8 @@ class ReputationMiner {
     } else {
       this.patriciaTreeContractDef = await this.loader.load({ contractName: "PatriciaTree" }, { abi: true, address: false, bytecode: true });
 
-      const abstractContract = new ethers.Contract(null, this.patriciaTreeContractDef.abi, this.ganacheWallet);
-      const contract = await abstractContract.deploy(this.patriciaTreeContractDef.bytecode);
-      await contract.deployed();
+      const contractFactory = new ethers.ContractFactory(this.patriciaTreeContractDef.abi, this.patriciaTreeContractDef.bytecode, this.ganacheWallet);
+      const contract = await contractFactory.deploy();
       this.reputationTree = new ethers.Contract(contract.address, this.patriciaTreeContractDef.abi, this.ganacheWallet);
     }
 
@@ -96,9 +95,8 @@ class ReputationMiner {
     if (this.useJsTree) {
       this.justificationTree = new patriciaJs.PatriciaTree();
     } else {
-      const abstractContract = new ethers.Contract(null, this.patriciaTreeContractDef.abi, this.ganacheWallet);
-      const contract = await abstractContract.deploy(this.patriciaTreeContractDef.bytecode);
-      await contract.deployed();
+      const contractFactory = new ethers.ContractFactory(this.patriciaTreeContractDef.abi, this.patriciaTreeContractDef.bytecode, this.ganacheWallet);
+      const contract = await contractFactory.deploy();
       this.justificationTree = new ethers.Contract(contract.address, this.patriciaTreeContractDef.abi, this.ganacheWallet);
     }
 
@@ -909,9 +907,8 @@ class ReputationMiner {
     } else {
       this.patriciaTreeContractDef = await this.loader.load({ contractName: "PatriciaTree" }, { abi: true, address: false, bytecode: true });
 
-      const abstractContract = new ethers.Contract(null, this.patriciaTreeContractDef.abi, this.ganacheWallet);
-      const contract = await abstractContract.deploy(this.patriciaTreeContractDef.bytecode);
-      await contract.deployed();
+      const contractFactory = new ethers.ContractFactory(this.patriciaTreeContractDef.abi, this.patriciaTreeContractDef.bytecode, this.ganacheWallet);
+      const contract = await contractFactory.deploy();
       this.reputationTree = new ethers.Contract(contract.address, this.patriciaTreeContractDef.abi, this.ganacheWallet);
     }
 

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -649,10 +649,9 @@ class ReputationMiner {
 
     const intermediateReputationHash = this.justificationHashes[targetNodeKey].jhLeafValue;
     const [branchMask, siblings] = await this.justificationTree.getProof(targetNodeKey);
-    const tx = await repCycle.respondToBinarySearchForChallenge(round, index, intermediateReputationHash, branchMask, siblings, {
+    return repCycle.respondToBinarySearchForChallenge(round, index, intermediateReputationHash, branchMask, siblings, {
       gasLimit: 1000000
     });
-    return tx;
   }
 
   /**
@@ -669,10 +668,9 @@ class ReputationMiner {
 
     const intermediateReputationHash = this.justificationHashes[targetNodeKey].jhLeafValue;
     const [branchMask, siblings] = await this.justificationTree.getProof(targetNodeKey);
-    const tx = await repCycle.confirmBinarySearchResult(round, index, intermediateReputationHash, branchMask, siblings, {
+    return repCycle.confirmBinarySearchResult(round, index, intermediateReputationHash, branchMask, siblings, {
       gasLimit: 1000000
     });
-    return tx;
   }
 
   /**
@@ -725,7 +723,7 @@ class ReputationMiner {
     //   this.justificationHashes[lastAgreeKey].newestReputationProof.value,
     //   this.justificationHashes[lastAgreeKey].newestReputationProof.siblings);
 
-    const tx = await repCycle.respondToChallenge(
+    return repCycle.respondToChallenge(
       [
         round,
         index,
@@ -750,7 +748,6 @@ class ReputationMiner {
       this.justificationHashes[lastAgreeKey].newestReputationProof.siblings,
       { gasLimit: 4000000 }
     );
-    return tx;
   }
 
   /**

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -609,8 +609,7 @@ class ReputationMiner {
     const totalnUpdates = lastLogEntry[4].add(lastLogEntry[5]).add(this.nReputationsBeforeLatestLog);
     const [branchMask2, siblings2] = await this.justificationTree.getProof(ReputationMiner.getHexString(totalnUpdates, 64));
     const [round, index] = await this.getMySubmissionRoundAndIndex();
-    const res = await repCycle.submitJustificationRootHash(round, index, jrh, branchMask1, siblings1, branchMask2, siblings2, { gasLimit: 6000000 });
-    return res;
+    return repCycle.submitJustificationRootHash(round, index, jrh, branchMask1, siblings1, branchMask2, siblings2, { gasLimit: 6000000 });
   }
 
   /**

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -10,51 +10,6 @@ const patriciaJs = require("./patricia");
 // const accountAddress = "0xbb46703786c2049d4d6dd43f5b4edf52a20fefe4";
 const secretKey = "0xe5c050bb6bfdd9c29397b8fe6ed59ad2f7df83d6fd213b473f84b489205d9fc7";
 
-// Adapted from https://github.com/ethers-io/ethers.js/issues/59
-// ===================================
-function RPCSigner(minerAddress, provider) {
-  this.address = minerAddress;
-  this.provider = provider;
-  const signer = this;
-  this.sendTransaction = async function sendTransaction(transaction) {
-    const tx = await this.buildTx(transaction);
-    return signer.provider.send("eth_sendTransaction", [tx]);
-  };
-
-  this._ethersType = "Signer";
-
-  this.getAddress = () => this.address;
-
-  this.estimateGas = async function estimateGas(transaction) {
-    const tx = this.buildTx(transaction);
-    const res = await signer.provider.send("eth_estimateGas", [tx]);
-    return ethers.utils.bigNumberify(res);
-  };
-
-  this.buildTx = async function buildTx(transaction) {
-    const tx = {
-      from: this.address
-    };
-    if (transaction.to != null) {
-      tx.to = await transaction.to;
-    }
-    if (transaction.data !== null) {
-      tx.data = transaction.data;
-    }
-
-    ["gasPrice", "nonce", "value"].forEach(key => {
-      if (transaction[key] != null) {
-        tx[key] = ethers.utils.hexlify(transaction[key]);
-      }
-    });
-    if (transaction.gasLimit != null) {
-      tx.gas = ethers.utils.hexlify(transaction.gasLimit);
-    }
-    return tx;
-  };
-}
-// ===================================
-
 class ReputationMiner {
   /**
    * Constructor for ReputationMiner
@@ -84,6 +39,7 @@ class ReputationMiner {
       this.ganacheWallet = new ethers.Wallet(secretKey, this.ganacheProvider);
     }
 
+    // This will have to support provider.getSigner https://docs.ethers.io/ethers.js/html/api-providers.html#jsonrpcprovider
     if (provider) {
       this.realProvider = provider;
     } else {
@@ -91,7 +47,7 @@ class ReputationMiner {
     }
 
     if (minerAddress) {
-      this.realWallet = new RPCSigner(minerAddress, this.realProvider);
+      this.realWallet = this.realProvider.getSigner(minerAddress);
     } else {
       this.realWallet = new ethers.Wallet(privateKey, this.realProvider);
       // TODO: Check that this wallet can stake?
@@ -111,7 +67,6 @@ class ReputationMiner {
     this.colonyContractDef = await this.loader.load({ contractName: "IColony" }, { abi: true, address: false });
 
     this.colonyNetwork = new ethers.Contract(colonyNetworkAddress, this.colonyNetworkContractDef.abi, this.realWallet);
-
     const tokenLockingAddress = await this.colonyNetwork.getTokenLocking();
     this.tokenLocking = new ethers.Contract(tokenLockingAddress, this.tokenLockingContractDef.abi, this.realWallet);
     const metaColonyAddress = await this.colonyNetwork.getMetaColony();
@@ -148,7 +103,7 @@ class ReputationMiner {
     }
 
     this.justificationHashes = {};
-    const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockNumber });
+    const addr = await this.colonyNetwork.getReputationMiningCycle.call(true, { blockTag: blockNumber });
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
 
     // Do updates
@@ -157,9 +112,9 @@ class ReputationMiner {
     // This is also the number of decays we have.
 
     // How many updates from the logs do we have?
-    const nLogEntries = await repCycle.getReputationUpdateLogLength({ blockNumber });
+    const nLogEntries = await repCycle.getReputationUpdateLogLength.call({ blockTag: blockNumber });
 
-    const lastLogEntry = await repCycle.getReputationUpdateLogEntry(nLogEntries.sub(1), { blockNumber });
+    const lastLogEntry = await repCycle.getReputationUpdateLogEntry(nLogEntries.sub(1), { blockTag: blockNumber });
     const totalnUpdates = lastLogEntry[4].add(lastLogEntry[5]).add(this.nReputationsBeforeLatestLog);
     const nReplacementLogEntries = await this.colonyNetwork.getReplacementReputationUpdateLogsExist(repCycle.address);
     const replacementLogEntriesExist = nReplacementLogEntries > 0;
@@ -232,7 +187,7 @@ class ReputationMiner {
     } else {
       const logEntryUpdateNumber = updateNumber.sub(this.nReputationsBeforeLatestLog);
       const logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(logEntryUpdateNumber, blockNumber);
-      logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber, { blockNumber });
+      logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber, { blockTag: blockNumber });
       if (checkForReplacement) {
         const potentialReplacementLogEntry = await this.colonyNetwork.getReplacementReputationUpdateLogEntry(repCycle.address, logEntryNumber);
         if (potentialReplacementLogEntry[3] !== "0x0000000000000000000000000000000000000000") {
@@ -244,9 +199,9 @@ class ReputationMiner {
     }
     // TODO This 'if' statement is only in for now to make tests easier to write, should be removed in the future.
     if (updateNumber.eq(0)) {
-      const nNodes = await this.colonyNetwork.getReputationRootHashNNodes({ blockNumber });
+      const nNodes = await this.colonyNetwork.getReputationRootHashNNodes({ blockTag: blockNumber });
       const localRootHash = await this.reputationTree.getRootHash();
-      const currentRootHash = await this.colonyNetwork.getReputationRootHash({ blockNumber });
+      const currentRootHash = await this.colonyNetwork.getReputationRootHash({ blockTag: blockNumber });
       if (!nNodes.eq(this.nReputations) || localRootHash !== currentRootHash) {
         console.log("Warning: client being initialized in bad state. Was the previous rootHash submitted correctly?");
         interimHash = await this.colonyNetwork.getReputationRootHash(); // eslint-disable-line no-await-in-loop
@@ -356,15 +311,15 @@ class ReputationMiner {
    */
   async getLogEntryNumberForLogUpdateNumber(_i, blockNumber) {
     const updateNumber = _i;
-    const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockNumber });
+    const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockTag: blockNumber });
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
-    const nLogEntries = await repCycle.getReputationUpdateLogLength({ blockNumber });
+    const nLogEntries = await repCycle.getReputationUpdateLogLength({ blockTag: blockNumber });
     let lower = ethers.utils.bigNumberify("0");
     let upper = nLogEntries.sub(1);
 
     while (!upper.eq(lower)) {
       const testIdx = lower.add(upper.sub(lower).div(2));
-      const testLogEntry = await repCycle.getReputationUpdateLogEntry(testIdx, { blockNumber }); // eslint-disable-line no-await-in-loop
+      const testLogEntry = await repCycle.getReputationUpdateLogEntry(testIdx, { blockTag: blockNumber }); // eslint-disable-line no-await-in-loop
       if (testLogEntry[5].gt(updateNumber)) {
         upper = testIdx.sub(1);
       } else if (testLogEntry[5].lte(updateNumber) && testLogEntry[5].add(testLogEntry[4]).gt(updateNumber)) {
@@ -386,10 +341,10 @@ class ReputationMiner {
     }
     // Else it's from a log entry
     const logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(updateNumber.sub(this.nReputationsBeforeLatestLog), blockNumber);
-    const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockNumber });
+    const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockTag: blockNumber });
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
 
-    const logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber, { blockNumber });
+    const logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber, { blockTag: blockNumber });
 
     const key = await this.getKeyForUpdateInLogEntry(updateNumber.sub(logEntry[5]).sub(this.nReputationsBeforeLatestLog), logEntry);
     return key;
@@ -536,17 +491,14 @@ class ReputationMiner {
     for (let i = ethers.utils.bigNumberify(startIndex); i.lte(balance.div(minStake)); i = i.add(1)) {
       // Iterate over entries until we find one that passes
       const entryHash = await repCycle.getEntryHash(this.minerAddress, i, hash); // eslint-disable-line no-await-in-loop
-
       const miningCycleDuration = 60 * 60 * 24;
       const constant = ethers.utils
         .bigNumberify(2)
         .pow(256)
         .sub(1)
         .div(miningCycleDuration);
-
       const block = await this.realProvider.getBlock("latest"); // eslint-disable-line no-await-in-loop
       const { timestamp } = block;
-
       const target = ethers.utils
         .bigNumberify(timestamp)
         .sub(reputationMiningWindowOpenTimestamp)
@@ -562,7 +514,6 @@ class ReputationMiner {
     //
     // Submit that entry
     const gas = await repCycle.estimate.submitRootHash(hash, this.nReputations, entryIndex);
-
     return repCycle.submitRootHash(hash, this.nReputations, entryIndex, { gasLimit: `0x${gas.mul(2).toString()}` });
   }
 

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -311,7 +311,7 @@ class ReputationMiner {
    * @param  {Number}  _i The update number we wish to determine which log entry in the reputationUpdateLog creates
    * @return {Promise}   A promise that resolves to the number of the corresponding log entry.
    */
-  async getLogEntryNumberForLogUpdateNumber(_i, blockNumber) {
+  async getLogEntryNumberForLogUpdateNumber(_i, blockNumber = "latest") {
     const updateNumber = _i;
     const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockTag: blockNumber });
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
@@ -335,7 +335,7 @@ class ReputationMiner {
     return lower;
   }
 
-  async getKeyForUpdateNumber(_i, blockNumber) {
+  async getKeyForUpdateNumber(_i, blockNumber = "latest") {
     const updateNumber = ethers.utils.bigNumberify(_i);
     if (updateNumber.lt(this.nReputationsBeforeLatestLog)) {
       // Then it's a decay

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -103,7 +103,7 @@ class ReputationMiner {
     }
 
     this.justificationHashes = {};
-    const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockNumber });
+    const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockTag: blockNumber });
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
 
     // Do updates
@@ -112,10 +112,10 @@ class ReputationMiner {
     // This is also the number of decays we have.
 
     // How many updates from the logs do we have?
-    const nLogEntries = await repCycle.getReputationUpdateLogLength({ blockNumber });
+    const nLogEntries = await repCycle.getReputationUpdateLogLength({ blockTag: blockNumber });
 
     const nLogEntriesString = nLogEntries.sub(1).toString();
-    const lastLogEntry = await repCycle.getReputationUpdateLogEntry(nLogEntriesString, { blockNumber });
+    const lastLogEntry = await repCycle.getReputationUpdateLogEntry(nLogEntriesString, { blockTag: blockNumber });
 
     const totalnUpdates = lastLogEntry[4].add(lastLogEntry[5]).add(this.nReputationsBeforeLatestLog);
     const nReplacementLogEntries = await this.colonyNetwork.getReplacementReputationUpdateLogsExist(repCycle.address);
@@ -189,7 +189,7 @@ class ReputationMiner {
     } else {
       const logEntryUpdateNumber = updateNumber.sub(this.nReputationsBeforeLatestLog);
       const logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(logEntryUpdateNumber, blockNumber);
-      logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber, { blockNumber });
+      logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber, { blockTag: blockNumber });
       if (checkForReplacement) {
         const potentialReplacementLogEntry = await this.colonyNetwork.getReplacementReputationUpdateLogEntry(repCycle.address, logEntryNumber);
         if (potentialReplacementLogEntry[3] !== "0x0000000000000000000000000000000000000000") {
@@ -201,9 +201,9 @@ class ReputationMiner {
     }
     // TODO This 'if' statement is only in for now to make tests easier to write, should be removed in the future.
     if (updateNumber.eq(0)) {
-      const nNodes = await this.colonyNetwork.getReputationRootHashNNodes({ blockNumber });
+      const nNodes = await this.colonyNetwork.getReputationRootHashNNodes({ blockTag: blockNumber });
       const localRootHash = await this.reputationTree.getRootHash();
-      const currentRootHash = await this.colonyNetwork.getReputationRootHash({ blockNumber });
+      const currentRootHash = await this.colonyNetwork.getReputationRootHash({ blockTag: blockNumber });
       if (!nNodes.eq(this.nReputations) || localRootHash !== currentRootHash) {
         console.log("Warning: client being initialized in bad state. Was the previous rootHash submitted correctly?");
         interimHash = await this.colonyNetwork.getReputationRootHash(); // eslint-disable-line no-await-in-loop
@@ -313,15 +313,15 @@ class ReputationMiner {
    */
   async getLogEntryNumberForLogUpdateNumber(_i, blockNumber) {
     const updateNumber = _i;
-    const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockNumber });
+    const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockTag: blockNumber });
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
-    const nLogEntries = await repCycle.getReputationUpdateLogLength({ blockNumber });
+    const nLogEntries = await repCycle.getReputationUpdateLogLength({ blockTag: blockNumber });
     let lower = ethers.utils.bigNumberify("0");
     let upper = nLogEntries.sub(1);
 
     while (!upper.eq(lower)) {
       const testIdx = lower.add(upper.sub(lower).div(2));
-      const testLogEntry = await repCycle.getReputationUpdateLogEntry(testIdx, { blockNumber }); // eslint-disable-line no-await-in-loop
+      const testLogEntry = await repCycle.getReputationUpdateLogEntry(testIdx, { blockTag: blockNumber }); // eslint-disable-line no-await-in-loop
       if (testLogEntry[5].gt(updateNumber)) {
         upper = testIdx.sub(1);
       } else if (testLogEntry[5].lte(updateNumber) && testLogEntry[5].add(testLogEntry[4]).gt(updateNumber)) {
@@ -343,10 +343,10 @@ class ReputationMiner {
     }
     // Else it's from a log entry
     const logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(updateNumber.sub(this.nReputationsBeforeLatestLog), blockNumber);
-    const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockNumber });
+    const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockTag: blockNumber });
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
 
-    const logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber, { blockNumber });
+    const logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber, { blockTag: blockNumber });
 
     const key = await this.getKeyForUpdateInLogEntry(updateNumber.sub(logEntry[5]).sub(this.nReputationsBeforeLatestLog), logEntry);
     return key;

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -114,7 +114,7 @@ class ReputationMiner {
     // How many updates from the logs do we have?
     const nLogEntries = await repCycle.getReputationUpdateLogLength.call({ blockTag: blockNumber });
 
-    const lastLogEntry = await repCycle.getReputationUpdateLogEntry(nLogEntries.sub(1), { blockTag: blockNumber });
+    const lastLogEntry = await repCycle.getReputationUpdateLogEntry.call(nLogEntries.sub(1), { blockTag: blockNumber });
     const totalnUpdates = lastLogEntry[4].add(lastLogEntry[5]).add(this.nReputationsBeforeLatestLog);
     const nReplacementLogEntries = await this.colonyNetwork.getReplacementReputationUpdateLogsExist(repCycle.address);
     const replacementLogEntriesExist = nReplacementLogEntries > 0;
@@ -187,7 +187,7 @@ class ReputationMiner {
     } else {
       const logEntryUpdateNumber = updateNumber.sub(this.nReputationsBeforeLatestLog);
       const logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(logEntryUpdateNumber, blockNumber);
-      logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber, { blockTag: blockNumber });
+      logEntry = await repCycle.getReputationUpdateLogEntry.call(logEntryNumber, { blockTag: blockNumber });
       if (checkForReplacement) {
         const potentialReplacementLogEntry = await this.colonyNetwork.getReplacementReputationUpdateLogEntry(repCycle.address, logEntryNumber);
         if (potentialReplacementLogEntry[3] !== "0x0000000000000000000000000000000000000000") {
@@ -199,9 +199,9 @@ class ReputationMiner {
     }
     // TODO This 'if' statement is only in for now to make tests easier to write, should be removed in the future.
     if (updateNumber.eq(0)) {
-      const nNodes = await this.colonyNetwork.getReputationRootHashNNodes({ blockTag: blockNumber });
+      const nNodes = await this.colonyNetwork.getReputationRootHashNNodes.call({ blockTag: blockNumber });
       const localRootHash = await this.reputationTree.getRootHash();
-      const currentRootHash = await this.colonyNetwork.getReputationRootHash({ blockTag: blockNumber });
+      const currentRootHash = await this.colonyNetwork.getReputationRootHash.call({ blockTag: blockNumber });
       if (!nNodes.eq(this.nReputations) || localRootHash !== currentRootHash) {
         console.log("Warning: client being initialized in bad state. Was the previous rootHash submitted correctly?");
         interimHash = await this.colonyNetwork.getReputationRootHash(); // eslint-disable-line no-await-in-loop
@@ -311,15 +311,15 @@ class ReputationMiner {
    */
   async getLogEntryNumberForLogUpdateNumber(_i, blockNumber) {
     const updateNumber = _i;
-    const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockTag: blockNumber });
+    const addr = await this.colonyNetwork.getReputationMiningCycle.call(true, { blockTag: blockNumber });
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
-    const nLogEntries = await repCycle.getReputationUpdateLogLength({ blockTag: blockNumber });
+    const nLogEntries = await repCycle.getReputationUpdateLogLength.call({ blockTag: blockNumber });
     let lower = ethers.utils.bigNumberify("0");
     let upper = nLogEntries.sub(1);
 
     while (!upper.eq(lower)) {
       const testIdx = lower.add(upper.sub(lower).div(2));
-      const testLogEntry = await repCycle.getReputationUpdateLogEntry(testIdx, { blockTag: blockNumber }); // eslint-disable-line no-await-in-loop
+      const testLogEntry = await repCycle.getReputationUpdateLogEntry.call(testIdx, { blockTag: blockNumber }); // eslint-disable-line no-await-in-loop
       if (testLogEntry[5].gt(updateNumber)) {
         upper = testIdx.sub(1);
       } else if (testLogEntry[5].lte(updateNumber) && testLogEntry[5].add(testLogEntry[4]).gt(updateNumber)) {
@@ -341,10 +341,10 @@ class ReputationMiner {
     }
     // Else it's from a log entry
     const logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(updateNumber.sub(this.nReputationsBeforeLatestLog), blockNumber);
-    const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockTag: blockNumber });
+    const addr = await this.colonyNetwork.getReputationMiningCycle.call(true, { blockTag: blockNumber });
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
 
-    const logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber, { blockTag: blockNumber });
+    const logEntry = await repCycle.getReputationUpdateLogEntry.call(logEntryNumber, { blockTag: blockNumber });
 
     const key = await this.getKeyForUpdateInLogEntry(updateNumber.sub(logEntry[5]).sub(this.nReputationsBeforeLatestLog), logEntry);
     return key;

--- a/packages/reputation-miner/package.json
+++ b/packages/reputation-miner/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@colony/colony-js-contract-loader-fs": "1.6.2",
     "bn.js": "^4.11.8",
-    "ethers": "https://github.com/area/ethers.js#typescript",
+    "ethers": "4.0.7",
     "express": "^4.16.3",
     "ganache-core": "^2.1.6",
     "sqlite": "^3.0.0",

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -1077,7 +1077,7 @@ contract("ColonyNetworkMining", accounts => {
 
       // TODO: Split off in to  another test here, but can't be bothered to refactor right now.
       await goodClient.respondToChallenge();
-      await checkErrorRevert(badClient.respondToChallenge());
+      await checkErrorRevertEthers(badClient.respondToChallenge(), "colony-reputation-mining-invalid-newest-reputation-proof");
 
       // Check
       const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 0);
@@ -1153,7 +1153,7 @@ contract("ColonyNetworkMining", accounts => {
       await badClient.confirmBinarySearchResult();
 
       await goodClient.respondToChallenge();
-      await checkErrorRevert(badClient.respondToChallenge());
+      await checkErrorRevertEthers(badClient.respondToChallenge(), "colony-reputation-mining-uid-changed-for-existing-reputation");
 
       // Check
       const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 0);
@@ -1406,7 +1406,7 @@ contract("ColonyNetworkMining", accounts => {
       await badClient.confirmBinarySearchResult();
 
       await goodClient.respondToChallenge();
-      await checkErrorRevert(badClient.respondToChallenge());
+      await checkErrorRevertEthers(badClient.respondToChallenge(), "colony-reputation-mining-proved-uid-inconsistent");
 
       // Check badclient respondToChallenge failed
       const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 0);
@@ -1484,7 +1484,7 @@ contract("ColonyNetworkMining", accounts => {
       await goodClient.confirmBinarySearchResult();
       await badClient.confirmBinarySearchResult();
 
-      await checkErrorRevert(badClient2.respondToChallenge(), "colony-reputation-mining-less-challenge-rounds-completed");
+      await checkErrorRevertEthers(badClient2.respondToChallenge(), "colony-reputation-mining-new-uid-incorrect");
       // Cleanup
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
       await repCycle.confirmNewHash(1);
@@ -2144,28 +2144,28 @@ contract("ColonyNetworkMining", accounts => {
       await goodClient.respondToBinarySearchForChallenge();
 
       // We need one more response to binary search from each side. Check we can't confirm early
-      await checkErrorRevert(goodClient.confirmBinarySearchResult());
+      await checkErrorRevertEthers(goodClient.confirmBinarySearchResult(), "colony-reputation-binary-search-incomplete");
       // Check we can't respond to challenge before we've completed the binary search
-      await checkErrorRevert(goodClient.respondToChallenge());
+      await checkErrorRevertEthers(goodClient.respondToChallenge(), "colony-reputation-mining-challenge-closed");
       await goodClient.respondToBinarySearchForChallenge();
 
       // Check we can't confirm even if we're done, but our opponent isn't
-      await checkErrorRevert(goodClient.confirmBinarySearchResult());
+      await checkErrorRevertEthers(goodClient.confirmBinarySearchResult(), "colony-reputation-binary-search-incomplete");
       await badClient.respondToBinarySearchForChallenge();
 
       // Check we can't respond to challenge before confirming result
-      await checkErrorRevert(goodClient.respondToChallenge());
+      await checkErrorRevertEthers(goodClient.respondToChallenge(), "colony-reputation-mining-binary-search-result-not-confirmed");
 
       // Now we can confirm
       await goodClient.confirmBinarySearchResult();
       await badClient.confirmBinarySearchResult();
 
       // Check we can't continue confirming
-      await checkErrorRevert(goodClient.respondToBinarySearchForChallenge());
+      await checkErrorRevertEthers(goodClient.respondToBinarySearchForChallenge(), "colony-reputation-mining-challenge-not-active");
       await goodClient.respondToChallenge();
 
       // Check we can't respond again
-      await checkErrorRevert(goodClient.respondToChallenge());
+      await checkErrorRevertEthers(goodClient.respondToChallenge(), "colony-reputation-mining-challenge-already-responded");
 
       addr = await colonyNetwork.getReputationMiningCycle(true);
       const repCycle = await IReputationMiningCycle.at(addr);
@@ -2377,8 +2377,17 @@ contract("ColonyNetworkMining", accounts => {
 
           await goodClient.confirmBinarySearchResult();
           await badClient.confirmBinarySearchResult();
-
-          await checkErrorRevert(badClient2.respondToChallenge());
+          if (args.word === "high") {
+            await checkErrorRevertEthers(
+              badClient2.respondToChallenge(),
+              "colony-reputation-mining-update-number-part-of-previous-log-entry-updates"
+            );
+          } else {
+            await checkErrorRevertEthers(
+              badClient2.respondToChallenge(),
+              "colony-reputation-mining-update-number-part-of-following-log-entry-updates"
+            );
+          }
 
           // Cleanup
           await goodClient.respondToChallenge();

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -1405,7 +1405,7 @@ contract("ColonyNetworkMining", accounts => {
       await badClient.confirmBinarySearchResult();
 
       await goodClient.respondToChallenge();
-      await badClient.respondToChallenge();
+      await checkErrorRevert(badClient.respondToChallenge());
 
       // Check badclient respondToChallenge failed
       const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 0);
@@ -2142,47 +2142,29 @@ contract("ColonyNetworkMining", accounts => {
       await badClient.respondToBinarySearchForChallenge();
       await goodClient.respondToBinarySearchForChallenge();
 
-      let tx;
-      let receipt;
       // We need one more response to binary search from each side. Check we can't confirm early
-      tx = await goodClient.confirmBinarySearchResult();
-      receipt = await web3GetTransactionReceipt(tx);
-      assert(receipt.status === false);
-
+      await checkErrorRevert(goodClient.confirmBinarySearchResult());
       // Check we can't respond to challenge before we've completed the binary search
-      tx = await goodClient.respondToChallenge();
-      receipt = await web3GetTransactionReceipt(tx);
-      assert(receipt.status === false);
-
+      await checkErrorRevert(goodClient.respondToChallenge());
       await goodClient.respondToBinarySearchForChallenge();
 
       // Check we can't confirm even if we're done, but our opponent isn't
-      tx = await goodClient.confirmBinarySearchResult();
-      receipt = await web3GetTransactionReceipt(tx);
-      assert(receipt.status === false);
-
+      await checkErrorRevert(goodClient.confirmBinarySearchResult());
       await badClient.respondToBinarySearchForChallenge();
 
       // Check we can't respond to challenge before confirming result
-      tx = await goodClient.respondToChallenge();
-      receipt = await web3GetTransactionReceipt(tx);
-      assert(receipt.status === false);
+      await checkErrorRevert(goodClient.respondToChallenge());
 
       // Now we can confirm
       await goodClient.confirmBinarySearchResult();
       await badClient.confirmBinarySearchResult();
 
       // Check we can't continue confirming
-      tx = await goodClient.respondToBinarySearchForChallenge();
-      receipt = await web3GetTransactionReceipt(tx);
-      assert(receipt.status === false);
-
+      await checkErrorRevert(goodClient.respondToBinarySearchForChallenge());
       await goodClient.respondToChallenge();
 
       // Check we can't respond again
-      tx = await goodClient.respondToChallenge();
-      receipt = await web3GetTransactionReceipt(tx);
-      assert(receipt.status === false);
+      await checkErrorRevert(goodClient.respondToChallenge());
 
       addr = await colonyNetwork.getReputationMiningCycle(true);
       const repCycle = await IReputationMiningCycle.at(addr);

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -8,6 +8,7 @@ import request from "async-request";
 import {
   forwardTime,
   checkErrorRevert,
+  checkErrorRevertEthers,
   web3GetTransactionReceipt,
   makeReputationKey,
   makeReputationValue,
@@ -857,7 +858,7 @@ contract("ColonyNetworkMining", accounts => {
       await goodClient.submitJustificationRootHash();
 
       // Check that we can't re-submit a JRH
-      await checkErrorRevert(goodClient.submitJustificationRootHash());
+      await checkErrorRevertEthers(goodClient.submitJustificationRootHash(), "colony-reputation-mining-hash-already-submitted");
 
       const submissionAfterJRHSubmitted = await repCycle.getDisputeRounds(0, 0);
       const jrh = await goodClient.justificationTree.getRootHash();

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -193,7 +193,7 @@ contract("ColonyNetworkMining", accounts => {
       // idx1.modn returns a javascript number, which is surprising!
       toInvalidateIdx = idx1.mod(2) === 1 ? idx1.sub(1) : idx1.add(1);
     }
-    await repCycle.invalidateHash(round1.toString(), toInvalidateIdx.toString());
+    return repCycle.invalidateHash(round1.toString(), toInvalidateIdx.toString());
   }
 
   afterEach(async () => {

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -152,13 +152,14 @@ contract("ColonyNetworkMining", accounts => {
       // Binary search will error when it is complete.
       let noError = true;
       while (noError) {
-        let txHash = await client1.respondToBinarySearchForChallenge(); // eslint-disable-line no-await-in-loop
-        let tx = await web3GetTransactionReceipt(txHash); // eslint-disable-line no-await-in-loop
+        let transactionObject;
+        transactionObject = await client1.respondToBinarySearchForChallenge(); // eslint-disable-line no-await-in-loop
+        let tx = await web3GetTransactionReceipt(transactionObject.hash); // eslint-disable-line no-await-in-loop
         if (!tx.status) {
           noError = false;
         }
-        txHash = await client2.respondToBinarySearchForChallenge(); // eslint-disable-line no-await-in-loop
-        tx = await web3GetTransactionReceipt(txHash); // eslint-disable-line no-await-in-loop
+        transactionObject = await client2.respondToBinarySearchForChallenge(); // eslint-disable-line no-await-in-loop
+        tx = await web3GetTransactionReceipt(transactionObject.hash); // eslint-disable-line no-await-in-loop
         if (!tx.status) {
           noError = false;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2790,9 +2790,9 @@ ethereumjs-wallet@0.6.0:
     utf8 "^2.1.1"
     uuid "^2.0.1"
 
-"ethers@https://github.com/area/ethers.js#typescript":
-  version "4.0.0-beta.12"
-  resolved "https://github.com/area/ethers.js#32b7fd0a86de074363b18ec61f7eeca74ce7bb97"
+ethers@4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.7.tgz#8c653618077a1fc60c5c1b2575da03561f0039f4"
   dependencies:
     "@types/node" "^10.3.2"
     aes-js "3.0.0"
@@ -2800,7 +2800,7 @@ ethereumjs-wallet@0.6.0:
     elliptic "6.3.3"
     hash.js "1.1.3"
     js-sha3 "0.5.7"
-    scrypt-js "2.0.3"
+    scrypt-js "2.0.4"
     setimmediate "1.0.4"
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
@@ -6304,9 +6304,9 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-scrypt-js@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.3.tgz#bb0040be03043da9a012a2cea9fc9f852cfc87d4"
+scrypt-js@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
 
 scrypt.js@0.2.0, scrypt.js@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Here we move back to the vanilla `ethers` release which [now provides support for making contract calls using the `blockTag` parameter](https://github.com/ethers-io/ethers.js/issues/226), https://github.com/ethers-io/ethers.js/issues/329
This is required functionality for the client syncing logic that was introduced in a custom version of ours of both `ethers` and `ganache-core` back in https://github.com/JoinColony/colonyNetwork/pull/311

Since the `ethers` release has jumped up a major version since then, we include a set of breaking fixes for v3 to v4.

Introducing `checkErrorRevertEthers` - an `ethers` specific helper function to check expected error message is present in the response. This is useful for the revert error checks coming back from the reputation mining client which currently uses `ethers.contract` (as opposed to `truffle-contract` as our tests do).

