### PR TITLE
Fix bad task exists modifier

### DIFF
--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -44,11 +44,6 @@ contract ColonyNetwork is ColonyNetworkStorage {
     _;
   }
 
-  modifier nonZero(uint256 parentSkillId) {
-    require(parentSkillId > 0, "colony-invalid-parent-skill-id");
-    _;
-  }
-
   function isColony(address _colony) public view returns (bool) {
     return _isColony[_colony];
   }
@@ -196,7 +191,6 @@ contract ColonyNetwork is ColonyNetworkStorage {
   function addSkill(uint _parentSkillId, bool _globalSkill) public stoppable
   skillExists(_parentSkillId)
   allowedToAddSkill(_globalSkill)
-  nonZero(_parentSkillId)
   returns (uint256)
   {
     skillCount += 1;

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -40,7 +40,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
   }
 
   modifier skillExists(uint skillId) {
-    require(skillCount >= skillId, "colony-invalid-skill-id");
+    require(skillId > 0 && skillCount >= skillId, "colony-invalid-skill-id");
     _;
   }
 

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -178,12 +178,12 @@ contract ColonyStorage is CommonStorage, DSMath {
 
   modifier skillExists(uint256 _skillId) {
     IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
-    require(_skillId <= colonyNetworkContract.getSkillCount(), "colony-skill-does-not-exist");
+    require(_skillId > 0 && _skillId <= colonyNetworkContract.getSkillCount(), "colony-skill-does-not-exist");
     _;
   }
 
   modifier domainExists(uint256 _domainId) {
-    require(_domainId <= domainCount, "colony-domain-does-not-exist");
+    require(_domainId > 0 && _domainId <= domainCount, "colony-domain-does-not-exist");
     _;
   }
 

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -154,7 +154,7 @@ contract ColonyStorage is CommonStorage, DSMath {
   }
 
   modifier taskExists(uint256 _id) {
-    require(_id <= taskCount, "colony-task-does-not-exist");
+    require(_id > 0 && _id <= taskCount, "colony-task-does-not-exist");
     _;
   }
 

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -153,7 +153,7 @@ contract ColonyTask is ColonyStorage {
     bytes4 sig;
     uint256 taskId;
     (sig, taskId) = deconstructCall(_data);
-    require(taskId <= taskCount, "colony-task-does-not-exist");
+    require(taskId > 0 && taskId <= taskCount, "colony-task-does-not-exist");
     require(tasks[taskId].status != FINALIZED, "colony-task-finalized");
     require(!roleAssignmentSigs[sig], "colony-task-change-is-role-assignement");
 

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -950,6 +950,22 @@ contract("ColonyTask", accounts => {
       );
     });
 
+    it("should fail to execute change of task brief, using invalid task id 0", async () => {
+      const taskId = 0;
+
+      await checkErrorRevert(
+        executeSignedTaskChange({
+          colony,
+          taskId,
+          functionName: "setTaskBrief",
+          signers: [MANAGER],
+          sigTypes: [0],
+          args: [taskId, SPECIFICATION_HASH_UPDATED]
+        }),
+        "colony-task-signatures-do-not-match-reviewer-1"
+      );
+    });
+
     it("should fail to execute task change, if the task is already finalized", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony, token });

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -962,7 +962,35 @@ contract("ColonyTask", accounts => {
           sigTypes: [0],
           args: [taskId, SPECIFICATION_HASH_UPDATED]
         }),
-        "colony-task-signatures-do-not-match-reviewer-1"
+        "colony-task-does-not-exist"
+      );
+    });
+
+    it("should fail to execute task changes, when trying to set domain or skill to 0", async () => {
+      const taskId = await makeTask({ colony });
+
+      await checkErrorRevert(
+        executeSignedTaskChange({
+          colony,
+          functionName: "setTaskDomain",
+          taskId,
+          signers: [MANAGER],
+          sigTypes: [0],
+          args: [taskId, 0]
+        }),
+        "colony-task-change-execution-failed"
+      );
+
+      await checkErrorRevert(
+        executeSignedTaskChange({
+          colony,
+          functionName: "setTaskSkill",
+          taskId,
+          signers: [MANAGER],
+          sigTypes: [0],
+          args: [taskId, 0]
+        }),
+        "colony-task-change-execution-failed"
       );
     });
 

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -270,7 +270,7 @@ contract("Meta Colony", accounts => {
     });
 
     it("should NOT be able to add a new root global skill", async () => {
-      await checkErrorRevert(metaColony.addGlobalSkill(0), "colony-invalid-parent-skill-id");
+      await checkErrorRevert(metaColony.addGlobalSkill(0), "colony-invalid-skill-id");
 
       const skillCount = await colonyNetwork.getSkillCount();
       assert.equal(skillCount.toNumber(), 3);


### PR DESCRIPTION
Closes #422 

Additionally updates the `skillExists` and `domainExists` modifiers similarly to `taskExists` to ensure those don't return `true` falsely as they are 1-based ids. 