### PR TITLE
Rename Colony owner role to founder

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -26,7 +26,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
   // This function, exactly as defined, is used in build scripts. Take care when updating.
   // Version number should be upped with every change in Colony or its dependency contracts or libraries.
-  function version() public pure returns (uint256) { return 1; }
+  function version() public pure returns (uint256 colonyVersion) { return 1; }
 
   function setFounderRole(address _user) public stoppable auth {
     // To allow only one address to have founder role at a time, we have to remove current founder from their role

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -29,7 +29,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   function version() public pure returns (uint256) { return 1; }
 
   function setFounderRole(address _user) public stoppable auth {
-    // To allow only one address to have owner role at a time, we have to remove current owner from their role
+    // To allow only one address to have founder role at a time, we have to remove current founder from their role
     ColonyAuthority colonyAuthority = ColonyAuthority(authority);
     colonyAuthority.setUserRole(msg.sender, FOUNDER_ROLE, false);
     colonyAuthority.setUserRole(_user, FOUNDER_ROLE, true);
@@ -39,7 +39,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     ColonyAuthority(authority).setUserRole(_user, ADMIN_ROLE, true);
   }
 
-  // Can only be called by the owner role.
+  // Can only be called by the founder role.
   function removeAdminRole(address _user) public stoppable auth {
     ColonyAuthority(authority).setUserRole(_user, ADMIN_ROLE, false);
   }

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -28,11 +28,11 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   // Version number should be upped with every change in Colony or its dependency contracts or libraries.
   function version() public pure returns (uint256) { return 1; }
 
-  function setOwnerRole(address _user) public stoppable auth {
+  function setFounderRole(address _user) public stoppable auth {
     // To allow only one address to have owner role at a time, we have to remove current owner from their role
     ColonyAuthority colonyAuthority = ColonyAuthority(authority);
-    colonyAuthority.setUserRole(msg.sender, OWNER_ROLE, false);
-    colonyAuthority.setUserRole(_user, OWNER_ROLE, true);
+    colonyAuthority.setUserRole(msg.sender, FOUNDER_ROLE, false);
+    colonyAuthority.setUserRole(_user, FOUNDER_ROLE, true);
   }
 
   function setAdminRole(address _user) public stoppable auth {

--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -34,7 +34,7 @@ contract ColonyAuthority is CommonAuthority {
     setFounderRoleCapability(colony, "mintTokens(uint256)");
     // Add global skill
     setFounderRoleCapability(colony, "addGlobalSkill(uint256)");
-    // Transfer ownership
+    // Transfer founder role
     setFounderRoleCapability(colony, "setFounderRole(address)");
     // Remove admin role
     setFounderRoleCapability(colony, "removeAdminRole(address)");

--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -22,57 +22,57 @@ import "./CommonAuthority.sol";
 
 
 contract ColonyAuthority is CommonAuthority {
-  uint8 ownerRole = 0;
+  uint8 founderRole = 0;
   uint8 adminRole = 1;
 
   constructor(address colony) public CommonAuthority(colony) {
     // Set token
-    setOwnerRoleCapability(colony, "setToken(address)");
+    setFounderRoleCapability(colony, "setToken(address)");
     // Bootstrap colony
-    setOwnerRoleCapability(colony, "bootstrapColony(address[],int256[])");
+    setFounderRoleCapability(colony, "bootstrapColony(address[],int256[])");
     // Mint tokens
-    setOwnerRoleCapability(colony, "mintTokens(uint256)");
+    setFounderRoleCapability(colony, "mintTokens(uint256)");
     // Add global skill
-    setOwnerRoleCapability(colony, "addGlobalSkill(uint256)");
+    setFounderRoleCapability(colony, "addGlobalSkill(uint256)");
     // Transfer ownership
-    setOwnerRoleCapability(colony, "setOwnerRole(address)");
+    setFounderRoleCapability(colony, "setFounderRole(address)");
     // Remove admin role
-    setOwnerRoleCapability(colony, "removeAdminRole(address)");
+    setFounderRoleCapability(colony, "removeAdminRole(address)");
     // Set recovery role
-    setOwnerRoleCapability(colony, "setRecoveryRole(address)");
+    setFounderRoleCapability(colony, "setRecoveryRole(address)");
     // Remove recovery role
-    setOwnerRoleCapability(colony, "removeRecoveryRole(address)");
+    setFounderRoleCapability(colony, "removeRecoveryRole(address)");
     // Upgrade colony
-    setOwnerRoleCapability(colony, "upgrade(uint256)");
+    setFounderRoleCapability(colony, "upgrade(uint256)");
     // Claim colony ENS label
-    setOwnerRoleCapability(colony, "registerColonyLabel(string,string)");
+    setFounderRoleCapability(colony, "registerColonyLabel(string,string)");
     // Set Network fee inverse
-    setOwnerRoleCapability(colony, "setNetworkFeeInverse(uint256)");
+    setFounderRoleCapability(colony, "setNetworkFeeInverse(uint256)");
     // Set Reward fee inverse
-    setOwnerRoleCapability(colony, "setRewardInverse(uint256)");
+    setFounderRoleCapability(colony, "setRewardInverse(uint256)");
     // Add colony version to the network
-    setOwnerRoleCapability(colony, "addNetworkColonyVersion(uint256,address)");
+    setFounderRoleCapability(colony, "addNetworkColonyVersion(uint256,address)");
 
     // Allocate funds
     setAdminRoleCapability(colony, "moveFundsBetweenPots(uint256,uint256,uint256,address)");
-    setOwnerRoleCapability(colony, "moveFundsBetweenPots(uint256,uint256,uint256,address)");
+    setFounderRoleCapability(colony, "moveFundsBetweenPots(uint256,uint256,uint256,address)");
     // Add domain
     setAdminRoleCapability(colony, "addDomain(uint256)");
-    setOwnerRoleCapability(colony, "addDomain(uint256)");
+    setFounderRoleCapability(colony, "addDomain(uint256)");
     // Add task
     setAdminRoleCapability(colony, "makeTask(bytes32,uint256,uint256,uint256)");
-    setOwnerRoleCapability(colony, "makeTask(bytes32,uint256,uint256,uint256)");
+    setFounderRoleCapability(colony, "makeTask(bytes32,uint256,uint256,uint256)");
     // Start next reward payout
     setAdminRoleCapability(colony, "startNextRewardPayout(address,bytes,bytes,uint256,bytes32[])");
-    setOwnerRoleCapability(colony, "startNextRewardPayout(address,bytes,bytes,uint256,bytes32[])");
+    setFounderRoleCapability(colony, "startNextRewardPayout(address,bytes,bytes,uint256,bytes32[])");
     // Set admin
     setAdminRoleCapability(colony, "setAdminRole(address)");
-    setOwnerRoleCapability(colony, "setAdminRole(address)");
+    setFounderRoleCapability(colony, "setAdminRole(address)");
   }
 
-  function setOwnerRoleCapability(address colony, bytes sig) private {
+  function setFounderRoleCapability(address colony, bytes sig) private {
     bytes4 functionSig = bytes4(keccak256(sig));
-    setRoleCapability(ownerRole, colony, functionSig, true);
+    setRoleCapability(founderRole, colony, functionSig, true);
   }
 
   function setAdminRoleCapability(address colony, bytes sig) private {

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -146,7 +146,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
     dsauth.setAuthority(authority);
 
     authority.setOwner(etherRouter);
-    colony.setOwnerRole(msg.sender);
+    colony.setFounderRole(msg.sender);
 
     // Colony will not have owner
     dsauth.setOwner(0x0);

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -87,7 +87,7 @@ contract ColonyStorage is CommonStorage, DSMath {
   uint256 domainCount;
 
   // Colony-wide roles
-  uint8 constant OWNER_ROLE = 0;
+  uint8 constant FOUNDER_ROLE = 0;
   uint8 constant ADMIN_ROLE = 1;
 
   // Task Roles

--- a/contracts/ContractRecovery.sol
+++ b/contracts/ContractRecovery.sol
@@ -72,7 +72,7 @@ contract ContractRecovery is CommonStorage {
 
   function exitRecoveryMode() public recovery auth {
     uint totalAuthorized = recoveryRolesCount;
-    // Don't double count the owner (if set);
+    // Don't double count the founder (if set);
     if (owner != 0x0 && !CommonAuthority(authority).hasUserRole(owner, RECOVERY_ROLE)) { 
       totalAuthorized += 1; 
     }
@@ -81,7 +81,7 @@ contract ContractRecovery is CommonStorage {
     recoveryMode = false;
   }
 
-  // Can only be called by the owner role.
+  // Can only be called by the founder role.
   function setRecoveryRole(address _user) public stoppable auth {
     require(recoveryRolesCount < ~uint64(0), "colony-maximum-num-recovery-roles");
     if (!CommonAuthority(authority).hasUserRole(_user, RECOVERY_ROLE)) {
@@ -90,7 +90,7 @@ contract ContractRecovery is CommonStorage {
     }
   }
 
-  // Can only be called by the owner role.
+  // Can only be called by the founder role.
   function removeRecoveryRole(address _user) public stoppable auth {
     if (CommonAuthority(authority).hasUserRole(_user, RECOVERY_ROLE)) {
       CommonAuthority(authority).setUserRole(_user, RECOVERY_ROLE, false);

--- a/contracts/ContractRecovery.sol
+++ b/contracts/ContractRecovery.sol
@@ -72,7 +72,7 @@ contract ContractRecovery is CommonStorage {
 
   function exitRecoveryMode() public recovery auth {
     uint totalAuthorized = recoveryRolesCount;
-    // Don't double count the founder (if set);
+    // Don't double count the owner (if set);
     if (owner != 0x0 && !CommonAuthority(authority).hasUserRole(owner, RECOVERY_ROLE)) { 
       totalAuthorized += 1; 
     }

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -131,20 +131,20 @@ contract IColony is IRecovery {
   /// that control has to be transferred to the colony after this call
   function setToken(address _token) public;
 
-  /// @notice Set new colony owner role.
-  /// @dev There can only be one address assigned to owner role at a time.
-  /// Whoever calls this function will lose their owner role
-  /// Can be called by owner role.
-  /// @param _user User we want to give an owner role to
-  function setOwnerRole(address _user) public;
+  /// @notice Set new colony founder role.
+  /// @dev There can only be one address assigned to founder role at a time.
+  /// Whoever calls this function will lose their founder role
+  /// Can be called by founder role.
+  /// @param _user User we want to give an founder role to
+  function setFounderRole(address _user) public;
 
   /// @notice Set new colony admin role.
-  /// Can be called by owner role or admin role.
+  /// Can be called by founder role or admin role.
   /// @param _user User we want to give an admin role to
   function setAdminRole(address _user) public;
 
   /// @notice Remove colony admin.
-  /// Can only be called by owner role.
+  /// Can only be called by founder role.
   /// @param _user User we want to remove admin role from
   function removeAdminRole(address _user) public;
 

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -106,19 +106,19 @@ contract IColony is IRecovery {
 
   // Implemented in DSAuth.sol
   /// @notice Get the `ColonyAuthority` for the colony
-  /// @return authority The `ColonyAuthority` contract address
-  function authority() public view returns (address authority);
+  /// @return colonyAuthority The `ColonyAuthority` contract address
+  function authority() public view returns (address colonyAuthority);
 
   /// @notice Get the colony `owner` address. This should be 0x0 at all times
   /// @dev Used for testing.
-  /// @return owner Address of the colony owner
-  function owner() public view returns (address owner);
+  /// @return colonyOwner Address of the colony owner
+  function owner() public view returns (address colonyOwner);
 
   // Implemented in Colony.sol
   /// @notice Get the Colony contract version
   /// Starts from 1 and is incremented with every deployed contract change
-  /// @return version Version number
-  function version() public pure returns (uint256 version);
+  /// @return colonyVersion Version number
+  function version() public pure returns (uint256 colonyVersion);
 
   /// @notice Upgrades a colony to a new Colony contract version `_newVersion`
   /// @dev Downgrades are not allowed, i.e. `_newVersion` should be higher than the currect colony version

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -101,8 +101,8 @@ contract IColonyNetwork is IRecovery {
 
   /// @notice Check if specific address is a colony created on colony network
   /// @param _colony Address of the colony
-  /// @return isColony true if specified address is a colony, otherwise false
-  function isColony(address _colony) public view returns (bool isColony);
+  /// @return addressIsColony true if specified address is a colony, otherwise false
+  function isColony(address _colony) public view returns (bool addressIsColony);
 
   /// @notice Adds a new skill to the global or local skills tree, under skill `_parentSkillId`
   /// Only the Meta Colony is allowed to add a global skill, called via `IColony.addGlobalSkill`

--- a/contracts/IRecovery.sol
+++ b/contracts/IRecovery.sol
@@ -38,17 +38,17 @@ contract IRecovery {
   function isInRecoveryMode() public view returns (bool inRecoveryMode);
 
   /// @notice Set new colony recovery role.
-  /// Can be called by owner.
+  /// Can be called by founder.
   /// @param _user User we want to give a recovery role to
   function setRecoveryRole(address _user) public;
 
   /// @notice Remove colony recovery role.
-  /// Can only be called by owner role.
+  /// Can only be called by founder role.
   /// @param _user User we want to remove recovery role from
   function removeRecoveryRole(address _user) public;
 
   /// @notice Return number of recovery roles.
-  /// @return numRoles Number of users with the recovery role (excluding owner)
+  /// @return numRoles Number of users with the recovery role (excluding founder)
   function numRecoveryRoles() public view returns(uint64 numRoles);
 
   /// @notice Update value of arbitrary storage variable.

--- a/scripts/generate-test-contracts.sh
+++ b/scripts/generate-test-contracts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version="$(grep 'function version() public pure returns (uint256) { return ' ./contracts/Colony.sol | sed 's/function version() public pure returns (uint256) { return //' | sed 's/; }//' | sed 's/ //g')"
+version="$(grep 'function version() public pure returns (uint256 colonyVersion) { return ' ./contracts/Colony.sol | sed 's/function version() public pure returns (uint256 colonyVersion) { return //' | sed 's/; }//' | sed 's/ //g')"
 echo "Current Colony contract version is $version"
 updated_version=$(($version + 1))
 echo "Updating version to $updated_version"
@@ -14,7 +14,7 @@ cp ./contracts/ColonyNetwork.sol ./contracts/UpdatedColonyNetwork.sol
 sed -i.bak "s/contract ColonyNetwork/contract UpdatedColonyNetwork/g" ./contracts/UpdatedColonyNetwork.sol
 sed -i.bak "s/address resolver;/address resolver;function isUpdated() public pure returns(bool) {return true;}/g" ./contracts/UpdatedColonyNetwork.sol
 sed -i.bak "s/contract Colony/contract UpdatedColony/g" ./contracts/UpdatedColony.sol
-sed -i.bak "s/function version() public pure returns (uint256) { return ${version}/function version() public pure returns (uint256) { return ${updated_version}/g" ./contracts/UpdatedColony.sol
+sed -i.bak "s/function version() public pure returns (uint256 colonyVersion) { return ${version}/function version() public pure returns (uint256 colonyVersion) { return ${updated_version}/g" ./contracts/UpdatedColony.sol
 sed -i.bak "s/contract UpdatedColony is ColonyStorage, PatriciaTreeProofs {/contract UpdatedColony is ColonyStorage, PatriciaTreeProofs {function isUpdated() public pure returns(bool) {return true;}/g" ./contracts/UpdatedColony.sol
 sed -i.bak "s/contract IColony/contract IUpdatedColony/g" ./contracts/IUpdatedColony.sol
 sed -i.bak "s/contract IUpdatedColony is IRecovery {/contract IUpdatedColony {function isUpdated() public pure returns(bool);/g" ./contracts/IUpdatedColony.sol

--- a/test/colony-network-recovery.js
+++ b/test/colony-network-recovery.js
@@ -85,12 +85,12 @@ contract("Colony Network Recovery", accounts => {
 
   describe("when using recovery mode", () => {
     it("should be able to add and remove recovery roles when not in recovery", async () => {
-      const owner = accounts[0];
+      const founder = accounts[0];
       let numRecoveryRoles;
 
       numRecoveryRoles = await colonyNetwork.numRecoveryRoles();
       assert.equal(numRecoveryRoles.toNumber(), 0);
-      colonyNetwork.setRecoveryRole(owner);
+      colonyNetwork.setRecoveryRole(founder);
       await colonyNetwork.setRecoveryRole(accounts[1]);
       await colonyNetwork.setRecoveryRole(accounts[2]);
       numRecoveryRoles = await colonyNetwork.numRecoveryRoles();
@@ -106,7 +106,7 @@ contract("Colony Network Recovery", accounts => {
       numRecoveryRoles = await colonyNetwork.numRecoveryRoles();
       assert.equal(numRecoveryRoles.toNumber(), 2);
 
-      await colonyNetwork.removeRecoveryRole(owner);
+      await colonyNetwork.removeRecoveryRole(founder);
       numRecoveryRoles = await colonyNetwork.numRecoveryRoles();
       assert.equal(numRecoveryRoles.toNumber(), 1);
     });

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -210,7 +210,7 @@ contract("Colony Network", accounts => {
   });
 
   describe("when upgrading a colony", () => {
-    it("should be able to upgrade a colony, if a sender has owner role", async () => {
+    it("should be able to upgrade a colony, if a sender has founder role", async () => {
       const token = await Token.new(...TOKEN_ARGS);
       const { logs } = await colonyNetwork.createColony(token.address);
       const { colonyAddress } = logs[0].args;
@@ -267,7 +267,7 @@ contract("Colony Network", accounts => {
       expect(version).to.eq.BN(currentColonyVersion);
     });
 
-    it("should NOT be able to upgrade a colony if sender don't have owner role", async () => {
+    it("should NOT be able to upgrade a colony if sender don't have founder role", async () => {
       const token = await Token.new(...TOKEN_ARGS);
       const { logs } = await colonyNetwork.createColony(token.address);
       const { colonyAddress } = logs[0].args;
@@ -362,7 +362,7 @@ contract("Colony Network", accounts => {
       await checkErrorRevert(colonyNetwork.registerUserLabel(username2, orbitDBAddress, { from: accounts[1] }), "colony-user-label-already-owned");
     });
 
-    it("should be able to register one unique label per colony, if owner", async () => {
+    it("should be able to register one unique label per colony, if founder", async () => {
       const colonyName = "test";
       const colonyName2 = "test2";
       const hash = namehash.hash("test.colony.joincolony.eth");
@@ -373,13 +373,13 @@ contract("Colony Network", accounts => {
       const { colonyAddress } = logs[0].args;
       const colony = await Colony.at(colonyAddress);
 
-      // Non-owner can't register label for colony
+      // Non-founder can't register label for colony
       await checkErrorRevert(colony.registerColonyLabel(colonyName, orbitDBAddress, { from: accounts[1] }));
 
-      // Owner cannot register blank label
+      // Founder cannot register blank label
       await checkErrorRevert(colony.registerColonyLabel("", orbitDBAddress, { from: accounts[0] }), "colony-colony-label-invalid");
 
-      // Owner can register label for colony
+      // Founder can register label for colony
       await colony.registerColonyLabel(colonyName, orbitDBAddress, { from: accounts[0] });
       const owner = await ensRegistry.owner(hash);
       assert.equal(owner, colonyNetwork.address);
@@ -413,7 +413,7 @@ contract("Colony Network", accounts => {
       const { colonyAddress } = logs[0].args;
       const colony = await Colony.at(colonyAddress);
       // Register colony
-      // Owner can register label for colony
+      // Founder can register label for colony
       await colony.registerColonyLabel("test", orbitDBAddress, { from: accounts[0] });
 
       // Check reverse lookup for colony

--- a/test/colony-recovery.js
+++ b/test/colony-recovery.js
@@ -94,7 +94,7 @@ contract("Colony Recovery", accounts => {
       await checkErrorRevert(colony.removeAdminRole(accounts[1]), "colony-in-recovery-mode");
       await checkErrorRevert(colony.setRecoveryRole(accounts[1]), "colony-in-recovery-mode");
       await checkErrorRevert(colony.removeRecoveryRole(accounts[1]), "colony-in-recovery-mode");
-      await checkErrorRevert(colony.setOwnerRole(accounts[1]), "colony-in-recovery-mode");
+      await checkErrorRevert(colony.setFounderRole(accounts[1]), "colony-in-recovery-mode");
     });
 
     it("should not be able to call normal functions while in recovery", async () => {

--- a/test/colony-recovery.js
+++ b/test/colony-recovery.js
@@ -58,13 +58,13 @@ contract("Colony Recovery", accounts => {
 
   describe("when using recovery mode", () => {
     it("should be able to add and remove recovery roles when not in recovery", async () => {
-      const owner = accounts[0];
+      const founder = accounts[0];
       let numRecoveryRoles;
 
       numRecoveryRoles = await colony.numRecoveryRoles();
       assert.equal(numRecoveryRoles.toNumber(), 0);
 
-      await colony.setRecoveryRole(owner);
+      await colony.setRecoveryRole(founder);
       await colony.setRecoveryRole(accounts[1]);
       await colony.setRecoveryRole(accounts[2]);
       numRecoveryRoles = await colony.numRecoveryRoles();
@@ -80,15 +80,15 @@ contract("Colony Recovery", accounts => {
       numRecoveryRoles = await colony.numRecoveryRoles();
       assert.equal(numRecoveryRoles.toNumber(), 2);
 
-      // Can remove owner
-      await colony.removeRecoveryRole(owner);
+      // Can remove founder
+      await colony.removeRecoveryRole(founder);
       numRecoveryRoles = await colony.numRecoveryRoles();
       assert.equal(numRecoveryRoles.toNumber(), 1);
     });
 
     it("should not be able to add and remove roles when in recovery", async () => {
-      const owner = accounts[0];
-      await colony.setRecoveryRole(owner);
+      const founder = accounts[0];
+      await colony.setRecoveryRole(founder);
       await colony.enterRecoveryMode();
       await checkErrorRevert(colony.setAdminRole(accounts[1]), "colony-in-recovery-mode");
       await checkErrorRevert(colony.removeAdminRole(accounts[1]), "colony-in-recovery-mode");
@@ -98,11 +98,11 @@ contract("Colony Recovery", accounts => {
     });
 
     it("should not be able to call normal functions while in recovery", async () => {
-      const owner = accounts[0];
-      await colony.setRecoveryRole(owner);
+      const founder = accounts[0];
+      await colony.setRecoveryRole(founder);
       await colony.enterRecoveryMode();
 
-      await metaColony.setRecoveryRole(owner);
+      await metaColony.setRecoveryRole(founder);
       await metaColony.enterRecoveryMode();
 
       await checkErrorRevert(colony.initialiseColony("0x0"), "colony-in-recovery-mode");
@@ -112,8 +112,8 @@ contract("Colony Recovery", accounts => {
     });
 
     it("should exit recovery mode with sufficient approvals", async () => {
-      const owner = accounts[0];
-      await colony.setRecoveryRole(owner);
+      const founder = accounts[0];
+      await colony.setRecoveryRole(founder);
       await colony.setRecoveryRole(accounts[1]);
       await colony.setRecoveryRole(accounts[2]);
 
@@ -133,8 +133,8 @@ contract("Colony Recovery", accounts => {
     });
 
     it("recovery users can work in recovery mode", async () => {
-      const owner = accounts[0];
-      await colony.setRecoveryRole(owner);
+      const founder = accounts[0];
+      await colony.setRecoveryRole(founder);
       await colony.setRecoveryRole(accounts[1]);
 
       await colony.enterRecoveryMode();
@@ -147,8 +147,8 @@ contract("Colony Recovery", accounts => {
     });
 
     it("users cannot approve twice", async () => {
-      const owner = accounts[0];
-      await colony.setRecoveryRole(owner);
+      const founder = accounts[0];
+      await colony.setRecoveryRole(founder);
       await colony.enterRecoveryMode();
       await colony.setStorageSlotRecovery(5, "0xdeadbeef");
 
@@ -157,15 +157,15 @@ contract("Colony Recovery", accounts => {
     });
 
     it("users cannot approve if unauthorized", async () => {
-      const owner = accounts[0];
-      await colony.setRecoveryRole(owner);
+      const founder = accounts[0];
+      await colony.setRecoveryRole(founder);
       await colony.enterRecoveryMode();
       await checkErrorRevert(colony.approveExitRecovery({ from: accounts[1] }));
     });
 
     it("should allow editing of general variables", async () => {
-      const owner = accounts[0];
-      await colony.setRecoveryRole(owner);
+      const founder = accounts[0];
+      await colony.setRecoveryRole(founder);
       await colony.enterRecoveryMode();
       await colony.setStorageSlotRecovery(5, "0xdeadbeef");
 
@@ -174,9 +174,9 @@ contract("Colony Recovery", accounts => {
     });
 
     it("should not allow editing of protected variables", async () => {
-      const owner = accounts[0];
+      const founder = accounts[0];
 
-      await colony.setRecoveryRole(owner);
+      await colony.setRecoveryRole(founder);
       await colony.enterRecoveryMode();
       await checkErrorRevert(colony.setStorageSlotRecovery(0, "0xdeadbeef"), "colony-common-protected-variable");
       // '6' is a protected location in Colony, but not ColonyNetwork. We get a different error.
@@ -184,11 +184,11 @@ contract("Colony Recovery", accounts => {
     });
 
     it("should allow upgrade to be called on a colony in and out of recovery mode", async () => {
-      const owner = accounts[0];
+      const founder = accounts[0];
       // Note that we can't upgrade, because we don't have a new version. But this test is still valid, because we're getting the
       // 'version must be newer' error, not a `colony-not-in-recovery-mode` or `colony-in-recovery-mode` error.
       await checkErrorRevert(colony.upgrade(1), "colony-version-must-be-newer");
-      await colony.setRecoveryRole(owner);
+      await colony.setRecoveryRole(founder);
       await colony.enterRecoveryMode();
       await checkErrorRevert(colony.upgrade(1), "colony-version-must-be-newer");
     });

--- a/test/colony.js
+++ b/test/colony.js
@@ -136,18 +136,18 @@ contract("Colony", accounts => {
   });
 
   describe("when working with permissions", () => {
-    it("should allow current founder role to transfer role to another address", async () => {
+    it("should allow current founder to transfer role to another address", async () => {
       const founderRole = 0;
-      const currentOwner = accounts[0];
-      const futureOwner = accounts[2];
+      const currentFounder = accounts[0];
+      const newFounder = accounts[2];
 
-      let hasRole = await authority.hasUserRole(currentOwner, founderRole);
-      assert(hasRole, `${currentOwner} does not have founder role`);
+      let hasRole = await authority.hasUserRole(currentFounder, founderRole);
+      assert(hasRole, `${currentFounder} does not have founder role`);
 
-      await colony.setFounderRole(futureOwner);
+      await colony.setFounderRole(newFounder);
 
-      hasRole = await authority.hasUserRole(futureOwner, founderRole);
-      assert(hasRole, `Ownership not transfered to ${futureOwner}`);
+      hasRole = await authority.hasUserRole(newFounder, founderRole);
+      assert(hasRole, `Founder role not transfered to ${newFounder}`);
     });
 
     it("should allow admin to assign colony admin role", async () => {

--- a/test/colony.js
+++ b/test/colony.js
@@ -136,17 +136,17 @@ contract("Colony", accounts => {
   });
 
   describe("when working with permissions", () => {
-    it("should allow current owner role to transfer role to another address", async () => {
-      const ownerRole = 0;
+    it("should allow current founder role to transfer role to another address", async () => {
+      const founderRole = 0;
       const currentOwner = accounts[0];
       const futureOwner = accounts[2];
 
-      let hasRole = await authority.hasUserRole(currentOwner, ownerRole);
-      assert(hasRole, `${currentOwner} does not have owner role`);
+      let hasRole = await authority.hasUserRole(currentOwner, founderRole);
+      assert(hasRole, `${currentOwner} does not have founder role`);
 
-      await colony.setOwnerRole(futureOwner);
+      await colony.setFounderRole(futureOwner);
 
-      hasRole = await authority.hasUserRole(futureOwner, ownerRole);
+      hasRole = await authority.hasUserRole(futureOwner, founderRole);
       assert(hasRole, `Ownership not transfered to ${futureOwner}`);
     });
 
@@ -170,7 +170,7 @@ contract("Colony", accounts => {
       assert(hasRole, `Admin role not assigned to ${user5}`);
     });
 
-    it("should allow owner to remove colony admin role", async () => {
+    it("should allow founder to remove colony admin role", async () => {
       const adminRole = 1;
 
       const user1 = accounts[1];
@@ -336,13 +336,13 @@ contract("Colony", accounts => {
       expect(defaultRewardInverse).to.eq.BN(maxUIntNumber);
     });
 
-    it("should allow the colony owner to set it", async () => {
+    it("should allow the colony founder to set it", async () => {
       await colony.setRewardInverse(234);
       const defaultRewardInverse = await colony.getRewardInverse();
       expect(defaultRewardInverse).to.eq.BN(234);
     });
 
-    it("should not allow anyone else but the colony owner to set it", async () => {
+    it("should not allow anyone else but the colony founder to set it", async () => {
       await colony.setRewardInverse(100);
       await checkErrorRevert(colony.setRewardInverse(234, { from: accounts[1] }));
       const defaultRewardInverse = await colony.getRewardInverse();

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -95,7 +95,7 @@ contract("Meta Colony", accounts => {
       assert.equal(rootSkillChild.toNumber(), 4);
     });
 
-    it("should not allow a non-owner role in the metacolony to add a global skill", async () => {
+    it("should not allow a non-founder role in the metacolony to add a global skill", async () => {
       await checkErrorRevert(metaColony.addGlobalSkill(1, { from: OTHER_ACCOUNT }));
     });
 
@@ -322,7 +322,7 @@ contract("Meta Colony", accounts => {
       token = await Token.at(tokenAddress);
     });
 
-    it("someone who does not have owner role should not be able to add domains", async () => {
+    it("someone who does not have founder role should not be able to add domains", async () => {
       await checkErrorRevert(colony.addDomain(1, { from: OTHER_ACCOUNT }));
     });
 
@@ -546,13 +546,13 @@ contract("Meta Colony", accounts => {
   });
 
   describe("when setting the network fee", () => {
-    it("should allow the meta colony owner to set the fee", async () => {
+    it("should allow the meta colony founder to set the fee", async () => {
       await metaColony.setNetworkFeeInverse(234);
       const fee = await colonyNetwork.getFeeInverse();
       assert.equal(fee, 234);
     });
 
-    it("should not allow anyone else but the meta colony owner to set the fee", async () => {
+    it("should not allow anyone else but the meta colony founder to set the fee", async () => {
       await checkErrorRevert(metaColony.setNetworkFeeInverse(234, { from: accounts[1] }));
       const fee = await colonyNetwork.getFeeInverse();
       assert.equal(fee, 0);

--- a/upgrade-test/colony-upgrade.js
+++ b/upgrade-test/colony-upgrade.js
@@ -104,8 +104,8 @@ contract("Colony contract upgrade", accounts => {
     });
 
     it("should return correct permissions", async () => {
-      const owner = await authority.hasUserRole(ACCOUNT_ONE, 0);
-      assert.isTrue(owner);
+      const founder = await authority.hasUserRole(ACCOUNT_ONE, 0);
+      assert.isTrue(founder);
     });
 
     it("should return correct token address", async () => {


### PR DESCRIPTION
Closes #369 

Unfortunately `ENS` and `MultiSigWallet` contracts also declare their separate `owner`s, however since those are built in their specifications and they are probably sufficiently detached from the Colony permissions model we've chosen not to refactor it.
