### PR TITLE
Big Old Test Refactor 1

### DIFF
--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -241,7 +241,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
       require(disputeRounds[round][opponentIdx].provedPreviousReputationUID >= disputeRounds[round][idx].provedPreviousReputationUID, "colony-reputation-mining-less-reputation-uids-proven");
 
       // Require that it has failed a challenge (i.e. failed to respond in time)
-      require(now - disputeRounds[round][idx].lastResponseTimestamp >= 600, "colony-reputation-mining-failed-to-respond-in-time"); //'In time' is ten minutes here.
+      require(now - disputeRounds[round][idx].lastResponseTimestamp >= 600, "colony-reputation-mining-not-timed-out"); // Timeout is ten minutes here.
 
       // Work out whether we are invalidating just the supplied idx or its opponent too.
       bool eliminateOpponent = false;

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -1,5 +1,5 @@
 import { toBN, soliditySha3 } from "web3-utils";
-import { getRandomString } from "./test-helper";
+import shortid from "shortid";
 
 const MANAGER_ROLE = 0;
 const EVALUATOR_ROLE = 1;
@@ -19,14 +19,16 @@ const MANAGER_RATING = 2;
 const WORKER_RATING = 3;
 const RATING_MULTIPLIER = { 1: -1, 2: 1, 3: 1.5 };
 const SECONDS_PER_DAY = 86400;
-const RATING_1_SALT = soliditySha3(getRandomString(10));
-const RATING_2_SALT = soliditySha3(getRandomString(10));
+const RATING_1_SALT = soliditySha3(shortid.generate());
+const RATING_2_SALT = soliditySha3(shortid.generate());
 const RATING_1_SECRET = soliditySha3(RATING_1_SALT, MANAGER_RATING);
 const RATING_2_SECRET = soliditySha3(RATING_2_SALT, WORKER_RATING);
 
 const ACTIVE_TASK_STATE = 0;
 const CANCELLED_TASK_STATE = 1;
 const FINALIZED_TASK_STATE = 2;
+
+const UINT256_MAX = toBN(0).notn(256);
 
 const WAD = toBN(10).pow(toBN(18));
 const MIN_STAKE = WAD.muln(2000);
@@ -60,6 +62,7 @@ module.exports = {
   ACTIVE_TASK_STATE,
   CANCELLED_TASK_STATE,
   FINALIZED_TASK_STATE,
+  UINT256_MAX,
   WAD,
   MIN_STAKE,
   DEFAULT_STAKE,

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -29,6 +29,7 @@ const CANCELLED_TASK_STATE = 1;
 const FINALIZED_TASK_STATE = 2;
 
 const UINT256_MAX = toBN(0).notn(256);
+const INT256_MAX = toBN(0).notn(255);
 
 const WAD = toBN(10).pow(toBN(18));
 const MIN_STAKE = WAD.muln(2000);
@@ -63,6 +64,7 @@ module.exports = {
   CANCELLED_TASK_STATE,
   FINALIZED_TASK_STATE,
   UINT256_MAX,
+  INT256_MAX,
   WAD,
   MIN_STAKE,
   DEFAULT_STAKE,

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -70,37 +70,7 @@ export async function executeSignedRoleAssignment({ colony, taskId, functionName
   return colony.executeTaskRoleAssignment(sigV, sigR, sigS, sigTypes, 0, txData);
 }
 
-export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain = 1, skill = 0, evaluator, worker }) {
-  const accounts = await web3GetAccounts();
-  const manager = accounts[0];
-  evaluator = evaluator || manager; // eslint-disable-line no-param-reassign
-  worker = worker || accounts[2]; // eslint-disable-line no-param-reassign
-
-  const taskId = await makeTask({ colony, domainId: domain });
-  // If the skill is not specified, default to the root global skill
-  if (skill === 0) {
-    const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId();
-    if (rootGlobalSkill.isZero()) throw new Error("Meta Colony is not setup and therefore the root global skill does not exist");
-
-    await executeSignedTaskChange({
-      colony,
-      taskId,
-      functionName: "setTaskSkill",
-      signers: [manager],
-      sigTypes: [0],
-      args: [taskId, rootGlobalSkill]
-    });
-  } else {
-    await executeSignedTaskChange({
-      colony,
-      taskId,
-      functionName: "setTaskSkill",
-      signers: [manager],
-      sigTypes: [0],
-      args: [taskId, skill]
-    });
-  }
-
+export async function assignRoles({ colony, taskId, manager, evaluator, worker }) {
   if (manager !== evaluator) {
     await executeSignedTaskChange({
       colony,
@@ -132,18 +102,29 @@ export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domain
     sigTypes,
     args: [taskId, worker]
   });
+}
 
-  const dueDateTimestamp = dueDate;
-  if (dueDateTimestamp) {
-    await executeSignedTaskChange({
-      colony,
-      taskId,
-      functionName: "setTaskDueDate",
-      signers,
-      sigTypes,
-      args: [taskId, dueDateTimestamp]
-    });
+export async function setupTask({ colonyNetwork, colony, dueDate, domainId = 1, skillId = 0 }) {
+  // If the skill is not specified, default to the root global skill
+  if (skillId === 0) {
+    skillId = await colonyNetwork.getRootGlobalSkillId(); // eslint-disable-line no-param-reassign
+    if (skillId.toNumber() === 0) throw new Error("Meta Colony is not setup and therefore the root global skill does not exist");
   }
+
+  const taskId = await makeTask({ colony, dueDate, domainId, skillId });
+
+  return taskId;
+}
+
+export async function setupAssignedTask({ colonyNetwork, colony, dueDate, domainId = 1, skillId = 0, evaluator, worker }) {
+  const accounts = await web3GetAccounts();
+  const manager = accounts[0];
+  evaluator = evaluator || manager; // eslint-disable-line no-param-reassign
+  worker = worker || accounts[2]; // eslint-disable-line no-param-reassign
+
+  const taskId = await setupTask({ colonyNetwork, colony, dueDate, domainId, skillId });
+  await assignRoles({ colony, taskId, manager, evaluator, worker });
+
   return taskId;
 }
 
@@ -152,8 +133,8 @@ export async function setupFundedTask({
   colony,
   token,
   dueDate,
-  domain,
-  skill,
+  domainId,
+  skillId,
   evaluator,
   worker,
   managerPayout = MANAGER_PAYOUT,
@@ -171,7 +152,7 @@ export async function setupFundedTask({
   } else {
     tokenAddress = token === ZERO_ADDRESS ? ZERO_ADDRESS : token.address;
   }
-  const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate, domain, skill, evaluator, worker });
+  const taskId = await setupTask({ colonyNetwork, colony, dueDate, domainId, skillId });
   const task = await colony.getTask(taskId);
   const potId = task[5];
   const managerPayoutBN = new BN(managerPayout);
@@ -180,38 +161,9 @@ export async function setupFundedTask({
   const totalPayouts = managerPayoutBN.add(workerPayoutBN).add(evaluatorPayoutBN);
   await colony.moveFundsBetweenPots(1, potId, totalPayouts, tokenAddress);
 
-  await executeSignedTaskChange({
-    colony,
-    taskId,
-    functionName: "setTaskManagerPayout",
-    signers: [manager],
-    sigTypes: [0],
-    args: [taskId, tokenAddress, managerPayout]
-  });
+  await colony.setAllTaskPayouts(taskId, tokenAddress, managerPayout, evaluatorPayout, workerPayout);
+  await assignRoles({ colony, taskId, manager, evaluator, worker });
 
-  let signers = manager === evaluator ? [manager] : [manager, evaluator];
-  let sigTypes = Array.from({ length: signers.length }, () => 0);
-
-  await executeSignedTaskChange({
-    colony,
-    taskId,
-    functionName: "setTaskEvaluatorPayout",
-    signers,
-    sigTypes,
-    args: [taskId, tokenAddress, evaluatorPayout]
-  });
-
-  signers = manager === worker ? [manager] : [manager, worker];
-  sigTypes = Array.from({ length: signers.length }, () => 0);
-
-  await executeSignedTaskChange({
-    colony,
-    taskId,
-    functionName: "setTaskWorkerPayout",
-    signers,
-    sigTypes,
-    args: [taskId, tokenAddress, workerPayout]
-  });
   return taskId;
 }
 
@@ -220,8 +172,8 @@ export async function setupRatedTask({
   colony,
   token,
   dueDate,
-  domain,
-  skill,
+  domainId,
+  skillId,
   evaluator,
   worker,
   managerPayout = MANAGER_PAYOUT,
@@ -242,8 +194,8 @@ export async function setupRatedTask({
     colony,
     token,
     dueDate,
-    domain,
-    skill,
+    domainId,
+    skillId,
     evaluator,
     worker,
     managerPayout,

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -750,7 +750,7 @@ contract("Colony Funding", accounts => {
       const taskId = await setupRatedTask({
         colonyNetwork,
         colony,
-        skill: id
+        skillId: id
       });
       await colony.finalizeTask(taskId);
 
@@ -840,7 +840,7 @@ contract("Colony Funding", accounts => {
         colonyNetwork,
         colony: newColony,
         token: newToken,
-        domain: domainCount
+        domainId: domainCount
       });
       await newColony.finalizeTask(taskId);
 

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -7,19 +7,18 @@ import bnChai from "bn-chai";
 import path from "path";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
-import {
-  MANAGER_ROLE,
-  EVALUATOR_ROLE,
-  WORKER_ROLE,
-  WORKER_PAYOUT,
-  INITIAL_FUNDING,
-  DEFAULT_STAKE,
-  MINING_CYCLE_DURATION,
-  ZERO_ADDRESS,
-  WAD
-} from "../helpers/constants";
+import { MANAGER_ROLE, EVALUATOR_ROLE, WORKER_ROLE, WORKER_PAYOUT, INITIAL_FUNDING, DEFAULT_STAKE, ZERO_ADDRESS, WAD } from "../helpers/constants";
 
-import { getTokenArgs, checkErrorRevert, web3GetBalance, forwardTime, currentBlockTime, bnSqrt, makeReputationKey } from "../helpers/test-helper";
+import {
+  getTokenArgs,
+  checkErrorRevert,
+  web3GetBalance,
+  forwardTime,
+  currentBlockTime,
+  bnSqrt,
+  makeReputationKey,
+  advanceMiningCycleNoContest
+} from "../helpers/test-helper";
 
 import {
   fundColonyWithTokens,
@@ -42,7 +41,6 @@ const IColonyNetwork = artifacts.require("IColonyNetwork");
 const Token = artifacts.require("Token");
 const ITokenLocking = artifacts.require("ITokenLocking");
 const DSRoles = artifacts.require("DSRoles");
-const IReputationMiningCycle = artifacts.require("IReputationMiningCycle");
 
 const contractLoader = new TruffleLoader({
   contractDir: path.resolve(__dirname, "..", "build", "contracts")
@@ -661,11 +659,9 @@ contract("Colony Funding", accounts => {
         denominatorSqrt,
         totalAmountSqrt
       ];
-      let addr = await colonyNetwork.getReputationMiningCycle(true);
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      let repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.submitRootHash("0x00", 0, 10);
-      await repCycle.confirmNewHash(0);
+
+      await advanceMiningCycleNoContest(colonyNetwork, this);
+
       await giveUserCLNYTokensAndStake(colonyNetwork, accounts[4], DEFAULT_STAKE);
       miningClient = new ReputationMiner({
         loader: contractLoader,
@@ -673,13 +669,11 @@ contract("Colony Funding", accounts => {
         realProviderPort: REAL_PROVIDER_PORT,
         useJsTree: true
       });
+
       await miningClient.initialise(colonyNetwork.address);
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-      addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
@@ -718,12 +712,7 @@ contract("Colony Funding", accounts => {
       const globalKey = await ReputationMiner.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
       await miningClient.insert(globalKey, toBN(10), 0);
 
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      const addr = await colonyNetwork.getReputationMiningCycle(true);
-      const repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill);
       const { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
@@ -751,20 +740,10 @@ contract("Colony Funding", accounts => {
       });
 
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      let addr = await colonyNetwork.getReputationMiningCycle(true);
-      let repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       const colonyWideReputationKey = makeReputationKey(colony.address, id);
       const { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
@@ -777,20 +756,10 @@ contract("Colony Funding", accounts => {
       await colony.bootstrapColony([userAddress2], [userReputation]);
 
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      let addr = await colonyNetwork.getReputationMiningCycle(true);
-      let repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
@@ -844,20 +813,10 @@ contract("Colony Funding", accounts => {
       });
 
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      let addr = await colonyNetwork.getReputationMiningCycle(true);
-      let repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill);
       let { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
@@ -894,20 +853,10 @@ contract("Colony Funding", accounts => {
       });
 
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      let addr = await colonyNetwork.getReputationMiningCycle(true);
-      let repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       const result = await newColony.getDomain(1);
       const rootDomainSkill = result.skillId;
@@ -963,12 +912,7 @@ contract("Colony Funding", accounts => {
       const globalKey = await ReputationMiner.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
       await miningClient.insert(globalKey, toBN(0), 0);
 
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      const addr = await colonyNetwork.getReputationMiningCycle(true);
-      const repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill);
       const { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
@@ -986,20 +930,10 @@ contract("Colony Funding", accounts => {
       await token.transfer(colony.address, userReputation3, { from: userAddress3 });
 
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      let addr = await colonyNetwork.getReputationMiningCycle(true);
-      let repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
@@ -1044,20 +978,10 @@ contract("Colony Funding", accounts => {
       await miningClient.insert(userKey, toBN(0), 0);
 
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      let addr = await colonyNetwork.getReputationMiningCycle(true);
-      let repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       const colonyWideReputationKey = makeReputationKey(colony.address, rootDomainSkill);
       let { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
@@ -1270,21 +1194,11 @@ contract("Colony Funding", accounts => {
 
       // Submit current hash in active reputation mining cycle
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      let addr = await colonyNetwork.getReputationMiningCycle(true);
-      let repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       // Reputation added while bootstrapping the colony is now in active reputation mining cycle, so submit the hash
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       const domain1 = await colony1.getDomain(1);
       const rootDomainSkill1 = domain1.skillId;
@@ -1394,21 +1308,11 @@ contract("Colony Funding", accounts => {
 
       // Submit current hash in active reputation mining cycle
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      let addr = await colonyNetwork.getReputationMiningCycle(true);
-      let repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       // Reputation added while bootstrapping the colony is now in active reputation mining cycle, so submit the hash
       await miningClient.addLogContentsToReputationTree();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      addr = await colonyNetwork.getReputationMiningCycle(true);
-      repCycle = await IReputationMiningCycle.at(addr);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
       const domain1 = await colony1.getDomain(1);
       const rootDomainSkill1 = domain1.skillId;
@@ -1537,21 +1441,11 @@ contract("Colony Funding", accounts => {
 
         // Submit current hash in active reputation mining cycle
         await miningClient.addLogContentsToReputationTree();
-        await forwardTime(MINING_CYCLE_DURATION, this);
-        await miningClient.submitRootHash();
-
-        let addr = await colonyNetwork.getReputationMiningCycle(true);
-        let repCycle = await IReputationMiningCycle.at(addr);
-        await repCycle.confirmNewHash(0);
+        await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
         // Reputation added while bootstrapping the colony is now in active reputation mining cycle, so submit the hash
         await miningClient.addLogContentsToReputationTree();
-        await forwardTime(MINING_CYCLE_DURATION, this);
-        await miningClient.submitRootHash();
-
-        addr = await colonyNetwork.getReputationMiningCycle(true);
-        repCycle = await IReputationMiningCycle.at(addr);
-        await repCycle.confirmNewHash(0);
+        await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
 
         const result = await newColony.getDomain(1);
         const rootDomainSkill = result.skillId;

--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -275,8 +275,8 @@ contract("ColonyNetworkAuction", accounts => {
       await tokenAuction.bid(amount, { from: BIDDER_1 });
       const receivedTotal = await tokenAuction.receivedTotal();
       const bid = await tokenAuction.bids(BIDDER_1);
-      assert(bid.lte(totalToEndAuction));
-      assert(receivedTotal.lte(totalToEndAuction));
+      assert.isTrue(bid.lte(totalToEndAuction));
+      assert.isTrue(receivedTotal.lte(totalToEndAuction));
       assert.equal(receivedTotal.toString(), bid.toString());
     });
 

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -17,7 +17,7 @@ import {
   submitAndForwardTimeToDispute
 } from "../helpers/test-helper";
 import { giveUserCLNYTokens, giveUserCLNYTokensAndStake, setupRatedTask, fundColonyWithTokens } from "../helpers/test-data-generator";
-import { WAD, MIN_STAKE, DEFAULT_STAKE, MINING_CYCLE_DURATION, DECAY_RATE, ZERO_ADDRESS } from "../helpers/constants";
+import { UINT256_MAX, WAD, MIN_STAKE, DEFAULT_STAKE, MINING_CYCLE_DURATION, DECAY_RATE, ZERO_ADDRESS } from "../helpers/constants";
 
 import ReputationMiner from "../packages/reputation-miner/ReputationMiner";
 import MaliciousReputationMinerExtraRep from "../packages/reputation-miner/test/MaliciousReputationMinerExtraRep";
@@ -367,8 +367,7 @@ contract("ColonyNetworkMining", accounts => {
     });
 
     it("should correctly calculate the miner weight", async () => {
-      const UINT256_MAX = new BN(0).notn(256);
-      const UINT32_MAX = new BN(0).notn(32);
+      const UINT32_MAX = UINT256_MAX.shrn(256 - 32);
       let weight;
 
       // Large weight (staked for UINT256_MAX, first submission)

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -16,7 +16,8 @@ import {
   getValidEntryNumber,
   submitAndForwardTimeToDispute
 } from "../helpers/test-helper";
-import { giveUserCLNYTokens, giveUserCLNYTokensAndStake, setupRatedTask, fundColonyWithTokens } from "../helpers/test-data-generator";
+
+import { giveUserCLNYTokens, giveUserCLNYTokensAndStake, setupFinalizedTask, fundColonyWithTokens } from "../helpers/test-data-generator";
 import { UINT256_MAX, WAD, MIN_STAKE, DEFAULT_STAKE, MINING_CYCLE_DURATION, DECAY_RATE, ZERO_ADDRESS } from "../helpers/constants";
 
 import ReputationMiner from "../packages/reputation-miner/ReputationMiner";
@@ -1460,7 +1461,7 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
 
-      const taskId = await setupRatedTask({
+      await setupFinalizedTask({
         colonyNetwork,
         colony: metaColony,
         managerPayout: 1000000000000,
@@ -1470,7 +1471,6 @@ contract("ColonyNetworkMining", accounts => {
         workerRating: 3,
         worker: accounts[3]
       });
-      await metaColony.finalizeTask(taskId);
 
       let addr = await colonyNetwork.getReputationMiningCycle(true);
       await forwardTime(MINING_CYCLE_DURATION, this);
@@ -1638,7 +1638,7 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
 
-      const taskId = await setupRatedTask({
+      await setupFinalizedTask({
         colonyNetwork,
         colony: metaColony,
         managerPayout: 1000000000000,
@@ -1648,7 +1648,6 @@ contract("ColonyNetworkMining", accounts => {
         workerRating: 3,
         worker: accounts[3]
       });
-      await metaColony.finalizeTask(taskId);
 
       let addr = await colonyNetwork.getReputationMiningCycle(true);
       let repCycle = await IReputationMiningCycle.at(addr);
@@ -1736,7 +1735,7 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
 
-      const taskId = await setupRatedTask({
+      await setupFinalizedTask({
         colonyNetwork,
         colony: metaColony,
         managerPayout: 1000000000000,
@@ -1746,7 +1745,6 @@ contract("ColonyNetworkMining", accounts => {
         workerRating: 3,
         worker: accounts[3]
       });
-      await metaColony.finalizeTask(taskId);
 
       let addr = await colonyNetwork.getReputationMiningCycle(true);
       let repCycle = await IReputationMiningCycle.at(addr);
@@ -1848,7 +1846,7 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
 
-      const taskId = await setupRatedTask({
+      await setupFinalizedTask({
         colonyNetwork,
         colony: metaColony,
         managerPayout: 1000000000000,
@@ -1857,7 +1855,6 @@ contract("ColonyNetworkMining", accounts => {
         managerRating: 3,
         workerRating: 3
       });
-      await metaColony.finalizeTask(taskId);
 
       let addr = await colonyNetwork.getReputationMiningCycle(true);
       let repCycle = await IReputationMiningCycle.at(addr);
@@ -2107,7 +2104,7 @@ contract("ColonyNetworkMining", accounts => {
 
       await badClient.initialise(colonyNetwork.address);
 
-      const taskId = await setupRatedTask( // eslint-disable-line
+      await setupFinalizedTask( // eslint-disable-line
         {
           colonyNetwork,
           colony: metaColony,
@@ -2118,7 +2115,6 @@ contract("ColonyNetworkMining", accounts => {
           workerPayout: 1
         }
       );
-      await metaColony.finalizeTask(taskId);
       await advanceTimeSubmitAndConfirmHash(this);
       await advanceTimeSubmitAndConfirmHash(this);
       let addr = await colonyNetwork.getReputationMiningCycle(false);
@@ -2126,7 +2122,7 @@ contract("ColonyNetworkMining", accounts => {
 
       let powerTwoEntries = false;
       while (!powerTwoEntries) {
-        const taskId = await setupRatedTask( // eslint-disable-line
+        await setupFinalizedTask( // eslint-disable-line
           {
             colonyNetwork,
             colony: metaColony,
@@ -2137,7 +2133,6 @@ contract("ColonyNetworkMining", accounts => {
             workerPayout: 1
           }
         );
-        await metaColony.finalizeTask(taskId); // eslint-disable-line no-await-in-loop
         const nLogEntries = await inactiveRepCycle.getReputationUpdateLogLength(); // eslint-disable-line no-await-in-loop
         const lastLogEntry = await inactiveRepCycle.getReputationUpdateLogEntry(nLogEntries - 1); // eslint-disable-line no-await-in-loop
         const currentHashNNodes = await colonyNetwork.getReputationRootHashNNodes(); // eslint-disable-line no-await-in-loop
@@ -2501,7 +2496,7 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       // TODO It would be so much better if we could do these in parallel, but until colonyNetwork#192 is fixed, we can't.
       for (let i = 0; i < 30; i += 1) {
-        const taskId = await setupRatedTask( // eslint-disable-line
+        await setupFinalizedTask( // eslint-disable-line
           {
             colonyNetwork,
             colony: metaColony,
@@ -2512,7 +2507,6 @@ contract("ColonyNetworkMining", accounts => {
             workerPayout: 1
           }
         );
-        await metaColony.finalizeTask(taskId); // eslint-disable-line no-await-in-loop
       }
       // Complete this reputation cycle
 
@@ -2573,7 +2567,7 @@ contract("ColonyNetworkMining", accounts => {
       let addr = await colonyNetwork.getReputationMiningCycle(true);
       let repCycle = await IReputationMiningCycle.at(addr);
 
-      const taskId = await setupRatedTask({
+      await setupFinalizedTask({
         colonyNetwork,
         colony: metaColony,
         managerPayout: 1000000000000,
@@ -2582,7 +2576,6 @@ contract("ColonyNetworkMining", accounts => {
         managerRating: 1,
         workerRating: 1
       });
-      await metaColony.finalizeTask(taskId);
 
       await forwardTime(MINING_CYCLE_DURATION, this);
       await repCycle.submitRootHash("0x00", 0, 10);
@@ -2613,7 +2606,7 @@ contract("ColonyNetworkMining", accounts => {
       let addr = await colonyNetwork.getReputationMiningCycle(true);
       let repCycle = await IReputationMiningCycle.at(addr);
 
-      const taskId = await setupRatedTask({
+      await setupFinalizedTask({
         colonyNetwork,
         colony: metaColony,
         worker: accounts[4],
@@ -2623,7 +2616,6 @@ contract("ColonyNetworkMining", accounts => {
         managerRating: 1,
         workerRating: 1
       });
-      await metaColony.finalizeTask(taskId);
 
       await forwardTime(MINING_CYCLE_DURATION, this);
       await repCycle.submitRootHash("0x00", 0, 10);
@@ -2664,7 +2656,7 @@ contract("ColonyNetworkMining", accounts => {
 
       const rootHash = await goodClient.getRootHash();
       await fundColonyWithTokens(metaColony, clny, new BN("4").mul(new BN("10").pow(new BN("75"))));
-      const taskId = await setupRatedTask({
+      await setupFinalizedTask({
         colonyNetwork,
         colony: metaColony,
         worker: MAIN_ACCOUNT,
@@ -2674,7 +2666,6 @@ contract("ColonyNetworkMining", accounts => {
         managerRating: 3,
         workerRating: 3
       });
-      await metaColony.finalizeTask(taskId);
 
       await forwardTime(MINING_CYCLE_DURATION, this);
       await repCycle.submitRootHash(rootHash, 2, 10);
@@ -2757,8 +2748,9 @@ contract("ColonyNetworkMining", accounts => {
       const repCycle = await IReputationMiningCycle.at(addr);
       await repCycle.submitRootHash("0x12345678", 10, 10);
       await fundColonyWithTokens(metaColony, clny, "350000000000000000000");
-      const taskId1 = await setupRatedTask({ colonyNetwork, colony: metaColony });
-      await metaColony.finalizeTask(taskId1); // Creates an entry in the reputation log for the worker and manager
+
+      // Creates an entry in the reputation log for the worker and manager
+      await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       addr = await colonyNetwork.getReputationMiningCycle(false);
       let inactiveReputationMiningCycle = await IReputationMiningCycle.at(addr);
 
@@ -2883,7 +2875,7 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
 
       // Do the task
-      const taskId = await setupRatedTask({
+      await setupFinalizedTask({
         colonyNetwork,
         colony: metaColony,
         skillId: 10,
@@ -2895,7 +2887,6 @@ contract("ColonyNetworkMining", accounts => {
         worker: OTHER_ACCOUNT,
         evaluator: accounts[2]
       });
-      await metaColony.finalizeTask(taskId);
 
       let addr = await colonyNetwork.getReputationMiningCycle(true);
       let repCycle = await IReputationMiningCycle.at(addr);
@@ -2967,7 +2958,7 @@ contract("ColonyNetworkMining", accounts => {
       // Do some tasks
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
-      const taskId = await setupRatedTask({
+      await setupFinalizedTask({
         colonyNetwork,
         colony: metaColony,
         skillId: 10,
@@ -2979,7 +2970,6 @@ contract("ColonyNetworkMining", accounts => {
         worker: OTHER_ACCOUNT,
         evaluator: accounts[2]
       });
-      await metaColony.finalizeTask(taskId);
 
       // Get current cycle & advance to next
       let addr = await colonyNetwork.getReputationMiningCycle(true);
@@ -3162,7 +3152,7 @@ contract("ColonyNetworkMining", accounts => {
       await goodClient2.initialise(colonyNetwork.address);
       // Make multiple reputation cycles, with different numbers tasks and blocks in them.
       for (let i = 0; i < 5; i += 1) {
-        const taskId = await setupRatedTask( // eslint-disable-line
+        await setupFinalizedTask( // eslint-disable-line
           {
             colonyNetwork,
             colony: metaColony,
@@ -3173,7 +3163,6 @@ contract("ColonyNetworkMining", accounts => {
             workerRating: 3
           }
         );
-        await metaColony.finalizeTask(taskId); // eslint-disable-line no-await-in-loop
       }
 
       await advanceTimeSubmitAndConfirmHash(this);
@@ -3185,7 +3174,7 @@ contract("ColonyNetworkMining", accounts => {
       await advanceTimeSubmitAndConfirmHash(this);
 
       for (let i = 0; i < 5; i += 1) {
-        const taskId = await setupRatedTask( // eslint-disable-line
+        await setupFinalizedTask( // eslint-disable-line
           {
             colonyNetwork,
             colony: metaColony,
@@ -3196,7 +3185,6 @@ contract("ColonyNetworkMining", accounts => {
             workerRating: 3
           }
         );
-        await metaColony.finalizeTask(taskId); // eslint-disable-line no-await-in-loop
       }
 
       await advanceTimeSubmitAndConfirmHash(this);
@@ -3228,7 +3216,7 @@ contract("ColonyNetworkMining", accounts => {
           await advanceTimeSubmitAndConfirmHash(this);
 
           for (let i = 0; i < 5; i += 1) {
-            const taskId = await setupRatedTask( // eslint-disable-line
+            await setupFinalizedTask( // eslint-disable-line
               {
                 colonyNetwork,
                 colony: metaColony,
@@ -3239,7 +3227,6 @@ contract("ColonyNetworkMining", accounts => {
                 workerRating: 3
               }
             );
-            await metaColony.finalizeTask(taskId); // eslint-disable-line no-await-in-loop
           }
 
           await advanceTimeSubmitAndConfirmHash(this);

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -139,9 +139,9 @@ contract("ColonyNetworkMining", accounts => {
       }
 
       [round2, idx2] = await client2.getMySubmissionRoundAndIndex();
-      assert(round1.eq(round2), "Clients do not have submissions in the same round");
+      assert.isTrue(round1.eq(round2), "Clients do not have submissions in the same round");
       const submission2before = await repCycle.getDisputeRounds(round2, idx2);
-      assert(
+      assert.isTrue(
         idx1
           .sub(idx2)
           .pow(2)
@@ -308,7 +308,7 @@ contract("ColonyNetworkMining", accounts => {
       const repCycle = await IReputationMiningCycle.at(addr);
       await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 0), "colony-reputation-mining-zero-entry-index-passed");
       const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      assert(nSubmittedHashes.isZero());
+      assert.isTrue(nSubmittedHashes.isZero());
     });
 
     it("should not allow someone to withdraw their stake if they have submitted a hash this round", async () => {
@@ -320,7 +320,7 @@ contract("ColonyNetworkMining", accounts => {
       let userLock = await tokenLocking.getUserLock(clny.address, MAIN_ACCOUNT);
       await checkErrorRevert(tokenLocking.withdraw(clny.address, userLock[1], { from: MAIN_ACCOUNT }), "colony-token-locking-hash-submitted");
       userLock = await tokenLocking.getUserLock(clny.address, MAIN_ACCOUNT);
-      assert(userLock[1].eq(DEFAULT_STAKE));
+      assert.isTrue(userLock[1].eq(DEFAULT_STAKE));
     });
 
     it("should allow a new reputation hash to be set if only one was submitted", async () => {
@@ -332,13 +332,13 @@ contract("ColonyNetworkMining", accounts => {
       await repCycle.submitRootHash("0x12345678", 10, 10);
       await repCycle.confirmNewHash(0);
       const newAddr = await colonyNetwork.getReputationMiningCycle(true);
-      assert(newAddr !== ZERO_ADDRESS);
-      assert(addr !== ZERO_ADDRESS);
-      assert(newAddr !== addr);
+      assert.isTrue(newAddr !== ZERO_ADDRESS);
+      assert.isTrue(addr !== ZERO_ADDRESS);
+      assert.isTrue(newAddr !== addr);
       const rootHash = await colonyNetwork.getReputationRootHash();
       assert.equal(rootHash, "0x1234567800000000000000000000000000000000000000000000000000000000");
       const rootHashNNodes = await colonyNetwork.getReputationRootHashNNodes();
-      assert(rootHashNNodes.eq(new BN(10)));
+      assert.isTrue(rootHashNNodes.eq(new BN(10)));
     });
 
     it("should not allow someone who is not ColonyNetwork to appendReputationUpdateLog", async () => {
@@ -408,9 +408,9 @@ contract("ColonyNetworkMining", accounts => {
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
       await repCycle.confirmNewHash(1);
       const newAddr = await colonyNetwork.getReputationMiningCycle(true);
-      assert(newAddr !== ZERO_ADDRESS);
-      assert(addr !== ZERO_ADDRESS);
-      assert(newAddr !== addr);
+      assert.isTrue(newAddr !== ZERO_ADDRESS);
+      assert.isTrue(addr !== ZERO_ADDRESS);
+      assert.isTrue(newAddr !== addr);
       const rootHash = await colonyNetwork.getReputationRootHash();
       const clientRootHash = await goodClient.getRootHash();
       assert.equal(rootHash, clientRootHash);
@@ -433,9 +433,9 @@ contract("ColonyNetworkMining", accounts => {
 
       await repCycle.confirmNewHash(2);
       const newAddr = await colonyNetwork.getReputationMiningCycle(true);
-      assert(newAddr !== ZERO_ADDRESS);
-      assert(addr !== ZERO_ADDRESS);
-      assert(newAddr !== addr);
+      assert.isTrue(newAddr !== ZERO_ADDRESS);
+      assert.isTrue(addr !== ZERO_ADDRESS);
+      assert.isTrue(newAddr !== addr);
       const rootHash = await colonyNetwork.getReputationRootHash();
       const clientRootHash = await goodClient.getRootHash();
       assert.equal(rootHash, clientRootHash);
@@ -453,9 +453,9 @@ contract("ColonyNetworkMining", accounts => {
       const repCycle = await IReputationMiningCycle.at(addr);
       await checkErrorRevert(repCycle.confirmNewHash(0), "colony-reputation-mining-final-round-not-completed");
       const newAddr = await colonyNetwork.getReputationMiningCycle(true);
-      assert(newAddr !== ZERO_ADDRESS);
-      assert(addr !== ZERO_ADDRESS);
-      assert(newAddr === addr);
+      assert.isTrue(newAddr !== ZERO_ADDRESS);
+      assert.isTrue(addr !== ZERO_ADDRESS);
+      assert.isTrue(newAddr === addr);
       // Eliminate one so that the afterAll works.
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
     });
@@ -577,7 +577,7 @@ contract("ColonyNetworkMining", accounts => {
       const repCycle = await IReputationMiningCycle.at(addr);
       await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, 10), "colony-reputation-mining-cycle-submission-not-within-target");
       const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      assert(nSubmittedHashes.isZero());
+      assert.isTrue(nSubmittedHashes.isZero());
     });
 
     it("should not allow someone to submit a new reputation hash to the next ReputationMiningCycle", async () => {
@@ -613,7 +613,7 @@ contract("ColonyNetworkMining", accounts => {
       const entryNumber2 = await getValidEntryNumber(colonyNetwork, MAIN_ACCOUNT, "0x87654321");
       await checkErrorRevert(repCycle.submitRootHash("0x87654321", 10, entryNumber2), "colony-reputation-mining-submitting-different-hash");
       const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      assert(nSubmittedHashes.eq(new BN(1)));
+      assert.isTrue(nSubmittedHashes.eq(new BN(1)));
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
     });
 
@@ -628,7 +628,7 @@ contract("ColonyNetworkMining", accounts => {
 
       await checkErrorRevert(repCycle.submitRootHash("0x12345678", 11, entryNumber), "colony-reputation-mining-submitting-different-nnodes");
       const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      assert(nSubmittedHashes.eq(new BN(1)));
+      assert.isTrue(nSubmittedHashes.eq(new BN(1)));
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
     });
 
@@ -644,7 +644,7 @@ contract("ColonyNetworkMining", accounts => {
 
       await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, entryNumber), "colony-reputation-mining-submitting-same-entry-index");
       const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      assert(nSubmittedHashes.eq(new BN(1)));
+      assert.isTrue(nSubmittedHashes.eq(new BN(1)));
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
     });
 
@@ -660,7 +660,7 @@ contract("ColonyNetworkMining", accounts => {
       await repCycle.submitRootHash("0x12345678", 10, entryNumber);
       await repCycle.submitRootHash("0x12345678", 10, entryNumber2);
       const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      assert(nSubmittedHashes.eq(new BN(1)));
+      assert.isTrue(nSubmittedHashes.eq(new BN(1)));
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
       await repCycle.confirmNewHash(0);
 
@@ -734,13 +734,13 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, accounts[2], DEFAULT_STAKE);
 
       let userLock0 = await tokenLocking.getUserLock(clny.address, MAIN_ACCOUNT);
-      assert(userLock0[1].eq(DEFAULT_STAKE));
+      assert.isTrue(userLock0[1].eq(DEFAULT_STAKE));
 
       let userLock1 = await tokenLocking.getUserLock(clny.address, OTHER_ACCOUNT);
-      assert(userLock1[1].eq(DEFAULT_STAKE));
+      assert.isTrue(userLock1[1].eq(DEFAULT_STAKE));
 
       let userLock2 = await tokenLocking.getUserLock(clny.address, accounts[2]);
-      assert(userLock2[1].eq(DEFAULT_STAKE));
+      assert.isTrue(userLock2[1].eq(DEFAULT_STAKE));
 
       // We want badclient2 to submit the same hash as badclient for this test.
       badClient2 = new MaliciousReputationMinerExtraRep(
@@ -826,7 +826,7 @@ contract("ColonyNetworkMining", accounts => {
     it('should not allow "startNextCycle" to be called if a cycle is in progress', async () => {
       const addr = await colonyNetwork.getReputationMiningCycle(true);
       await forwardTime(MINING_CYCLE_DURATION, this);
-      assert(parseInt(addr, 16) !== 0);
+      assert.isTrue(parseInt(addr, 16) !== 0);
       await checkErrorRevert(colonyNetwork.startNextCycle(), "colony-reputation-mining-still-active");
     });
 
@@ -882,7 +882,7 @@ contract("ColonyNetworkMining", accounts => {
 
       const righthash = await goodClient.getRootHash();
       const wronghash = await badClient.getRootHash();
-      assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
+      assert.isTrue(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
 
       const nSubmittedHashes = await repCycle.getNSubmittedHashes();
       assert.equal(nSubmittedHashes, 2);
@@ -938,7 +938,7 @@ contract("ColonyNetworkMining", accounts => {
 
       const righthash = await goodClient.getRootHash();
       const wronghash = await badClient.getRootHash();
-      assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
+      assert.isTrue(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
 
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
       await repCycle.confirmNewHash(1);
@@ -982,7 +982,7 @@ contract("ColonyNetworkMining", accounts => {
 
         const righthash = await goodClient.getRootHash();
         const wronghash = await badClient.getRootHash();
-        assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
+        assert.isTrue(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
 
         await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
         addr = await colonyNetwork.getReputationMiningCycle(true);
@@ -1029,7 +1029,7 @@ contract("ColonyNetworkMining", accounts => {
 
       const righthash = await goodClient.getRootHash();
       const wronghash = await badClient.getRootHash();
-      assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
+      assert.isTrue(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
 
       const nSubmittedHashes = await repCycle.getNSubmittedHashes();
       assert.equal(nSubmittedHashes, 2);
@@ -1164,7 +1164,7 @@ contract("ColonyNetworkMining", accounts => {
 
       const righthash = await goodClient.getRootHash();
       const wronghash = await badClient.getRootHash();
-      assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
+      assert.isTrue(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
 
       await goodClient.submitJustificationRootHash();
       await badClient.submitJustificationRootHash();
@@ -1252,7 +1252,7 @@ contract("ColonyNetworkMining", accounts => {
 
       const righthash = await goodClient.getRootHash();
       const wronghash = await badClient.getRootHash();
-      assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
+      assert.isTrue(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
 
       await goodClient.submitJustificationRootHash();
       await badClient.submitJustificationRootHash();
@@ -1332,7 +1332,7 @@ contract("ColonyNetworkMining", accounts => {
 
       const righthash = await goodClient.getRootHash();
       const wronghash = await badClient.getRootHash();
-      assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
+      assert.isTrue(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
 
       await goodClient.submitJustificationRootHash();
       await badClient.submitJustificationRootHash();
@@ -1417,7 +1417,7 @@ contract("ColonyNetworkMining", accounts => {
 
       const righthash = await goodClient.getRootHash();
       const wronghash = await badClient.getRootHash();
-      assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
+      assert.isTrue(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
 
       await goodClient.submitJustificationRootHash();
       await badClient.submitJustificationRootHash();
@@ -1556,7 +1556,7 @@ contract("ColonyNetworkMining", accounts => {
 
       let righthash = await goodClient.getRootHash();
       let wronghash = await badClient.getRootHash();
-      assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
+      assert.isTrue(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
 
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
 
@@ -1578,7 +1578,7 @@ contract("ColonyNetworkMining", accounts => {
 
       righthash = await goodClient.getRootHash();
       wronghash = await badClient.getRootHash();
-      assert(righthash === wronghash, "Hashes from clients are not equal - not starting from the same state");
+      assert.isTrue(righthash === wronghash, "Hashes from clients are not equal - not starting from the same state");
 
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
 
@@ -1590,7 +1590,7 @@ contract("ColonyNetworkMining", accounts => {
 
       righthash = await goodClient.getRootHash();
       wronghash = await badClient.getRootHash();
-      assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
+      assert.isTrue(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
 
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
       await repCycle.confirmNewHash(1);
@@ -1975,7 +1975,7 @@ contract("ColonyNetworkMining", accounts => {
 
     it("should prevent a hash from advancing if it might still get an opponent", async function advancingTest() {
       this.timeout(10000000);
-      assert(accounts.length >= 8, "Not enough accounts for test to run");
+      assert.isTrue(accounts.length >= 8, "Not enough accounts for test to run");
       const accountsForTest = accounts.slice(0, 8);
       for (let i = 0; i < 8; i += 1) {
         await giveUserCLNYTokensAndStake(colonyNetwork, accountsForTest[i], DEFAULT_STAKE); // eslint-disable-line no-await-in-loop
@@ -2380,7 +2380,7 @@ contract("ColonyNetworkMining", accounts => {
 
           const righthash = await badClient.getRootHash();
           const wronghash = await badClient2.getRootHash();
-          assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
+          assert.isTrue(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
 
           await badClient2.submitJustificationRootHash();
           await badClient.submitJustificationRootHash();
@@ -3005,7 +3005,7 @@ contract("ColonyNetworkMining", accounts => {
 
       const righthash = await goodClient.getRootHash();
       const wronghash = await badClient.getRootHash();
-      assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
+      assert.isTrue(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
 
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
       await repCycle.confirmNewHash(1);

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -561,7 +561,7 @@ contract("ColonyNetworkMining", accounts => {
       await goodClient.submitRootHash();
       await badClient.submitRootHash();
 
-      await checkErrorRevert(repCycle.invalidateHash(0, 1), "colony-reputation-mining-failed-to-respond-in-time");
+      await checkErrorRevert(repCycle.invalidateHash(0, 1), "colony-reputation-mining-not-timed-out");
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
       await checkErrorRevert(repCycle.confirmNewHash(1), "colony-reputation-mining-final-round-not-completed");
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -2886,7 +2886,7 @@ contract("ColonyNetworkMining", accounts => {
       const taskId = await setupRatedTask({
         colonyNetwork,
         colony: metaColony,
-        skill: 10,
+        skillId: 10,
         managerPayout: 1000000000000,
         evaluatorPayout: 1000000000000,
         workerPayout: 1000000000000,
@@ -2970,7 +2970,7 @@ contract("ColonyNetworkMining", accounts => {
       const taskId = await setupRatedTask({
         colonyNetwork,
         colony: metaColony,
-        skill: 10,
+        skillId: 10,
         managerPayout: 1000000000000,
         evaluatorPayout: 1000000000000,
         workerPayout: 1000000000000,

--- a/test/colony.js
+++ b/test/colony.js
@@ -150,12 +150,12 @@ contract("Colony", accounts => {
       const newFounder = accounts[2];
 
       let hasRole = await authority.hasUserRole(currentFounder, founderRole);
-      assert(hasRole, `${currentFounder} does not have founder role`);
+      assert.isTrue(hasRole, `${currentFounder} does not have founder role`);
 
       await colony.setFounderRole(newFounder);
 
       hasRole = await authority.hasUserRole(newFounder, founderRole);
-      assert(hasRole, `Founder role not transfered to ${newFounder}`);
+      assert.isTrue(hasRole, `Founder role not transfered to ${newFounder}`);
     });
 
     it("should allow admin to assign colony admin role", async () => {
@@ -168,14 +168,14 @@ contract("Colony", accounts => {
 
       const functionSig = getFunctionSignature("setAdminRole(address)");
       const canCall = await authority.canCall(user1, colony.address, functionSig);
-      assert(canCall, `Address ${user1} can't call 'setAdminRole' function`);
+      assert.isTrue(canCall, `Address ${user1} can't call 'setAdminRole' function`);
 
       await colony.setAdminRole(user5, {
         from: user1
       });
 
       const hasRole = await authority.hasUserRole(user5, adminRole);
-      assert(hasRole, `Admin role not assigned to ${user5}`);
+      assert.isTrue(hasRole, `Admin role not assigned to ${user5}`);
     });
 
     it("should allow founder to remove colony admin role", async () => {
@@ -186,12 +186,12 @@ contract("Colony", accounts => {
       await colony.setAdminRole(user1);
 
       let hasRole = await authority.hasUserRole(user1, adminRole);
-      assert(hasRole, `Admin role not assigned to ${user1}`);
+      assert.isTrue(hasRole, `Admin role not assigned to ${user1}`);
 
       await colony.removeAdminRole(user1);
 
       hasRole = await authority.hasUserRole(user1, adminRole);
-      assert(!hasRole, `Admin role not removed from ${user1}`);
+      assert.isTrue(!hasRole, `Admin role not removed from ${user1}`);
     });
 
     it("should not allow admin to remove admin role", async () => {
@@ -204,14 +204,14 @@ contract("Colony", accounts => {
       await colony.setAdminRole(user2);
 
       let hasRole = await authority.hasUserRole(user1, adminRole);
-      assert(hasRole, `Admin role not assigned to ${user1}`);
+      assert.isTrue(hasRole, `Admin role not assigned to ${user1}`);
       hasRole = await authority.hasUserRole(user2, adminRole);
-      assert(hasRole, `Admin role not assigned to ${user2}`);
+      assert.isTrue(hasRole, `Admin role not assigned to ${user2}`);
 
       await checkErrorRevert(colony.removeAdminRole(user1, { from: user2 }), "ds-auth-unauthorized");
 
       hasRole = await authority.hasUserRole(user1, adminRole);
-      assert(hasRole, `${user1} is removed from admin role from another admin`);
+      assert.isTrue(hasRole, `${user1} is removed from admin role from another admin`);
     });
 
     it("should allow admin to call predetermined functions", async () => {

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -1,7 +1,7 @@
 /* globals artifacts */
 import { INITIAL_FUNDING, DELIVERABLE_HASH } from "../helpers/constants";
 import { checkErrorRevert, getTokenArgs } from "../helpers/test-helper";
-import { fundColonyWithTokens, setupFundedTask, setupRatedTask, executeSignedTaskChange, makeTask } from "../helpers/test-data-generator";
+import { fundColonyWithTokens, setupFundedTask, setupFinalizedTask, executeSignedTaskChange, makeTask } from "../helpers/test-data-generator";
 
 import { setupColonyVersionResolver } from "../helpers/upgradable-contracts";
 
@@ -514,8 +514,7 @@ contract("Meta Colony", accounts => {
       await metaColony.addGlobalSkill(1);
       await metaColony.addGlobalSkill(5);
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await setupRatedTask({ colonyNetwork, colony });
-      await colony.finalizeTask(taskId);
+      const taskId = await setupFinalizedTask({ colonyNetwork, colony });
       await checkErrorRevert(colony.setTaskSkill(taskId, 6), "colony-task-complete");
 
       const task = await colony.getTask(taskId);

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -200,7 +200,7 @@ contract("Colony Reputation Updates", accounts => {
       const taskId1 = await setupRatedTask({
         colonyNetwork,
         colony: metaColony,
-        skill: 5
+        skillId: 5
       });
       await metaColony.finalizeTask(taskId1);
       let repLogEntryWorker = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(3);
@@ -213,7 +213,7 @@ contract("Colony Reputation Updates", accounts => {
       const taskId2 = await setupRatedTask({
         colonyNetwork,
         colony: metaColony,
-        skill: 6
+        skillId: 6
       });
       await metaColony.finalizeTask(taskId2);
       repLogEntryWorker = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(7);


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Partial soln to #317 

<!--- Summary of changes including design decisions -->

- Remove circular dependency between `constants.js` and `test-helper.js`
- Utilize bulk assignment of task properties when generating tasks (10-15% speedup).
- Replace `assert` with `assert.isTrue`.
- Clarify a reputation mining error message re: timeouts.
- Introduce `setupFinalizedTask` to remove recurring boilerplate.
- Introduce `advanceMiningCycleNoContest` and `getActiveRepCycle` to remove recurring boilerplate.