### PR TITLE
Prevent moving tokens to/from the same pot

### DIFF
--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -122,7 +122,8 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   stoppable
   auth
   {
-    // Prevent moving funds from between the same pot causing the pot balance to overflow
+    // Prevent moving funds from between the same pot, which otherwise would cause the pot balance to
+    // increment by _amount.
     require(_fromPot != _toPot, "colony-funding-cannot-move-funds-between-the-same-pot");
 
     // Prevent people moving funds from the pot for paying out token holders

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -122,6 +122,9 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   stoppable
   auth
   {
+    // Prevent moving funds from between the same pot causing the pot balance to overflow
+    require(_fromPot != _toPot, "colony-funding-cannot-move-funds-between-the-same-pot");
+
     // Prevent people moving funds from the pot for paying out token holders
     require(_fromPot > 0, "colony-funding-cannot-move-funds-from-rewards-pot");
 

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -120,6 +120,13 @@ contract("Colony Funding", accounts => {
       assert.equal(pot2Balance.toNumber(), 51);
     });
 
+    it("should not let tokens be moved between the same pot", async () => {
+      await fundColonyWithTokens(colony, otherToken, 1);
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, 1, 1, otherToken.address), "colony-funding-cannot-move-funds-between-the-same-pot");
+      const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      assert.equal(colonyPotBalance.toNumber(), 1, "should have a pot balance of 1");
+    });
+
     it("should not let tokens be moved from the pot for payouts to token holders", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await makeTask({ colony });


### PR DESCRIPTION
This pull request adds a requirement to `moveFundsBetweenPots` to disallow funds being moved to/from the same pot. It also adds a corresponding test to ensure this action is not possible.

Resolves #448