### PR TITLE
Expose `ColonyAuthority.hasUserRole` on `Colony`

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -50,6 +50,10 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     emit ColonyAdminRoleRemoved(_user);
   }
 
+  function hasUserRole(address _user, uint8 _role) public view returns (bool) {
+    return ColonyAuthority(authority).hasUserRole(_user, _role);
+  }
+
   function setToken(address _token) public
   stoppable
   auth

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -69,6 +69,12 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _user User we want to remove admin role from
   function removeAdminRole(address _user) public;
 
+  /// @notice Check whether a given user has a given role for the colony.
+  /// Calls the function of the same name on the colony's authority contract.
+  /// @param _user The user whose role we want to check
+  /// @param _role The role we want to check for
+  function hasUserRole(address _user, uint8 _role) public view returns (bool hasRole);
+
   /// @notice Get the colony token
   /// @return tokenAddress Address of the token contract
   function getToken() public view returns (address tokenAddress);

--- a/test/colony.js
+++ b/test/colony.js
@@ -149,12 +149,12 @@ contract("Colony", accounts => {
       const currentFounder = accounts[0];
       const newFounder = accounts[2];
 
-      let hasRole = await authority.hasUserRole(currentFounder, founderRole);
+      let hasRole = await colony.hasUserRole(currentFounder, founderRole);
       assert.isTrue(hasRole, `${currentFounder} does not have founder role`);
 
       await colony.setFounderRole(newFounder);
 
-      hasRole = await authority.hasUserRole(newFounder, founderRole);
+      hasRole = await colony.hasUserRole(newFounder, founderRole);
       assert.isTrue(hasRole, `Founder role not transfered to ${newFounder}`);
     });
 
@@ -174,7 +174,7 @@ contract("Colony", accounts => {
         from: user1
       });
 
-      const hasRole = await authority.hasUserRole(user5, adminRole);
+      const hasRole = await colony.hasUserRole(user5, adminRole);
       assert.isTrue(hasRole, `Admin role not assigned to ${user5}`);
     });
 
@@ -185,12 +185,12 @@ contract("Colony", accounts => {
 
       await colony.setAdminRole(user1);
 
-      let hasRole = await authority.hasUserRole(user1, adminRole);
+      let hasRole = await colony.hasUserRole(user1, adminRole);
       assert.isTrue(hasRole, `Admin role not assigned to ${user1}`);
 
       await colony.removeAdminRole(user1);
 
-      hasRole = await authority.hasUserRole(user1, adminRole);
+      hasRole = await colony.hasUserRole(user1, adminRole);
       assert.isTrue(!hasRole, `Admin role not removed from ${user1}`);
     });
 
@@ -203,14 +203,14 @@ contract("Colony", accounts => {
       await colony.setAdminRole(user1);
       await colony.setAdminRole(user2);
 
-      let hasRole = await authority.hasUserRole(user1, adminRole);
+      let hasRole = await colony.hasUserRole(user1, adminRole);
       assert.isTrue(hasRole, `Admin role not assigned to ${user1}`);
-      hasRole = await authority.hasUserRole(user2, adminRole);
+      hasRole = await colony.hasUserRole(user2, adminRole);
       assert.isTrue(hasRole, `Admin role not assigned to ${user2}`);
 
       await checkErrorRevert(colony.removeAdminRole(user1, { from: user2 }), "ds-auth-unauthorized");
 
-      hasRole = await authority.hasUserRole(user1, adminRole);
+      hasRole = await colony.hasUserRole(user1, adminRole);
       assert.isTrue(hasRole, `${user1} is removed from admin role from another admin`);
     });
 

--- a/upgrade-test/colony-upgrade.js
+++ b/upgrade-test/colony-upgrade.js
@@ -13,7 +13,6 @@ const ColonyTask = artifacts.require("ColonyTask");
 const ColonyFunding = artifacts.require("ColonyFunding");
 const UpdatedColony = artifacts.require("UpdatedColony");
 const IUpdatedColony = artifacts.require("IUpdatedColony");
-const ColonyAuthority = artifacts.require("ColonyAuthority");
 const Token = artifacts.require("Token");
 const ContractRecovery = artifacts.require("ContractRecovery");
 
@@ -24,7 +23,6 @@ contract("Colony contract upgrade", accounts => {
   let colony;
   let colonyTask;
   let colonyFunding;
-  let authority;
   let token;
   let colonyNetwork;
   let updatedColony;
@@ -49,8 +47,6 @@ contract("Colony contract upgrade", accounts => {
     colonyTask = await ColonyTask.new();
     colonyFunding = await ColonyFunding.new();
     contractRecovery = await ContractRecovery.new();
-    const authorityAddress = await colony.authority();
-    authority = await ColonyAuthority.at(authorityAddress);
     const tokenAddress = await colony.getToken();
     token = await Token.at(tokenAddress);
 
@@ -104,7 +100,7 @@ contract("Colony contract upgrade", accounts => {
     });
 
     it("should return correct permissions", async () => {
-      const founder = await authority.hasUserRole(ACCOUNT_ONE, 0);
+      const founder = await colony.hasUserRole(ACCOUNT_ONE, 0);
       assert.isTrue(founder);
     });
 


### PR DESCRIPTION
This PR exposes the `hasUserRole` function from the colony's authority contract on the colony. It also uses the colony to check `hasUserRole` in tests (rather than the authority directly) in tests.

The main motivation for doing this is that it will make interacting with the colony's user permissions via libraries like colonyJS easier.