### PR TITLE
Big Old Test Refactor 2

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -125,7 +125,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   stoppable
   auth
   {
-    return token.mint(_wad);
+    token.mint(_wad);
   }
 
   function mintTokensForColonyNetwork(uint _wad) public stoppable {

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -1,24 +1,34 @@
 import { toBN, soliditySha3 } from "web3-utils";
 import shortid from "shortid";
 
+const UINT256_MAX = toBN(0).notn(256);
+const INT256_MAX = toBN(0).notn(255);
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
 const MANAGER_ROLE = 0;
 const EVALUATOR_ROLE = 1;
 const WORKER_ROLE = 2;
+
 // The base58 decoded, bytes32 converted hex value of a test task ipfsHash "QmNSUYVKDSvPUnRLKmuxk9diJ6yS96r1TrAXzjTiBcCLAL"
 const SPECIFICATION_HASH = "0x017dfd85d4f6cb4dcd715a88101f7b1f06cd1e009b2327a0809d01eb9c91f231";
 // The above bytes32 hash where the last raw byte was changed from 1 -> 2
 const SPECIFICATION_HASH_UPDATED = "0x017dfd85d4f6cb4dcd715a88101f7b1f06cd1e009b2327a0809d01eb9c91f232";
 // The base58 decoded, bytes32 converted hex value of a test task ipfsHash "qmv8ndh7ageh9b24zngaextmuhj7aiuw3scc8hkczvjkww"
 const DELIVERABLE_HASH = "0xfb027a4d64f29d83e27769cb05d945e67ef7396fa1bd73ef53f065311fd3313e";
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-const INITIAL_FUNDING = toBN(360 * 1e18);
-const MANAGER_PAYOUT = toBN(100 * 1e18);
-const EVALUATOR_PAYOUT = toBN(50 * 1e18);
-const WORKER_PAYOUT = toBN(200 * 1e18);
+
+const WAD = toBN(10).pow(toBN(18));
+const MIN_STAKE = WAD.muln(2000);
+const DEFAULT_STAKE = MIN_STAKE.muln(1000);
+
+const INITIAL_FUNDING = WAD.muln(360);
+const MANAGER_PAYOUT = WAD.muln(100);
+const EVALUATOR_PAYOUT = WAD.muln(50);
+const WORKER_PAYOUT = WAD.muln(200);
+
 const MANAGER_RATING = 2;
 const WORKER_RATING = 3;
 const RATING_MULTIPLIER = { 1: -1, 2: 1, 3: 1.5 };
-const SECONDS_PER_DAY = 86400;
+
 const RATING_1_SALT = soliditySha3(shortid.generate());
 const RATING_2_SALT = soliditySha3(shortid.generate());
 const RATING_1_SECRET = soliditySha3(RATING_1_SALT, MANAGER_RATING);
@@ -28,13 +38,7 @@ const ACTIVE_TASK_STATE = 0;
 const CANCELLED_TASK_STATE = 1;
 const FINALIZED_TASK_STATE = 2;
 
-const UINT256_MAX = toBN(0).notn(256);
-const INT256_MAX = toBN(0).notn(255);
-
-const WAD = toBN(10).pow(toBN(18));
-const MIN_STAKE = WAD.muln(2000);
-const DEFAULT_STAKE = MIN_STAKE.muln(1000);
-
+const SECONDS_PER_DAY = 86400;
 const MINING_CYCLE_DURATION = 60 * 60 * 24; // 24 hours
 const DECAY_RATE = {
   NUMERATOR:    toBN("992327946262944"), // eslint-disable-line prettier/prettier
@@ -42,13 +46,18 @@ const DECAY_RATE = {
 };
 
 module.exports = {
+  UINT256_MAX,
+  INT256_MAX,
+  ZERO_ADDRESS,
   MANAGER_ROLE,
   EVALUATOR_ROLE,
   WORKER_ROLE,
   SPECIFICATION_HASH,
   SPECIFICATION_HASH_UPDATED,
   DELIVERABLE_HASH,
-  SECONDS_PER_DAY,
+  WAD,
+  MIN_STAKE,
+  DEFAULT_STAKE,
   INITIAL_FUNDING,
   MANAGER_PAYOUT,
   EVALUATOR_PAYOUT,
@@ -63,12 +72,7 @@ module.exports = {
   ACTIVE_TASK_STATE,
   CANCELLED_TASK_STATE,
   FINALIZED_TASK_STATE,
-  UINT256_MAX,
-  INT256_MAX,
-  WAD,
-  MIN_STAKE,
-  DEFAULT_STAKE,
+  SECONDS_PER_DAY,
   MINING_CYCLE_DURATION,
-  DECAY_RATE,
-  ZERO_ADDRESS
+  DECAY_RATE
 };

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -26,7 +26,7 @@ const EVALUATOR_PAYOUT = WAD.muln(50);
 const WORKER_PAYOUT = WAD.muln(200);
 
 const MANAGER_RATING = 2;
-const WORKER_RATING = 3;
+const WORKER_RATING = 2;
 const RATING_MULTIPLIER = { 1: -1, 2: 1, 3: 1.5 };
 
 const RATING_1_SALT = soliditySha3(shortid.generate());

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -1,8 +1,9 @@
-import { toBN, soliditySha3 } from "web3-utils";
+import { soliditySha3 } from "web3-utils";
+import { BN } from "bn.js";
 import shortid from "shortid";
 
-const UINT256_MAX = toBN(0).notn(256);
-const INT256_MAX = toBN(0).notn(255);
+const UINT256_MAX = new BN(0).notn(256);
+const INT256_MAX = new BN(0).notn(255);
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 const MANAGER_ROLE = 0;
@@ -16,7 +17,7 @@ const SPECIFICATION_HASH_UPDATED = "0x017dfd85d4f6cb4dcd715a88101f7b1f06cd1e009b
 // The base58 decoded, bytes32 converted hex value of a test task ipfsHash "qmv8ndh7ageh9b24zngaextmuhj7aiuw3scc8hkczvjkww"
 const DELIVERABLE_HASH = "0xfb027a4d64f29d83e27769cb05d945e67ef7396fa1bd73ef53f065311fd3313e";
 
-const WAD = toBN(10).pow(toBN(18));
+const WAD = new BN(10).pow(new BN(18));
 const MIN_STAKE = WAD.muln(2000);
 const DEFAULT_STAKE = MIN_STAKE.muln(1000);
 
@@ -41,8 +42,8 @@ const FINALIZED_TASK_STATE = 2;
 const SECONDS_PER_DAY = 86400;
 const MINING_CYCLE_DURATION = 60 * 60 * 24; // 24 hours
 const DECAY_RATE = {
-  NUMERATOR:    toBN("992327946262944"), // eslint-disable-line prettier/prettier
-  DENOMINATOR: toBN("1000000000000000")
+  NUMERATOR:    new BN("992327946262944"), // eslint-disable-line prettier/prettier
+  DENOMINATOR: new BN("1000000000000000")
 };
 
 module.exports = {

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -359,19 +359,17 @@ export async function setupMetaColonyWithLockedCLNYToken(colonyNetwork) {
   return { metaColony, clnyToken };
 }
 
-export async function setupMetaColonyWithUNLockedCLNYToken(colonyNetwork) {
-  const { metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork);
+export async function unlockCLNYToken(metaColony) {
+  const clnyAddress = await metaColony.getToken();
+  const clny = await Token.at(clnyAddress);
+
   // Unlock CLNY and Transfer ownership to MetaColony
   const accounts = await web3GetAccounts();
-  await clnyToken.unlock({ from: accounts[11] });
-  await clnyToken.setOwner(metaColony.address, { from: accounts[11] });
+  await clny.unlock({ from: accounts[11] });
+  await clny.setOwner(metaColony.address, { from: accounts[11] });
+
   // TODO: Shoult we clear the Authority as well?
-  // await clnyToken.setAuthority(0x0, { from: accounts[11] });
-
-  const locked = await clnyToken.locked();
-  assert.isFalse(locked);
-
-  return { metaColony, clnyToken };
+  // await clny.setAuthority(0x0, { from: accounts[11] });
 }
 
 export async function setupColonyNetwork() {

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -402,5 +402,5 @@ export async function setupRandomColony(colonyNetwork) {
   const colony = await IColony.at(colonyAddress);
   await token.setOwner(colonyAddress);
 
-  return colony;
+  return { colony, token };
 }

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -23,6 +23,7 @@ import { createSignatures, createSignaturesTrezor, web3GetAccounts } from "./tes
 const { setupColonyVersionResolver } = require("../helpers/upgradable-contracts");
 
 const IColony = artifacts.require("IColony");
+const IMetaColony = artifacts.require("IMetaColony");
 const ITokenLocking = artifacts.require("ITokenLocking");
 const Token = artifacts.require("Token");
 const TokenAuthority = artifacts.require("./TokenAuthority");
@@ -284,6 +285,7 @@ export async function giveUserCLNYTokens(colonyNetwork, userAddress, amount) {
   const clnyAddress = await metaColony.getToken();
   const clny = await Token.at(clnyAddress);
 
+  const accounts = await web3GetAccounts();
   await clny.mint(amount, { from: accounts[11] });
   await clny.transfer(userAddress, amount, { from: accounts[11] });
 }

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -18,7 +18,7 @@ import {
   DELIVERABLE_HASH,
   ZERO_ADDRESS
 } from "./constants";
-import { createSignatures, createSignaturesTrezor, web3GetAccounts } from "./test-helper";
+import { getTokenArgs, createSignatures, createSignaturesTrezor, web3GetAccounts } from "./test-helper";
 
 const { setupColonyVersionResolver } = require("../helpers/upgradable-contracts");
 
@@ -26,6 +26,7 @@ const IColony = artifacts.require("IColony");
 const IMetaColony = artifacts.require("IMetaColony");
 const ITokenLocking = artifacts.require("ITokenLocking");
 const Token = artifacts.require("Token");
+const ERC20ExtendedToken = artifacts.require("ERC20ExtendedToken");
 const TokenAuthority = artifacts.require("./TokenAuthority");
 const EtherRouter = artifacts.require("EtherRouter");
 const Resolver = artifacts.require("Resolver");
@@ -391,4 +392,15 @@ export async function setupColonyNetwork() {
   await colonyNetwork.setMiningResolver(reputationMiningCycleResolverAddress);
 
   return colonyNetwork;
+}
+
+export async function setupRandomColony(colonyNetwork) {
+  const tokenArgs = getTokenArgs();
+  const token = await ERC20ExtendedToken.new(...tokenArgs);
+  const { logs } = await colonyNetwork.createColony(token.address);
+  const { colonyAddress } = logs[0].args;
+  const colony = await IColony.at(colonyAddress);
+  await token.setOwner(colonyAddress);
+
+  return colony;
 }

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -163,7 +163,7 @@ export async function checkErrorRevertEthers(promise, errorMessage) {
   const txid = tx.hash;
 
   const receipt = await web3GetTransactionReceipt(txid);
-  assert.isFalse(receipt.status, `Transaction succeeded, but expected to fail`);
+  assert.isFalse(receipt.status, `Transaction succeeded, but expected to fail with: ${errorMessage}`);
 
   const response = await web3GetRawCall({ from: tx.from, to: tx.to, data: tx.data, gas: tx.gasLimit.toNumber(), value: tx.value.toNumber() });
   const reason = extractReasonString(response);
@@ -436,11 +436,12 @@ export async function getActiveRepCycle(colonyNetwork) {
   return repCycle;
 }
 
-export async function advanceMiningCycleNoContest(colonyNetwork, test, miningClient = undefined, minerAddress) {
+export async function advanceMiningCycleNoContest({ colonyNetwork, test, miningClient, minerAddress }) {
   await forwardTime(MINING_CYCLE_DURATION, test);
   const repCycle = await getActiveRepCycle(colonyNetwork);
 
   if (miningClient !== undefined) {
+    await miningClient.addLogContentsToReputationTree();
     await miningClient.submitRootHash();
   } else {
     const accounts = await web3GetAccounts();

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -411,6 +411,25 @@ export async function submitAndForwardTimeToDispute(clients, test) {
   await forwardTime(MINING_CYCLE_DURATION / 2, test);
 }
 
+export async function runBinarySearch(client1, client2) {
+  // Loop while doing the binary search, checking we were successful at each point
+  // Binary search will error when it is complete.
+  let noError = true;
+  while (noError) {
+    let transactionObject;
+    transactionObject = await client1.respondToBinarySearchForChallenge(); // eslint-disable-line no-await-in-loop
+    let tx = await web3GetTransactionReceipt(transactionObject.hash); // eslint-disable-line no-await-in-loop
+    if (!tx.status) {
+      noError = false;
+    }
+    transactionObject = await client2.respondToBinarySearchForChallenge(); // eslint-disable-line no-await-in-loop
+    tx = await web3GetTransactionReceipt(transactionObject.hash); // eslint-disable-line no-await-in-loop
+    if (!tx.status) {
+      noError = false;
+    }
+  }
+}
+
 export async function getActiveRepCycle(colonyNetwork) {
   const addr = await colonyNetwork.getReputationMiningCycle(true);
   const repCycle = await IReputationMiningCycle.at(addr);

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -436,13 +436,13 @@ export async function getActiveRepCycle(colonyNetwork) {
   return repCycle;
 }
 
-export async function advanceMiningCycleNoContest({ colonyNetwork, test, miningClient, minerAddress }) {
+export async function advanceMiningCycleNoContest({ colonyNetwork, client, minerAddress, test }) {
   await forwardTime(MINING_CYCLE_DURATION, test);
   const repCycle = await getActiveRepCycle(colonyNetwork);
 
-  if (miningClient !== undefined) {
-    await miningClient.addLogContentsToReputationTree();
-    await miningClient.submitRootHash();
+  if (client !== undefined) {
+    await client.addLogContentsToReputationTree();
+    await client.submitRootHash();
   } else {
     const accounts = await web3GetAccounts();
     minerAddress = minerAddress || accounts[5]; // eslint-disable-line no-param-reassign

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -1,6 +1,6 @@
 /* globals artifacts */
 import { BN } from "bn.js";
-import { toBN, sha3 } from "web3-utils";
+import { sha3 } from "web3-utils";
 import chai from "chai";
 import bnChai from "bn-chai";
 
@@ -461,7 +461,7 @@ contract("Colony Funding", accounts => {
     });
 
     it("should allow funds to be removed from a task if there are no more payouts of that token to be claimed", async () => {
-      await fundColonyWithTokens(colony, otherToken, new BN(363).mul(WAD));
+      await fundColonyWithTokens(colony, otherToken, WAD.muln(363));
       const taskId = await setupFinalizedTask({ colonyNetwork, colony, token: otherToken });
       await colony.moveFundsBetweenPots(1, 2, 10, otherToken.address);
       await colony.claimPayout(taskId, MANAGER_ROLE, otherToken.address);
@@ -626,8 +626,8 @@ contract("Colony Funding", accounts => {
     let client;
     let colonyWideReputationProof;
     let userReputationProof1;
-    const initialFunding = new BN(100).mul(WAD);
-    const userReputation = new BN(50).mul(WAD);
+    const initialFunding = WAD.muln(100);
+    const userReputation = WAD.muln(50);
     const userTokens = userReputation;
     const totalReputation = userReputation;
     const totalTokens = userReputation;
@@ -713,7 +713,7 @@ contract("Colony Funding", accounts => {
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
       const globalKey = await ReputationMiner.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
-      await client.insert(globalKey, toBN(10), 0);
+      await client.insert(globalKey, new BN(10), 0);
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
@@ -901,7 +901,7 @@ contract("Colony Funding", accounts => {
       const rootDomainSkill = result.skillId;
 
       const globalKey = await ReputationMiner.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
-      await client.insert(globalKey, toBN(0), 0);
+      await client.insert(globalKey, new BN(0), 0);
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
@@ -916,7 +916,7 @@ contract("Colony Funding", accounts => {
     });
 
     it("should not be able to claim tokens if user does not have any tokens", async () => {
-      const userReputation3 = toBN(10 * 1e18);
+      const userReputation3 = WAD.muln(10);
       await colony.bootstrapColony([userAddress3], [userReputation3]);
       await token.transfer(colony.address, userReputation3, { from: userAddress3 });
 
@@ -955,7 +955,7 @@ contract("Colony Funding", accounts => {
     });
 
     it("should not be able to claim tokens if user does not have any reputation", async () => {
-      const userTokens3 = toBN(1e3);
+      const userTokens3 = new BN(1000);
 
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
@@ -963,7 +963,7 @@ contract("Colony Funding", accounts => {
       await colony.bootstrapColony([userAddress1], [userTokens3]);
 
       const userKey = await ReputationMiner.getKey(colony.address, rootDomainSkill, userAddress3);
-      await client.insert(userKey, toBN(0), 0);
+      await client.insert(userKey, new BN(0), 0);
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
       await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
@@ -1076,7 +1076,7 @@ contract("Colony Funding", accounts => {
         const squareRoots = [...initialSquareRoots];
         // If we are passing total reputation, total tokens or denominator, we will divide by 2, else multiply
         const functionName = [2, 3, 5].includes(i) ? "div" : "mul";
-        squareRoots[i] = toBN(squareRoots[i])[functionName](toBN(2));
+        squareRoots[i] = new BN(squareRoots[i])[functionName](new BN(2));
 
         return checkErrorRevert(
           colony.claimRewardPayout(payoutId, squareRoots, ...userReputationProof1, {
@@ -1208,7 +1208,7 @@ contract("Colony Funding", accounts => {
       const userTokensSqrt = bnSqrt(userTokens);
       const totalReputationSqrt = bnSqrt(userReputation, true);
       // Both colony1 and colony2 are giving the user `userReputation` amount of tokens
-      const totalTokensSqrt = bnSqrt(userReputation.mul(toBN(2)), true);
+      const totalTokensSqrt = bnSqrt(userReputation.muln(2), true);
       const numeratorSqrt = bnSqrt(userReputationSqrt.mul(userTokensSqrt));
       const denominatorSqrt = bnSqrt(totalReputationSqrt.mul(totalTokensSqrt), true);
       const balance = await colony.getPotBalance(0, otherToken.address);
@@ -1319,7 +1319,7 @@ contract("Colony Funding", accounts => {
       const userTokensSqrt = bnSqrt(userTokens);
       const totalReputationSqrt = bnSqrt(userReputation, true);
       // Both colony1 and colony2 are giving the user `userReputation` amount of tokens
-      const totalTokensSqrt = bnSqrt(userReputation.mul(toBN(2)), true);
+      const totalTokensSqrt = bnSqrt(userReputation.muln(2), true);
       const numeratorSqrt = bnSqrt(userReputationSqrt.mul(userTokensSqrt));
       const denominatorSqrt = bnSqrt(totalReputationSqrt.mul(totalTokensSqrt), true);
       const balance = await colony.getPotBalance(0, otherToken.address);
@@ -1366,37 +1366,31 @@ contract("Colony Funding", accounts => {
 
     const reputations = [
       {
-        totalReputation: toBN(3),
-        totalAmountOfPayoutTokens: toBN(90000000)
+        totalReputation: new BN(3),
+        totalAmountOfPayoutTokens: new BN(90000000)
       },
       {
-        totalReputation: toBN(30),
-        totalAmountOfPayoutTokens: toBN(90000000)
+        totalReputation: new BN(30),
+        totalAmountOfPayoutTokens: new BN(90000000)
       },
       {
-        totalReputation: toBN(30000000000),
-        totalAmountOfPayoutTokens: toBN(90000000000)
+        totalReputation: new BN(30000000000),
+        totalAmountOfPayoutTokens: new BN(90000000000)
       },
       {
-        totalReputation: toBN(3).mul(toBN(10).pow(toBN(76))),
-        totalAmountOfPayoutTokens: toBN(9).mul(toBN(10).pow(toBN(76)))
+        totalReputation: new BN(10).pow(new BN(76)).muln(3),
+        totalAmountOfPayoutTokens: new BN(10).pow(new BN(76)).muln(9)
       },
       {
         // This is highest possible value for colony-wide reputation that can be used for reward payouts
-        totalReputation: bnSqrt(
-          toBN(2)
-            .pow(toBN(256))
-            .sub(toBN(1))
-        ).pow(toBN(2)),
-        totalAmountOfPayoutTokens: toBN(2)
-          .pow(toBN(256))
-          .sub(toBN(1))
+        totalReputation: bnSqrt(UINT256_MAX).pow(new BN(2)),
+        totalAmountOfPayoutTokens: UINT256_MAX
       }
     ];
 
     reputations.forEach(data =>
       it(`should calculate fairly precise reward payout for:
-        user reputation/tokens: ${data.totalReputation.div(toBN(3)).toString()}
+        user reputation/tokens: ${data.totalReputation.divn(3).toString()}
         total reputation/tokens: ${data.totalReputation.toString()}`, async () => {
         // Setting up a new token and colony
         const tokenArgs = getTokenArgs();
@@ -1414,8 +1408,8 @@ contract("Colony Funding", accounts => {
         await newColony.mintTokens(data.totalReputation);
 
         // Every user has equal amount of reputation and tokens (totalReputationAndTokens / 3)
-        const reputationPerUser = data.totalReputation.div(toBN(3));
-        const tokensPerUser = toBN(reputationPerUser);
+        const reputationPerUser = data.totalReputation.divn(3);
+        const tokensPerUser = new BN(reputationPerUser);
         // Giving colony's native tokens to 3 users.
         // Reputation log is appended to inactive reputation mining cycle
         await newColony.bootstrapColony([userAddress1, userAddress2, userAddress3], [reputationPerUser, reputationPerUser, reputationPerUser]);
@@ -1451,7 +1445,7 @@ contract("Colony Funding", accounts => {
         const totalSupply = await newToken.totalSupply();
         const colonyTokens = await newToken.balanceOf(newColony.address);
         // Transforming it to BN instance
-        const totalTokensHeldByUsers = toBN(totalSupply.sub(colonyTokens));
+        const totalTokensHeldByUsers = new BN(totalSupply.sub(colonyTokens));
 
         // Get users locked token amount from token locking contract
         const info = await tokenLocking.getUserLock(newToken.address, userAddress1);
@@ -1460,7 +1454,7 @@ contract("Colony Funding", accounts => {
         // Calculating the reward payout for one user locally to check against on-chain result
         const numerator = bnSqrt(userLockedTokens.mul(reputationPerUser));
         const denominator = bnSqrt(totalTokensHeldByUsers.mul(data.totalReputation));
-        const factor = toBN(10).pow(toBN(100));
+        const factor = new BN(10).pow(new BN(100));
         const percent = numerator.mul(factor).div(denominator);
         let reward = amountAvailableForPayout.mul(percent).div(factor);
         const feeInverse = await colonyNetwork.getFeeInverse();

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -678,7 +678,7 @@ contract("Colony Funding", accounts => {
       });
       await client.initialise(colonyNetwork.address);
 
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
@@ -715,7 +715,7 @@ contract("Colony Funding", accounts => {
       const globalKey = await ReputationMiner.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
       await client.insert(globalKey, new BN(10), 0);
 
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
       const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill);
       const { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
@@ -742,8 +742,8 @@ contract("Colony Funding", accounts => {
         skillId: id
       });
 
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
       const colonyWideReputationKey = makeReputationKey(colony.address, id);
       const { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
@@ -755,8 +755,8 @@ contract("Colony Funding", accounts => {
     it("should not be able to claim the reward if passed reputation is not sender's", async () => {
       await colony.bootstrapColony([userAddress2], [userReputation]);
 
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
@@ -809,8 +809,8 @@ contract("Colony Funding", accounts => {
         from: userAddress1
       });
 
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
       const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill);
       let { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
@@ -846,8 +846,8 @@ contract("Colony Funding", accounts => {
         from: userAddress1
       });
 
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
       const result = await newColony.getDomain(1);
       const rootDomainSkill = result.skillId;
@@ -903,7 +903,7 @@ contract("Colony Funding", accounts => {
       const globalKey = await ReputationMiner.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
       await client.insert(globalKey, new BN(0), 0);
 
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
       const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill);
       const { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
@@ -920,8 +920,8 @@ contract("Colony Funding", accounts => {
       await colony.bootstrapColony([userAddress3], [userReputation3]);
       await token.transfer(colony.address, userReputation3, { from: userAddress3 });
 
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
@@ -965,8 +965,8 @@ contract("Colony Funding", accounts => {
       const userKey = await ReputationMiner.getKey(colony.address, rootDomainSkill, userAddress3);
       await client.insert(userKey, new BN(0), 0);
 
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
       const colonyWideReputationKey = makeReputationKey(colony.address, rootDomainSkill);
       let { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
@@ -1178,10 +1178,10 @@ contract("Colony Funding", accounts => {
       await colony2.bootstrapColony([userAddress1], [userReputation]);
 
       // Submit current hash in active reputation mining cycle
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
       // Reputation added while bootstrapping the colony is now in active reputation mining cycle, so submit the hash
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
       const domain1 = await colony1.getDomain(1);
       const rootDomainSkill1 = domain1.skillId;
@@ -1290,10 +1290,10 @@ contract("Colony Funding", accounts => {
       await colony2.bootstrapColony([userAddress1], [userReputation]);
 
       // Submit current hash in active reputation mining cycle
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
       // Reputation added while bootstrapping the colony is now in active reputation mining cycle, so submit the hash
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
       const domain1 = await colony1.getDomain(1);
       const rootDomainSkill1 = domain1.skillId;
@@ -1415,10 +1415,10 @@ contract("Colony Funding", accounts => {
         await newColony.bootstrapColony([userAddress1, userAddress2, userAddress3], [reputationPerUser, reputationPerUser, reputationPerUser]);
 
         // Submit current hash in active reputation mining cycle
-        await advanceMiningCycleNoContest({ colonyNetwork, this: this, miningClient: client });
+        await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
         // Reputation added while bootstrapping the colony is now in active reputation mining cycle, so submit the hash
-        await advanceMiningCycleNoContest({ colonyNetwork, this: this, miningClient: client });
+        await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
         const result = await newColony.getDomain(1);
         const rootDomainSkill = result.skillId;

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -623,7 +623,7 @@ contract("Colony Funding", accounts => {
   });
 
   describe("when creating reward payouts", async () => {
-    let miningClient;
+    let client;
     let colonyWideReputationProof;
     let userReputationProof1;
     const initialFunding = new BN(100).mul(WAD);
@@ -667,28 +667,26 @@ contract("Colony Funding", accounts => {
         totalAmountSqrt
       ];
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       await giveUserCLNYTokensAndStake(colonyNetwork, accounts[4], DEFAULT_STAKE);
-      miningClient = new ReputationMiner({
+      client = new ReputationMiner({
         loader: contractLoader,
         minerAddress: accounts[4],
         realProviderPort: REAL_PROVIDER_PORT,
         useJsTree: true
       });
+      await client.initialise(colonyNetwork.address);
 
-      await miningClient.initialise(colonyNetwork.address);
-      await miningClient.addLogContentsToReputationTree();
-
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
       const colonyWideReputationKey = makeReputationKey(colony.address, rootDomainSkill);
-      let { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
+      let { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
       const userReputationKey = makeReputationKey(colony.address, rootDomainSkill, userAddress1);
-      ({ key, value, branchMask, siblings } = await miningClient.getReputationProofObject(userReputationKey));
+      ({ key, value, branchMask, siblings } = await client.getReputationProofObject(userReputationKey));
       userReputationProof1 = [key, value, branchMask, siblings];
     });
 
@@ -696,7 +694,7 @@ contract("Colony Funding", accounts => {
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
       const fakeColonyWideReputationKey = makeReputationKey(colony.address, rootDomainSkill, userAddress1);
-      const { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(fakeColonyWideReputationKey);
+      const { key, value, branchMask, siblings } = await client.getReputationProofObject(fakeColonyWideReputationKey);
       const newFakeColonyWideReputationProof = [key, value, branchMask, siblings];
       await checkErrorRevert(
         colony.startNextRewardPayout(otherToken.address, ...newFakeColonyWideReputationProof),
@@ -715,12 +713,12 @@ contract("Colony Funding", accounts => {
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
       const globalKey = await ReputationMiner.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
-      await miningClient.insert(globalKey, toBN(10), 0);
+      await client.insert(globalKey, toBN(10), 0);
 
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
       const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill);
-      const { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
+      const { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
 
       await checkErrorRevert(
@@ -744,14 +742,11 @@ contract("Colony Funding", accounts => {
         skillId: id
       });
 
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
-
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
       const colonyWideReputationKey = makeReputationKey(colony.address, id);
-      const { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
+      const { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       const newColonyWideReputationProof = [key, value, branchMask, siblings];
 
       checkErrorRevert(colony.startNextRewardPayout(otherToken.address, ...newColonyWideReputationProof), "colony-reputation-invalid-skill-id");
@@ -760,24 +755,21 @@ contract("Colony Funding", accounts => {
     it("should not be able to claim the reward if passed reputation is not sender's", async () => {
       await colony.bootstrapColony([userAddress2], [userReputation]);
 
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
-
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
 
       const colonyWideReputationKey = makeReputationKey(colony.address, rootDomainSkill);
-      let { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
+      let { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
 
       const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
 
       const userReputationKey = makeReputationKey(colony.address, rootDomainSkill, userAddress2);
-      ({ key, value, branchMask, siblings } = await miningClient.getReputationProofObject(userReputationKey));
+      ({ key, value, branchMask, siblings } = await client.getReputationProofObject(userReputationKey));
       const newUserReputationProof = [key, value, branchMask, siblings];
 
       await checkErrorRevert(
@@ -817,21 +809,18 @@ contract("Colony Funding", accounts => {
         from: userAddress1
       });
 
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
-
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
       const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill);
-      let { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
+      let { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
 
       ({ logs } = await newColony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof));
       const payoutId = logs[0].args.rewardPayoutId;
 
       const userReputationKey = makeReputationKey(newColony.address, domainSkill, userAddress1);
-      ({ key, value, branchMask, siblings } = await miningClient.getReputationProofObject(userReputationKey));
+      ({ key, value, branchMask, siblings } = await client.getReputationProofObject(userReputationKey));
       const userReputationProof = [key, value, branchMask, siblings];
 
       await checkErrorRevert(
@@ -857,16 +846,13 @@ contract("Colony Funding", accounts => {
         from: userAddress1
       });
 
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
-
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
       const result = await newColony.getDomain(1);
       const rootDomainSkill = result.skillId;
       const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill);
-      const { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
+      const { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
 
       await checkErrorRevert(
@@ -915,12 +901,12 @@ contract("Colony Funding", accounts => {
       const rootDomainSkill = result.skillId;
 
       const globalKey = await ReputationMiner.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
-      await miningClient.insert(globalKey, toBN(0), 0);
+      await client.insert(globalKey, toBN(0), 0);
 
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
       const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill);
-      const { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
+      const { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
 
       await checkErrorRevert(
@@ -934,16 +920,13 @@ contract("Colony Funding", accounts => {
       await colony.bootstrapColony([userAddress3], [userReputation3]);
       await token.transfer(colony.address, userReputation3, { from: userAddress3 });
 
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
-
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
       const colonyWideReputationKey = makeReputationKey(colony.address, rootDomainSkill);
-      let { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
+      let { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
 
       const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
@@ -960,7 +943,7 @@ contract("Colony Funding", accounts => {
       const squareRoots = [userReputation3Sqrt, 0, totalReputationSqrt, totalTokensSqrt, 0, denominatorSqrt, amountAvailableForPayoutSqrt];
 
       const userReputationKey = makeReputationKey(colony.address, rootDomainSkill, userAddress3);
-      ({ key, value, branchMask, siblings } = await miningClient.getReputationProofObject(userReputationKey));
+      ({ key, value, branchMask, siblings } = await client.getReputationProofObject(userReputationKey));
       const userReputationProof3 = [key, value, branchMask, siblings];
 
       await checkErrorRevert(
@@ -980,16 +963,13 @@ contract("Colony Funding", accounts => {
       await colony.bootstrapColony([userAddress1], [userTokens3]);
 
       const userKey = await ReputationMiner.getKey(colony.address, rootDomainSkill, userAddress3);
-      await miningClient.insert(userKey, toBN(0), 0);
+      await client.insert(userKey, toBN(0), 0);
 
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
-
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
       const colonyWideReputationKey = makeReputationKey(colony.address, rootDomainSkill);
-      let { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
+      let { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
 
       await token.transfer(userAddress3, userTokens3, { from: userAddress1 });
@@ -1009,7 +989,7 @@ contract("Colony Funding", accounts => {
       const squareRoots = [0, userTokens3Sqrt, totalReputationSqrt, totalTokensSqrt, 0, denominatorSqrt, amountAvailableForPayoutSqrt];
 
       const userReputationKey = makeReputationKey(colony.address, rootDomainSkill, userAddress3);
-      ({ key, value, branchMask, siblings } = await miningClient.getReputationProofObject(userReputationKey));
+      ({ key, value, branchMask, siblings } = await client.getReputationProofObject(userReputationKey));
       const userReputationProof3 = [key, value, branchMask, siblings];
 
       await checkErrorRevert(
@@ -1198,23 +1178,21 @@ contract("Colony Funding", accounts => {
       await colony2.bootstrapColony([userAddress1], [userReputation]);
 
       // Submit current hash in active reputation mining cycle
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
       // Reputation added while bootstrapping the colony is now in active reputation mining cycle, so submit the hash
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
       const domain1 = await colony1.getDomain(1);
       const rootDomainSkill1 = domain1.skillId;
       let colonyWideReputationKey = makeReputationKey(colony1.address, rootDomainSkill1);
-      let { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey, true);
+      let { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey, true);
       const colonyWideReputationProof1 = [key, value, branchMask, siblings];
 
       const domain2 = await colony2.getDomain(1);
       const rootDomainSkill2 = domain2.skillId;
       colonyWideReputationKey = makeReputationKey(colony2.address, rootDomainSkill2);
-      ({ key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey));
+      ({ key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey));
       const colonyWideReputationProof2 = [key, value, branchMask, siblings];
 
       // This will allow token locking contract to sent tokens on users behalf
@@ -1247,12 +1225,12 @@ contract("Colony Funding", accounts => {
       ];
 
       let userReputationKey = makeReputationKey(colony1.address, rootDomainSkill1, userAddress1);
-      ({ key, value, branchMask, siblings } = await miningClient.getReputationProofObject(userReputationKey));
+      ({ key, value, branchMask, siblings } = await client.getReputationProofObject(userReputationKey));
       const userReputationProofForColony1 = [key, value, branchMask, siblings];
       await colony1.claimRewardPayout(payoutId1, squareRoots, ...userReputationProofForColony1, { from: userAddress1 });
 
       userReputationKey = makeReputationKey(colony2.address, rootDomainSkill2, userAddress1);
-      ({ key, value, branchMask, siblings } = await miningClient.getReputationProofObject(userReputationKey));
+      ({ key, value, branchMask, siblings } = await client.getReputationProofObject(userReputationKey));
       const userReputationProofForColony2 = [key, value, branchMask, siblings];
       await colony2.claimRewardPayout(payoutId2, squareRoots, ...userReputationProofForColony2, { from: userAddress1 });
 
@@ -1312,23 +1290,21 @@ contract("Colony Funding", accounts => {
       await colony2.bootstrapColony([userAddress1], [userReputation]);
 
       // Submit current hash in active reputation mining cycle
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
       // Reputation added while bootstrapping the colony is now in active reputation mining cycle, so submit the hash
-      await miningClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
       const domain1 = await colony1.getDomain(1);
       const rootDomainSkill1 = domain1.skillId;
       let colonyWideReputationKey = makeReputationKey(colony1.address, rootDomainSkill1);
-      let { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey, true);
+      let { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey, true);
       const colonyWideReputationProof1 = [key, value, branchMask, siblings];
 
       const domain2 = await colony2.getDomain(1);
       const rootDomainSkill2 = domain2.skillId;
       colonyWideReputationKey = makeReputationKey(colony2.address, rootDomainSkill2);
-      ({ key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey));
+      ({ key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey));
       const colonyWideReputationProof2 = [key, value, branchMask, siblings];
 
       // This will allow token locking contract to sent tokens on users behalf
@@ -1360,7 +1336,7 @@ contract("Colony Funding", accounts => {
       ];
 
       const userReputationKey = makeReputationKey(colony2.address, rootDomainSkill2, userAddress1);
-      ({ key, value, branchMask, siblings } = await miningClient.getReputationProofObject(userReputationKey));
+      ({ key, value, branchMask, siblings } = await client.getReputationProofObject(userReputationKey));
       const userReputationProofForColony2 = [key, value, branchMask, siblings];
 
       await checkErrorRevert(
@@ -1445,17 +1421,15 @@ contract("Colony Funding", accounts => {
         await newColony.bootstrapColony([userAddress1, userAddress2, userAddress3], [reputationPerUser, reputationPerUser, reputationPerUser]);
 
         // Submit current hash in active reputation mining cycle
-        await miningClient.addLogContentsToReputationTree();
-        await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+        await advanceMiningCycleNoContest({ colonyNetwork, this: this, miningClient: client });
 
         // Reputation added while bootstrapping the colony is now in active reputation mining cycle, so submit the hash
-        await miningClient.addLogContentsToReputationTree();
-        await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+        await advanceMiningCycleNoContest({ colonyNetwork, this: this, miningClient: client });
 
         const result = await newColony.getDomain(1);
         const rootDomainSkill = result.skillId;
         const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill);
-        let { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey, true);
+        let { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey, true);
         colonyWideReputationProof = [key, value, branchMask, siblings];
 
         // This will allow token locking contract to sent tokens on users behalf
@@ -1513,7 +1487,7 @@ contract("Colony Funding", accounts => {
         ];
 
         let userReputationKey = makeReputationKey(newColony.address, rootDomainSkill, userAddress1);
-        ({ key, value, branchMask, siblings } = await miningClient.getReputationProofObject(userReputationKey));
+        ({ key, value, branchMask, siblings } = await client.getReputationProofObject(userReputationKey));
         const userReputationProofForColony1 = [key, value, branchMask, siblings];
 
         const colonyNetworkBalanceBeforeClaim1 = await payoutToken.balanceOf(colonyNetwork.address);
@@ -1553,7 +1527,7 @@ contract("Colony Funding", accounts => {
         console.log("Remaining after claim 1: ", remainingAfterClaim1.toString());
 
         userReputationKey = makeReputationKey(newColony.address, rootDomainSkill, userAddress2);
-        ({ key, value, branchMask, siblings } = await miningClient.getReputationProofObject(userReputationKey));
+        ({ key, value, branchMask, siblings } = await client.getReputationProofObject(userReputationKey));
         const userReputationProofForColony2 = [key, value, branchMask, siblings];
 
         await newColony.claimRewardPayout(payoutId, squareRoots, ...userReputationProofForColony2, {
@@ -1578,7 +1552,7 @@ contract("Colony Funding", accounts => {
         console.log("Remaining after claim 2: ", remainingAfterClaim2.toString());
 
         userReputationKey = makeReputationKey(newColony.address, rootDomainSkill, userAddress3);
-        ({ key, value, branchMask, siblings } = await miningClient.getReputationProofObject(userReputationKey));
+        ({ key, value, branchMask, siblings } = await client.getReputationProofObject(userReputationKey));
         const userReputationProofForColony3 = [key, value, branchMask, siblings];
 
         await newColony.claimRewardPayout(payoutId, squareRoots, ...userReputationProofForColony3, {

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -69,11 +69,8 @@ contract("Colony Funding", accounts => {
   });
 
   beforeEach(async () => {
-    colony = await setupRandomColony(colonyNetwork);
+    ({ colony, token } = await setupRandomColony(colonyNetwork));
     await colony.setRewardInverse(100);
-
-    const tokenAddress = await colony.getToken();
-    token = await ERC20ExtendedToken.at(tokenAddress);
 
     const otherTokenArgs = getTokenArgs();
     otherToken = await ERC20ExtendedToken.new(...otherTokenArgs);

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -26,7 +26,8 @@ import {
   executeSignedTaskChange,
   executeSignedRoleAssignment,
   makeTask,
-  giveUserCLNYTokensAndStake
+  giveUserCLNYTokensAndStake,
+  setupRandomColony
 } from "../helpers/test-data-generator";
 
 import ReputationMiner from "../packages/reputation-miner/ReputationMiner";
@@ -68,13 +69,12 @@ contract("Colony Funding", accounts => {
   });
 
   beforeEach(async () => {
-    const tokenArgs = getTokenArgs();
-    token = await ERC20ExtendedToken.new(...tokenArgs);
-    const { logs } = await colonyNetwork.createColony(token.address);
-    const { colonyAddress } = logs[0].args;
-    await token.setOwner(colonyAddress);
-    colony = await IColony.at(colonyAddress);
+    colony = await setupRandomColony(colonyNetwork);
     await colony.setRewardInverse(100);
+
+    const tokenAddress = await colony.getToken();
+    token = await ERC20ExtendedToken.at(tokenAddress);
+
     const otherTokenArgs = getTokenArgs();
     otherToken = await ERC20ExtendedToken.new(...otherTokenArgs);
   });

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -926,17 +926,15 @@ contract("ColonyNetworkMining", accounts => {
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
-      await fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING.muln(3));
-      await setupFinalizedTask({ colonyNetwork, colony: metaColony });
-      await setupFinalizedTask({ colonyNetwork, colony: metaColony });
+      await fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING);
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
-      // Should be 13 updates: 1 for the previous mining cycle and 3x4 for the tasks.
+      // Should be 5 updates: 1 for the previous mining cycle and 1x4 for the task.
       const repCycle = await getActiveRepCycle(colonyNetwork);
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
-      assert.equal(nInactiveLogEntries.toNumber(), 13);
+      assert.equal(nInactiveLogEntries.toNumber(), 5);
 
       badClient = new MaliciousReputationMinerWrongNNodes(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
@@ -996,17 +994,15 @@ contract("ColonyNetworkMining", accounts => {
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
-      await fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING.muln(3));
-      await setupFinalizedTask({ colonyNetwork, colony: metaColony });
-      await setupFinalizedTask({ colonyNetwork, colony: metaColony });
+      await fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING);
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
-      // Should be 13 updates: 1 for the previous mining cycle and 3x4 for the tasks.
+      // Should be 5 updates: 1 for the previous mining cycle and 1x4 for the task.
       let repCycle = await getActiveRepCycle(colonyNetwork);
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
-      assert.equal(nInactiveLogEntries.toNumber(), 13);
+      assert.equal(nInactiveLogEntries.toNumber(), 5);
 
       badClient = new MaliciousReputationMinerWrongNNodes2(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
@@ -1043,17 +1039,15 @@ contract("ColonyNetworkMining", accounts => {
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
-      await fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING.muln(3));
-      await setupFinalizedTask({ colonyNetwork, colony: metaColony });
-      await setupFinalizedTask({ colonyNetwork, colony: metaColony });
+      await fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING);
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
-      // Should be 13 updates: 1 for the previous mining cycle and 3x4 for the tasks.
+      // Should be 5 updates: 1 for the previous mining cycle and 1x4 for the tasks.
       const repCycle = await getActiveRepCycle(colonyNetwork);
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
-      assert.equal(nInactiveLogEntries.toNumber(), 13);
+      assert.equal(nInactiveLogEntries.toNumber(), 5);
 
       badClient = new MaliciousReputationMinerWrongJRH(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
@@ -1074,17 +1068,15 @@ contract("ColonyNetworkMining", accounts => {
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
-      await fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING.muln(3));
-      await setupFinalizedTask({ colonyNetwork, colony: metaColony });
-      await setupFinalizedTask({ colonyNetwork, colony: metaColony });
+      await fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING);
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
-      // Should be 13 updates: 1 for the previous mining cycle and 3x4 for the tasks.
+      // Should be 5 updates: 1 for the previous mining cycle and 1x4 for the tasks.
       const repCycle = await getActiveRepCycle(colonyNetwork);
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
-      assert.equal(nInactiveLogEntries.toNumber(), 13);
+      assert.equal(nInactiveLogEntries.toNumber(), 5);
 
       badClient = new MaliciousReputationMinerWrongJRH(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
@@ -1116,10 +1108,10 @@ contract("ColonyNetworkMining", accounts => {
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
-      const repCycle = await getActiveRepCycle(colonyNetwork);
       // The update log should contain the person being rewarded for the previous
-      // update cycle, and reputation updates for three task completions (manager, worker, evaluator);
-      // That's seven in total.
+      // update cycle, and reputation updates for 3 task completions (manager, worker, evaluator);
+      // That's 13 in total.
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 13);
 
@@ -1218,9 +1210,8 @@ contract("ColonyNetworkMining", accounts => {
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
+      // Should be 13 updates: 1 for the previous mining cycle and 3x4 for the task.
       const repCycle = await getActiveRepCycle(colonyNetwork);
-
-      // Should be 13 updates: 1 for the previous mining cycle and 3x4 for the tasks.
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 13);
 

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -2753,14 +2753,10 @@ contract("ColonyNetworkMining", accounts => {
       let inactiveReputationMiningCycle = await IReputationMiningCycle.at(addr);
       const initialRepLogLength = await inactiveReputationMiningCycle.getReputationUpdateLogLength();
 
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      let repCycle = await getActiveRepCycle(colonyNetwork);
-      await repCycle.submitRootHash("0x12345678", 10, 10, { from: MAIN_ACCOUNT });
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
-      // This confirmation should freeze the reputation log that we added the above task entries to
-      // and move it to the inactive rep log
-      repCycle = await getActiveRepCycle(colonyNetwork);
+      // This confirmation should freeze the reputation log that we added the above task entries to and move it to the inactive rep log
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       assert.equal(inactiveReputationMiningCycle.address, repCycle.address);
 
       const finalRepLogLength = await repCycle.getReputationUpdateLogLength();

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -65,6 +65,10 @@ const useJsTree = true;
 const REWARD = WAD.muln(1200); // 1200 CLNY
 
 contract("ColonyNetworkMining", accounts => {
+  const MANAGER = accounts[0];
+  const EVALUATOR = accounts[1];
+  const WORKER = accounts[2];
+
   const MAIN_ACCOUNT = accounts[5];
   const OTHER_ACCOUNT = accounts[6];
   const OTHER_ACCOUNT2 = accounts[7];
@@ -112,8 +116,8 @@ contract("ColonyNetworkMining", accounts => {
     await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
 
     // Advance two cycles to clear active and inactive state.
-    await advanceMiningCycleNoContest(colonyNetwork, this);
-    await advanceMiningCycleNoContest(colonyNetwork, this);
+    await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
+    await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
     // The inactive reputation log now has the reward for this miner, and the accepted state is empty.
     // This is the same starting point for all tests.
@@ -325,7 +329,7 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
-      await advanceMiningCycleNoContest(colonyNetwork, this); // Defaults to (0x00, 0)
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT }); // Defaults to (0x00, 0)
 
       const newRepCycle = await getActiveRepCycle(colonyNetwork);
       assert.notEqual(newRepCycle.address, ZERO_ADDRESS);
@@ -877,7 +881,7 @@ contract("ColonyNetworkMining", accounts => {
       await fundColonyWithTokens(metaColony, clny);
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       // Should be 5 updates: 1 for the previous mining cycle and 4 for the task.
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -1199,7 +1203,7 @@ contract("ColonyNetworkMining", accounts => {
         await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
 
         // Advance to next cycle
-        await advanceMiningCycleNoContest(colonyNetwork, this);
+        await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
         let repCycle = await getActiveRepCycle(colonyNetwork);
         await forwardTime(MINING_CYCLE_DURATION, this);
@@ -1237,7 +1241,7 @@ contract("ColonyNetworkMining", accounts => {
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
 
@@ -1363,7 +1367,7 @@ contract("ColonyNetworkMining", accounts => {
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
 
@@ -1428,7 +1432,7 @@ contract("ColonyNetworkMining", accounts => {
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
 
@@ -1486,7 +1490,7 @@ contract("ColonyNetworkMining", accounts => {
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
 
@@ -1557,7 +1561,7 @@ contract("ColonyNetworkMining", accounts => {
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
 
@@ -1610,7 +1614,7 @@ contract("ColonyNetworkMining", accounts => {
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await setupFinalizedTask({ colonyNetwork, colony: metaColony, worker: accounts[3] });
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       badClient = new MaliciousReputationMinerExtraRep(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
@@ -1650,10 +1654,10 @@ contract("ColonyNetworkMining", accounts => {
     it(`if a reputation decay calculation is wrong, it should be handled correctly`, async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       let repCycle = await getActiveRepCycle(colonyNetwork);
 
@@ -1781,7 +1785,6 @@ contract("ColonyNetworkMining", accounts => {
       const [branchMask1, siblings1] = await goodClient.justificationTree.getProof(`0x${new BN("0").toString(16, 64)}`);
       const [branchMask2, siblings2] = await goodClient.justificationTree.getProof(`0x${totalnUpdates.toString(16, 64)}`);
       const [round, index] = await goodClient.getMySubmissionRoundAndIndex();
-      const jrh = await goodClient.justificationTree.getRootHash();
 
       await checkErrorRevert(
         repCycle.confirmJustificationRootHash(round, index, "123456", siblings1, branchMask2, siblings2),
@@ -1811,7 +1814,7 @@ contract("ColonyNetworkMining", accounts => {
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       badClient = new MaliciousReputationMinerExtraRep(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
@@ -1884,14 +1887,12 @@ contract("ColonyNetworkMining", accounts => {
       await fundColonyWithTokens(metaColony, clny);
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       await badClient.initialise(colonyNetwork.address);
-
-      await goodClient.addLogContentsToReputationTree();
       await badClient.addLogContentsToReputationTree();
 
-      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
@@ -1965,7 +1966,7 @@ contract("ColonyNetworkMining", accounts => {
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       badClient = new MaliciousReputationMinerExtraRep(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
@@ -2079,7 +2080,7 @@ contract("ColonyNetworkMining", accounts => {
       }
 
       // We need to complete the current reputation cycle so that all the required log entries are present
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       const clients = await Promise.all(
         accountsForTest.map(async (addr, index) => {
@@ -2195,17 +2196,16 @@ contract("ColonyNetworkMining", accounts => {
         colonyNetwork,
         colony: metaColony,
         token: clny,
+        manager: MAIN_ACCOUNT,
+        worker: OTHER_ACCOUNT,
         workerRating: 1,
         managerPayout: 1,
         evaluatorPayout: 1,
         workerPayout: 1
       });
 
-      await goodClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
-
-      await goodClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
 
       const addr = await colonyNetwork.getReputationMiningCycle(false);
       const inactiveRepCycle = await IReputationMiningCycle.at(addr);
@@ -2216,7 +2216,7 @@ contract("ColonyNetworkMining", accounts => {
           {
             colonyNetwork,
             colony: metaColony,
-            colonyToken: clny,
+            token: clny,
             manager: MAIN_ACCOUNT,
             worker: OTHER_ACCOUNT,
             workerRating: 1,
@@ -2238,8 +2238,7 @@ contract("ColonyNetworkMining", accounts => {
         }
       }
 
-      await goodClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
 
       await goodClient.resetDB();
       await goodClient.saveCurrentState();
@@ -2254,10 +2253,6 @@ contract("ColonyNetworkMining", accounts => {
       // Incomplete binary search
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
-      await badClient.respondToBinarySearchForChallenge();
-      await goodClient.respondToBinarySearchForChallenge();
-      await badClient.respondToBinarySearchForChallenge();
-      await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
@@ -2443,7 +2438,7 @@ contract("ColonyNetworkMining", accounts => {
           await setupFinalizedTask({ colonyNetwork, colony: metaColony });
           await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
-          await advanceMiningCycleNoContest(colonyNetwork, this);
+          await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
           const repCycle = await getActiveRepCycle(colonyNetwork);
 
           badClient = new MaliciousReputationMinerExtraRep(
@@ -2511,7 +2506,7 @@ contract("ColonyNetworkMining", accounts => {
       }
 
       // We need to complete the current reputation cycle so that all the required log entries are present
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       const clients = await Promise.all(
         accounts.slice(3, 11).map(async (addr, index) => {
@@ -2569,8 +2564,8 @@ contract("ColonyNetworkMining", accounts => {
       }
 
       // Complete two reputation cycles to process the log
-      await advanceMiningCycleNoContest(colonyNetwork, this);
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
     });
 
     it("should allow submitted hashes to go through multiple responses to a challenge", async () => {
@@ -2621,7 +2616,7 @@ contract("ColonyNetworkMining", accounts => {
         workerRating: 1
       });
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -2659,7 +2654,7 @@ contract("ColonyNetworkMining", accounts => {
         workerRating: 1
       });
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -2777,10 +2772,6 @@ contract("ColonyNetworkMining", accounts => {
     it("should keep reputation updates that occur during one update window for the next window", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
 
-      const repCycle = await getActiveRepCycle(colonyNetwork);
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MAIN_ACCOUNT });
-
       // Creates an entry in the reputation log for the worker and manager
       await fundColonyWithTokens(metaColony, clny);
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -2791,7 +2782,7 @@ contract("ColonyNetworkMining", accounts => {
 
       await forwardTime(MINING_CYCLE_DURATION, this);
       let repCycle = await getActiveRepCycle(colonyNetwork);
-      await repCycle.submitRootHash("0x12345678", 10, 10);
+      await repCycle.submitRootHash("0x12345678", 10, 10, { from: MAIN_ACCOUNT });
       await repCycle.confirmNewHash(0);
 
       // This confirmation should freeze the reputation log that we added the above task entries to
@@ -2819,7 +2810,7 @@ contract("ColonyNetworkMining", accounts => {
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       // Should be 13 updates: 1 for the previous mining cycle and 3x4 for the tasks.
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -2834,19 +2825,19 @@ contract("ColonyNetworkMining", accounts => {
       // 3. Miner's reputation for metaColony's root skill
       // 4. Miner's reputation for mining skill
       // x. Colony-wide total reputation for metacolony's root skill (same as 1)
-      // x. Manager reputation for metaColony's root skill (same as 3, by virtue of manager and miner being MAIN_ACCOUNT)
+      // 5. Manager reputation for metaColony's root skill
       // x. Colony-wide total reputation for metacolony's root skill (same as 1)
-      // x. Evaluator reputation for metaColony's root skill (same as 3, by virtue of evaluator and manager being MAIN_ACCOUNT)
+      // x. Evaluator reputation for metaColony's root skill (same as 5, by virtue of evaluator and manager being MANAGER)
       // x. Colony-wide total reputation for metacolony's root skill (same as 1)
-      // 5. Worker reputation for metacolony's root skill
-      // 6. Colony-wide total reputation for global skill task was in
-      // 7. Worker reputation for global skill task was in
+      // 6. Worker reputation for metacolony's root skill
+      // 7. Colony-wide total reputation for global skill task was in
+      // 8. Worker reputation for global skill task was in
 
       const GLOBAL_SKILL = new BN(1);
       const META_ROOT_SKILL = new BN(2);
       const MINING_SKILL = new BN(3);
 
-      assert.equal(Object.keys(goodClient.reputations).length, 7);
+      assert.equal(Object.keys(goodClient.reputations).length, 8);
       let key;
       let value;
 
@@ -2861,29 +2852,34 @@ contract("ColonyNetworkMining", accounts => {
       value = makeReputationValue(REWARD, 2);
       assert.equal(goodClient.reputations[key], value);
 
-      // 3. Reputation reward for MAIN_ACCOUNT for being the manager for the tasks created by setupFinalizedTask
+      // 3. Reputation reward for MAIN_ACCOUNT for metacolony's root skill
       key = makeReputationKey(metaColony.address, META_ROOT_SKILL, MAIN_ACCOUNT);
-      value = makeReputationValue(REWARD.add(MANAGER_PAYOUT.add(EVALUATOR_PAYOUT).muln(3)), 3);
+      value = makeReputationValue(REWARD, 3);
       assert.equal(goodClient.reputations[key], value);
 
-      // 4. Reputation reward for MAIN_ACCOUNT for submitting the previous reputation hash
+      // 4. Reputation reward for MAIN_ACCOUNT for mining skill
       key = makeReputationKey(metaColony.address, MINING_SKILL, MAIN_ACCOUNT);
       value = makeReputationValue(REWARD, 4);
       assert.equal(goodClient.reputations[key], value);
 
-      // 5. Reputation reward for OTHER_ACCOUNT2 for being the worker for the tasks created by giveUserCLNYTokens
-      key = makeReputationKey(metaColony.address, META_ROOT_SKILL, OTHER_ACCOUNT2);
-      value = makeReputationValue(WORKER_PAYOUT.muln(3), 5);
+      // 5. Reputation reward for MANAGER for being the manager & evaluator for the tasks
+      key = makeReputationKey(metaColony.address, META_ROOT_SKILL, MANAGER);
+      value = makeReputationValue(MANAGER_PAYOUT.add(EVALUATOR_PAYOUT).muln(3), 5);
       assert.equal(goodClient.reputations[key], value);
 
-      // 6. Colony-wide total reputation for global skill task was in
-      key = makeReputationKey(metaColony.address, GLOBAL_SKILL);
+      // 6. Reputation reward for WORKER for being the worker for the tasks
+      key = makeReputationKey(metaColony.address, META_ROOT_SKILL, WORKER);
       value = makeReputationValue(WORKER_PAYOUT.muln(3), 6);
       assert.equal(goodClient.reputations[key], value);
 
-      // 7. Worker reputation for global skill task was in
-      key = makeReputationKey(metaColony.address, GLOBAL_SKILL, OTHER_ACCOUNT2);
+      // 7. Colony-wide total reputation for global skill task was in
+      key = makeReputationKey(metaColony.address, GLOBAL_SKILL);
       value = makeReputationValue(WORKER_PAYOUT.muln(3), 7);
+      assert.equal(goodClient.reputations[key], value);
+
+      // 8. Worker reputation for global skill task was in
+      key = makeReputationKey(metaColony.address, GLOBAL_SKILL, WORKER);
+      value = makeReputationValue(WORKER_PAYOUT.muln(3), 8);
       assert.equal(goodClient.reputations[key], value);
     });
 
@@ -2902,20 +2898,16 @@ contract("ColonyNetworkMining", accounts => {
       await fundColonyWithTokens(metaColony, clny);
 
       // Do the task
-      const payout = new BN("1000000000000");
       await setupFinalizedTask({
         colonyNetwork,
         colony: metaColony,
         skillId: 10,
-        manager: MAIN_ACCOUNT,
-        worker: OTHER_ACCOUNT,
-        evaluator: OTHER_ACCOUNT2
-        managerPayout: payout,
-        evaluatorPayout: payout,
-        workerPayout: payout
+        manager: MANAGER,
+        evaluator: EVALUATOR,
+        worker: WORKER
       });
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       // Should be 5 updates: 1 for the previous mining cycle and 4 for the task.
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -2928,30 +2920,32 @@ contract("ColonyNetworkMining", accounts => {
       const MINING_SKILL = 3;
 
       const reputationProps = [
-        { id: 1, skillId: META_ROOT_SKILL, account: undefined, value: REWARD.add(payout.muln(3)) }, // eslint-disable-line prettier/prettier
+        { id: 1, skillId: META_ROOT_SKILL, account: undefined, value: REWARD.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT).add(WORKER_PAYOUT) }, // eslint-disable-line prettier/prettier
         { id: 2, skillId: MINING_SKILL, account: undefined, value: REWARD },
-        { id: 3, skillId: META_ROOT_SKILL, account: MAIN_ACCOUNT, value: REWARD.add(payout) }, // eslint-disable-line prettier/prettier
+        { id: 3, skillId: META_ROOT_SKILL, account: MAIN_ACCOUNT, value: REWARD },
         { id: 4, skillId: MINING_SKILL, account: MAIN_ACCOUNT, value: REWARD },
-        { id: 5, skillId: META_ROOT_SKILL, account: OTHER_ACCOUNT2, value: payout },
-        { id: 6, skillId: META_ROOT_SKILL, account: OTHER_ACCOUNT, value: payout },
 
-        { id: 7, skillId: 9, account: undefined, value: payout },
-        { id: 8, skillId: 8, account: undefined, value: payout },
-        { id: 9, skillId: 7, account: undefined, value: payout },
-        { id: 10, skillId: 6, account: undefined, value: payout },
-        { id: 11, skillId: 5, account: undefined, value: payout },
-        { id: 12, skillId: 4, account: undefined, value: payout },
-        { id: 13, skillId: 1, account: undefined, value: payout },
-        { id: 14, skillId: 10, account: undefined, value: payout },
+        { id: 5, skillId: META_ROOT_SKILL, account: MANAGER, value: MANAGER_PAYOUT },
+        { id: 6, skillId: META_ROOT_SKILL, account: EVALUATOR, value: EVALUATOR_PAYOUT },
+        { id: 7, skillId: META_ROOT_SKILL, account: WORKER, value: WORKER_PAYOUT },
 
-        { id: 15, skillId: 9, account: OTHER_ACCOUNT, value: payout },
-        { id: 16, skillId: 8, account: OTHER_ACCOUNT, value: payout },
-        { id: 17, skillId: 7, account: OTHER_ACCOUNT, value: payout },
-        { id: 18, skillId: 6, account: OTHER_ACCOUNT, value: payout },
-        { id: 19, skillId: 5, account: OTHER_ACCOUNT, value: payout },
-        { id: 20, skillId: 4, account: OTHER_ACCOUNT, value: payout },
-        { id: 21, skillId: 1, account: OTHER_ACCOUNT, value: payout },
-        { id: 22, skillId: 10, account: OTHER_ACCOUNT, value: payout }
+        { id: 8, skillId: 9, account: undefined, value: WORKER_PAYOUT },
+        { id: 9, skillId: 8, account: undefined, value: WORKER_PAYOUT },
+        { id: 10, skillId: 7, account: undefined, value: WORKER_PAYOUT },
+        { id: 11, skillId: 6, account: undefined, value: WORKER_PAYOUT },
+        { id: 12, skillId: 5, account: undefined, value: WORKER_PAYOUT },
+        { id: 13, skillId: 4, account: undefined, value: WORKER_PAYOUT },
+        { id: 14, skillId: 1, account: undefined, value: WORKER_PAYOUT },
+        { id: 15, skillId: 10, account: undefined, value: WORKER_PAYOUT },
+
+        { id: 16, skillId: 9, account: WORKER, value: WORKER_PAYOUT },
+        { id: 17, skillId: 8, account: WORKER, value: WORKER_PAYOUT },
+        { id: 18, skillId: 7, account: WORKER, value: WORKER_PAYOUT },
+        { id: 19, skillId: 6, account: WORKER, value: WORKER_PAYOUT },
+        { id: 20, skillId: 5, account: WORKER, value: WORKER_PAYOUT },
+        { id: 21, skillId: 4, account: WORKER, value: WORKER_PAYOUT },
+        { id: 22, skillId: 1, account: WORKER, value: WORKER_PAYOUT },
+        { id: 23, skillId: 10, account: WORKER, value: WORKER_PAYOUT }
       ];
 
       assert.equal(Object.keys(goodClient.reputations).length, reputationProps.length);
@@ -2982,7 +2976,7 @@ contract("ColonyNetworkMining", accounts => {
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await setupFinalizedTask({ colonyNetwork, colony: metaColony, skillId: 10 });
 
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       // Should be 13 updates: 1 for the previous mining cycle and 3x4 for the tasks.
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -3008,10 +3002,7 @@ contract("ColonyNetworkMining", accounts => {
 
     it("Should allow a user to prove their reputation", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
-      await advanceMiningCycleNoContest(colonyNetwork, this);
-
-      await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
-      await advanceMiningCycleNoContest(colonyNetwork, this);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: MAIN_ACCOUNT });
 
       await goodClient.addLogContentsToReputationTree();
       const newRootHash = await goodClient.getRootHash();
@@ -3022,13 +3013,10 @@ contract("ColonyNetworkMining", accounts => {
       await repCycle.submitRootHash(newRootHash, 10, "0x00", 10, { from: MAIN_ACCOUNT });
       await repCycle.confirmNewHash(0);
 
-      let key = `0x${new BN(metaColony.address.slice(2), 16).toString(16, 40)}`; // Colony address as bytes
-      key += `${new BN("2").toString(16, 64)}`; // SkillId as uint256
-      key += `${new BN(MAIN_ACCOUNT.slice(2), 16).toString(16, 40)}`; // User address as bytes
-
+      const key = makeReputationKey(metaColony.address, new BN("2"), MAIN_ACCOUNT);
       const value = goodClient.reputations[key];
       const [branchMask, siblings] = await goodClient.getProof(key);
-      const isValid = await metaColony.verifyReputationProof(`${key}`, `${value}`, branchMask, siblings);
+      const isValid = await metaColony.verifyReputationProof(key, value, branchMask, siblings, { from: MAIN_ACCOUNT });
       assert.isTrue(isValid);
     });
 
@@ -3128,13 +3116,12 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
 
       // Make multiple reputation cycles, with different numbers tasks and blocks in them.
-      fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING.muln(5));
+      await fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING.muln(5));
       for (let i = 0; i < 5; i += 1) {
         await setupFinalizedTask({ colonyNetwork, colony: metaColony }); // eslint-disable-line no-await-in-loop
       }
 
-      await goodClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
 
       // Advance four blocks
       await forwardTime(1, this);
@@ -3142,22 +3129,16 @@ contract("ColonyNetworkMining", accounts => {
       await forwardTime(1, this);
       await forwardTime(1, this);
 
-      await goodClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
 
-      fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING.muln(5));
+      await fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING.muln(5));
       for (let i = 0; i < 5; i += 1) {
         await setupFinalizedTask({ colonyNetwork, colony: metaColony }); // eslint-disable-line no-await-in-loop
       }
 
-      await goodClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
-
-      await goodClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
-
-      await goodClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
 
       goodClient2 = new ReputationMiner({
         loader: contractLoader,
@@ -3189,16 +3170,14 @@ contract("ColonyNetworkMining", accounts => {
           await goodClient2.sync(startingBlockNumber);
 
           // Do some additional updates.
-          await goodClient.addLogContentsToReputationTree();
-          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+          await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
 
           fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING.muln(5));
           for (let i = 0; i < 5; i += 1) {
             await setupFinalizedTask({ colonyNetwork, colony: metaColony }); // eslint-disable-line no-await-in-loop
           }
 
-          await goodClient.addLogContentsToReputationTree();
-          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+          await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
 
           // Advance four blocks
           await forwardTime(1, this);
@@ -3206,8 +3185,7 @@ contract("ColonyNetworkMining", accounts => {
           await forwardTime(1, this);
           await forwardTime(1, this);
 
-          await goodClient.addLogContentsToReputationTree();
-          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+          await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
 
           // Update it again - note that we're passing in the old startingBlockNumber still. If it applied
           // all of the updates from that block number, it would fail, because it would be replaying some
@@ -3228,17 +3206,10 @@ contract("ColonyNetworkMining", accounts => {
           const savedHash = await goodClient.reputationTree.getRootHash();
 
           // Do some additional updates.
-          await goodClient.addLogContentsToReputationTree();
-          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
-
-          await goodClient.addLogContentsToReputationTree();
-          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
-
-          await goodClient.addLogContentsToReputationTree();
-          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
-
-          await goodClient.addLogContentsToReputationTree();
-          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+          await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
+          await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
+          await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
+          await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
 
           // Tell goodClient2 to load from the database
           await goodClient2.loadState(savedHash);
@@ -3273,8 +3244,7 @@ contract("ColonyNetworkMining", accounts => {
       const value = goodClient.reputations[key];
       const [branchMask, siblings] = await goodClient.getProof(key);
 
-      await goodClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
 
       // So now we have a different state
       await goodClient.saveCurrentState();
@@ -3303,10 +3273,7 @@ contract("ColonyNetworkMining", accounts => {
 
     beforeEach(async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
-
-      await goodClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
-
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
       await goodClient.saveCurrentState();
 
       client = new ReputationMinerClient({
@@ -3353,8 +3320,7 @@ contract("ColonyNetworkMining", accounts => {
       const [branchMask, siblings] = await goodClient.getProof(key);
       const value = goodClient.reputations[key];
 
-      await goodClient.addLogContentsToReputationTree();
-      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
 
       const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/${MAIN_ACCOUNT}`;
       const res = await request(url);
@@ -3380,8 +3346,7 @@ contract("ColonyNetworkMining", accounts => {
           const startingBlock = await currentBlock();
           const startingBlockNumber = startingBlock.number;
 
-          await goodClient.addLogContentsToReputationTree();
-          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+          await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: goodClient });
           await client._miner.sync(startingBlockNumber); // eslint-disable-line no-underscore-dangle
 
           const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/${accounts[4]}`;

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -106,6 +106,7 @@ contract("ColonyNetworkMining", accounts => {
     await goodClient.initialise(colonyNetwork.address);
     await badClient.initialise(colonyNetwork.address);
     await badClient2.initialise(colonyNetwork.address);
+
     // Kick off reputation mining.
     // TODO: Tests for the first reputation cycle (when log empty) should be done in another file
     await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
@@ -2823,7 +2824,7 @@ contract("ColonyNetworkMining", accounts => {
       // These should be:
       // 1. Colony-wide total reputation for metacolony's root skill
       key = makeReputationKey(metaColony.address, META_ROOT_SKILL);
-      value = makeReputationValue(REWARD.add(MANAGER_PAYOUT.add(EVALUATOR_PAYOUT).add(WORKER_PAYOUT).muln(3)).add(WAD.muln(300)), 1); // eslint-disable-line prettier/prettier
+      value = makeReputationValue(REWARD.add(MANAGER_PAYOUT.add(EVALUATOR_PAYOUT).add(WORKER_PAYOUT).muln(3)), 1); // eslint-disable-line prettier/prettier
       assert.equal(client.reputations[key], value);
 
       // 2. Colony-wide total reputation for mining skill
@@ -2843,17 +2844,17 @@ contract("ColonyNetworkMining", accounts => {
 
       // 5. Reputation reward for OTHER_ACCOUNT2 for being the worker for the tasks created by giveUserCLNYTokens
       key = makeReputationKey(metaColony.address, META_ROOT_SKILL, OTHER_ACCOUNT2);
-      value = makeReputationValue(WORKER_PAYOUT.muln(3).add(WAD.muln(300)), 5);
+      value = makeReputationValue(WORKER_PAYOUT.muln(3), 5);
       assert.equal(client.reputations[key], value);
 
       // 6. Colony-wide total reputation for global skill task was in
       key = makeReputationKey(metaColony.address, GLOBAL_SKILL);
-      value = makeReputationValue(WORKER_PAYOUT.muln(3).add(WAD.muln(300)), 6);
+      value = makeReputationValue(WORKER_PAYOUT.muln(3), 6);
       assert.equal(client.reputations[key], value);
 
       // 7. Worker reputation for global skill task was in
       key = makeReputationKey(metaColony.address, GLOBAL_SKILL, OTHER_ACCOUNT2);
-      value = makeReputationValue(WORKER_PAYOUT.muln(3).add(WAD.muln(300)), 7);
+      value = makeReputationValue(WORKER_PAYOUT.muln(3), 7);
       assert.equal(client.reputations[key], value);
     });
 

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -110,10 +110,11 @@ contract("ColonyNetworkMining", accounts => {
     // Kick off reputation mining.
     // TODO: Tests for the first reputation cycle (when log empty) should be done in another file
     await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
-    // Advance one reputation cycle
+
+    // Advance two cycles to clear active and inactive state.
     await advanceMiningCycleNoContest(colonyNetwork, this);
-    // Advance another reputation cycle
     await advanceMiningCycleNoContest(colonyNetwork, this);
+
     // The inactive reputation log now has the reward for this miner, and the accepted state is empty.
     // This is the same starting point for all tests.
     const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -189,13 +190,11 @@ contract("ColonyNetworkMining", accounts => {
     // Finish the current cycle. Can only do this at the start of a new cycle, if anyone has submitted a hash in this current cycle.
     await forwardTime(MINING_CYCLE_DURATION, this);
     const repCycle = await getActiveRepCycle(colonyNetwork);
-    let nSubmittedHashes = await repCycle.getNSubmittedHashes();
-    nSubmittedHashes = nSubmittedHashes.toNumber();
-    if (nSubmittedHashes > 0) {
-      let nInvalidatedHashes = await repCycle.getNInvalidatedHashes();
-      nInvalidatedHashes = nInvalidatedHashes.toNumber();
-      if (nSubmittedHashes - nInvalidatedHashes === 1) {
-        await repCycle.confirmNewHash(nSubmittedHashes === 1 ? 0 : 1); // Not a general solution - only works for one or two submissions.
+    const nSubmittedHashes = await repCycle.getNSubmittedHashes();
+    if (nSubmittedHashes.gtn(0)) {
+      const nInvalidatedHashes = await repCycle.getNInvalidatedHashes();
+      if (nSubmittedHashes.sub(nInvalidatedHashes).eqn(1)) {
+        await repCycle.confirmNewHash(nSubmittedHashes.eqn(1) ? 0 : 1); // Not a general solution - only works for one or two submissions.
         // But for now, that's okay.
       } else {
         // We shouldn't get here. If this fires during a test, you haven't finished writing the test.
@@ -227,8 +226,10 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, 9000);
       await clny.approve(tokenLocking.address, 5000, { from: OTHER_ACCOUNT });
       await tokenLocking.deposit(clny.address, 5000, { from: OTHER_ACCOUNT });
+
       const userBalance = await clny.balanceOf(OTHER_ACCOUNT);
       assert.equal(userBalance.toNumber(), 4000);
+
       const info = await tokenLocking.getUserLock(clny.address, OTHER_ACCOUNT);
       const stakedBalance = new BN(info.balance);
       assert.equal(stakedBalance.toNumber(), 5000);
@@ -237,6 +238,7 @@ contract("ColonyNetworkMining", accounts => {
     it("should allow miners to withdraw staked CLNY", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, 5000);
       await tokenLocking.withdraw(clny.address, 5000, { from: OTHER_ACCOUNT });
+
       const info = await tokenLocking.getUserLock(clny.address, OTHER_ACCOUNT);
       const stakedBalance = new BN(info.balance);
       assert.equal(stakedBalance.toNumber(), 0);
@@ -245,9 +247,12 @@ contract("ColonyNetworkMining", accounts => {
     it("should not allow miners to deposit more CLNY than they have", async () => {
       await giveUserCLNYTokens(colonyNetwork, OTHER_ACCOUNT, 9000);
       await clny.approve(tokenLocking.address, 10000, { from: OTHER_ACCOUNT });
+
       await checkErrorRevert(tokenLocking.deposit(clny.address, 10000, { from: OTHER_ACCOUNT }), "ds-token-insufficient-balance");
+
       const userBalance = await clny.balanceOf(OTHER_ACCOUNT);
       assert.equal(userBalance.toNumber(), 9000);
+
       const info = await tokenLocking.getUserLock(clny.address, OTHER_ACCOUNT);
       const stakedBalance = new BN(info.balance);
       assert.equal(stakedBalance.toNumber(), 0);
@@ -256,10 +261,13 @@ contract("ColonyNetworkMining", accounts => {
     it("should not allow miners to withdraw more CLNY than they staked, even if enough has been staked total", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, 9000);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, 9000);
+
       await checkErrorRevert(tokenLocking.withdraw(clny.address, 10000, { from: OTHER_ACCOUNT }), "ds-math-sub-underflow");
+
       const info = await tokenLocking.getUserLock(clny.address, OTHER_ACCOUNT);
       const stakedBalance = new BN(info.balance);
       assert.equal(stakedBalance.toNumber(), 9000);
+
       const userBalance = await clny.balanceOf(OTHER_ACCOUNT);
       assert.equal(userBalance.toNumber(), 0);
     });
@@ -270,6 +278,7 @@ contract("ColonyNetworkMining", accounts => {
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION);
       await repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MAIN_ACCOUNT });
+
       const submitterAddress = await repCycle.getSubmittedHashes("0x12345678", 10, "0x00", 0);
       assert.equal(submitterAddress, MAIN_ACCOUNT);
     });
@@ -281,10 +290,12 @@ contract("ColonyNetworkMining", accounts => {
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION + 400); // Well after the window has closed
       await repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MAIN_ACCOUNT });
+
       await checkErrorRevert(
         repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: OTHER_ACCOUNT }),
         "colony-reputation-mining-cycle-submissions-closed"
       );
+
       const submitterAddress = await repCycle.getSubmittedHashes("0x12345678", 10, "0x00", 0);
       assert.equal(submitterAddress, MAIN_ACCOUNT);
     });
@@ -292,34 +303,38 @@ contract("ColonyNetworkMining", accounts => {
     it("should not allow someone to submit a new reputation hash if they are not staking", async () => {
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION);
+
       await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, "0x00", 0), "colony-reputation-mining-zero-entry-index-passed");
+
       const nSubmittedHashes = await repCycle.getNSubmittedHashes();
       assert.isTrue(nSubmittedHashes.isZero());
     });
 
     it("should not allow someone to withdraw their stake if they have submitted a hash this round", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
+
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION, this);
       await repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MAIN_ACCOUNT });
-      let userLock = await tokenLocking.getUserLock(clny.address, MAIN_ACCOUNT);
+
+      const userLock = await tokenLocking.getUserLock(clny.address, MAIN_ACCOUNT);
       await checkErrorRevert(tokenLocking.withdraw(clny.address, userLock.balance, { from: MAIN_ACCOUNT }), "colony-token-locking-hash-submitted");
-      userLock = await tokenLocking.getUserLock(clny.address, MAIN_ACCOUNT);
-      assert.isTrue(new BN(userLock.balance).eq(DEFAULT_STAKE));
     });
 
     it("should allow a new reputation hash to be set if only one was submitted", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
 
-      const addr = await colonyNetwork.getReputationMiningCycle(true);
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await advanceMiningCycleNoContest(colonyNetwork, this); // Defaults to (0x00, 0)
 
-      const newAddr = await colonyNetwork.getReputationMiningCycle(true);
-      assert.isTrue(newAddr !== ZERO_ADDRESS);
-      assert.isTrue(addr !== ZERO_ADDRESS);
-      assert.isTrue(newAddr !== addr);
+      const newRepCycle = await getActiveRepCycle(colonyNetwork);
+      assert.notEqual(newRepCycle.address, ZERO_ADDRESS);
+      assert.notEqual(repCycle.address, ZERO_ADDRESS);
+      assert.notEqual(newRepCycle.address, repCycle.address);
+
       const rootHash = await colonyNetwork.getReputationRootHash();
       assert.equal(rootHash, "0x0000000000000000000000000000000000000000000000000000000000000000");
+
       const rootHashNNodes = await colonyNetwork.getReputationRootHashNNodes();
       assert.equal(rootHashNNodes.toNumber(), 0);
     });
@@ -328,27 +343,22 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
-      const nLogEntriesBefore = await repCycle.getReputationUpdateLogLength();
       await checkErrorRevert(
         repCycle.appendReputationUpdateLog(MAIN_ACCOUNT, 100, 0, metaColony.address, 0, 1),
         "colony-reputation-mining-sender-not-network"
       );
-      const nLogEntriesAfter = await repCycle.getReputationUpdateLogLength();
-      assert.equal(nLogEntriesBefore.toString(), nLogEntriesAfter.toString());
     });
 
     it("should not allow someone who is not ColonyNetwork to reset the ReputationMiningCycle window", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
-      const windowOpenTimestampBefore = await repCycle.getReputationMiningWindowOpenTimestamp();
       await checkErrorRevert(repCycle.resetWindow(), "colony-reputation-mining-sender-not-network");
-      const windowOpenTimestampAfter = await repCycle.getReputationMiningWindowOpenTimestamp();
-      assert.equal(windowOpenTimestampBefore.toString(), windowOpenTimestampAfter.toString());
     });
 
     it("should correctly calculate the miner weight", async () => {
       const UINT32_MAX = UINT256_MAX.shrn(256 - 32);
+      const T = 7776000;
       let weight;
 
       // Large weight (staked for UINT256_MAX, first submission)
@@ -364,11 +374,11 @@ contract("ColonyNetworkMining", accounts => {
       assert.equal("541666647483886633", weight.toString());
 
       // Middle weight I (staked for T, first submission)
-      weight = await colonyNetwork.calculateMinerWeight(7776000, 0);
+      weight = await colonyNetwork.calculateMinerWeight(T, 0);
       assert.equal("625000000000000000", weight.toString());
 
       // Middle weight II (staked for T, last submission)
-      weight = await colonyNetwork.calculateMinerWeight(7776000, 11);
+      weight = await colonyNetwork.calculateMinerWeight(T, 11);
       assert.equal("338541666666666667", weight.toString());
 
       // Smallest weight (staked for 0, last submission)
@@ -381,18 +391,21 @@ contract("ColonyNetworkMining", accounts => {
     it("should allow a new reputation hash to be set if all but one submitted have been eliminated", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
-      const repCycle = await getActiveRepCycle(colonyNetwork);
 
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
       await repCycle.confirmNewHash(1);
-      const newAddr = await colonyNetwork.getReputationMiningCycle(true);
-      assert.isTrue(newAddr !== ZERO_ADDRESS);
-      assert.isTrue(repCycle.address !== ZERO_ADDRESS);
-      assert.isTrue(newAddr !== repCycle.address);
+
+      const newRepCycle = await getActiveRepCycle(colonyNetwork);
+      assert.notEqual(newRepCycle.address, ZERO_ADDRESS);
+      assert.notEqual(repCycle.address, ZERO_ADDRESS);
+      assert.notEqual(newRepCycle.address, repCycle.address);
+
       const rootHash = await colonyNetwork.getReputationRootHash();
       const clientRootHash = await goodClient.getRootHash();
       assert.equal(rootHash, clientRootHash);
+
       const rootHashNNodes = await colonyNetwork.getReputationRootHashNNodes();
       assert.equal(rootHashNNodes.toString(), goodClient.nReputations.toString());
     });
@@ -401,21 +414,23 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT2, DEFAULT_STAKE);
-      const repCycle = await getActiveRepCycle(colonyNetwork);
 
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([goodClient, badClient, badClient2], this);
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
       await accommodateChallengeAndInvalidateHash(this, badClient2); // Invalidate the 'null' that partners the third hash submitted.
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient2);
-
       await repCycle.confirmNewHash(2);
-      const newAddr = await colonyNetwork.getReputationMiningCycle(true);
-      assert.isTrue(newAddr !== ZERO_ADDRESS);
-      assert.isTrue(repCycle.address !== ZERO_ADDRESS);
-      assert.isTrue(newAddr !== repCycle.address);
+
+      const newRepCycle = await getActiveRepCycle(colonyNetwork);
+      assert.notEqual(newRepCycle.address, ZERO_ADDRESS);
+      assert.notEqual(repCycle.address, ZERO_ADDRESS);
+      assert.notEqual(newRepCycle.address, repCycle.address);
+
       const rootHash = await colonyNetwork.getReputationRootHash();
       const clientRootHash = await goodClient.getRootHash();
       assert.equal(rootHash, clientRootHash);
+
       const rootHashNNodes = await colonyNetwork.getReputationRootHashNNodes();
       assert.equal(rootHashNNodes.toString(), goodClient.nReputations.toString());
     });
@@ -423,14 +438,17 @@ contract("ColonyNetworkMining", accounts => {
     it("should not allow a new reputation hash to be set if more than one was submitted and they have not been elimintated", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
-      const repCycle = await getActiveRepCycle(colonyNetwork);
 
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
+
       await checkErrorRevert(repCycle.confirmNewHash(0), "colony-reputation-mining-final-round-not-completed");
-      const newAddr = await colonyNetwork.getReputationMiningCycle(true);
-      assert.isTrue(newAddr !== ZERO_ADDRESS);
-      assert.isTrue(repCycle.address !== ZERO_ADDRESS);
-      assert.isTrue(newAddr === repCycle.address);
+
+      const newRepCycle = await getActiveRepCycle(colonyNetwork);
+      assert.notEqual(newRepCycle.address, ZERO_ADDRESS);
+      assert.notEqual(repCycle.address, ZERO_ADDRESS);
+      assert.equal(newRepCycle.address, repCycle.address);
+
       // Eliminate one so that the afterAll works.
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
     });
@@ -441,6 +459,7 @@ contract("ColonyNetworkMining", accounts => {
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
+
       await checkErrorRevert(accommodateChallengeAndInvalidateHash(this, goodClient), "colony-reputation-mining-cannot-invalidate-final-hash");
     });
 
@@ -448,12 +467,12 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT2, DEFAULT_STAKE);
-      const repCycle = await getActiveRepCycle(colonyNetwork);
 
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([goodClient, badClient, badClient2], this);
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
       await accommodateChallengeAndInvalidateHash(this, badClient2);
-      await forwardTime(MINING_CYCLE_DURATION / 6, this);
+
       await checkErrorRevert(repCycle.invalidateHash(1, 2), "colony-reputation-mining-dispute-id-not-in-range");
 
       // Cleanup after test
@@ -464,12 +483,13 @@ contract("ColonyNetworkMining", accounts => {
     it("should fail if one tries to invalidate a hash that has completed more challenge rounds than its opponent", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
-      const repCycle = await getActiveRepCycle(colonyNetwork);
 
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       await goodClient.confirmJustificationRootHash();
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
+
       await checkErrorRevert(repCycle.invalidateHash(0, 0), "colony-reputation-mining-less-challenge-rounds-completed");
 
       // Cleanup after test
@@ -480,10 +500,11 @@ contract("ColonyNetworkMining", accounts => {
     it("should not allow a hash to be invalidated multiple times, which would move extra copies of its opponent to the next stage", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
-      const repCycle = await getActiveRepCycle(colonyNetwork);
 
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
+
       await checkErrorRevert(repCycle.invalidateHash(0, 1), "colony-reputation-mining-proposed-hash-empty");
     });
 
@@ -491,10 +512,10 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
 
-      await submitAndForwardTimeToDispute([goodClient, badClient], this);
       const repCycle = await getActiveRepCycle(colonyNetwork);
-
+      await submitAndForwardTimeToDispute([goodClient, badClient], this);
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
+
       await checkErrorRevert(repCycle.invalidateHash(0, 0), "colony-reputation-mining-hash-already-progressed");
     });
 
@@ -502,11 +523,11 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT2, DEFAULT_STAKE);
-      const repCycle = await getActiveRepCycle(colonyNetwork);
 
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([badClient, badClient2, goodClient], this);
-      await forwardTime(MINING_CYCLE_DURATION / 6, this);
       await repCycle.invalidateHash(0, 1);
+
       await accommodateChallengeAndInvalidateHash(this, goodClient);
       await repCycle.confirmNewHash(1);
     });
@@ -514,17 +535,21 @@ contract("ColonyNetworkMining", accounts => {
     it("should prevent invalidation of hashes before they have timed out on a challenge", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
-      const repCycle = await getActiveRepCycle(colonyNetwork);
 
-      await forwardTime(MINING_CYCLE_DURATION / 2, this);
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await goodClient.addLogContentsToReputationTree();
       await badClient.addLogContentsToReputationTree();
+
+      await forwardTime(MINING_CYCLE_DURATION / 2, this);
       await goodClient.submitRootHash();
       await badClient.submitRootHash();
 
       await checkErrorRevert(repCycle.invalidateHash(0, 1), "colony-reputation-mining-not-timed-out");
+
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
+
       await checkErrorRevert(repCycle.confirmNewHash(1), "colony-reputation-mining-final-round-not-completed");
+
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
       await repCycle.confirmNewHash(1);
     });
@@ -533,18 +558,19 @@ contract("ColonyNetworkMining", accounts => {
   describe("Submission eligibility", () => {
     it("should not allow someone to submit a new reputation hash if they are ineligible", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
+
       const repCycle = await getActiveRepCycle(colonyNetwork);
 
       await checkErrorRevert(
         repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MAIN_ACCOUNT }),
         "colony-reputation-mining-cycle-submission-not-within-target"
       );
-      const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      assert.isTrue(nSubmittedHashes.isZero());
     });
 
     it("should not allow someone to submit a new reputation hash to the next ReputationMiningCycle", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
+
+      // Inactive mining cycle
       const addr = await colonyNetwork.getReputationMiningCycle(false);
       const repCycle = await IReputationMiningCycle.at(addr);
 
@@ -552,42 +578,41 @@ contract("ColonyNetworkMining", accounts => {
         repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MAIN_ACCOUNT }),
         "colony-reputation-mining-cycle-not-open"
       );
-      const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      assert.equal(nSubmittedHashes.toString(), "0");
     });
 
     it("should allow someone to submit a new reputation hash if they are eligible inside the window", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
-      const repCycle = await getActiveRepCycle(colonyNetwork);
 
-      // Find an entry that will be eligible in the last 60 seconds of the window
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
+
+      // Find an entry that will be eligible in the second half of the window
       const entryNumber = await getValidEntryNumber(colonyNetwork, MAIN_ACCOUNT, "0x12345678");
       await repCycle.submitRootHash("0x12345678", 10, "0x00", entryNumber, { from: MAIN_ACCOUNT });
-      await forwardTime(MINING_CYCLE_DURATION / 2, this);
     });
 
     it("should not allow a user to back more than one hash in a single cycle", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
-      const repCycle = await getActiveRepCycle(colonyNetwork);
 
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
+
       const entryNumber = await getValidEntryNumber(colonyNetwork, MAIN_ACCOUNT, "0x12345678");
       await repCycle.submitRootHash("0x12345678", 10, "0x00", entryNumber, { from: MAIN_ACCOUNT });
+
       const entryNumber2 = await getValidEntryNumber(colonyNetwork, MAIN_ACCOUNT, "0x87654321");
       await checkErrorRevert(
         repCycle.submitRootHash("0x87654321", 10, "0x00", entryNumber2, { from: MAIN_ACCOUNT }),
         "colony-reputation-mining-submitting-different-hash"
       );
-      const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      assert.isTrue(nSubmittedHashes.eq(new BN(1)));
     });
 
     it("should not allow a user to back the same hash with different number of nodes in a single cycle", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
-      const repCycle = await getActiveRepCycle(colonyNetwork);
 
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
+
       const entryNumber = await getValidEntryNumber(colonyNetwork, MAIN_ACCOUNT, "0x12345678");
       await repCycle.submitRootHash("0x12345678", 10, "0x00", entryNumber, { from: MAIN_ACCOUNT });
 
@@ -595,8 +620,6 @@ contract("ColonyNetworkMining", accounts => {
         repCycle.submitRootHash("0x12345678", 11, "0x00", entryNumber, { from: MAIN_ACCOUNT }),
         "colony-reputation-mining-submitting-different-nnodes"
       );
-      const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      assert.isTrue(nSubmittedHashes.eq(new BN(1)));
     });
 
     it("should not allow a user to back the same hash with same number of nodes but different JRH in a single cycle", async () => {
@@ -622,31 +645,31 @@ contract("ColonyNetworkMining", accounts => {
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
-      const entryNumber = await getValidEntryNumber(colonyNetwork, MAIN_ACCOUNT, "0x12345678");
 
+      const entryNumber = await getValidEntryNumber(colonyNetwork, MAIN_ACCOUNT, "0x12345678");
       await repCycle.submitRootHash("0x12345678", 10, "0x00", entryNumber, { from: MAIN_ACCOUNT });
 
       await checkErrorRevert(
         repCycle.submitRootHash("0x12345678", 10, "0x00", entryNumber, { from: MAIN_ACCOUNT }),
         "colony-reputation-mining-submitting-same-entry-index"
       );
-      const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      assert.isTrue(nSubmittedHashes.eq(new BN(1)));
-      await forwardTime(MINING_CYCLE_DURATION / 2, this);
     });
 
     it("should allow a user to back the same hash more than once in a same cycle with different entries, and be rewarded", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
-      let repCycle = await getActiveRepCycle(colonyNetwork);
 
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
+
       const entryNumber = await getValidEntryNumber(colonyNetwork, MAIN_ACCOUNT, "0x12345678");
       const entryNumber2 = await getValidEntryNumber(colonyNetwork, MAIN_ACCOUNT, "0x12345678", entryNumber + 1);
 
       await repCycle.submitRootHash("0x12345678", 10, "0x00", entryNumber, { from: MAIN_ACCOUNT });
       await repCycle.submitRootHash("0x12345678", 10, "0x00", entryNumber2, { from: MAIN_ACCOUNT });
+
       const nSubmittedHashes = await repCycle.getNSubmittedHashes();
       assert.isTrue(nSubmittedHashes.eq(new BN(1)));
+
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
       await repCycle.confirmNewHash(0);
 
@@ -655,10 +678,10 @@ contract("ColonyNetworkMining", accounts => {
       assert.equal(balance1Updated.toString(), REWARD.toString(), "Account was not rewarded properly");
 
       const addr = await colonyNetwork.getReputationMiningCycle(false);
-      repCycle = await IReputationMiningCycle.at(addr);
+      const inactiveRepCycle = await IReputationMiningCycle.at(addr);
 
       // Check that they will be getting the reputation owed to them.
-      let repLogEntryMiner = await repCycle.getReputationUpdateLogEntry(0);
+      let repLogEntryMiner = await inactiveRepCycle.getReputationUpdateLogEntry(0);
       assert.strictEqual(repLogEntryMiner.user, MAIN_ACCOUNT);
       assert.isTrue(new BN(repLogEntryMiner.amount).sub(REWARD.divn(2)).gtn(0));
       assert.strictEqual(repLogEntryMiner.skillId, "3");
@@ -666,7 +689,7 @@ contract("ColonyNetworkMining", accounts => {
       assert.strictEqual(repLogEntryMiner.nUpdates, "4");
       assert.strictEqual(repLogEntryMiner.nPreviousUpdates, "0");
 
-      repLogEntryMiner = await repCycle.getReputationUpdateLogEntry(1);
+      repLogEntryMiner = await inactiveRepCycle.getReputationUpdateLogEntry(1);
       assert.strictEqual(repLogEntryMiner.user, MAIN_ACCOUNT);
       assert.isTrue(new BN(repLogEntryMiner.amount).sub(REWARD.divn(2)).ltn(0));
       assert.strictEqual(repLogEntryMiner.skillId, "3");
@@ -674,7 +697,7 @@ contract("ColonyNetworkMining", accounts => {
       assert.strictEqual(repLogEntryMiner.nUpdates, "4");
       assert.strictEqual(repLogEntryMiner.nPreviousUpdates, "4");
 
-      const reputationUpdateLogLength = await repCycle.getReputationUpdateLogLength();
+      const reputationUpdateLogLength = await inactiveRepCycle.getReputationUpdateLogLength();
       assert.equal(reputationUpdateLogLength.toString(), 2);
     });
 
@@ -683,11 +706,13 @@ contract("ColonyNetworkMining", accounts => {
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION - 600, this);
+
       let entryNumber = await getValidEntryNumber(colonyNetwork, MAIN_ACCOUNT, "0x12345678", 1);
       for (let i = 1; i <= 12; i += 1) {
         await repCycle.submitRootHash("0x12345678", 10, "0x00", entryNumber, { from: MAIN_ACCOUNT }); // eslint-disable-line no-await-in-loop
         entryNumber = await getValidEntryNumber(colonyNetwork, MAIN_ACCOUNT, "0x12345678", entryNumber + 1); // eslint-disable-line no-await-in-loop
       }
+
       await checkErrorRevert(
         repCycle.submitRootHash("0x12345678", 10, "0x00", entryNumber, { from: MAIN_ACCOUNT }),
         "colony-reputation-mining-max-number-miners-reached"
@@ -696,24 +721,25 @@ contract("ColonyNetworkMining", accounts => {
 
     it("should prevent submission of hashes with an invalid entry for the balance of a user", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
-      const repCycle = await getActiveRepCycle(colonyNetwork);
 
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION, this);
+
       await checkErrorRevert(
         repCycle.submitRootHash("0x12345678", 10, "0x00", 1000000000000, { from: MAIN_ACCOUNT }),
         "colony-reputation-mining-stake-minimum-not-met-for-index"
       );
-      const entryNumber = await getValidEntryNumber(colonyNetwork, MAIN_ACCOUNT, "0x87654321");
-      await repCycle.submitRootHash("0x87654321", 10, "0x00", entryNumber, { from: OTHER_ACCOUNT });
+
+      await repCycle.submitRootHash("0x87654321", 10, "0x00", 10, { from: OTHER_ACCOUNT });
     });
 
     it("should prevent submission of hashes with a valid entry, but invalid hash for the current time", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
+
       await checkErrorRevert(
-        repCycle.submitRootHash("0x12345678", 10, "0x00", 1, { from: MAIN_ACCOUNT }),
+        repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MAIN_ACCOUNT }),
         "colony-reputation-mining-cycle-submission-not-within-target"
       );
     });
@@ -758,21 +784,22 @@ contract("ColonyNetworkMining", accounts => {
     it("should reward all stakers if they submitted the agreed new hash", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
-      let repCycle = await getActiveRepCycle(colonyNetwork);
 
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
+
       const entryNumber = await getValidEntryNumber(colonyNetwork, MAIN_ACCOUNT, "0x12345678");
       const entryNumber2 = await getValidEntryNumber(colonyNetwork, OTHER_ACCOUNT, "0x12345678");
 
       await repCycle.submitRootHash("0x12345678", 10, "0x00", entryNumber, { from: MAIN_ACCOUNT });
       await repCycle.submitRootHash("0x12345678", 10, "0x00", entryNumber2, { from: OTHER_ACCOUNT });
+
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
       await repCycle.confirmNewHash(0);
 
       // Check that they have had their balance increase
       const balance1Updated = await clny.balanceOf(MAIN_ACCOUNT);
       const balance2Updated = await clny.balanceOf(OTHER_ACCOUNT);
-
       // More than half of the reward
       assert.isTrue(balance1Updated.sub(REWARD.divn(2)).gtn(0), "Account was not rewarded properly");
       // Less than half of the reward
@@ -781,10 +808,10 @@ contract("ColonyNetworkMining", accounts => {
       assert.closeTo(balance1Updated.add(balance2Updated).sub(REWARD).toNumber(), 0, 2); // eslint-disable-line prettier/prettier
 
       const addr = await colonyNetwork.getReputationMiningCycle(false);
-      repCycle = await IReputationMiningCycle.at(addr);
+      const inactiveRepCycle = await IReputationMiningCycle.at(addr);
 
       // Check that they will be getting the reputation owed to them.
-      let repLogEntryMiner = await repCycle.getReputationUpdateLogEntry(0);
+      let repLogEntryMiner = await inactiveRepCycle.getReputationUpdateLogEntry(0);
       assert.strictEqual(repLogEntryMiner.user, MAIN_ACCOUNT);
       assert.strictEqual(repLogEntryMiner.amount, balance1Updated.toString());
       assert.strictEqual(repLogEntryMiner.skillId, "3");
@@ -792,7 +819,7 @@ contract("ColonyNetworkMining", accounts => {
       assert.strictEqual(repLogEntryMiner.nUpdates, "4");
       assert.strictEqual(repLogEntryMiner.nPreviousUpdates, "0");
 
-      repLogEntryMiner = await repCycle.getReputationUpdateLogEntry(1);
+      repLogEntryMiner = await inactiveRepCycle.getReputationUpdateLogEntry(1);
       assert.strictEqual(repLogEntryMiner.user, OTHER_ACCOUNT);
       assert.strictEqual(repLogEntryMiner.amount, balance2Updated.toString());
       assert.strictEqual(repLogEntryMiner.skillId, "3");
@@ -800,7 +827,7 @@ contract("ColonyNetworkMining", accounts => {
       assert.strictEqual(repLogEntryMiner.nUpdates, "4");
       assert.strictEqual(repLogEntryMiner.nPreviousUpdates, "4");
 
-      const reputationUpdateLogLength = await repCycle.getReputationUpdateLogLength();
+      const reputationUpdateLogLength = await inactiveRepCycle.getReputationUpdateLogLength();
       assert.equal(reputationUpdateLogLength.toString(), 2);
     });
   });
@@ -814,14 +841,17 @@ contract("ColonyNetworkMining", accounts => {
     });
 
     it('should not allow "startNextCycle" to be called if a cycle is in progress', async () => {
-      const addr = await colonyNetwork.getReputationMiningCycle(true);
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION, this);
-      assert.isTrue(parseInt(addr, 16) !== 0);
+
+      assert.isTrue(parseInt(repCycle.address, 16) !== 0);
+
       await checkErrorRevert(colonyNetwork.startNextCycle(), "colony-reputation-mining-still-active");
     });
 
     it('should not allow "rewardStakersWithReputation" to be called by someone not the colonyNetwork', async () => {
       const repCycle = await getActiveRepCycle(colonyNetwork);
+
       await checkErrorRevert(
         repCycle.rewardStakersWithReputation([MAIN_ACCOUNT], [1], ZERO_ADDRESS, 10000, 3),
         "colony-reputation-mining-sender-not-network"
@@ -829,12 +859,13 @@ contract("ColonyNetworkMining", accounts => {
     });
 
     it('should not allow "initialise" to be called on either the active or inactive ReputationMiningCycle', async () => {
-      let repCycle = await getActiveRepCycle(colonyNetwork);
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await checkErrorRevert(repCycle.initialise(MAIN_ACCOUNT, OTHER_ACCOUNT), "colony-reputation-mining-cycle-already-initialised");
 
       const addr = await colonyNetwork.getReputationMiningCycle(false);
-      repCycle = await IReputationMiningCycle.at(addr);
-      await checkErrorRevert(repCycle.initialise(MAIN_ACCOUNT, OTHER_ACCOUNT), "colony-reputation-mining-cycle-already-initialised");
+      const inactiveRepCycle = await IReputationMiningCycle.at(addr);
+
+      await checkErrorRevert(inactiveRepCycle.initialise(MAIN_ACCOUNT, OTHER_ACCOUNT), "colony-reputation-mining-cycle-already-initialised");
     });
   });
 
@@ -1136,6 +1167,7 @@ contract("ColonyNetworkMining", accounts => {
 
       let repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION, this);
+
       await goodClient.addLogContentsToReputationTree();
       await goodClient.submitRootHash();
 
@@ -1144,35 +1176,30 @@ contract("ColonyNetworkMining", accounts => {
         0,
         "0xfffffffff"
       );
-      badClient.entryToFalsify = "-1";
       await badClient.initialise(colonyNetwork.address);
       await badClient.addLogContentsToReputationTree();
-      badClient.entryToFalsify = "0";
 
       await repCycle.confirmNewHash(0);
-      repCycle = await getActiveRepCycle(colonyNetwork);
-
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       const righthash = await goodClient.getRootHash();
       const wronghash = await badClient.getRootHash();
       assert.notEqual(righthash, wronghash, "Hashes from clients are equal, surprisingly");
 
+      repCycle = await getActiveRepCycle(colonyNetwork);
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
       await repCycle.confirmNewHash(1);
     });
 
     // These tests are useful for checking that every type of parent / child / user / colony-wide-sum skills are accounted for
     // correctly. Unsure if I should force them to be run every time.
-    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19].forEach(async badIndex => {
+    [0, 1, 2, 3, 4, 5, 6, 7].forEach(async badIndex => {
       it.skip(`should cope if wrong reputation transition is transition ${badIndex}`, async function advancingTest() {
         await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
         await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
 
         // Advance to next cycle
         await advanceMiningCycleNoContest(colonyNetwork, this);
-
-        await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
 
         let repCycle = await getActiveRepCycle(colonyNetwork);
         await forwardTime(MINING_CYCLE_DURATION, this);
@@ -1185,21 +1212,18 @@ contract("ColonyNetworkMining", accounts => {
           badIndex,
           "0xfffffffff"
         );
-        badClient.entryToFalsify = "-1";
         await badClient.initialise(colonyNetwork.address);
         await badClient.addLogContentsToReputationTree();
-        badClient.entryToFalsify = badIndex.toString();
 
         await repCycle.confirmNewHash(0);
-
         await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
         const righthash = await goodClient.getRootHash();
         const wronghash = await badClient.getRootHash();
         assert.notEqual(righthash, wronghash, "Hashes from clients are equal, surprisingly");
 
-        await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
         repCycle = await getActiveRepCycle(colonyNetwork);
+        await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
         await repCycle.confirmNewHash(1);
       });
     });
@@ -1443,10 +1467,10 @@ contract("ColonyNetworkMining", accounts => {
       // Both sides have completed the same amount of challenges, but one has proved that a large number already exists
       // than the other, so when we call invalidate hash, only one will be eliminated.
 
-      await forwardTime(MINING_CYCLE_DURATION / 6, this);
       // Check that we can't invalidate the one that proved a higher reputation already existed
       await checkErrorRevert(repCycle.invalidateHash(0, 0), "colony-reputation-mining-less-reputation-uids-proven");
 
+      await forwardTime(MINING_CYCLE_DURATION / 6, this);
       await repCycle.invalidateHash(0, 1);
       await repCycle.confirmNewHash(1);
       const confirmedHash = await colonyNetwork.getReputationRootHash();
@@ -1492,22 +1516,21 @@ contract("ColonyNetworkMining", accounts => {
 
       await goodClient.respondToChallenge();
       await badClient.respondToChallenge();
-      // These calls should throw
-      await badClient.respondToChallenge();
-      await badClient.respondToChallenge();
+
+      await checkErrorRevertEthers(badClient.respondToChallenge(), "colony-reputation-mining-challenge-already-responded");
 
       // Check
       const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 0);
       const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 1);
-
       assert.equal(goodSubmissionAfterResponseToChallenge.challengeStepCompleted - badSubmissionAfterResponseToChallenge.challengeStepCompleted, 1);
+
       // Both sides have completed the same amount of challenges, but one has proved that the reputation existed previously,
       // whereas the other has not, and any respondToChallenges after the first didn't work.
 
-      await forwardTime(MINING_CYCLE_DURATION / 6, this);
       // Check that we can't invalidate the good client submission
       await checkErrorRevert(repCycle.invalidateHash(0, 0), "colony-reputation-mining-less-challenge-rounds-completed");
 
+      await forwardTime(MINING_CYCLE_DURATION / 6, this);
       await repCycle.invalidateHash(0, 1);
       await repCycle.confirmNewHash(1);
       const confirmedHash = await colonyNetwork.getReputationRootHash();
@@ -1572,7 +1595,6 @@ contract("ColonyNetworkMining", accounts => {
       assert.equal(goodSubmissionAfterResponseToChallenge.challengeStepCompleted - badSubmissionAfterResponseToChallenge.challengeStepCompleted, 2);
 
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
-
       await repCycle.invalidateHash(0, 1);
       await repCycle.confirmNewHash(1);
       const confirmedHash = await colonyNetwork.getReputationRootHash();
@@ -1649,20 +1671,20 @@ contract("ColonyNetworkMining", accounts => {
       assert.notEqual(righthash, wronghash, "Hashes from clients are equal, surprisingly");
 
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
-
       await repCycle.confirmNewHash(1);
+
       badClient = new MaliciousReputationMinerExtraRep(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         1,
         "0xfffffffff"
       );
       await badClient.initialise(colonyNetwork.address);
+
       const keys = Object.keys(goodClient.reputations);
       for (let i = 0; i < keys.length; i += 1) {
         const key = keys[i];
         const value = goodClient.reputations[key];
         const score = new BN(value.slice(2, 66), 16);
-
         await badClient.insert(key, score, 0); // eslint-disable-line no-await-in-loop
       }
 
@@ -1748,17 +1770,18 @@ contract("ColonyNetworkMining", accounts => {
     it("should prevent a user from confirming a JRH they can't prove is correct", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
-      const repCycle = await getActiveRepCycle(colonyNetwork);
 
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
-      const [branchMask1, siblings1] = await goodClient.justificationTree.getProof(`0x${new BN("0").toString(16, 64)}`);
       const nLogEntries = await repCycle.getReputationUpdateLogLength();
       const lastLogEntry = await repCycle.getReputationUpdateLogEntry(nLogEntries.subn(1));
       const totalnUpdates = new BN(lastLogEntry.nUpdates).add(new BN(lastLogEntry.nPreviousUpdates));
 
+      const [branchMask1, siblings1] = await goodClient.justificationTree.getProof(`0x${new BN("0").toString(16, 64)}`);
       const [branchMask2, siblings2] = await goodClient.justificationTree.getProof(`0x${totalnUpdates.toString(16, 64)}`);
       const [round, index] = await goodClient.getMySubmissionRoundAndIndex();
+      const jrh = await goodClient.justificationTree.getRootHash();
 
       await checkErrorRevert(
         repCycle.confirmJustificationRootHash(round, index, "123456", siblings1, branchMask2, siblings2),
@@ -1817,6 +1840,7 @@ contract("ColonyNetworkMining", accounts => {
       const [agreeStateBranchMask, agreeStateSiblings] = await goodClient.justificationTree.getProof(`0x${lastAgreeIdx.toString(16, 64)}`);
       const [disagreeStateBranchMask, disagreeStateSiblings] = await goodClient.justificationTree.getProof(`0x${firstDisagreeIdx.toString(16, 64)}`);
       const logEntryNumber = await goodClient.getLogEntryNumberForLogUpdateNumber(lastAgreeIdx.toString());
+
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [
@@ -1864,14 +1888,10 @@ contract("ColonyNetworkMining", accounts => {
 
       await badClient.initialise(colonyNetwork.address);
 
-      badClient.entryToFalsify = "-1";
-
       await goodClient.addLogContentsToReputationTree();
       await badClient.addLogContentsToReputationTree();
 
       await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
-
-      badClient.entryToFalsify = "1";
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
@@ -1930,6 +1950,7 @@ contract("ColonyNetworkMining", accounts => {
         ),
         "colony-reputation-mining-uid-not-decay"
       );
+
       // Cleanup
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
       await repCycle.confirmNewHash(1);
@@ -1973,6 +1994,7 @@ contract("ColonyNetworkMining", accounts => {
       const [agreeStateBranchMask, agreeStateSiblings] = await goodClient.justificationTree.getProof(`0x${lastAgreeIdx.toString(16, 64)}`);
       const [disagreeStateBranchMask, disagreeStateSiblings] = await goodClient.justificationTree.getProof(`0x${firstDisagreeIdx.toString(16, 64)}`);
       const logEntryNumber = await goodClient.getLogEntryNumberForLogUpdateNumber(lastAgreeIdx.toString());
+
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [
@@ -2004,6 +2026,7 @@ contract("ColonyNetworkMining", accounts => {
         ),
         "colony-reputation-mining-invalid-before-reputation-proof"
       );
+
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [
@@ -2074,14 +2097,15 @@ contract("ColonyNetworkMining", accounts => {
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
-      for (let i = 0; i < clients.length; i += 1) {
+
+      for (let i = 0; i < 8; i += 1) {
         // Doing these individually rather than in a big loop because with many instances of the EVM
         // churning away at once, I *think* it's slower.
         await clients[i].addLogContentsToReputationTree(); // eslint-disable-line no-await-in-loop
         await clients[i].submitRootHash(); // eslint-disable-line no-await-in-loop
         await clients[i].confirmJustificationRootHash(); // eslint-disable-line no-await-in-loop
-        console.log(`Client ${i} of ${clients.length - 1} submitted JRH`); // eslint-disable-line no-console
       }
+
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
 
       await accommodateChallengeAndInvalidateHash(this, clients[0], clients[1]);
@@ -2104,7 +2128,6 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
-
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       await goodClient.confirmJustificationRootHash();
@@ -2139,16 +2162,16 @@ contract("ColonyNetworkMining", accounts => {
       const submission = await repCycle.getDisputeRounds(round, index);
       const targetNode = submission.lowerBound;
       const targetNodeKey = ReputationMiner.getHexString(targetNode, 64);
-
       const [branchMask, siblings] = await goodClient.justificationTree.getProof(targetNodeKey);
+
       await checkErrorRevert(
         repCycle.confirmBinarySearchResult(round, index, "0x00", branchMask, siblings),
         "colony-reputation-mining-invalid-binary-search-confirmation"
       );
 
       // Cleanup
-      await goodClient.confirmBinarySearchResult();
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
+      await goodClient.confirmBinarySearchResult();
       await repCycle.invalidateHash(0, 1);
       await repCycle.confirmNewHash(1);
     });
@@ -2165,24 +2188,25 @@ contract("ColonyNetworkMining", accounts => {
         5,
         0xfffffffff
       );
-
       await badClient.initialise(colonyNetwork.address);
 
-      await setupFinalizedTask( // eslint-disable-line
-        {
-          colonyNetwork,
-          colony: metaColony,
-          colonyToken: clny,
-          manager: MAIN_ACCOUNT,
-          worker: OTHER_ACCOUNT,
-          workerRating: 1,
-          managerPayout: 1,
-          evaluatorPayout: 1,
-          workerPayout: 1
-        }
-      );
-      await advanceTimeSubmitAndConfirmHash(this);
-      await advanceTimeSubmitAndConfirmHash(this);
+      await fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING);
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        token: clny,
+        workerRating: 1,
+        managerPayout: 1,
+        evaluatorPayout: 1,
+        workerPayout: 1
+      });
+
+      await goodClient.addLogContentsToReputationTree();
+      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+
+      await goodClient.addLogContentsToReputationTree();
+      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+
       const addr = await colonyNetwork.getReputationMiningCycle(false);
       const inactiveRepCycle = await IReputationMiningCycle.at(addr);
 
@@ -2201,17 +2225,22 @@ contract("ColonyNetworkMining", accounts => {
             workerPayout: 1
           }
         );
+
         const nLogEntries = await inactiveRepCycle.getReputationUpdateLogLength(); // eslint-disable-line no-await-in-loop
         const lastLogEntry = await inactiveRepCycle.getReputationUpdateLogEntry(nLogEntries - 1); // eslint-disable-line no-await-in-loop
         const currentHashNNodes = await colonyNetwork.getReputationRootHashNNodes(); // eslint-disable-line no-await-in-loop
         const nUpdates = new BN(lastLogEntry.nUpdates).add(new BN(lastLogEntry.nPreviousUpdates)).add(currentHashNNodes);
+
         // The total number of updates we expect is the nPreviousUpdates in the last entry of the log plus the number
         // of updates that log entry implies by itself, plus the number of decays (the number of nodes in current state)
         if (parseInt(nUpdates.toString(2).slice(1), 10) === 0) {
           powerTwoEntries = true;
         }
       }
-      await advanceTimeSubmitAndConfirmHash(this);
+
+      await goodClient.addLogContentsToReputationTree();
+      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+
       await goodClient.resetDB();
       await goodClient.saveCurrentState();
       const savedHash = await goodClient.reputationTree.getRootHash();
@@ -2238,6 +2267,7 @@ contract("ColonyNetworkMining", accounts => {
 
       // We need one more response to binary search from each side. Check we can't confirm early
       await checkErrorRevertEthers(goodClient.confirmBinarySearchResult(), "colony-reputation-binary-search-incomplete");
+
       // Check we can't respond to challenge before we've completed the binary search
       await checkErrorRevertEthers(goodClient.respondToChallenge(), "colony-reputation-binary-search-incomplete");
       await goodClient.respondToBinarySearchForChallenge();
@@ -2260,9 +2290,8 @@ contract("ColonyNetworkMining", accounts => {
       // Check we can't respond again
       await checkErrorRevertEthers(goodClient.respondToChallenge(), "colony-reputation-mining-challenge-already-responded");
 
-      const repCycle = await getActiveRepCycle(colonyNetwork);
-
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await repCycle.invalidateHash(0, 1);
       await repCycle.confirmNewHash(1);
     });
@@ -2272,7 +2301,6 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
-
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       await goodClient.confirmJustificationRootHash();
@@ -2300,7 +2328,6 @@ contract("ColonyNetworkMining", accounts => {
       await badClient.initialise(colonyNetwork.address);
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
-
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       await goodClient.confirmJustificationRootHash();
@@ -2317,6 +2344,7 @@ contract("ColonyNetworkMining", accounts => {
       const userAddress = logEntry.user.slice(2);
       const skillId = new BN(logEntry.skillId);
 
+      // Linter fail
       const wrongColonyKey = `0x${new BN(0, 16).toString(16, 40)}${new BN(skillId.toString()).toString(16, 64)}${new BN(userAddress, 16).toString(
         16,
         40
@@ -2334,16 +2362,19 @@ contract("ColonyNetworkMining", accounts => {
         repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], wrongColonyKey, [], "0x00", [], "0x00", [], "0x00", "0x00", []),
         "colony-reputation-mining-colony-address-mismatch"
       );
+
       await checkErrorRevert(
         repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], wrongReputationKey, [], "0x00", [], "0x00", [], "0x00", "0x00", []),
         "colony-reputation-mining-skill-id-mismatch"
       );
+
       await checkErrorRevert(
         repCycle.respondToChallenge([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], wrongUserKey, [], "0x00", [], "0x00", [], "0x00", "0x00", []),
         "colony-reputation-mining-user-address-mismatch"
       );
-      await goodClient.respondToChallenge();
+
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
+      await goodClient.respondToChallenge();
       await repCycle.invalidateHash(0, 1);
       await repCycle.confirmNewHash(1);
     });
@@ -2353,7 +2384,6 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
-
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       await goodClient.confirmJustificationRootHash();
@@ -2394,6 +2424,7 @@ contract("ColonyNetworkMining", accounts => {
 
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
       await goodClient.submitRootHash();
+
       await checkErrorRevert(repCycle.confirmNewHash(0), "colony-reputation-mining-submission-window-still-open");
 
       // Cleanup
@@ -2413,7 +2444,6 @@ contract("ColonyNetworkMining", accounts => {
           await setupFinalizedTask({ colonyNetwork, colony: metaColony });
 
           await advanceMiningCycleNoContest(colonyNetwork, this);
-
           const repCycle = await getActiveRepCycle(colonyNetwork);
 
           badClient = new MaliciousReputationMinerExtraRep(
@@ -2446,6 +2476,7 @@ contract("ColonyNetworkMining", accounts => {
 
           await goodClient.confirmBinarySearchResult();
           await badClient.confirmBinarySearchResult();
+
           if (args.word === "high") {
             await checkErrorRevertEthers(
               badClient2.respondToChallenge(),
@@ -2459,8 +2490,8 @@ contract("ColonyNetworkMining", accounts => {
           }
 
           // Cleanup
-          await goodClient.respondToChallenge();
           await forwardTime(MINING_CYCLE_DURATION / 6, this);
+          await goodClient.respondToChallenge();
           await repCycle.invalidateHash(0, 0);
           await repCycle.confirmNewHash(1);
         });
@@ -2547,7 +2578,6 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
-
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       await goodClient.confirmJustificationRootHash();
@@ -2594,7 +2624,6 @@ contract("ColonyNetworkMining", accounts => {
       await advanceMiningCycleNoContest(colonyNetwork, this);
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
-
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       await goodClient.confirmJustificationRootHash();
@@ -2633,7 +2662,6 @@ contract("ColonyNetworkMining", accounts => {
       await advanceMiningCycleNoContest(colonyNetwork, this);
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
-
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       await goodClient.confirmJustificationRootHash();
@@ -2651,10 +2679,12 @@ contract("ColonyNetworkMining", accounts => {
       await setupFinalizedTask({ colonyNetwork, colony: metaColony, worker: MAIN_ACCOUNT });
       await setupFinalizedTask({ colonyNetwork, colony: metaColony, worker: OTHER_ACCOUNT });
 
+      const bigPayout = new BN("10").pow(new BN("75"));
+
       badClient = new MaliciousReputationMinerExtraRep(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         29,
-        new BN("-10").pow(new BN("75")).muln(2)
+        bigPayout.muln(2).neg()
       );
       await badClient.initialise(colonyNetwork.address);
 
@@ -2663,20 +2693,20 @@ contract("ColonyNetworkMining", accounts => {
       const globalKey = await ReputationMiner.getKey(metaColony.address, rootGlobalSkill, ZERO_ADDRESS);
       const userKey = await ReputationMiner.getKey(metaColony.address, rootGlobalSkill, MAIN_ACCOUNT);
 
-      await goodClient.insert(globalKey, new BN("2").pow(new BN("256")).subn(2), 0);
-      await goodClient.insert(userKey, new BN("2").pow(new BN("256")).subn(2), 0);
-      await badClient.insert(globalKey, new BN("2").pow(new BN("256")).subn(2), 0);
-      await badClient.insert(userKey, new BN("2").pow(new BN("256")).subn(2), 0);
+      await goodClient.insert(globalKey, UINT256_MAX.subn(1), 0);
+      await goodClient.insert(userKey, UINT256_MAX.subn(1), 0);
+      await badClient.insert(globalKey, UINT256_MAX.subn(1), 0);
+      await badClient.insert(userKey, UINT256_MAX.subn(1), 0);
 
       const rootHash = await goodClient.getRootHash();
-      await fundColonyWithTokens(metaColony, clny, new BN("4").mul(new BN("10").pow(new BN("75"))));
+      await fundColonyWithTokens(metaColony, clny, bigPayout.muln(4));
       await setupFinalizedTask({
         colonyNetwork,
         colony: metaColony,
         worker: MAIN_ACCOUNT,
-        managerPayout: new BN("10").pow(new BN("75")),
-        evaluatorPayout: new BN("10").pow(new BN("75")),
-        workerPayout: new BN("10").pow(new BN("75")),
+        managerPayout: bigPayout,
+        evaluatorPayout: bigPayout,
+        workerPayout: bigPayout,
         managerRating: 3,
         workerRating: 3
       });
@@ -2686,7 +2716,6 @@ contract("ColonyNetworkMining", accounts => {
       await repCycle.confirmNewHash(0);
 
       repCycle = await getActiveRepCycle(colonyNetwork);
-
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       await goodClient.confirmJustificationRootHash();
@@ -2699,9 +2728,10 @@ contract("ColonyNetworkMining", accounts => {
     it("should calculate reputation decays differently if they are large", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+
       badClient = new MaliciousReputationMinerExtraRep(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
-        -1,
+        1,
         new BN("10")
       );
       await badClient.initialise(colonyNetwork.address);
@@ -2711,10 +2741,10 @@ contract("ColonyNetworkMining", accounts => {
       const globalKey = await ReputationMiner.getKey(metaColony.address, rootGlobalSkill, ZERO_ADDRESS);
       const userKey = await ReputationMiner.getKey(metaColony.address, rootGlobalSkill, MAIN_ACCOUNT);
 
-      await goodClient.insert(globalKey, new BN("2").pow(new BN("256")).subn(2), 0);
-      await goodClient.insert(userKey, new BN("2").pow(new BN("256")).subn(2), 0);
-      await badClient.insert(globalKey, new BN("2").pow(new BN("256")).subn(2), 0);
-      await badClient.insert(userKey, new BN("2").pow(new BN("256")).subn(2), 0);
+      await goodClient.insert(globalKey, UINT256_MAX.subn(1), 0);
+      await goodClient.insert(userKey, UINT256_MAX.subn(1), 0);
+      await badClient.insert(globalKey, UINT256_MAX.subn(1), 0);
+      await badClient.insert(userKey, UINT256_MAX.subn(1), 0);
 
       const rootHash = await goodClient.getRootHash();
 
@@ -2722,10 +2752,7 @@ contract("ColonyNetworkMining", accounts => {
       await repCycle.submitRootHash(rootHash, 2, "0x00", 10, { from: MAIN_ACCOUNT });
       await repCycle.confirmNewHash(0);
 
-      badClient.entryToFalsify = "1";
-
       repCycle = await getActiveRepCycle(colonyNetwork);
-
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       await goodClient.confirmJustificationRootHash();
@@ -2734,15 +2761,11 @@ contract("ColonyNetworkMining", accounts => {
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
       await repCycle.confirmNewHash(1);
 
-      const largeCalculationResult = new BN("2")
-        .pow(new BN("256"))
-        .subn(2)
+      const largeCalculationResult = UINT256_MAX.subn(1)
         .div(DECAY_RATE.DENOMINATOR)
         .mul(DECAY_RATE.NUMERATOR);
 
-      const smallCalculationResult = new BN("2")
-        .pow(new BN("256"))
-        .subn(2)
+      const smallCalculationResult = UINT256_MAX.subn(1)
         .mul(DECAY_RATE.NUMERATOR)
         .div(DECAY_RATE.DENOMINATOR);
 
@@ -2757,26 +2780,33 @@ contract("ColonyNetworkMining", accounts => {
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION, this);
       await repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MAIN_ACCOUNT });
-      await fundColonyWithTokens(metaColony, clny, "350000000000000000000");
 
       // Creates an entry in the reputation log for the worker and manager
+      await fundColonyWithTokens(metaColony, clny);
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
+
       let addr = await colonyNetwork.getReputationMiningCycle(false);
       let inactiveReputationMiningCycle = await IReputationMiningCycle.at(addr);
-
       const initialRepLogLength = await inactiveReputationMiningCycle.getReputationUpdateLogLength();
+
+      await forwardTime(MINING_CYCLE_DURATION, this);
+      let repCycle = await getActiveRepCycle(colonyNetwork);
+      await repCycle.submitRootHash("0x12345678", 10, 10);
       await repCycle.confirmNewHash(0);
+
       // This confirmation should freeze the reputation log that we added the above task entries to
       // and move it to the inactive rep log
-      const addr2 = await colonyNetwork.getReputationMiningCycle(true);
-      assert.equal(addr, addr2);
-      const reputationMiningCycle = await IReputationMiningCycle.at(addr2);
-      const finalRepLogLength = await reputationMiningCycle.getReputationUpdateLogLength();
+      repCycle = await getActiveRepCycle(colonyNetwork);
+      assert.equal(inactiveReputationMiningCycle.address, repCycle.address);
+
+      const finalRepLogLength = await repCycle.getReputationUpdateLogLength();
       assert.equal(finalRepLogLength.toNumber(), initialRepLogLength.toNumber());
+
       // Check the active log now has one entry in it (which will be the rewards for the miner who submitted
       // the accepted hash.
       addr = await colonyNetwork.getReputationMiningCycle(false);
       inactiveReputationMiningCycle = await IReputationMiningCycle.at(addr);
+
       const activeRepLogLength = await inactiveReputationMiningCycle.getReputationUpdateLogLength();
       assert.equal(activeRepLogLength.toNumber(), 1);
     });
@@ -2796,9 +2826,7 @@ contract("ColonyNetworkMining", accounts => {
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 13);
 
-      const client = new ReputationMiner({ loader: contractLoader, minerAddress: MAIN_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree });
-      await client.initialise(colonyNetwork.address);
-      await client.addLogContentsToReputationTree();
+      await goodClient.addLogContentsToReputationTree();
       // Check the client's tree has seven entries. In order these were added (and therefore in order of reputation UID),
       // these are:
       // 1. Colony-wide total reputation for metaColony's root skill
@@ -2818,44 +2846,45 @@ contract("ColonyNetworkMining", accounts => {
       const META_ROOT_SKILL = new BN(2);
       const MINING_SKILL = new BN(3);
 
-      assert.equal(Object.keys(client.reputations).length, 7);
+      assert.equal(Object.keys(goodClient.reputations).length, 7);
       let key;
       let value;
+
       // These should be:
       // 1. Colony-wide total reputation for metacolony's root skill
       key = makeReputationKey(metaColony.address, META_ROOT_SKILL);
       value = makeReputationValue(REWARD.add(MANAGER_PAYOUT.add(EVALUATOR_PAYOUT).add(WORKER_PAYOUT).muln(3)), 1); // eslint-disable-line prettier/prettier
-      assert.equal(client.reputations[key], value);
+      assert.equal(goodClient.reputations[key], value);
 
       // 2. Colony-wide total reputation for mining skill
       key = makeReputationKey(metaColony.address, MINING_SKILL);
       value = makeReputationValue(REWARD, 2);
-      assert.equal(client.reputations[key], value);
+      assert.equal(goodClient.reputations[key], value);
 
       // 3. Reputation reward for MAIN_ACCOUNT for being the manager for the tasks created by setupFinalizedTask
       key = makeReputationKey(metaColony.address, META_ROOT_SKILL, MAIN_ACCOUNT);
       value = makeReputationValue(REWARD.add(MANAGER_PAYOUT.add(EVALUATOR_PAYOUT).muln(3)), 3);
-      assert.equal(client.reputations[key], value);
+      assert.equal(goodClient.reputations[key], value);
 
       // 4. Reputation reward for MAIN_ACCOUNT for submitting the previous reputation hash
       key = makeReputationKey(metaColony.address, MINING_SKILL, MAIN_ACCOUNT);
       value = makeReputationValue(REWARD, 4);
-      assert.equal(client.reputations[key], value);
+      assert.equal(goodClient.reputations[key], value);
 
       // 5. Reputation reward for OTHER_ACCOUNT2 for being the worker for the tasks created by giveUserCLNYTokens
       key = makeReputationKey(metaColony.address, META_ROOT_SKILL, OTHER_ACCOUNT2);
       value = makeReputationValue(WORKER_PAYOUT.muln(3), 5);
-      assert.equal(client.reputations[key], value);
+      assert.equal(goodClient.reputations[key], value);
 
       // 6. Colony-wide total reputation for global skill task was in
       key = makeReputationKey(metaColony.address, GLOBAL_SKILL);
       value = makeReputationValue(WORKER_PAYOUT.muln(3), 6);
-      assert.equal(client.reputations[key], value);
+      assert.equal(goodClient.reputations[key], value);
 
       // 7. Worker reputation for global skill task was in
       key = makeReputationKey(metaColony.address, GLOBAL_SKILL, OTHER_ACCOUNT2);
       value = makeReputationValue(WORKER_PAYOUT.muln(3), 7);
-      assert.equal(client.reputations[key], value);
+      assert.equal(goodClient.reputations[key], value);
     });
 
     it("The reputation mining client should correctly update parent reputations", async () => {
@@ -2873,17 +2902,17 @@ contract("ColonyNetworkMining", accounts => {
       await fundColonyWithTokens(metaColony, clny);
 
       // Do the task
+      const payout = new BN("1000000000000");
       await setupFinalizedTask({
         colonyNetwork,
         colony: metaColony,
         skillId: 10,
-        managerPayout: 1000000000000,
-        evaluatorPayout: 1000000000000,
-        workerPayout: 1000000000000,
-        workerRating: 2,
         manager: MAIN_ACCOUNT,
         worker: OTHER_ACCOUNT,
         evaluator: OTHER_ACCOUNT2
+        managerPayout: payout,
+        evaluatorPayout: payout,
+        workerPayout: payout
       });
 
       await advanceMiningCycleNoContest(colonyNetwork, this);
@@ -2899,30 +2928,30 @@ contract("ColonyNetworkMining", accounts => {
       const MINING_SKILL = 3;
 
       const reputationProps = [
-        { id: 1, skillId: META_ROOT_SKILL, account: undefined, value: REWARD.add(new BN("3000000000000")) }, // eslint-disable-line prettier/prettier
+        { id: 1, skillId: META_ROOT_SKILL, account: undefined, value: REWARD.add(payout.muln(3)) }, // eslint-disable-line prettier/prettier
         { id: 2, skillId: MINING_SKILL, account: undefined, value: REWARD },
-        { id: 3, skillId: META_ROOT_SKILL, account: MAIN_ACCOUNT, value: REWARD.add(new BN("1000000000000")) }, // eslint-disable-line prettier/prettier
+        { id: 3, skillId: META_ROOT_SKILL, account: MAIN_ACCOUNT, value: REWARD.add(payout) }, // eslint-disable-line prettier/prettier
         { id: 4, skillId: MINING_SKILL, account: MAIN_ACCOUNT, value: REWARD },
-        { id: 5, skillId: META_ROOT_SKILL, account: OTHER_ACCOUNT2, value: 1000000000000 },
-        { id: 6, skillId: META_ROOT_SKILL, account: OTHER_ACCOUNT, value: 1000000000000 },
+        { id: 5, skillId: META_ROOT_SKILL, account: OTHER_ACCOUNT2, value: payout },
+        { id: 6, skillId: META_ROOT_SKILL, account: OTHER_ACCOUNT, value: payout },
 
-        { id: 7, skillId: 9, account: undefined, value: 1000000000000 },
-        { id: 8, skillId: 8, account: undefined, value: 1000000000000 },
-        { id: 9, skillId: 7, account: undefined, value: 1000000000000 },
-        { id: 10, skillId: 6, account: undefined, value: 1000000000000 },
-        { id: 11, skillId: 5, account: undefined, value: 1000000000000 },
-        { id: 12, skillId: 4, account: undefined, value: 1000000000000 },
-        { id: 13, skillId: 1, account: undefined, value: 1000000000000 },
-        { id: 14, skillId: 10, account: undefined, value: 1000000000000 },
+        { id: 7, skillId: 9, account: undefined, value: payout },
+        { id: 8, skillId: 8, account: undefined, value: payout },
+        { id: 9, skillId: 7, account: undefined, value: payout },
+        { id: 10, skillId: 6, account: undefined, value: payout },
+        { id: 11, skillId: 5, account: undefined, value: payout },
+        { id: 12, skillId: 4, account: undefined, value: payout },
+        { id: 13, skillId: 1, account: undefined, value: payout },
+        { id: 14, skillId: 10, account: undefined, value: payout },
 
-        { id: 15, skillId: 9, account: OTHER_ACCOUNT, value: 1000000000000 },
-        { id: 16, skillId: 8, account: OTHER_ACCOUNT, value: 1000000000000 },
-        { id: 17, skillId: 7, account: OTHER_ACCOUNT, value: 1000000000000 },
-        { id: 18, skillId: 6, account: OTHER_ACCOUNT, value: 1000000000000 },
-        { id: 19, skillId: 5, account: OTHER_ACCOUNT, value: 1000000000000 },
-        { id: 20, skillId: 4, account: OTHER_ACCOUNT, value: 1000000000000 },
-        { id: 21, skillId: 1, account: OTHER_ACCOUNT, value: 1000000000000 },
-        { id: 22, skillId: 10, account: OTHER_ACCOUNT, value: 1000000000000 }
+        { id: 15, skillId: 9, account: OTHER_ACCOUNT, value: payout },
+        { id: 16, skillId: 8, account: OTHER_ACCOUNT, value: payout },
+        { id: 17, skillId: 7, account: OTHER_ACCOUNT, value: payout },
+        { id: 18, skillId: 6, account: OTHER_ACCOUNT, value: payout },
+        { id: 19, skillId: 5, account: OTHER_ACCOUNT, value: payout },
+        { id: 20, skillId: 4, account: OTHER_ACCOUNT, value: payout },
+        { id: 21, skillId: 1, account: OTHER_ACCOUNT, value: payout },
+        { id: 22, skillId: 10, account: OTHER_ACCOUNT, value: payout }
       ];
 
       assert.equal(Object.keys(goodClient.reputations).length, reputationProps.length);
@@ -2984,10 +3013,8 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokens(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await advanceMiningCycleNoContest(colonyNetwork, this);
 
-      const client = new ReputationMiner({ loader: contractLoader, minerAddress: MAIN_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree });
-      await client.initialise(colonyNetwork.address);
-      await client.addLogContentsToReputationTree();
-      const newRootHash = await client.getRootHash();
+      await goodClient.addLogContentsToReputationTree();
+      const newRootHash = await goodClient.getRootHash();
 
       await forwardTime(MINING_CYCLE_DURATION, this);
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -2999,17 +3026,16 @@ contract("ColonyNetworkMining", accounts => {
       key += `${new BN("2").toString(16, 64)}`; // SkillId as uint256
       key += `${new BN(MAIN_ACCOUNT.slice(2), 16).toString(16, 40)}`; // User address as bytes
 
-      const value = client.reputations[key];
-      const proof = await client.getProof(key);
-      const [branchMask, siblings] = proof;
-
-      const validProof = await metaColony.verifyReputationProof(`${key}`, `${value}`, branchMask, siblings, { from: MAIN_ACCOUNT });
-      assert.equal(validProof, true);
+      const value = goodClient.reputations[key];
+      const [branchMask, siblings] = await goodClient.getProof(key);
+      const isValid = await metaColony.verifyReputationProof(`${key}`, `${value}`, branchMask, siblings);
+      assert.isTrue(isValid);
     });
 
     it("Should correctly decay a reputation to zero, and then 'decay' to zero in subsequent cycles", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+
       badClient = new MaliciousReputationMinerExtraRep(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         1,
@@ -3018,7 +3044,7 @@ contract("ColonyNetworkMining", accounts => {
       await badClient.initialise(colonyNetwork.address);
 
       const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId();
-      const globalKey = await ReputationMiner.getKey(metaColony.address, rootGlobalSkill, "0x0000000000000000000000000000000000000000");
+      const globalKey = await ReputationMiner.getKey(metaColony.address, rootGlobalSkill, ZERO_ADDRESS);
       const userKey = await ReputationMiner.getKey(metaColony.address, rootGlobalSkill, MAIN_ACCOUNT);
 
       await goodClient.insert(globalKey, new BN("1"), 0);
@@ -3042,7 +3068,6 @@ contract("ColonyNetworkMining", accounts => {
       );
 
       repCycle = await getActiveRepCycle(colonyNetwork);
-
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       await goodClient.confirmJustificationRootHash();
@@ -3059,6 +3084,7 @@ contract("ColonyNetworkMining", accounts => {
         goodClient.reputations[decayKey]
       );
 
+      // If we use the existing badClient we get `Error: invalid BigNumber value`, not sure why.
       badClient = new MaliciousReputationMinerExtraRep(
         { loader: contractLoader, minerAddress: OTHER_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree },
         1,
@@ -3075,7 +3101,6 @@ contract("ColonyNetworkMining", accounts => {
       }
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-
       await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
 
       repCycle = await getActiveRepCycle(colonyNetwork);
@@ -3091,14 +3116,6 @@ contract("ColonyNetworkMining", accounts => {
     it.skip("should abort if a deposit did not complete correctly");
   });
 
-  async function advanceTimeSubmitAndConfirmHash(test) {
-    await forwardTime(MINING_CYCLE_DURATION, test);
-    await goodClient.addLogContentsToReputationTree();
-    await goodClient.submitRootHash();
-    const repCycle = await getActiveRepCycle(colonyNetwork);
-    await repCycle.confirmNewHash(0);
-  }
-
   describe("Miner syncing functionality", () => {
     let startingBlockNumber;
     let goodClient2;
@@ -3109,6 +3126,39 @@ contract("ColonyNetworkMining", accounts => {
 
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+
+      // Make multiple reputation cycles, with different numbers tasks and blocks in them.
+      fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING.muln(5));
+      for (let i = 0; i < 5; i += 1) {
+        await setupFinalizedTask({ colonyNetwork, colony: metaColony }); // eslint-disable-line no-await-in-loop
+      }
+
+      await goodClient.addLogContentsToReputationTree();
+      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+
+      // Advance four blocks
+      await forwardTime(1, this);
+      await forwardTime(1, this);
+      await forwardTime(1, this);
+      await forwardTime(1, this);
+
+      await goodClient.addLogContentsToReputationTree();
+      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+
+      fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING.muln(5));
+      for (let i = 0; i < 5; i += 1) {
+        await setupFinalizedTask({ colonyNetwork, colony: metaColony }); // eslint-disable-line no-await-in-loop
+      }
+
+      await goodClient.addLogContentsToReputationTree();
+      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+
+      await goodClient.addLogContentsToReputationTree();
+      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+
+      await goodClient.addLogContentsToReputationTree();
+      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+
       goodClient2 = new ReputationMiner({
         loader: contractLoader,
         minerAddress: OTHER_ACCOUNT,
@@ -3116,46 +3166,6 @@ contract("ColonyNetworkMining", accounts => {
         useJsTree
       });
       await goodClient2.initialise(colonyNetwork.address);
-      // Make multiple reputation cycles, with different numbers tasks and blocks in them.
-      for (let i = 0; i < 5; i += 1) {
-        await setupFinalizedTask( // eslint-disable-line
-          {
-            colonyNetwork,
-            colony: metaColony,
-            managerPayout: 1000000000000,
-            evaluatorPayout: 1000000000000,
-            workerPayout: 1000000000000,
-            managerRating: 3,
-            workerRating: 3
-          }
-        );
-      }
-
-      await advanceTimeSubmitAndConfirmHash(this);
-
-      await forwardTime(1, this);
-      await forwardTime(1, this);
-      await forwardTime(1, this);
-      await forwardTime(1, this);
-      await advanceTimeSubmitAndConfirmHash(this);
-
-      for (let i = 0; i < 5; i += 1) {
-        await setupFinalizedTask( // eslint-disable-line
-          {
-            colonyNetwork,
-            colony: metaColony,
-            managerPayout: 1000000000000,
-            evaluatorPayout: 1000000000000,
-            workerPayout: 1000000000000,
-            managerRating: 3,
-            workerRating: 3
-          }
-        );
-      }
-
-      await advanceTimeSubmitAndConfirmHash(this);
-      await advanceTimeSubmitAndConfirmHash(this);
-      await advanceTimeSubmitAndConfirmHash(this);
     });
 
     // Because these tests rely on a custom, teeny-tiny-hacked version of ganache-cli, they don't work with solidity-coverage.
@@ -3179,31 +3189,25 @@ contract("ColonyNetworkMining", accounts => {
           await goodClient2.sync(startingBlockNumber);
 
           // Do some additional updates.
-          await advanceTimeSubmitAndConfirmHash(this);
+          await goodClient.addLogContentsToReputationTree();
+          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
 
+          fundColonyWithTokens(metaColony, clny, INITIAL_FUNDING.muln(5));
           for (let i = 0; i < 5; i += 1) {
-            await setupFinalizedTask( // eslint-disable-line
-              {
-                colonyNetwork,
-                colony: metaColony,
-                managerPayout: 1000000000000,
-                evaluatorPayout: 1000000000000,
-                workerPayout: 1000000000000,
-                managerRating: 3,
-                workerRating: 3
-              }
-            );
+            await setupFinalizedTask({ colonyNetwork, colony: metaColony }); // eslint-disable-line no-await-in-loop
           }
 
-          await advanceTimeSubmitAndConfirmHash(this);
+          await goodClient.addLogContentsToReputationTree();
+          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
 
+          // Advance four blocks
           await forwardTime(1, this);
           await forwardTime(1, this);
           await forwardTime(1, this);
           await forwardTime(1, this);
-          await forwardTime(MINING_CYCLE_DURATION, this);
 
-          await advanceTimeSubmitAndConfirmHash(this);
+          await goodClient.addLogContentsToReputationTree();
+          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
 
           // Update it again - note that we're passing in the old startingBlockNumber still. If it applied
           // all of the updates from that block number, it would fail, because it would be replaying some
@@ -3224,10 +3228,17 @@ contract("ColonyNetworkMining", accounts => {
           const savedHash = await goodClient.reputationTree.getRootHash();
 
           // Do some additional updates.
-          await advanceTimeSubmitAndConfirmHash(this);
-          await advanceTimeSubmitAndConfirmHash(this);
-          await advanceTimeSubmitAndConfirmHash(this);
-          await advanceTimeSubmitAndConfirmHash(this);
+          await goodClient.addLogContentsToReputationTree();
+          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+
+          await goodClient.addLogContentsToReputationTree();
+          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+
+          await goodClient.addLogContentsToReputationTree();
+          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+
+          await goodClient.addLogContentsToReputationTree();
+          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
 
           // Tell goodClient2 to load from the database
           await goodClient2.loadState(savedHash);
@@ -3245,8 +3256,10 @@ contract("ColonyNetworkMining", accounts => {
     it("should be able to successfully save the current state to the database and then load it", async () => {
       await goodClient.resetDB();
       await goodClient.saveCurrentState();
+
       const client1Hash = await goodClient.reputationTree.getRootHash();
       await goodClient2.loadState(client1Hash);
+
       const client2Hash = await goodClient2.reputationTree.getRootHash();
       assert.equal(client1Hash, client2Hash);
     });
@@ -3254,15 +3267,17 @@ contract("ColonyNetworkMining", accounts => {
     it("should be able to correctly get the proof for a reputation in a historical state without affecting the current miner state", async () => {
       await goodClient.resetDB();
       await goodClient.saveCurrentState();
+
       const clientHash1 = await goodClient.reputationTree.getRootHash();
       const key = Object.keys(goodClient.reputations)[0];
       const value = goodClient.reputations[key];
       const [branchMask, siblings] = await goodClient.getProof(key);
 
-      await advanceTimeSubmitAndConfirmHash(this);
+      await goodClient.addLogContentsToReputationTree();
+      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+
       // So now we have a different state
       await goodClient.saveCurrentState();
-
       const clientHash2 = await goodClient.reputationTree.getRootHash();
       assert.notEqual(clientHash1, clientHash2);
 
@@ -3272,6 +3287,7 @@ contract("ColonyNetworkMining", accounts => {
       assert.equal(value, retrievedValue);
       assert.equal(branchMask, retrievedBranchMask);
       assert.equal(siblings.length, retrievedSiblings.length);
+
       for (let i = 0; i < retrievedSiblings.length; i += 1) {
         assert.equal(siblings[i], retrievedSiblings[i]);
         assert.equal(siblings[i], retrievedSiblings[i]);
@@ -3284,9 +3300,13 @@ contract("ColonyNetworkMining", accounts => {
 
   describe("Reputation Mining Client", () => {
     let client;
+
     beforeEach(async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
-      await advanceTimeSubmitAndConfirmHash();
+
+      await goodClient.addLogContentsToReputationTree();
+      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
+
       await goodClient.saveCurrentState();
 
       client = new ReputationMinerClient({
@@ -3308,6 +3328,7 @@ contract("ColonyNetworkMining", accounts => {
       const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/${MAIN_ACCOUNT}`;
       const res = await request(url);
       assert.equal(res.statusCode, 200);
+
       const oracleProofObject = JSON.parse(res.body);
       const key = makeReputationKey(metaColony.address, new BN(2), MAIN_ACCOUNT);
 
@@ -3316,10 +3337,12 @@ contract("ColonyNetworkMining", accounts => {
 
       assert.equal(branchMask, oracleProofObject.branchMask);
       assert.equal(siblings.length, oracleProofObject.siblings.length);
+
       for (let i = 0; i < oracleProofObject.siblings.length; i += 1) {
         assert.equal(siblings[i], oracleProofObject.siblings[i]);
         assert.equal(siblings[i], oracleProofObject.siblings[i]);
       }
+
       assert.equal(key, oracleProofObject.key);
       assert.equal(value, oracleProofObject.value);
     });
@@ -3330,19 +3353,22 @@ contract("ColonyNetworkMining", accounts => {
       const [branchMask, siblings] = await goodClient.getProof(key);
       const value = goodClient.reputations[key];
 
-      await advanceTimeSubmitAndConfirmHash();
+      await goodClient.addLogContentsToReputationTree();
+      await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
 
       const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/${MAIN_ACCOUNT}`;
       const res = await request(url);
       assert.equal(res.statusCode, 200);
-      const oracleProofObject = JSON.parse(res.body);
 
+      const oracleProofObject = JSON.parse(res.body);
       assert.equal(branchMask, oracleProofObject.branchMask);
       assert.equal(siblings.length, oracleProofObject.siblings.length);
+
       for (let i = 0; i < oracleProofObject.siblings.length; i += 1) {
         assert.equal(siblings[i], oracleProofObject.siblings[i]);
         assert.equal(siblings[i], oracleProofObject.siblings[i]);
       }
+
       assert.equal(key, oracleProofObject.key);
       assert.equal(value, oracleProofObject.value);
     });
@@ -3353,8 +3379,11 @@ contract("ColonyNetworkMining", accounts => {
           const rootHash = await goodClient.getRootHash();
           const startingBlock = await currentBlock();
           const startingBlockNumber = startingBlock.number;
-          await advanceTimeSubmitAndConfirmHash();
+
+          await goodClient.addLogContentsToReputationTree();
+          await advanceMiningCycleNoContest(colonyNetwork, this, goodClient);
           await client._miner.sync(startingBlockNumber); // eslint-disable-line no-underscore-dangle
+
           const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/${accounts[4]}`;
           const res = await request(url);
           assert.equal(res.statusCode, 400);

--- a/test/colony-network-recovery.js
+++ b/test/colony-network-recovery.js
@@ -237,7 +237,7 @@ contract("Colony Network Recovery", accounts => {
           });
           await newClient.initialise(colonyNetwork.address);
 
-          const colony = await setupRandomColony(colonyNetwork);
+          const { colony } = await setupRandomColony(colonyNetwork);
           await colony.mintTokens(1000000000000000);
           await colony.bootstrapColony([accounts[5]], [1000000000000000]);
 
@@ -308,7 +308,7 @@ contract("Colony Network Recovery", accounts => {
           });
           await ignorantclient.initialise(colonyNetwork.address);
 
-          const colony = await setupRandomColony(colonyNetwork);
+          const { colony } = await setupRandomColony(colonyNetwork);
           await colony.mintTokens(1000000000000000);
           await colony.bootstrapColony([accounts[0]], [1000000000000000]);
 

--- a/test/colony-network-recovery.js
+++ b/test/colony-network-recovery.js
@@ -241,13 +241,13 @@ contract("Colony Network Recovery", accounts => {
           await colony.mintTokens(1000000000000000);
           await colony.bootstrapColony([accounts[5]], [1000000000000000]);
 
-          await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+          await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
           const repCycle = await getActiveRepCycle(colonyNetwork);
           const invalidEntry = await repCycle.getReputationUpdateLogEntry(5);
           invalidEntry.amount = 0;
 
-          await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+          await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
           const domain = await colony.getDomain(1);
           const rootSkill = domain.skillId;

--- a/test/colony-network-recovery.js
+++ b/test/colony-network-recovery.js
@@ -6,7 +6,6 @@ import path from "path";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 import {
   forwardTime,
-  getTokenArgs,
   makeReputationKey,
   currentBlock,
   currentBlockTime,
@@ -16,7 +15,7 @@ import {
   getActiveRepCycle,
   advanceMiningCycleNoContest
 } from "../helpers/test-helper";
-import { setupFinalizedTask, giveUserCLNYTokensAndStake, fundColonyWithTokens } from "../helpers/test-data-generator";
+import { setupFinalizedTask, giveUserCLNYTokensAndStake, fundColonyWithTokens, setupRandomColony } from "../helpers/test-data-generator";
 import ReputationMiner from "../packages/reputation-miner/ReputationMiner";
 import { setupEtherRouter } from "../helpers/upgradable-contracts";
 import { DEFAULT_STAKE, MINING_CYCLE_DURATION } from "../helpers/constants";
@@ -238,14 +237,7 @@ contract("Colony Network Recovery", accounts => {
           });
           await newClient.initialise(colonyNetwork.address);
 
-          const tokenArgs = getTokenArgs();
-          const token = await ERC20ExtendedToken.new(...tokenArgs);
-          const { logs } = await colonyNetwork.createColony(token.address);
-          const { colonyAddress } = logs[0].args;
-
-          await token.setOwner(colonyAddress);
-          const colony = await IColony.at(colonyAddress);
-
+          const colony = await setupRandomColony(colonyNetwork);
           await colony.mintTokens(1000000000000000);
           await colony.bootstrapColony([accounts[5]], [1000000000000000]);
 
@@ -316,14 +308,7 @@ contract("Colony Network Recovery", accounts => {
           });
           await ignorantclient.initialise(colonyNetwork.address);
 
-          const tokenArgs = getTokenArgs();
-          const token = await ERC20ExtendedToken.new(...tokenArgs);
-          const { logs } = await colonyNetwork.createColony(token.address);
-          const { colonyAddress } = logs[0].args;
-
-          await token.setOwner(colonyAddress);
-          const colony = await IColony.at(colonyAddress);
-
+          const colony = await setupRandomColony(colonyNetwork);
           await colony.mintTokens(1000000000000000);
           await colony.bootstrapColony([accounts[0]], [1000000000000000]);
 

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -192,8 +192,8 @@ contract("Colony Network", accounts => {
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       const newVersion = currentColonyVersion.addn(1);
       await metaColony.addNetworkColonyVersion(newVersion, SAMPLE_RESOLVER);
-
-      await checkErrorRevert(colony.setResolver(SAMPLE_RESOLVER), "ds-auth-unauthorized");
+      const etherRouter = await EtherRouter.at(colony.address);
+      await checkErrorRevert(etherRouter.setResolver(SAMPLE_RESOLVER), "ds-auth-unauthorized");
     });
 
     it("should NOT be able to upgrade a colony to a lower version", async () => {

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -74,7 +74,7 @@ contract("Colony Network", accounts => {
 
   describe("when creating new colonies", () => {
     it("should allow users to create new colonies", async () => {
-      const colony = await setupRandomColony(colonyNetwork);
+      const { colony } = await setupRandomColony(colonyNetwork);
       const colonyCount = await colonyNetwork.getColonyCount();
       assert.notEqual(colony.address, ZERO_ADDRESS);
       expect(colonyCount).to.eq.BN(2);
@@ -119,7 +119,7 @@ contract("Colony Network", accounts => {
     });
 
     it("when any colony is created, should have the root local skill initialised", async () => {
-      const colony = await setupRandomColony(colonyNetwork);
+      const { colony } = await setupRandomColony(colonyNetwork);
 
       const rootLocalSkill = await colonyNetwork.getSkill(1);
       expect(parseInt(rootLocalSkill.nParents, 10)).to.be.zero;
@@ -167,7 +167,7 @@ contract("Colony Network", accounts => {
     });
 
     it("should be able to get the Colony version", async () => {
-      const colony = await setupRandomColony(colonyNetwork);
+      const { colony } = await setupRandomColony(colonyNetwork);
       const actualColonyVersion = await colony.version();
       expect(version).to.eq.BN(actualColonyVersion);
     });
@@ -175,7 +175,7 @@ contract("Colony Network", accounts => {
 
   describe("when upgrading a colony", () => {
     it("should be able to upgrade a colony, if a sender has founder role", async () => {
-      const colony = await setupRandomColony(colonyNetwork);
+      const { colony } = await setupRandomColony(colonyNetwork);
       const colonyEtherRouter = await EtherRouter.at(colony.address);
 
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
@@ -188,7 +188,7 @@ contract("Colony Network", accounts => {
     });
 
     it("should not be able to set colony resolver by directly calling `setResolver`", async () => {
-      const colony = await setupRandomColony(colonyNetwork);
+      const { colony } = await setupRandomColony(colonyNetwork);
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       const newVersion = currentColonyVersion.addn(1);
       await metaColony.addNetworkColonyVersion(newVersion, SAMPLE_RESOLVER);
@@ -197,7 +197,7 @@ contract("Colony Network", accounts => {
     });
 
     it("should NOT be able to upgrade a colony to a lower version", async () => {
-      const colony = await setupRandomColony(colonyNetwork);
+      const { colony } = await setupRandomColony(colonyNetwork);
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       const newVersion = currentColonyVersion.subn(1);
       await metaColony.addNetworkColonyVersion(newVersion, SAMPLE_RESOLVER);
@@ -207,7 +207,7 @@ contract("Colony Network", accounts => {
     });
 
     it("should NOT be able to upgrade a colony to a nonexistent version", async () => {
-      const colony = await setupRandomColony(colonyNetwork);
+      const { colony } = await setupRandomColony(colonyNetwork);
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       const newVersion = currentColonyVersion.addn(1);
 
@@ -216,7 +216,7 @@ contract("Colony Network", accounts => {
     });
 
     it("should NOT be able to upgrade a colony if sender don't have founder role", async () => {
-      const colony = await setupRandomColony(colonyNetwork);
+      const { colony } = await setupRandomColony(colonyNetwork);
       const colonyEtherRouter = await EtherRouter.at(colony.address);
       const colonyResolver = await colonyEtherRouter.resolver();
 
@@ -303,7 +303,7 @@ contract("Colony Network", accounts => {
       const colonyName2 = "test2";
       const hash = namehash.hash("test.colony.joincolony.eth");
 
-      const colony = await setupRandomColony(colonyNetwork);
+      const { colony } = await setupRandomColony(colonyNetwork);
 
       // Non-founder can't register label for colony
       await checkErrorRevert(colony.registerColonyLabel(colonyName, orbitDBAddress, { from: accounts[1] }), "ds-auth-unauthorized");
@@ -340,7 +340,7 @@ contract("Colony Network", accounts => {
       await colonyNetwork.registerUserLabel("test", orbitDBAddress, { from: accounts[1] });
 
       // Set up colony
-      const colony = await setupRandomColony(colonyNetwork);
+      const { colony } = await setupRandomColony(colonyNetwork);
 
       // Register colony
       // Founder can register label for colony

--- a/test/colony-recovery.js
+++ b/test/colony-recovery.js
@@ -16,7 +16,7 @@ contract("Colony Recovery", accounts => {
   });
 
   beforeEach(async () => {
-    colony = await setupRandomColony(colonyNetwork);
+    ({ colony } = await setupRandomColony(colonyNetwork));
   });
 
   describe("when using recovery mode", () => {

--- a/test/colony-recovery.js
+++ b/test/colony-recovery.js
@@ -1,11 +1,6 @@
-/* globals artifacts */
-
 import { SPECIFICATION_HASH, ZERO_ADDRESS } from "../helpers/constants";
-import { web3GetStorageAt, checkErrorRevert, getTokenArgs } from "../helpers/test-helper";
-import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken } from "../helpers/test-data-generator";
-
-const IColony = artifacts.require("IColony");
-const ERC20ExtendedToken = artifacts.require("ERC20ExtendedToken");
+import { web3GetStorageAt, checkErrorRevert } from "../helpers/test-helper";
+import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony } from "../helpers/test-data-generator";
 
 contract("Colony Recovery", accounts => {
   let colony;
@@ -21,11 +16,7 @@ contract("Colony Recovery", accounts => {
   });
 
   beforeEach(async () => {
-    const tokenArgs = getTokenArgs();
-    const token = await ERC20ExtendedToken.new(...tokenArgs);
-    const { logs } = await colonyNetwork.createColony(token.address);
-    const { colonyAddress } = logs[0].args;
-    colony = await IColony.at(colonyAddress);
+    colony = await setupRandomColony(colonyNetwork);
   });
 
   describe("when using recovery mode", () => {

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -1685,9 +1685,7 @@ contract("ColonyTask", accounts => {
         token,
         managerPayout: 99,
         workerPayout: 1,
-        evaluatorPayout: 2,
-        managerRating: 2,
-        workerRating: 2
+        evaluatorPayout: 2
       });
 
       const networkBalance1 = await token.balanceOf(colonyNetwork.address);

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -1,9 +1,10 @@
 /* global artifacts */
-import { toBN } from "web3-utils";
+import { BN } from "bn.js";
 import chai from "chai";
 import bnChai from "bn-chai";
 
 import {
+  WAD,
   MANAGER_ROLE,
   EVALUATOR_ROLE,
   WORKER_ROLE,
@@ -1543,13 +1544,13 @@ contract("ColonyTask", accounts => {
       await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
 
       const networkBalanceAfter = await token.balanceOf(colonyNetwork.address);
-      expect(networkBalanceAfter.sub(networkBalanceBefore)).to.eq.BN(toBN(1 * 1e18).addn(1));
+      expect(networkBalanceAfter.sub(networkBalanceBefore)).to.eq.BN(WAD.addn(1));
 
       const managerBalanceAfter = await token.balanceOf(MANAGER);
-      expect(managerBalanceAfter.sub(managerBalanceBefore)).to.eq.BN(toBN(99 * 1e18).subn(1));
+      expect(managerBalanceAfter.sub(managerBalanceBefore)).to.eq.BN(WAD.muln(99).subn(1));
 
       const potBalanceAfter = await colony.getPotBalance(taskPotId, token.address);
-      expect(potBalanceBefore.sub(potBalanceAfter)).to.eq.BN(toBN(100 * 1e18));
+      expect(potBalanceBefore.sub(potBalanceAfter)).to.eq.BN(WAD.muln(100));
     });
 
     it("should payout agreed ether for a task", async () => {
@@ -1578,13 +1579,13 @@ contract("ColonyTask", accounts => {
       await colony.claimPayout(taskId, WORKER_ROLE, ZERO_ADDRESS, { from: WORKER, gasPrice: 0 });
 
       const workerBalanceAfter = await web3GetBalance(WORKER);
-      expect(toBN(workerBalanceAfter).sub(toBN(workerBalanceBefore))).to.eq.BN(toBN(197));
+      expect(new BN(workerBalanceAfter).sub(new BN(workerBalanceBefore))).to.eq.BN(new BN(197));
 
       const metaBalanceAfter = await web3GetBalance(metaColony.address);
-      expect(toBN(metaBalanceAfter).sub(toBN(metaBalanceBefore))).to.eq.BN(3);
+      expect(new BN(metaBalanceAfter).sub(new BN(metaBalanceBefore))).to.eq.BN(3);
 
       const potBalanceAfter = await colony.getPotBalance(taskPotId, ZERO_ADDRESS);
-      expect(potBalanceBefore.sub(potBalanceAfter)).to.eq.BN(toBN(200));
+      expect(potBalanceBefore.sub(potBalanceAfter)).to.eq.BN(new BN(200));
     });
 
     it("should disburse nothing for unsatisfactory work, for manager and worker", async () => {

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -74,12 +74,9 @@ contract("ColonyTask", accounts => {
     const metaColonyAddress = await colonyNetwork.getMetaColony();
     metaColony = await IMetaColony.at(metaColonyAddress);
 
-    colony = await setupRandomColony(colonyNetwork);
+    ({ colony, token } = await setupRandomColony(colonyNetwork));
     await colony.setRewardInverse(100);
     await colony.setAdminRole(COLONY_ADMIN);
-
-    const tokenAddress = await colony.getToken();
-    token = await Token.at(tokenAddress);
 
     const otherTokenArgs = getTokenArgs();
     otherToken = await Token.new(...otherTokenArgs);

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -40,7 +40,8 @@ import {
   setupFundedTask,
   executeSignedTaskChange,
   executeSignedRoleAssignment,
-  makeTask
+  makeTask,
+  setupRandomColony
 } from "../helpers/test-data-generator";
 
 const ethers = require("ethers");
@@ -50,7 +51,6 @@ chai.use(bnChai(web3.utils.BN));
 
 const EtherRouter = artifacts.require("EtherRouter");
 const IMetaColony = artifacts.require("IMetaColony");
-const IColony = artifacts.require("IColony");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const Token = artifacts.require("Token");
 
@@ -73,17 +73,15 @@ contract("ColonyTask", accounts => {
     const metaColonyAddress = await colonyNetwork.getMetaColony();
     metaColony = await IMetaColony.at(metaColonyAddress);
 
-    const tokenArgs = getTokenArgs();
-    token = await Token.new(...tokenArgs);
-    const { logs } = await colonyNetwork.createColony(token.address);
-    const { colonyAddress } = logs[0].args;
-    await token.setOwner(colonyAddress);
-    colony = await IColony.at(colonyAddress);
+    colony = await setupRandomColony(colonyNetwork);
     await colony.setRewardInverse(100);
+    await colony.setAdminRole(COLONY_ADMIN);
+
+    const tokenAddress = await colony.getToken();
+    token = await Token.at(tokenAddress);
+
     const otherTokenArgs = getTokenArgs();
     otherToken = await Token.new(...otherTokenArgs);
-
-    await colony.setAdminRole(COLONY_ADMIN);
   });
 
   describe("when creating tasks", () => {

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -152,11 +152,9 @@ contract("ColonyTask", accounts => {
     it("should return the correct number of tasks", async () => {
       const taskCountBefore = await colony.getTaskCount();
 
-      await makeTask({ colony });
-      await makeTask({ colony });
-      await makeTask({ colony });
-      await makeTask({ colony });
-      await makeTask({ colony });
+      for (let i = 0; i < 5; i += 1) {
+        await makeTask({ colony }); // eslint-disable-line no-await-in-loop
+      }
 
       const taskCountAfter = await colony.getTaskCount();
       expect(taskCountAfter).to.be.eq.BN(taskCountBefore.addn(5));
@@ -1194,12 +1192,7 @@ contract("ColonyTask", accounts => {
       dueDate += SECONDS_PER_DAY * 4;
       const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
 
-      await expectEvent(
-        colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH, {
-          from: WORKER
-        }),
-        "TaskDeliverableSubmitted"
-      );
+      await expectEvent(colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH, { from: WORKER }), "TaskDeliverableSubmitted");
     });
   });
 

--- a/test/colony.js
+++ b/test/colony.js
@@ -40,10 +40,7 @@ contract("Colony", accounts => {
   });
 
   beforeEach(async () => {
-    colony = await setupRandomColony(colonyNetwork);
-
-    const tokenAddress = await colony.getToken();
-    token = await ERC20ExtendedToken.at(tokenAddress);
+    ({ colony, token } = await setupRandomColony(colonyNetwork));
 
     const authorityAddress = await colony.authority();
     authority = await ColonyAuthority.at(authorityAddress);

--- a/test/colony.js
+++ b/test/colony.js
@@ -15,12 +15,11 @@ import {
   WAD
 } from "../helpers/constants";
 import { getTokenArgs, web3GetBalance, checkErrorRevert, expectAllEvents, getFunctionSignature } from "../helpers/test-helper";
-import { makeTask, setupColonyNetwork, setupMetaColonyWithLockedCLNYToken } from "../helpers/test-data-generator";
+import { makeTask, setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony } from "../helpers/test-data-generator";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
 
-const IColony = artifacts.require("IColony");
 const ERC20ExtendedToken = artifacts.require("ERC20ExtendedToken");
 const ColonyAuthority = artifacts.require("ColonyAuthority");
 const IReputationMiningCycle = artifacts.require("IReputationMiningCycle");
@@ -41,12 +40,11 @@ contract("Colony", accounts => {
   });
 
   beforeEach(async () => {
-    const tokenArgs = getTokenArgs();
-    token = await ERC20ExtendedToken.new(...tokenArgs);
-    const { logs } = await colonyNetwork.createColony(token.address);
-    const { colonyAddress } = logs[0].args;
-    await token.setOwner(colonyAddress);
-    colony = await IColony.at(colonyAddress);
+    colony = await setupRandomColony(colonyNetwork);
+
+    const tokenAddress = await colony.getToken();
+    token = await ERC20ExtendedToken.at(tokenAddress);
+
     const authorityAddress = await colony.authority();
     authority = await ColonyAuthority.at(authorityAddress);
   });

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -1,6 +1,6 @@
 /* globals artifacts */
 import { INITIAL_FUNDING, DELIVERABLE_HASH } from "../helpers/constants";
-import { checkErrorRevert, getTokenArgs } from "../helpers/test-helper";
+import { checkErrorRevert } from "../helpers/test-helper";
 import {
   fundColonyWithTokens,
   setupFundedTask,
@@ -8,14 +8,13 @@ import {
   executeSignedTaskChange,
   makeTask,
   setupColonyNetwork,
-  setupMetaColonyWithLockedCLNYToken
+  setupMetaColonyWithLockedCLNYToken,
+  setupRandomColony
 } from "../helpers/test-data-generator";
 
-const IColony = artifacts.require("IColony");
 const ERC20ExtendedToken = artifacts.require("ERC20ExtendedToken");
 
 contract("Meta Colony", accounts => {
-  let TOKEN_ARGS;
   const MANAGER = accounts[0];
   const OTHER_ACCOUNT = accounts[1];
   const WORKER = accounts[2];
@@ -289,11 +288,8 @@ contract("Meta Colony", accounts => {
 
   describe("when adding domains in a regular colony", () => {
     beforeEach(async () => {
-      TOKEN_ARGS = getTokenArgs();
-      const newToken = await ERC20ExtendedToken.new(...TOKEN_ARGS);
-      const { logs } = await colonyNetwork.createColony(newToken.address);
-      const { colonyAddress } = logs[0].args;
-      colony = await IColony.at(colonyAddress);
+      colony = await setupRandomColony(colonyNetwork);
+
       const tokenAddress = await colony.getToken();
       token = await ERC20ExtendedToken.at(tokenAddress);
     });
@@ -355,12 +351,10 @@ contract("Meta Colony", accounts => {
 
   describe("when setting domain and skill on task", () => {
     beforeEach(async () => {
-      TOKEN_ARGS = getTokenArgs();
-      token = await ERC20ExtendedToken.new(...TOKEN_ARGS);
-      const { logs } = await colonyNetwork.createColony(token.address);
-      const { colonyAddress } = logs[0].args;
-      await token.setOwner(colonyAddress);
-      colony = await IColony.at(colonyAddress);
+      colony = await setupRandomColony(colonyNetwork);
+
+      const tokenAddress = await colony.getToken();
+      token = await ERC20ExtendedToken.at(tokenAddress);
     });
 
     it("should be able to set domain on task", async () => {

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -1,4 +1,3 @@
-/* globals artifacts */
 import { INITIAL_FUNDING, DELIVERABLE_HASH } from "../helpers/constants";
 import { checkErrorRevert } from "../helpers/test-helper";
 import {
@@ -11,8 +10,6 @@ import {
   setupMetaColonyWithLockedCLNYToken,
   setupRandomColony
 } from "../helpers/test-data-generator";
-
-const ERC20ExtendedToken = artifacts.require("ERC20ExtendedToken");
 
 contract("Meta Colony", accounts => {
   const MANAGER = accounts[0];
@@ -288,10 +285,7 @@ contract("Meta Colony", accounts => {
 
   describe("when adding domains in a regular colony", () => {
     beforeEach(async () => {
-      colony = await setupRandomColony(colonyNetwork);
-
-      const tokenAddress = await colony.getToken();
-      token = await ERC20ExtendedToken.at(tokenAddress);
+      ({ colony, token } = await setupRandomColony(colonyNetwork));
     });
 
     it("someone who does not have founder role should not be able to add domains", async () => {
@@ -351,10 +345,7 @@ contract("Meta Colony", accounts => {
 
   describe("when setting domain and skill on task", () => {
     beforeEach(async () => {
-      colony = await setupRandomColony(colonyNetwork);
-
-      const tokenAddress = await colony.getToken();
-      token = await ERC20ExtendedToken.at(tokenAddress);
+      ({ colony, token } = await setupRandomColony(colonyNetwork));
     });
 
     it("should be able to set domain on task", async () => {

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -1,11 +1,8 @@
 /* globals artifacts */
-import { toBN } from "web3-utils";
 import { BN } from "bn.js";
 import chai from "chai";
 import bnChai from "bn-chai";
 
-import { INT256_MAX, WAD, MANAGER_PAYOUT, WORKER_PAYOUT } from "../helpers/constants";
-import { checkErrorRevert } from "../helpers/test-helper";
 import {
   fundColonyWithTokens,
   setupRatedTask,
@@ -13,6 +10,9 @@ import {
   setupColonyNetwork,
   setupMetaColonyWithLockedCLNYToken
 } from "../helpers/test-data-generator";
+
+import { INT256_MAX, WAD, MANAGER_PAYOUT, EVALUATOR_PAYOUT, WORKER_PAYOUT } from "../helpers/constants";
+import { checkErrorRevert } from "../helpers/test-helper";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
@@ -49,7 +49,7 @@ contract("Reputation Updates", accounts => {
 
       const repLogEntryManager = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(0);
       assert.strictEqual(repLogEntryManager.user, MANAGER);
-      expect(new BN(repLogEntryManager.amount)).to.eq.BN(toBN(100 * 1e18));
+      expect(new BN(repLogEntryManager.amount)).to.eq.BN(MANAGER_PAYOUT);
       assert.strictEqual(repLogEntryManager.skillId, "2");
       assert.strictEqual(repLogEntryManager.colony, metaColony.address);
       assert.strictEqual(repLogEntryManager.nUpdates, "2");
@@ -57,7 +57,7 @@ contract("Reputation Updates", accounts => {
 
       const repLogEntryEvaluator = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(1);
       assert.strictEqual(repLogEntryEvaluator.user, EVALUATOR);
-      expect(new BN(repLogEntryEvaluator.amount)).to.eq.BN(toBN(50 * 1e18));
+      expect(new BN(repLogEntryEvaluator.amount)).to.eq.BN(EVALUATOR_PAYOUT);
       assert.strictEqual(repLogEntryEvaluator.skillId, "2");
       assert.strictEqual(repLogEntryEvaluator.colony, metaColony.address);
       assert.strictEqual(repLogEntryEvaluator.nUpdates, "2");
@@ -65,7 +65,7 @@ contract("Reputation Updates", accounts => {
 
       const repLogEntryWorker = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(2);
       assert.strictEqual(repLogEntryWorker.user, WORKER);
-      expect(new BN(repLogEntryWorker.amount)).to.eq.BN(toBN(300 * 1e18));
+      expect(new BN(repLogEntryWorker.amount)).to.eq.BN(WORKER_PAYOUT);
       assert.strictEqual(repLogEntryWorker.skillId, "2");
       assert.strictEqual(repLogEntryWorker.colony, metaColony.address);
       assert.strictEqual(repLogEntryWorker.nUpdates, "2");
@@ -163,15 +163,15 @@ contract("Reputation Updates", accounts => {
       await metaColony.addGlobalSkill(4);
       await metaColony.addGlobalSkill(5);
       await metaColony.addGlobalSkill(6);
+
       await setupFinalizedTask({ colonyNetwork, colony: metaColony, skillId: 5 });
       let repLogEntryWorker = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(3);
-      const result = toBN(WORKER_PAYOUT).muln(3).divn(2); // eslint-disable-line prettier/prettier
-      assert.strictEqual(repLogEntryWorker.amount, result.toString());
+      assert.strictEqual(repLogEntryWorker.amount, WORKER_PAYOUT.toString());
       assert.strictEqual(repLogEntryWorker.nUpdates, "6");
 
       await setupFinalizedTask({ colonyNetwork, colony: metaColony, skillId: 6 });
       repLogEntryWorker = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(7);
-      assert.strictEqual(repLogEntryWorker.amount, result.toString());
+      assert.strictEqual(repLogEntryWorker.amount, WORKER_PAYOUT.toString());
       assert.strictEqual(repLogEntryWorker.nUpdates, "8"); // Negative reputation change means children change as well.
     });
 
@@ -189,9 +189,7 @@ contract("Reputation Updates", accounts => {
         token: clnyToken,
         managerPayout,
         evaluatorPayout,
-        workerPayout,
-        workerRating: 2,
-        managerRating: 2
+        workerPayout
       });
 
       // Check the task pot is correctly funded with the max amount

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -50,23 +50,23 @@ contract("Token Locking", addresses => {
     await colony.mintTokens(usersTokens + otherUserTokens);
     await colony.bootstrapColony([userAddress], [usersTokens]);
 
-    await advanceMiningCycleNoContest(colonyNetwork, this);
-    await giveUserCLNYTokensAndStake(colonyNetwork, addresses[4], DEFAULT_STAKE);
+    await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
-    const miningClient = new ReputationMiner({
+    await giveUserCLNYTokensAndStake(colonyNetwork, addresses[4], DEFAULT_STAKE);
+    const client = new ReputationMiner({
       loader: contractLoader,
       minerAddress: addresses[4],
       realProviderPort: REAL_PROVIDER_PORT,
       useJsTree: true
     });
-    await miningClient.initialise(colonyNetwork.address);
-    await miningClient.addLogContentsToReputationTree();
-    await advanceMiningCycleNoContest(colonyNetwork, this, miningClient);
+    await client.initialise(colonyNetwork.address);
+
+    await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
 
     const result = await colony.getDomain(1);
     const rootDomainSkill = result.skillId;
     const colonyWideReputationKey = makeReputationKey(colony.address, rootDomainSkill);
-    const { key, value, branchMask, siblings } = await miningClient.getReputationProofObject(colonyWideReputationKey);
+    const { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
     colonyWideReputationProof = [key, value, branchMask, siblings];
   });
 

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -58,7 +58,7 @@ contract("Token Locking", addresses => {
     });
     await client.initialise(colonyNetwork.address);
 
-    await advanceMiningCycleNoContest({ colonyNetwork, test: this, miningClient: client });
+    await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
     const result = await colony.getDomain(1);
     const rootDomainSkill = result.skillId;

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -37,12 +37,9 @@ contract("Token Locking", addresses => {
   });
 
   beforeEach(async () => {
-    colony = await setupRandomColony(colonyNetwork);
+    ({ colony, token } = await setupRandomColony(colonyNetwork));
     await colony.mintTokens(usersTokens + otherUserTokens);
     await colony.bootstrapColony([userAddress], [usersTokens]);
-
-    const tokenAddress = await colony.getToken();
-    token = await ERC20ExtendedToken.at(tokenAddress);
 
     const tokenArgs = getTokenArgs();
     otherToken = await ERC20ExtendedToken.new(...tokenArgs);


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Partial soln to #317 

<!--- Summary of changes including design decisions -->

- Enable reputation-free CLNY distribution for miners.
- Set default rating for worker to a sensible `2`.
- Consolidate boilerplate in `colony-network-mining`.
- Create consistent usage for `advanceMiningCycleNoContest`.
- General cleaning, refactoring, and making-consistent.
- Introduce `setupRandomColony` and remove frequent setup boilerplate.