### PR TITLE
Add expected errors to accommodateChallengeAndInvalidateHash

### DIFF
--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -170,6 +170,18 @@ export async function checkErrorRevertEthers(promise, errorMessage) {
   assert.equal(reason, errorMessage);
 }
 
+export async function checkErrorIfRevertEthers(promise, errorMessage) {
+  const tx = await promise;
+  const txid = tx.hash;
+
+  const receipt = await web3GetTransactionReceipt(txid);
+  if (!receipt.status) {
+    const response = await web3GetRawCall({ from: tx.from, to: tx.to, data: tx.data, gas: tx.gasLimit.toNumber(), value: tx.value.toNumber() });
+    const reason = extractReasonString(response);
+    assert.equal(reason, errorMessage);
+  }
+}
+
 export function getRandomString(_length) {
   const length = _length || 7;
   let randString = "";

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -170,20 +170,17 @@ export async function checkErrorRevertEthers(promise, errorMessage) {
   assert.equal(reason, errorMessage);
 }
 
-export async function checkErrorIfRevertEthers(promise, errorMessage, check) {
+export async function checkSuccessEthers(promise, errorMessage) {
   const tx = await promise;
   const txid = tx.hash;
 
   const receipt = await web3GetTransactionReceipt(txid);
-  if (!receipt.status && check) {
-    const response = await web3GetRawCall({ from: tx.from, to: tx.to, data: tx.data, gas: tx.gasLimit.toNumber(), value: tx.value.toNumber() });
-    const reason = extractReasonString(response);
-    if (!errorMessage) {
-      throw new Error(`Transaction failed unexpectedly with error ${reason}`);
-    }
-    assert.equal(reason, errorMessage, "Transaction failed, but with wrong error message");
+  if (receipt.status) {
+    return;
   }
-  return receipt.status;
+  const response = await web3GetRawCall({ from: tx.from, to: tx.to, data: tx.data, gas: tx.gasLimit.toNumber(), value: tx.value.toNumber() });
+  const reason = extractReasonString(response);
+  assert.isTrue(receipt.status, `${errorMessage} with error ${reason}`);
 }
 
 export function getRandomString(_length) {

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -170,16 +170,20 @@ export async function checkErrorRevertEthers(promise, errorMessage) {
   assert.equal(reason, errorMessage);
 }
 
-export async function checkErrorIfRevertEthers(promise, errorMessage) {
+export async function checkErrorIfRevertEthers(promise, errorMessage, check) {
   const tx = await promise;
   const txid = tx.hash;
 
   const receipt = await web3GetTransactionReceipt(txid);
-  if (!receipt.status) {
+  if (!receipt.status && check) {
     const response = await web3GetRawCall({ from: tx.from, to: tx.to, data: tx.data, gas: tx.gasLimit.toNumber(), value: tx.value.toNumber() });
     const reason = extractReasonString(response);
-    assert.equal(reason, errorMessage);
+    if (!errorMessage) {
+      throw new Error(`Transaction failed unexpectedly with error ${reason}`);
+    }
+    assert.equal(reason, errorMessage, "Transaction failed, but with wrong error message");
   }
+  return receipt.status;
 }
 
 export function getRandomString(_length) {

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongNNodes.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongNNodes.js
@@ -10,11 +10,6 @@ class MaliciousReputationMinerWrongNNodes extends ReputationMiner {
     this.entryToFalsify = entryToFalsify.toString();
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  async respondToChallenge() {
-    // This client sometimes won't be able to respond to challenge - we mess up its JRH with a hash it doesn't know about
-  }
-
   async submitRootHash(startIndex = 1) {
     const hash = await this.getRootHash();
     const repCycle = await this.getActiveRepCycle();

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -92,6 +92,8 @@ contract("ColonyNetworkMining", accounts => {
     metaColony = await IMetaColony.at(metaColonyAddress);
     const clnyAddress = await metaColony.getToken();
     clny = await Token.at(clnyAddress);
+    goodClient = new ReputationMiner({ loader: contractLoader, minerAddress: MAIN_ACCOUNT, realProviderPort: REAL_PROVIDER_PORT, useJsTree });
+    await goodClient.resetDB();
   });
 
   beforeEach(async () => {
@@ -2365,7 +2367,6 @@ contract("ColonyNetworkMining", accounts => {
 
       await advanceMiningCycleNoContest({ colonyNetwork, client: goodClient, test: this });
 
-      await goodClient.resetDB();
       await goodClient.saveCurrentState();
       const savedHash = await goodClient.reputationTree.getRootHash();
 
@@ -3340,7 +3341,6 @@ contract("ColonyNetworkMining", accounts => {
       ? it.skip
       : it("The client should be able to correctly sync to the current state from an old, correct state loaded from the database", async () => {
           // Save to the database
-          await goodClient.resetDB();
           await goodClient.saveCurrentState();
           const savedHash = await goodClient.reputationTree.getRootHash();
 
@@ -3364,7 +3364,6 @@ contract("ColonyNetworkMining", accounts => {
         });
 
     it("should be able to successfully save the current state to the database and then load it", async () => {
-      await goodClient.resetDB();
       await goodClient.saveCurrentState();
 
       const client1Hash = await goodClient.reputationTree.getRootHash();
@@ -3375,7 +3374,6 @@ contract("ColonyNetworkMining", accounts => {
     });
 
     it("should be able to correctly get the proof for a reputation in a historical state without affecting the current miner state", async () => {
-      await goodClient.resetDB();
       await goodClient.saveCurrentState();
 
       const clientHash1 = await goodClient.reputationTree.getRootHash();

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -173,10 +173,12 @@ contract("ColonyNetworkMining", accounts => {
 
     let submission1 = await repCycle.getDisputeRounds(round1, idx1);
     let binarySearchStep = -1;
-    while (submission1.lowerBound !== submission1.upperBound) {
+    let binarySearchError = false;
+    while (submission1.lowerBound !== submission1.upperBound && binarySearchError === false) {
       binarySearchStep += 1;
       if (errors.client1.respondToBinarySearchForChallenge[binarySearchStep]) {
         await checkErrorRevertEthers(client1.respondToBinarySearchForChallenge(), errors.client1.respondToBinarySearchForChallenge[binarySearchStep]); // eslint-disable-line no-await-in-loop
+        binarySearchError = true;
       } else {
         // eslint-disable-next-line no-await-in-loop
         await checkSuccessEthers(
@@ -186,6 +188,7 @@ contract("ColonyNetworkMining", accounts => {
       }
       if (errors.client2.respondToBinarySearchForChallenge[binarySearchStep]) {
         await checkErrorRevertEthers(client2.respondToBinarySearchForChallenge(), errors.client2.respondToBinarySearchForChallenge[binarySearchStep]); // eslint-disable-line no-await-in-loop
+        binarySearchError = true;
       } else {
         // eslint-disable-next-line no-await-in-loop
         await checkSuccessEthers(

--- a/test/colony-network-mining.js
+++ b/test/colony-network-mining.js
@@ -483,7 +483,7 @@ contract("ColonyNetworkMining", accounts => {
   });
 
   describe("Elimination of submissions", () => {
-    it.only("should allow a new reputation hash to be set if all but one submitted have been eliminated", async () => {
+    it("should allow a new reputation hash to be set if all but one submitted have been eliminated", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
 
@@ -507,7 +507,7 @@ contract("ColonyNetworkMining", accounts => {
       assert.equal(rootHashNNodes.toString(), goodClient.nReputations.toString());
     });
 
-    it.only("should allow a new reputation hash to be moved to the next stage of competition even if it does not have a partner", async () => {
+    it("should allow a new reputation hash to be moved to the next stage of competition even if it does not have a partner", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT2, DEFAULT_STAKE);
@@ -551,7 +551,9 @@ contract("ColonyNetworkMining", accounts => {
       assert.equal(newRepCycle.address, repCycle.address);
 
       // Eliminate one so that the afterAll works.
-      await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
+      await accommodateChallengeAndInvalidateHash(this, goodClient, badClient, {
+        client2: { respondToChallenge: "colony-reputation-mining-invalid-newest-reputation-proof" }
+      });
     });
 
     it("should not allow the last reputation hash to be eliminated", async () => {
@@ -559,8 +561,11 @@ contract("ColonyNetworkMining", accounts => {
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-      await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
+      await accommodateChallengeAndInvalidateHash(this, goodClient, badClient, {
+        client2: { respondToChallenge: "colony-reputation-mining-invalid-newest-reputation-proof" }
+      });
 
+      // TODO: this should just call invalidateHash, right?
       await checkErrorRevert(accommodateChallengeAndInvalidateHash(this, goodClient), "colony-reputation-mining-cannot-invalidate-final-hash");
     });
 
@@ -571,13 +576,17 @@ contract("ColonyNetworkMining", accounts => {
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([goodClient, badClient, badClient2], this);
-      await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
+      await accommodateChallengeAndInvalidateHash(this, goodClient, badClient, {
+        client2: { respondToChallenge: "colony-reputation-mining-invalid-newest-reputation-proof" }
+      });
       await accommodateChallengeAndInvalidateHash(this, badClient2);
 
       await checkErrorRevert(repCycle.invalidateHash(1, 2), "colony-reputation-mining-dispute-id-not-in-range");
 
       // Cleanup after test
-      await accommodateChallengeAndInvalidateHash(this, goodClient, badClient2);
+      await accommodateChallengeAndInvalidateHash(this, goodClient, badClient2, {
+        client2: { respondToChallenge: "colony-reputation-mining-invalid-newest-reputation-proof" }
+      });
       await repCycle.confirmNewHash(2);
     });
 
@@ -604,7 +613,9 @@ contract("ColonyNetworkMining", accounts => {
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-      await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
+      await accommodateChallengeAndInvalidateHash(this, goodClient, badClient, {
+        client2: { respondToChallenge: "colony-reputation-mining-invalid-newest-reputation-proof" }
+      });
 
       await checkErrorRevert(repCycle.invalidateHash(0, 1), "colony-reputation-mining-proposed-hash-empty");
     });
@@ -615,7 +626,9 @@ contract("ColonyNetworkMining", accounts => {
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-      await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
+      await accommodateChallengeAndInvalidateHash(this, goodClient, badClient, {
+        client2: { respondToChallenge: "colony-reputation-mining-invalid-newest-reputation-proof" }
+      });
 
       await checkErrorRevert(repCycle.invalidateHash(0, 0), "colony-reputation-mining-hash-already-progressed");
     });
@@ -651,7 +664,9 @@ contract("ColonyNetworkMining", accounts => {
 
       await checkErrorRevert(repCycle.confirmNewHash(1), "colony-reputation-mining-final-round-not-completed");
 
-      await accommodateChallengeAndInvalidateHash(this, goodClient, badClient);
+      await accommodateChallengeAndInvalidateHash(this, goodClient, badClient, {
+        client2: { respondToChallenge: "colony-reputation-mining-invalid-newest-reputation-proof" }
+      });
       await repCycle.confirmNewHash(1);
     });
   });


### PR DESCRIPTION
This add another `errors` parameter to `accommodateChallengeAndInvalidateHash`, which contains two properties - `client1` and `client2`. Each of these, if it exists, is expected to contain an object that contains one of the properties:

* `confirmJustificationRootHash`
* `respondToBinarySearchForChallenge`
* `confirmBinarySearchResult`
* `respondToChallenge`

If defined, these properties should contain the string of the expected error to be returned. The exception is `respondToBinarySearchForChallenge`, which should contain an array, with each element containing the expected error (if any) for the `nth` call to `respondToBinarySearchForChallenge` for that client - for example, if `error-string` was expected on the third call to `respondToBinarySearchForChallenge` for client 2, a valid object to pass would be

```
{ client2: { respondToBinarySearchForChallenge: [undefined, undefined, "error-string"] } } 
```

If an expected error is thrown, none of the other calls are fired aside from the same call on `client2` if `client1` was the one that errored.

Part of #317 