### PR TITLE
Add better error when trying to claim a payout for a too-recent deposit

### DIFF
--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -197,7 +197,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   }
 
   function startNextRewardPayout(address _token, bytes memory key, bytes memory value, uint256 branchMask, bytes32[] memory siblings)
-  public auth stoppable 
+  public auth stoppable
   {
     ITokenLocking tokenLocking = ITokenLocking(IColonyNetwork(colonyNetworkAddress).getTokenLocking());
     uint256 totalLockCount = tokenLocking.lockToken(address(token));
@@ -330,13 +330,15 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
 
   function calculateRewardForUser(uint256 payoutId, uint256[7] memory squareRoots, uint256 userReputation) internal returns (address, uint256) {
     RewardPayoutCycle memory payout = rewardPayoutCycles[payoutId];
+
     // Checking if payout is active
     require(block.timestamp - payout.blockTimestamp <= 60 days, "colony-reward-payout-not-active");
 
-    uint256 userTokens;
     ITokenLocking tokenLocking = ITokenLocking(IColonyNetwork(colonyNetworkAddress).getTokenLocking());
-    userTokens = tokenLocking.getUserLock(address(token), msg.sender).balance;
+    uint256 userDepositTimestamp = tokenLocking.getUserLock(address(token), msg.sender).timestamp;
+    uint256 userTokens = tokenLocking.getUserLock(address(token), msg.sender).balance;
 
+    require(userDepositTimestamp <= payout.blockTimestamp, "colony-reward-payout-deposit-too-recent");
     require(userTokens > 0, "colony-reward-payout-invalid-user-tokens");
     require(userReputation > 0, "colony-reward-payout-invalid-user-reputation");
 


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #437 

<!--- Summary of changes including design decisions -->

Currently, only nonzero deposits are subject to lock restrictions for deposits and withdrawals. As such, an additional restriction is needed to ensure that fresh deposits (in which the balance is increased from 0 after a payout process has begun) do not allow users to claim rewards.

We add a simple timestamp comparison when claiming payouts, to ensure that the deposit was made prior to the reward process being initiated:

```
require(userDepositTimestamp <= payout.blockTimestamp, "colony-reward-payout-deposit-too-recent");
```

Alternative implementations based on using lock restrictions for zero-valued deposits were not used here, on the grounds that such an implementation would require new depositors to "waive" all past payout cycles (to bring their deposit lock up to speed); an unnecessary burden for new users.
