### PR TITLE
Add getPot function

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -271,6 +271,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
       potId: potCount
     });
 
+    pots[potCount].domainId = domainCount;
+
     emit DomainAdded(domainCount);
     emit PotAdded(potCount);
   }

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -211,6 +211,7 @@ contract ColonyDataTypes {
   struct Pot {
     mapping (address => uint256) balance;
     uint256 taskId;
+    uint256 domainId;
   }
 
   struct Domain {

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -119,6 +119,10 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     return pots[_potId].balance[_token];
   }
 
+  function getPot(uint256 _potId) public view returns (Pot pot) {
+    pot = pots[_potId];
+  }
+
   function moveFundsBetweenPots(uint256 _fromPot, uint256 _toPot, uint256 _amount, address _token) public
   stoppable
   auth

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -119,8 +119,10 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     return pots[_potId].balance[_token];
   }
 
-  function getPot(uint256 _potId) public view returns (Pot pot) {
-    pot = pots[_potId];
+  function getPotInformation(uint256 _potId) public view returns (uint256 taskId, uint256 domainId) {
+    Pot storage pot = pots[_potId];
+    taskId = pot.taskId;
+    domainId = pot.domainId;
   }
 
   function moveFundsBetweenPots(uint256 _fromPot, uint256 _toPot, uint256 _amount, address _token) public

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -117,10 +117,13 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @return domain The domain
   function getDomain(uint256 _id) public view returns (Domain domain);
 
-  /// @notice Get a pot by id
+  /// @notice Get the non-mapping properties of a pot by id
   /// @param _id Id of the pot which details to get
-  /// @return pot The pot
-  function getPot(uint256 _id) public view returns (Pot pot);
+  /// @return uint256 The taskId the pot is associated with
+  /// @return uint256 The domainId the pot is associated with
+  /// @dev Exactly one of taskId and domainId should return nonzero, unless _id is 0 (the reward pot, which is 
+  ///      the only pot not associated with a task or a domain), in which case both are.
+  function getPotInformation(uint256 _id) public view returns (uint256 taskId, uint256 domainId);
 
   /// @notice Get the number of domains in the colony
   /// @return count The domain count. Min 1 as the root domain is created at the same time as the colony

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -117,6 +117,11 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @return domain The domain
   function getDomain(uint256 _id) public view returns (Domain domain);
 
+  /// @notice Get a pot by id
+  /// @param _id Id of the pot which details to get
+  /// @return pot The pot
+  function getPot(uint256 _id) public view returns (Pot pot);
+
   /// @notice Get the number of domains in the colony
   /// @return count The domain count. Min 1 as the root domain is created at the same time as the colony
   function getDomainCount() public view returns (uint256 count);

--- a/test/colony.js
+++ b/test/colony.js
@@ -101,6 +101,20 @@ contract("Colony", accounts => {
       const rootLocalSkillId = await colonyNetwork.getSkillCount();
       assert.equal(domain.skillId, rootLocalSkillId.toNumber());
     });
+
+    it("should let pot information be read", async () => {
+      const taskId = await makeTask({ colony });
+      const taskInfo = await colony.getTask(taskId);
+      let potInfo = await colony.getPotInformation(taskInfo.potId);
+      assert.equal(potInfo.taskId.toString(), taskId.toString(), "Unexpected pot task ID");
+      assert.equal(potInfo.domainId.toString(), "0", "Unexpected pot task ID");
+
+      // Read pot info about a pot in a domain
+      const domainInfo = await colony.getDomain(1);
+      potInfo = await colony.getPotInformation(domainInfo.potId);
+      assert.equal(potInfo.taskId.toString(), "0", "Unexpected pot task ID");
+      assert.equal(potInfo.domainId.toString(), "1", "Unexpected pot task ID");
+    });
   });
 
   describe("when working with permissions", () => {


### PR DESCRIPTION
Feature request from FE team.

I have taken the liberty of... anticipating another request from the FE team, which is being able to look up the domain a pot is associated with in the case of those pots, and adding a `domainid` property to pots.