### PR TITLE
Fix stop blockchain script killing browser

### DIFF
--- a/scripts/stop-blockchain-client.sh
+++ b/scripts/stop-blockchain-client.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-pid=$(lsof -i:8545 -t); 
+pid=$(lsof -i:8545 -sTCP:LISTEN -t); 
 
 echo "Killing blockchain client process $pid on port 8545"
 kill -TERM $pid || kill -KILL $pid


### PR DESCRIPTION
Currently if metamask is connected to ganache on running tests it will be killed by stop blokchain script. Suggested solution kills only processes that are listening on port 8545 and not killing proccesses that established connection to ganache