### PR TITLE
Require task skill before assigning worker

### DIFF
--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -302,6 +302,7 @@ contract ColonyTask is ColonyStorage {
   function setTaskWorkerRole(uint256 _id, address _user) public stoppable self {
     // Can only assign role if no one is currently assigned to it
     require(tasks[_id].roles[WORKER].user == address(0x0), "colony-task-worker-role-already-assigned");
+    require(tasks[_id].skills[0] > 0, "colony-task-skill-not-set");
     setTaskRoleUser(_id, WORKER, _user);
   }
 

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -36,7 +36,7 @@ const ColonyTask = artifacts.require("ColonyTask");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const ContractRecovery = artifacts.require("ContractRecovery");
 
-export async function makeTask({ colony, hash = SPECIFICATION_HASH, domainId = 1, skillId = 0, dueDate = 0, manager }) {
+export async function makeTask({ colony, hash = SPECIFICATION_HASH, domainId = 1, skillId = 1, dueDate = 0, manager }) {
   const accounts = await web3GetAccounts();
   manager = manager || accounts[0]; // eslint-disable-line no-param-reassign
   // Only Colony admins are allowed to make Tasks, make the account an admin

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -263,6 +263,40 @@ contract("ColonyTask", accounts => {
       assert.equal(evaluator.user, newEvaluator);
     });
 
+    it("should not allow a worker to be assigned if the task has no skill", async () => {
+      const taskId = await makeTask({ colony, skillId: 0 });
+
+      await checkErrorRevert(
+        executeSignedRoleAssignment({
+          colony,
+          taskId,
+          functionName: "setTaskWorkerRole",
+          signers: [MANAGER, WORKER],
+          sigTypes: [0, 0],
+          args: [taskId, WORKER]
+        }),
+        "colony-task-role-assignment-execution-failed"
+      );
+
+      await executeSignedTaskChange({
+        colony,
+        taskId,
+        functionName: "setTaskSkill",
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, 1] // skillId 1
+      });
+
+      executeSignedRoleAssignment({
+        colony,
+        taskId,
+        functionName: "setTaskWorkerRole",
+        signers: [MANAGER, WORKER],
+        sigTypes: [0, 0],
+        args: [taskId, WORKER]
+      });
+    });
+
     it("should not allow the worker or evaluator roles to be assigned only by manager", async () => {
       const newEvaluator = accounts[1];
       assert.notEqual(MANAGER, newEvaluator);

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -461,9 +461,10 @@ contract("Meta Colony", accounts => {
       await metaColony.addGlobalSkill(1);
       await metaColony.addGlobalSkill(5);
 
-      await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskSkill(1, 5, { from: OTHER_ACCOUNT }), "colony-not-self");
-      const task = await colony.getTask(1);
+      const taskId = await makeTask({ colony, skillId: 0 });
+      await checkErrorRevert(colony.setTaskSkill(taskId, 5, { from: OTHER_ACCOUNT }), "colony-not-self");
+
+      const task = await colony.getTask(taskId);
       assert.equal(task[8][0].toNumber(), 0);
     });
 


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #473 

<!--- Summary of changes including design decisions -->

Require `skillId > 0` before assigning worker.