### PR TITLE
Fix bug with deposit timestamp in claimRewardPayout

### DIFF
--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -338,7 +338,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     uint256 userDepositTimestamp = tokenLocking.getUserLock(address(token), msg.sender).timestamp;
     uint256 userTokens = tokenLocking.getUserLock(address(token), msg.sender).balance;
 
-    require(userDepositTimestamp <= payout.blockTimestamp, "colony-reward-payout-deposit-too-recent");
+    require(userDepositTimestamp < payout.blockTimestamp, "colony-reward-payout-deposit-too-recent");
     require(userTokens > 0, "colony-reward-payout-invalid-user-tokens");
     require(userReputation > 0, "colony-reward-payout-invalid-user-reputation");
 

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -332,6 +332,7 @@ contract("All", accounts => {
 
       await newToken.approve(tokenLocking.address, workerReputation, { from: WORKER });
       await tokenLocking.deposit(newToken.address, workerReputation, { from: WORKER });
+      await forwardTime(1, this);
 
       const tx = await newColony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = tx.logs[0].args.rewardPayoutId;

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -977,6 +977,7 @@ contract("Colony Funding", accounts => {
       await token.transfer(userAddress3, userTokens3, { from: userAddress1 });
       await token.approve(tokenLocking.address, userTokens3, { from: userAddress3 });
       await tokenLocking.deposit(token.address, userTokens3, { from: userAddress3 });
+      await forwardTime(1, this);
 
       const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
@@ -1127,8 +1128,6 @@ contract("Colony Funding", accounts => {
       const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
 
-      // Make a deposit, strictly after the payout process starts.
-      await forwardTime(1, this);
       await token.approve(tokenLocking.address, userTokens, { from: userAddress1 });
       await tokenLocking.deposit(token.address, userTokens, { from: userAddress1 });
 
@@ -1193,6 +1192,7 @@ contract("Colony Funding", accounts => {
       // This will allow token locking contract to sent tokens on users behalf
       await newToken.approve(tokenLocking.address, userReputation, { from: userAddress1 });
       await tokenLocking.deposit(newToken.address, userReputation, { from: userAddress1 });
+      await forwardTime(1, this);
 
       ({ logs } = await colony1.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof1));
       const payoutId1 = logs[0].args.rewardPayoutId;
@@ -1428,6 +1428,7 @@ contract("Colony Funding", accounts => {
         await tokenLocking.deposit(newToken.address, tokensPerUser, { from: userAddress1 });
         await tokenLocking.deposit(newToken.address, tokensPerUser, { from: userAddress2 });
         await tokenLocking.deposit(newToken.address, tokensPerUser, { from: userAddress3 });
+        await forwardTime(1, this);
 
         ({ logs } = await newColony.startNextRewardPayout(payoutToken.address, ...colonyWideReputationProof));
         const payoutId = logs[0].args.rewardPayoutId;


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->

<!--- Summary of changes including design decisions -->

Follow-on to #472. First time around I made the conditional `<=`, which could allow a malicious miner to pad a single block (same timestamp) with multiple withdrawals. A strict inequality will prevent this by requiring the deposit to be in a previous block.