### PR TITLE
Wait ethers contract transaction to be confirmed

### DIFF
--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -159,28 +159,32 @@ export async function checkErrorRevert(promise, errorMessage) {
 }
 
 export async function checkErrorRevertEthers(promise, errorMessage) {
-  const tx = await promise;
-  const txid = tx.hash;
+  let receipt;
+  try {
+    receipt = await promise;
+  } catch (err) {
+    const txid = err.transactionHash;
+    const tx = await web3GetTransaction(txid);
+    const response = await web3GetRawCall({ from: tx.from, to: tx.to, data: tx.input, gas: tx.gas, value: tx.value });
+    const reason = extractReasonString(response);
+    assert.equal(reason, errorMessage);
+    return;
+  }
 
-  const receipt = await web3GetTransactionReceipt(txid);
-  assert.isFalse(receipt.status, `Transaction succeeded, but expected to fail with: ${errorMessage}`);
-
-  const response = await web3GetRawCall({ from: tx.from, to: tx.to, data: tx.data, gas: tx.gasLimit.toNumber(), value: tx.value.toNumber() });
-  const reason = extractReasonString(response);
-  assert.equal(reason, errorMessage);
+  assert.equal(receipt.status, 0, `Transaction succeeded, but expected to fail with: ${errorMessage}`);
 }
 
 export async function checkSuccessEthers(promise, errorMessage) {
-  const tx = await promise;
-  const txid = tx.hash;
+  const receipt = await promise;
 
-  const receipt = await web3GetTransactionReceipt(txid);
-  if (receipt.status) {
+  if (receipt.status === 1) {
     return;
   }
-  const response = await web3GetRawCall({ from: tx.from, to: tx.to, data: tx.data, gas: tx.gasLimit.toNumber(), value: tx.value.toNumber() });
+  const txid = receipt.transactionHash;
+  const tx = await web3GetTransaction(txid);
+  const response = await web3GetRawCall({ from: tx.from, to: tx.to, data: tx.input, gas: tx.gas, value: tx.value });
   const reason = extractReasonString(response);
-  assert.isTrue(receipt.status, `${errorMessage} with error ${reason}`);
+  assert.equal(receipt.status, 1, `${errorMessage} with error ${reason}`);
 }
 
 export function getRandomString(_length) {
@@ -421,8 +425,7 @@ export async function submitAndForwardTimeToDispute(clients, test) {
   await forwardTime(MINING_CYCLE_DURATION / 2, test);
   for (let i = 0; i < clients.length; i += 1) {
     await clients[i].addLogContentsToReputationTree(); // eslint-disable-line no-await-in-loop
-    const tx = await clients[i].submitRootHash(); // eslint-disable-line no-await-in-loop
-    await tx.wait(); // eslint-disable-line no-await-in-loop
+    await clients[i].submitRootHash(); // eslint-disable-line no-await-in-loop
   }
   await forwardTime(MINING_CYCLE_DURATION / 2, test);
 }
@@ -432,15 +435,15 @@ export async function runBinarySearch(client1, client2) {
   // Binary search will error when it is complete.
   let noError = true;
   while (noError) {
-    let transactionObject;
-    transactionObject = await client1.respondToBinarySearchForChallenge(); // eslint-disable-line no-await-in-loop
-    let tx = await web3GetTransactionReceipt(transactionObject.hash); // eslint-disable-line no-await-in-loop
-    if (!tx.status) {
+    try {
+      await client1.respondToBinarySearchForChallenge(); // eslint-disable-line no-await-in-loop
+    } catch (err) {
       noError = false;
     }
-    transactionObject = await client2.respondToBinarySearchForChallenge(); // eslint-disable-line no-await-in-loop
-    tx = await web3GetTransactionReceipt(transactionObject.hash); // eslint-disable-line no-await-in-loop
-    if (!tx.status) {
+
+    try {
+      await client2.respondToBinarySearchForChallenge(); // eslint-disable-line no-await-in-loop
+    } catch (err) {
       noError = false;
     }
   }
@@ -538,6 +541,7 @@ async function navigateChallenge(colonyNetwork, client1, client2, errors) {
     idx1.sub(idx2).pow(2).eq(1), // eslint-disable-line prettier/prettier
     "Clients are not facing each other in this round"
   );
+
   if (submission2before.jrhNNodes === "0") {
     if (errors.client2.confirmJustificationRootHash) {
       await checkErrorRevertEthers(client2.confirmJustificationRootHash(), errors.client2.confirmJustificationRootHash);

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -125,15 +125,18 @@ class ReputationMinerClient {
         // Assume we've been given back the tx hash.
         tx = await this._miner.realProvider.getTransaction(tx);
       }
+      console.log("⛏️ Transaction waiting to be mined", tx);
+      await tx.wait();
 
-      console.log("Confirming new reputation hash...");
-
+      console.log("🆗 Confirming new reputation hash");
       // Confirm hash
       // We explicitly use the previous nonce +1, in case we're using Infura and we end up
       // querying a node that hasn't had the above transaction propagate to it yet.
       tx = await repCycle.confirmNewHash(0, { gasLimit: 3500000, nonce: tx.nonce + 1 });
+      console.log("⛏️ Transaction waiting to be mined", tx);
+      await tx.wait();
 
-      console.log("✅ New reputation hash confirmed, via TX", tx);
+      console.log("✅ New reputation hash confirmed");
       // this.timeout = setTimeout(() => this.checkSubmissionWindow(), 86400000);
       // console.log("⌛️ will next check in one hour and one minute");
       this.timeout = setTimeout(() => this.checkSubmissionWindow(), 10000);

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimNew.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimNew.js
@@ -1,6 +1,6 @@
-import ReputationMiner from "../ReputationMiner";
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
-class MaliciousReputationMinerClaimNew extends ReputationMiner {
+class MaliciousReputationMinerClaimNew extends ReputationMinerTestWrapper {
   // Only difference between this and the 'real' client should be that it claims a reputation update
   // corresponds to a reputation that didn't previously exist in the tree.
   constructor(opts, entryToFalsify) {
@@ -22,7 +22,9 @@ class MaliciousReputationMinerClaimNew extends ReputationMiner {
     }
     await super.addSingleReputationUpdate(updateNumber, repCycle, blockNumber);
     if (updateNumber.toString() === this.entryToFalsify) {
-      this.justificationHashes[ReputationMiner.getHexString(updateNumber.sub(1), 64)].nextUpdateProof = await this.getReputationProofObject("0");
+      this.justificationHashes[
+        ReputationMinerTestWrapper.getHexString(updateNumber.sub(1), 64)
+      ].nextUpdateProof = await this.getReputationProofObject("0");
     }
     this.beWrongThisCycle = false;
   }

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
@@ -1,9 +1,9 @@
 import BN from "bn.js";
-import ReputationMiningClient from "../ReputationMiner";
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
 const ethers = require("ethers");
 
-class MaliciousReputationMiningNoOriginReputation extends ReputationMiningClient {
+class MaliciousReputationMiningNoOriginReputation extends ReputationMinerTestWrapper {
   // This client will claim there is no originReputationUID, whether there is one or not
   //
   constructor(opts, entryToFalsify, amountToFalsify) {
@@ -30,7 +30,7 @@ class MaliciousReputationMiningNoOriginReputation extends ReputationMiningClient
     const logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber);
     const originSkillUpdateNumber = logEntry.nUpdates.add(logEntry.nPreviousUpdates).add(this.nReputationsBeforeLatestLog).sub(1);
     const originReputationKey = await this.getKeyForUpdateNumber(originSkillUpdateNumber);
-    this.justificationHashes[ReputationMiningClient.getHexString(updateNumber, 64)].originReputationProof.key = originReputationKey;
+    this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].originReputationProof.key = originReputationKey;
 
     // Set the child skill key
     const relativeUpdateNumber = updateNumber.sub(this.nReputationsBeforeLatestLog).sub(logEntry.nPreviousUpdates);
@@ -44,7 +44,7 @@ class MaliciousReputationMiningNoOriginReputation extends ReputationMiningClient
     } else {
       childKey = await this.getKeyForUpdateNumber(updateNumber);
     }
-    this.justificationHashes[ReputationMiningClient.getHexString(updateNumber, 64)].childReputationProof = 
+    this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].childReputationProof = 
       await this.getReputationProofObject(childKey);
 
     this.alterThisEntry = false;
@@ -67,8 +67,8 @@ class MaliciousReputationMiningNoOriginReputation extends ReputationMiningClient
     const firstDisagreeIdx = submission[8];
     const lastAgreeIdx = firstDisagreeIdx.sub(1);
     const reputationKey = await this.getKeyForUpdateNumber(lastAgreeIdx);
-    const lastAgreeKey = ReputationMiningClient.getHexString(lastAgreeIdx, 64);
-    const firstDisagreeKey = ReputationMiningClient.getHexString(firstDisagreeIdx, 64);
+    const lastAgreeKey = ReputationMinerTestWrapper.getHexString(lastAgreeIdx, 64);
+    const firstDisagreeKey = ReputationMinerTestWrapper.getHexString(firstDisagreeIdx, 64);
 
     const [agreeStateBranchMask, agreeStateSiblings] = await this.justificationTree.getProof(lastAgreeKey);
     const [disagreeStateBranchMask, disagreeStateSiblings] = await this.justificationTree.getProof(firstDisagreeKey);
@@ -77,15 +77,14 @@ class MaliciousReputationMiningNoOriginReputation extends ReputationMiningClient
       logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(lastAgreeIdx.sub(this.nReputationsBeforeLatestLog));
     }
 
-
     // console.log([
     //   round,
     //   index,
     //   this.justificationHashes[firstDisagreeKey].justUpdatedProof.branchMask,
     //   this.justificationHashes[lastAgreeKey].nextUpdateProof.nNodes,
-    //   ReputationMiningClient.getHexString(agreeStateBranchMask),
+    //   ReputationMinerTestWrapper.getHexString(agreeStateBranchMask),
     //   this.justificationHashes[firstDisagreeKey].justUpdatedProof.nNodes,
-    //   ReputationMiningClient.getHexString(disagreeStateBranchMask),
+    //   ReputationMinerTestWrapper.getHexString(disagreeStateBranchMask),
     //   this.justificationHashes[lastAgreeKey].newestReputationProof.branchMask,
     //   logEntryNumber,
     //   "0",
@@ -113,9 +112,9 @@ class MaliciousReputationMiningNoOriginReputation extends ReputationMiningClient
         index,
         this.justificationHashes[firstDisagreeKey].justUpdatedProof.branchMask,
         this.justificationHashes[lastAgreeKey].nextUpdateProof.nNodes,
-        ReputationMiningClient.getHexString(agreeStateBranchMask),
+        ReputationMinerTestWrapper.getHexString(agreeStateBranchMask),
         this.justificationHashes[firstDisagreeKey].justUpdatedProof.nNodes,
-        ReputationMiningClient.getHexString(disagreeStateBranchMask),
+        ReputationMinerTestWrapper.getHexString(disagreeStateBranchMask),
         this.justificationHashes[lastAgreeKey].newestReputationProof.branchMask,
         logEntryNumber,
         "0",
@@ -145,7 +144,7 @@ class MaliciousReputationMiningNoOriginReputation extends ReputationMiningClient
       this.justificationHashes[lastAgreeKey].childReputationProof.siblings,
       { gasLimit: 4000000 }
     );
-    return tx;
+    return tx.wait();
   }
 }
 

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimWrongChildReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimWrongChildReputation.js
@@ -1,8 +1,8 @@
-import ReputationMiningClient from "../ReputationMiner";
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
 const WRONG_ADDRESS = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 
-class MaliciousReputationMiningWrongChildReputation extends ReputationMiningClient {
+class MaliciousReputationMiningWrongChildReputation extends ReputationMinerTestWrapper {
   // This client will claim there is no originReputationUID, whether there is one or not
   //
   constructor(opts, whatToFalsify) {
@@ -13,7 +13,7 @@ class MaliciousReputationMiningWrongChildReputation extends ReputationMiningClie
   async addSingleReputationUpdate(updateNumber, repCycle, blockNumber, checkForReplacement) {
     await super.addSingleReputationUpdate(updateNumber, repCycle, blockNumber, checkForReplacement);
 
-    const correctKey = this.justificationHashes[ReputationMiningClient.getHexString(updateNumber, 64)].childReputationProof.key;
+    const correctKey = this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].childReputationProof.key;
     let wrongKey;
     if (this.whatToFalsify === "colonyAddress"){
       wrongKey = `0x${WRONG_ADDRESS}${correctKey.slice(WRONG_ADDRESS.length + 2)}`;
@@ -24,7 +24,7 @@ class MaliciousReputationMiningWrongChildReputation extends ReputationMiningClie
       // Falsify the user address
       wrongKey = `${correctKey.slice(0, WRONG_ADDRESS.length + 2 + 64)}${WRONG_ADDRESS}`;
     }
-    this.justificationHashes[ReputationMiningClient.getHexString(updateNumber, 64)].childReputationProof.key = wrongKey;
+    this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].childReputationProof.key = wrongKey;
   }
 }
 

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimWrongOriginReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimWrongOriginReputation.js
@@ -1,8 +1,8 @@
-import ReputationMiningClient from "../ReputationMiner";
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
 const WRONG_ADDRESS = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 
-class MaliciousReputationMiningWrongOriginReputation extends ReputationMiningClient {
+class MaliciousReputationMiningWrongOriginReputation extends ReputationMinerTestWrapper {
   // This client will claim there is no originReputationUID, whether there is one or not
   //
   constructor(opts, entryToFalsify, amountToFalsify, whatToFalsify) {

--- a/packages/reputation-miner/test/MaliciousReputationMinerExtraRep.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerExtraRep.js
@@ -1,6 +1,6 @@
-import ReputationMiner from "../ReputationMiner";
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
-class MaliciousReputationMinerExtraRep extends ReputationMiner {
+class MaliciousReputationMinerExtraRep extends ReputationMinerTestWrapper {
   // Only difference between this and the 'real' client should be that it adds some extra
   // reputation to one entry being parsed.
   constructor(opts, entryToFalsify, amountToFalsify) {

--- a/packages/reputation-miner/test/MaliciousReputationMinerReuseUID.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerReuseUID.js
@@ -1,7 +1,7 @@
 import BN from "bn.js";
-import ReputationMiner from "../ReputationMiner";
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
-class MaliciousReputationMinerReuseUID extends ReputationMiner {
+class MaliciousReputationMinerReuseUID extends ReputationMinerTestWrapper {
   // This client will reuse a UID for a reputation
   constructor(opts, entryToFalsify, amountToFalsify) {
     super(opts);

--- a/packages/reputation-miner/test/MaliciousReputationMinerUnsure.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerUnsure.js
@@ -1,6 +1,6 @@
-import ReputationMiner from "../ReputationMiner";
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
-class MaliciousReputationMinerClaimNew extends ReputationMiner {
+class MaliciousReputationMinerClaimNew extends ReputationMinerTestWrapper {
   // Not really sure how to describe this malicous mining client...
   // It ends up proving a too-large newest reputation for the nNodes it claimed in the
   // JRH (so in the test in question, the intermediate value had 6 nodes, but it proves
@@ -28,13 +28,12 @@ class MaliciousReputationMinerClaimNew extends ReputationMiner {
     // Note that this won't remove it from the PatriciaTree - which is what we want
     await super.addSingleReputationUpdate(updateNumber, repCycle, blockNumber);
     if (updateNumber.toString() === this.entryToFalsify) {
-      this.justificationHashes[ReputationMiner.getHexString(parseInt(this.entryToFalsify, 10) - 1, 64)].nextUpdateProof.value = this.getValueAsBytes(
-        0,
-        0
-      );
+      this.justificationHashes[
+        ReputationMinerTestWrapper.getHexString(parseInt(this.entryToFalsify, 10) - 1, 64)
+      ].nextUpdateProof.value = this.getValueAsBytes(0, 0);
       // Need to fix the newest hash that we claim
       // const key = Object.keys(this.reputations)[this.nReputations - 1];
-      this.justificationHashes[ReputationMiner.getHexString(parseInt(this.entryToFalsify, 10), 64)].newestReputationProof = newestProof;
+      this.justificationHashes[ReputationMinerTestWrapper.getHexString(parseInt(this.entryToFalsify, 10), 64)].newestReputationProof = newestProof;
     }
   }
 }

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongJRH.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongJRH.js
@@ -1,8 +1,8 @@
-import ReputationMiner from "../ReputationMiner";
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
 const ethers = require("ethers");
 
-class MaliciousReputationMinerWrongJRH extends ReputationMiner {
+class MaliciousReputationMinerWrongJRH extends ReputationMinerTestWrapper {
   // Only difference between this and the 'real' client should be that it submits a bad JRH
 
   constructor(opts, entryToFalsify) {
@@ -60,7 +60,8 @@ class MaliciousReputationMinerWrongJRH extends ReputationMiner {
     // Submit that entry
     const gas = await repCycle.estimate.submitRootHash(hash, this.nReputations, jrh, entryIndex);
 
-    return repCycle.submitRootHash(hash, this.nReputations, jrh, entryIndex, { gasLimit: `0x${gas.toString(16)}` });
+    const tx = await repCycle.submitRootHash(hash, this.nReputations, jrh, entryIndex, { gasLimit: `0x${gas.toString(16)}` });
+    return tx.wait();
   }
 }
 

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongNNodes.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongNNodes.js
@@ -1,8 +1,8 @@
-import ReputationMiner from "../ReputationMiner";
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
 const ethers = require("ethers");
 
-class MaliciousReputationMinerWrongNNodes extends ReputationMiner {
+class MaliciousReputationMinerWrongNNodes extends ReputationMinerTestWrapper {
   // Only difference between this and the 'real' client should be that it submits a bad JRH
 
   constructor(opts, entryToFalsify) {
@@ -50,7 +50,10 @@ class MaliciousReputationMinerWrongNNodes extends ReputationMiner {
     // Submit that entry with the wrong NNodes
     const gas = await repCycle.estimate.submitRootHash(hash, this.nReputations.add(this.entryToFalsify), jrh, entryIndex);
 
-    return repCycle.submitRootHash(hash, this.nReputations.add(this.entryToFalsify), jrh, entryIndex, { gasLimit: `0x${gas.toString(16)}` });
+    const tx = await repCycle.submitRootHash(hash, this.nReputations.add(this.entryToFalsify), jrh, entryIndex, {
+      gasLimit: `0x${gas.toString(16)}`
+    });
+    return tx.wait();
   }
 
   async getMySubmissionRoundAndIndex() {

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongNNodes2.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongNNodes2.js
@@ -1,6 +1,6 @@
-import ReputationMiner from "../ReputationMiner";
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
-class MaliciousReputationMinerWrongNNodes2 extends ReputationMiner {
+class MaliciousReputationMinerWrongNNodes2 extends ReputationMinerTestWrapper {
   // This client will reuse a UID for a reputation
   constructor(opts, entryToFalsify, amountToFalsify) {
     super(opts);

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongNewestReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongNewestReputation.js
@@ -1,7 +1,7 @@
 import BN from "bn.js";
-import ReputationMiningClient from "../ReputationMiner";
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
-class MaliciousReputationMiningWrongNewestReputation extends ReputationMiningClient {
+class MaliciousReputationMiningWrongNewestReputation extends ReputationMinerTestWrapper {
   // This client will supply the wrong newest reputation as part of its proof
   constructor(opts, amountToFalsify) {
     super(opts);

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -1,8 +1,8 @@
-import ReputationMiningClient from "../ReputationMiner";
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
 const ethers = require("ethers");
 
-class MaliciousReputationMiningWrongProofLogEntry extends ReputationMiningClient {
+class MaliciousReputationMiningWrongProofLogEntry extends ReputationMinerTestWrapper {
   // This client will supply the wrong log entry as part of its proof
   constructor(opts, amountToFalsify) {
     super(opts);
@@ -66,7 +66,8 @@ class MaliciousReputationMiningWrongProofLogEntry extends ReputationMiningClient
       this.justificationHashes[lastAgreeKey].childReputationProof.siblings,
       { gasLimit: 4000000 }
     );
-    return tx;
+
+    return tx.wait();
   }
 }
 

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongUID.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongUID.js
@@ -1,7 +1,7 @@
 import BN from "bn.js";
-import ReputationMiner from "../ReputationMiner";
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
-class MaliciousReputationMinerWrongUID extends ReputationMiner {
+class MaliciousReputationMinerWrongUID extends ReputationMinerTestWrapper {
   // This client uses the wrong UID for a reputation (even an existing one)
   constructor(opts, entryToFalsify, amountToFalsify) {
     super(opts);

--- a/packages/reputation-miner/test/ReputationMinerTestWrapper.js
+++ b/packages/reputation-miner/test/ReputationMinerTestWrapper.js
@@ -1,0 +1,30 @@
+import ReputationMiner from "../ReputationMiner";
+
+class ReputationMinerTestWrapper extends ReputationMiner {
+  async submitRootHash(startIndex) {
+    const tx = await super.submitRootHash(startIndex);
+    return tx.wait();
+  }
+
+  async confirmJustificationRootHash() {
+    const tx = await super.confirmJustificationRootHash();
+    return tx.wait();
+  }
+
+  async respondToBinarySearchForChallenge() {
+    const tx = await super.respondToBinarySearchForChallenge();
+    return tx.wait();
+  }
+
+  async confirmBinarySearchResult() {
+    const tx = await super.confirmBinarySearchResult();
+    return tx.wait();
+  }
+
+  async respondToChallenge() {
+    const tx = await super.respondToChallenge();
+    return tx.wait();
+  }
+}
+
+export default ReputationMinerTestWrapper;

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -17,8 +17,7 @@ import {
   SPECIFICATION_HASH,
   DELIVERABLE_HASH,
   SECONDS_PER_DAY,
-  DEFAULT_STAKE,
-  MINING_CYCLE_DURATION
+  DEFAULT_STAKE
 } from "../helpers/constants";
 
 import {
@@ -27,9 +26,10 @@ import {
   forwardTime,
   bnSqrt,
   makeReputationKey,
-  runBinarySearch,
   getActiveRepCycle,
-  advanceMiningCycleNoContest
+  advanceMiningCycleNoContest,
+  submitAndForwardTimeToDispute,
+  accommodateChallengeAndInvalidateHash
 } from "../helpers/test-helper";
 
 import {
@@ -41,7 +41,7 @@ import {
   setupRandomColony
 } from "../helpers/test-data-generator";
 
-import ReputationMiner from "../packages/reputation-miner/ReputationMiner";
+import ReputationMinerTestWrapper from "../packages/reputation-miner/test/ReputationMinerTestWrapper";
 import MaliciousReputationMinerExtraRep from "../packages/reputation-miner/test/MaliciousReputationMinerExtraRep";
 
 const DSToken = artifacts.require("DSToken");
@@ -63,7 +63,6 @@ contract("All", function(accounts) {
   const MANAGER = accounts[0];
   const EVALUATOR = MANAGER;
   const WORKER = accounts[2];
-  const MAIN_ACCOUNT = accounts[5];
 
   let colony;
   let token;
@@ -213,14 +212,9 @@ contract("All", function(accounts) {
       await giveUserCLNYTokensAndStake(colonyNetwork, STAKER2, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, STAKER3, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, minerAddress: STAKER1 });
 
-      let repCycle = await getActiveRepCycle(colonyNetwork);
-
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await repCycle.submitRootHash("0x00", 0, "0x00", 1, { from: STAKER1 });
-      await repCycle.confirmNewHash(0);
-
-      const goodClient = new ReputationMiner({ loader: contractLoader, minerAddress: STAKER1, realProviderPort: REAL_PROVIDER_PORT });
+      const goodClient = new ReputationMinerTestWrapper({ loader: contractLoader, minerAddress: STAKER1, realProviderPort: REAL_PROVIDER_PORT });
       const badClient = new MaliciousReputationMinerExtraRep(
         { loader: contractLoader, minerAddress: STAKER2, realProviderPort: REAL_PROVIDER_PORT },
         1,
@@ -236,44 +230,16 @@ contract("All", function(accounts) {
       await badClient2.initialise(colonyNetwork.address);
 
       // Submit hashes
-      await goodClient.addLogContentsToReputationTree();
-      await badClient.addLogContentsToReputationTree();
-      await badClient2.addLogContentsToReputationTree();
-
-      await forwardTime(MINING_CYCLE_DURATION / 2, this);
-      await goodClient.submitRootHash();
-      await badClient.submitRootHash();
-      await badClient2.submitRootHash();
-      await forwardTime(MINING_CYCLE_DURATION / 2, this);
-
+      await submitAndForwardTimeToDispute([goodClient, badClient, badClient2], this);
       // Session of respond / invalidate between our 3 submissions
-      await goodClient.confirmJustificationRootHash();
-      await badClient.confirmJustificationRootHash();
-      await badClient2.confirmJustificationRootHash();
-
-      repCycle = await getActiveRepCycle(colonyNetwork);
-      await repCycle.invalidateHash(0, 3); // Bye for R1
-
-      await runBinarySearch(goodClient, badClient);
-
-      await goodClient.confirmBinarySearchResult();
-      await badClient.confirmBinarySearchResult();
-
-      // We now know where they disagree
-      await goodClient.respondToChallenge();
-      // badClient will fail this if we try
-      // await badClient.respondToChallenge();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await repCycle.invalidateHash(0, 1);
-
-      await runBinarySearch(goodClient, badClient);
-
-      await goodClient.confirmBinarySearchResult();
-      await badClient2.confirmBinarySearchResult();
-
-      await goodClient.respondToChallenge();
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await repCycle.invalidateHash(1, 0);
+      await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
+        client2: { respondToChallenge: "colony-reputation-mining-increased-reputation-value-incorrect" }
+      });
+      await accommodateChallengeAndInvalidateHash(colonyNetwork, this, badClient2); // Invalidate the 'null' that partners the third hash submitted.
+      await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient2, {
+        client2: { respondToChallenge: "colony-reputation-mining-increased-reputation-value-incorrect" }
+      });
+      const repCycle = await getActiveRepCycle(colonyNetwork);
       await repCycle.confirmNewHash(2);
 
       // withdraw
@@ -299,26 +265,17 @@ contract("All", function(accounts) {
       await newColony.bootstrapColony([WORKER, MANAGER], [workerReputation, managerReputation]);
 
       await giveUserCLNYTokensAndStake(colonyNetwork, accounts[8], DEFAULT_STAKE);
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
-      let repCycle = await getActiveRepCycle(colonyNetwork);
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await repCycle.submitRootHash("0x00", 0, "0x00", 10, { from: MAIN_ACCOUNT });
-      await repCycle.confirmNewHash(0);
-
-      const miningClient = new ReputationMiner({
+      const miningClient = new ReputationMinerTestWrapper({
         loader: contractLoader,
         minerAddress: accounts[8],
         realProviderPort: REAL_PROVIDER_PORT,
         useJsTree: true
       });
+
       await miningClient.initialise(colonyNetwork.address);
-      await miningClient.addLogContentsToReputationTree();
-
-      await forwardTime(MINING_CYCLE_DURATION, this);
-      await miningClient.submitRootHash();
-
-      repCycle = await getActiveRepCycle(colonyNetwork);
-      await repCycle.confirmNewHash(0);
+      await advanceMiningCycleNoContest({ colonyNetwork, client: miningClient, minerAddress: accounts[0], test: this });
 
       const result = await newColony.getDomain(1);
       const rootDomainSkill = result.skillId;

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -43,7 +43,7 @@ import {
   setupRandomColony
 } from "../helpers/test-data-generator";
 
-import ReputationMiner from "../packages/reputation-miner/ReputationMiner";
+import ReputationMinerTestWrapper from "../packages/reputation-miner/test/ReputationMinerTestWrapper";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
@@ -679,7 +679,7 @@ contract("Colony Funding", accounts => {
       ];
 
       await giveUserCLNYTokensAndStake(colonyNetwork, accounts[4], DEFAULT_STAKE);
-      client = new ReputationMiner({
+      client = new ReputationMinerTestWrapper({
         loader: contractLoader,
         minerAddress: accounts[4],
         realProviderPort: REAL_PROVIDER_PORT,
@@ -729,7 +729,7 @@ contract("Colony Funding", accounts => {
 
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
-      const globalKey = await ReputationMiner.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
+      const globalKey = await ReputationMinerTestWrapper.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
       await client.insert(globalKey, new BN(10), 0);
 
       await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
@@ -904,7 +904,7 @@ contract("Colony Funding", accounts => {
       const result = await newColony.getDomain(1);
       const rootDomainSkill = result.skillId;
 
-      const globalKey = await ReputationMiner.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
+      const globalKey = await ReputationMinerTestWrapper.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
       await client.insert(globalKey, new BN(0), 0);
 
       await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
@@ -964,7 +964,7 @@ contract("Colony Funding", accounts => {
 
       await colony.bootstrapColony([userAddress1], [userTokens3]);
 
-      const userKey = await ReputationMiner.getKey(colony.address, rootDomainSkill, userAddress3);
+      const userKey = await ReputationMinerTestWrapper.getKey(colony.address, rootDomainSkill, userAddress3);
       await client.insert(userKey, new BN(0), 0);
 
       await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });

--- a/test/colony-network-recovery.js
+++ b/test/colony-network-recovery.js
@@ -16,7 +16,7 @@ import {
   advanceMiningCycleNoContest
 } from "../helpers/test-helper";
 import { setupFinalizedTask, giveUserCLNYTokensAndStake, fundColonyWithTokens, setupRandomColony } from "../helpers/test-data-generator";
-import ReputationMiner from "../packages/reputation-miner/ReputationMiner";
+import ReputationMinerTestWrapper from "../packages/reputation-miner/test/ReputationMinerTestWrapper";
 import { setupEtherRouter } from "../helpers/upgradable-contracts";
 import { DEFAULT_STAKE, MINING_CYCLE_DURATION } from "../helpers/constants";
 
@@ -58,7 +58,7 @@ contract("Colony Network Recovery", accounts => {
     const clnyAddress = await metaColony.getToken();
     clny = await Token.at(clnyAddress);
 
-    client = new ReputationMiner({
+    client = new ReputationMinerTestWrapper({
       loader: contractLoader,
       minerAddress: accounts[5],
       realProviderPort: REAL_PROVIDER_PORT,
@@ -229,7 +229,7 @@ contract("Colony Network Recovery", accounts => {
           await client.saveCurrentState();
           const startingHash = await client.getRootHash();
 
-          const newClient = new ReputationMiner({
+          const newClient = new ReputationMinerTestWrapper({
             loader: contractLoader,
             minerAddress: accounts[5],
             realProviderPort: REAL_PROVIDER_PORT,
@@ -300,7 +300,7 @@ contract("Colony Network Recovery", accounts => {
           await client.saveCurrentState();
           const startingHash = await client.getRootHash();
 
-          const ignorantclient = new ReputationMiner({
+          const ignorantclient = new ReputationMinerTestWrapper({
             loader: contractLoader,
             minerAddress: accounts[5],
             realProviderPort: REAL_PROVIDER_PORT,
@@ -447,7 +447,7 @@ contract("Colony Network Recovery", accounts => {
           await submitAndForwardTimeToDispute([client], this);
           await newActiveCycle.confirmNewHash(0);
 
-          const newClient = new ReputationMiner({
+          const newClient = new ReputationMinerTestWrapper({
             loader: contractLoader,
             minerAddress: accounts[5],
             realProviderPort: REAL_PROVIDER_PORT,

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -5,7 +5,7 @@ import { getTokenArgs, checkErrorRevert, forwardTime, makeReputationKey, getBloc
 import { giveUserCLNYTokensAndStake, setupRandomColony } from "../helpers/test-data-generator";
 import { MIN_STAKE, DEFAULT_STAKE, ZERO_ADDRESS } from "../helpers/constants";
 
-import ReputationMiner from "../packages/reputation-miner/ReputationMiner";
+import ReputationMinerTestWrapper from "../packages/reputation-miner/test/ReputationMinerTestWrapper";
 
 const EtherRouter = artifacts.require("EtherRouter");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
@@ -45,7 +45,7 @@ contract("Token Locking", addresses => {
     otherToken = await DSToken.new(tokenArgs[1]);
 
     await giveUserCLNYTokensAndStake(colonyNetwork, addresses[4], DEFAULT_STAKE);
-    const client = new ReputationMiner({
+    const client = new ReputationMinerTestWrapper({
       loader: contractLoader,
       minerAddress: addresses[4],
       realProviderPort: REAL_PROVIDER_PORT,


### PR DESCRIPTION
Closes #487 

Here we ensure all `ethers` contract transaction are confirmed via `wait()`. Relevant only to the mining client as that's where `ethers` contracts are used to wrap `ReputationMiningCycle`s.

This also entails changes to test helper functions for confirming transaction success/error as we are now getting back the transaction receipt (on successful ethers contract calls). Sample `ethers` receipt:
```
{ contractAddress: null,
  transactionIndex: 0,
  gasUsed: BigNumber { _hex: '0x2dc68' },
  logsBloom: '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
  blockHash: '0x3563eada39e96bfc861c36f6196d417257bd6605d4660fd8052bee972d9682c7',
  transactionHash: '0xc0e0443991b15aeb4a26abf9ed81a64bab0fcdaa91c0b865238ef6967f37083c',
  logs: [],
  blockNumber: 443,
  confirmations: 1,
  cumulativeGasUsed: BigNumber { _hex: '0x2dc68' },
  status: 1,
  byzantium: true,
  events: [] }
```
On transaction error `ethers` throws so we're catching that and still examining the error is expected.