### PR TITLE
In reputation update log set nChildren to 0 for positive updates

### DIFF
--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -268,8 +268,8 @@ contract ColonyNetwork is ColonyNetworkStorage {
   skillExists(_skillId)
   {
     uint nParents = skills[_skillId].nParents;
-    // TODO: Is it cheaper to check if _amount is <0, and if not, just set nChildren to 0, because children won't be updated for such an update?
-    uint nChildren = skills[_skillId].nChildren;
+    // We only update child skill reputation if the update is negative, otherwise just set nChildren to 0 to save gas
+    uint nChildren = _amount < 0 ? skills[_skillId].nChildren : 0;
     IReputationMiningCycle(inactiveReputationMiningCycle).appendReputationUpdateLog(
       _user,
       _amount,


### PR DESCRIPTION
Closes #341 

Using `finalizeTask` gas cost to measure gains (as that's where `appendReputationUpdateLog` is called most often with both positive and negative amounts).

Baseline: [637,698](https://circleci.com/gh/JoinColony/colonyNetwork/5737)
Without setting nChildren for positive updates: [636,926](https://circleci.com/gh/JoinColony/colonyNetwork/5749)