### PR TITLE
Consistent contract references in storage

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -59,14 +59,14 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   }
 
   function getToken() public view returns (address) {
-    return address(token);
+    return token;
   }
 
   function initialiseColony(address _colonyNetworkAddress, address _token) public stoppable {
     require(colonyNetworkAddress == address(0x0), "colony-already-initialised-network");
-    require(address(token) == address(0x0), "colony-already-initialised-token");
+    require(token == address(0x0), "colony-already-initialised-token");
     colonyNetworkAddress = _colonyNetworkAddress;
-    token = ERC20Extended(_token);
+    token = _token;
 
     // Initialise the task update reviewers
     setFunctionReviewers(bytes4(keccak256("setTaskBrief(uint256,bytes32)")), TaskRole.Manager, TaskRole.Worker);
@@ -106,7 +106,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     for (uint i = 0; i < _users.length; i++) {
       require(_amounts[i] >= 0, "colony-bootstrap-bad-amount-input");
       
-      token.transfer(_users[i], uint(_amounts[i]));
+      ERC20Extended(token).transfer(_users[i], uint(_amounts[i]));
       IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_users[i], _amounts[i], domains[1].skillId);
     }
 
@@ -118,9 +118,9 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   auth
   {
     if (address(this) == IColonyNetwork(colonyNetworkAddress).getMetaColony()) {
-      token.mint(_wad);
+      ERC20Extended(token).mint(_wad);
     } else {
-      token.mint(address(this), _wad);
+      ERC20Extended(token).mint(address(this), _wad);
     }
   }
 
@@ -129,8 +129,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     require(msg.sender == colonyNetworkAddress, "colony-access-denied-only-network-allowed");
     // Function only valid on the Meta Colony
     require(address(this) == IColonyNetwork(colonyNetworkAddress).getMetaColony(), "colony-access-denied-only-meta-colony-allowed");
-    token.mint(_wad);
-    token.transfer(colonyNetworkAddress, _wad);
+    ERC20Extended(token).mint(_wad);
+    ERC20Extended(token).transfer(colonyNetworkAddress, _wad);
   }
 
   function registerColonyLabel(string memory colonyName, string memory orbitdb) public stoppable auth {

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -203,11 +203,11 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   public auth stoppable
   {
     ITokenLocking tokenLocking = ITokenLocking(IColonyNetwork(colonyNetworkAddress).getTokenLocking());
-    uint256 totalLockCount = tokenLocking.lockToken(address(token));
+    uint256 totalLockCount = tokenLocking.lockToken(token);
 
     require(!activeRewardPayouts[_token], "colony-reward-payout-token-active");
 
-    uint256 totalTokens = sub(token.totalSupply(), token.balanceOf(address(this)));
+    uint256 totalTokens = sub(ERC20Extended(token).totalSupply(), ERC20Extended(token).balanceOf(address(this)));
     require(totalTokens > 0, "colony-reward-payout-invalid-total-tokens");
 
     bytes32 rootHash = IColonyNetwork(colonyNetworkAddress).getReputationRootHash();
@@ -338,8 +338,8 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     require(block.timestamp - payout.blockTimestamp <= 60 days, "colony-reward-payout-not-active");
 
     ITokenLocking tokenLocking = ITokenLocking(IColonyNetwork(colonyNetworkAddress).getTokenLocking());
-    uint256 userDepositTimestamp = tokenLocking.getUserLock(address(token), msg.sender).timestamp;
-    uint256 userTokens = tokenLocking.getUserLock(address(token), msg.sender).balance;
+    uint256 userDepositTimestamp = tokenLocking.getUserLock(token, msg.sender).timestamp;
+    uint256 userTokens = tokenLocking.getUserLock(token, msg.sender).balance;
 
     require(userDepositTimestamp < payout.blockTimestamp, "colony-reward-payout-deposit-too-recent");
     require(userTokens > 0, "colony-reward-payout-invalid-user-tokens");
@@ -366,7 +366,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
 
     uint256 reward = (mul(squareRoots[4], squareRoots[6]) / squareRoots[5]) ** 2;
 
-    tokenLocking.unlockTokenForUser(address(token), msg.sender, payoutId);
+    tokenLocking.unlockTokenForUser(token, msg.sender, payoutId);
 
     return (payout.tokenAddress, reward);
   }

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -32,7 +32,7 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, DSMath {
   // and add it to IColony.sol
 
   address colonyNetworkAddress; // Storage slot 6
-  ERC20Extended token; // Storage slot 7
+  address token; // Storage slot 7
   uint256 rewardInverse; // Storage slot 8
 
   uint256 taskCount; // Storage slot 9

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -469,7 +469,7 @@ contract ColonyTask is ColonyStorage {
       role.rating = role.rateFail ? TaskRatings.Unsatisfactory : TaskRatings.Satisfactory;
     }
 
-    uint256 payout = task.payouts[roleId][address(token)];
+    uint256 payout = task.payouts[roleId][token];
     int256 reputation = getReputation(payout, role.rating, role.rateFail);
 
     colonyNetworkContract.appendReputationUpdateLog(role.user, reputation, domains[task.domainId].skillId);


### PR DESCRIPTION
Following the discussion from #colony-network channel in Slack we decided to keep storage variables that hold contract addresses of type `address` rather than the type of the contract they store. This is for clarity and consistency.