### PR TITLE
Enable mythril nightly run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,10 @@ step_pull_solc_docker: &step_pull_solc_docker
     run:
       name: "Pull solc docker image"
       command: docker pull ethereum/solc:0.4.23
+step_pull_mythril_docker: &step_pull_mythril_docker
+    run:
+      name: "Pull mythril dev docker image"
+      command: docker pull mythril/myth-dev
 jobs:
   lint-and-unit-test:
     <<: *job_common
@@ -104,10 +108,34 @@ jobs:
       # Save coverage artifacts
       - store_artifacts:
           path: coverage
-
+  security-analysis:
+    <<: *job_common
+    steps:
+      - checkout
+      - <<: *step_restore_cache
+      - setup_remote_docker
+      - <<: *step_pull_solc_docker
+      - <<: *step_pull_mythril_docker
+      - <<: *step_setup_global_packages
+      - run:
+          name: "Mythril security analysis"
+          command: | 
+            docker create -v "$pwd"/build --name colonynetwork alpine:3.4 /bin/true
+            docker cp build/* colonynetwork:/build 
+            docker run --volumes-from colonynetwork mythril/myth-dev myth --truffle --execution-timeout 40 -v 3
 workflows:
   version: 2
   commit:
     jobs:
       - lint-and-unit-test
       - test-coverage
+nightly:
+    triggers:
+      - schedule:
+          cron: "0 1 * * *" # 1am UTC
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
+      - security-analysis

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -259,6 +259,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
 
   function getChildSkillId(uint _skillId, uint _childSkillIndex) public view returns (uint256) {
     Skill storage skill = skills[_skillId];
+    require(_childSkillIndex < skill.children.length, "colony-network-out-of-range-child-skill-index");
     return skill.children[_childSkillIndex];
   }
 

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "shortid": "^2.2.14",
     "solidity-coverage": "0.5.11",
     "solidity-parser-antlr": "^0.4.0",
-    "truffle": "^5.0.1",
+    "truffle": "^5.0.2",
     "web3-utils": "^1.0.0-beta.37"
   },
   "private": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7161,9 +7161,9 @@ trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
 
-truffle@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.1.tgz#bd4c3aa15201935c8e35506d9fbabd07814d2323"
+truffle@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.2.tgz#7fc99c8309314e885ddaadacc081675adebddd81"
   dependencies:
     app-module-path "^2.2.0"
     mocha "^4.1.0"


### PR DESCRIPTION
Part of #319 

Here we run [mythril security analysis tool](https://github.com/ConsenSys/mythril-classic) against our codebase. We're using the dev version of it until the next release due to https://github.com/ConsenSys/mythril-classic/issues/873
The configuration in `docker` run in CI had to be a bit odd as it is not possible to mount the contracts' build folder to the `mythril` docker image as described in the [Circle documentation](https://circleci.com/docs/2.0/building-docker-images/#mounting-folders). The workaround there was applied and working in our solution. 

All contracts except interfaces (which contain no logic) are analysed. For reference, here are the registry of codes `mythril` reports https://smartcontractsecurity.github.io/SWC-registry/

One of the reported issues was found to be a valid improvement suggestion more than a bug to do with adding a check to validate array bounds on `skill.children[]` before returning a member at given index there.

This will enable a nightly build in CI triggering at 1am UTC that currently only runs the above `mythril` job. The intention is to expand that with more checks that are too chunky to run in standard build but still give us the opportunity to catch any issues before Production releases. Anything these nightly builds catch shouldn't be eligible for the bug bounty even though it's merged in `develop` so perhaps we'll need to make that explicit in the Bug Bounty terms when we merge this.

The `mythril` report issues currently cannot be silenced selectively or flagged as acceptable risk, so it makes it difficult in the report to tell if we have any new valid issues. Still it provides a level of reporting we need so we'll just have to suck it up and trawl through it every now and again with our morning coffee to hand-filter potential new issues.