### PR TITLE
Prevent reputation being changed during insertion of new one

### DIFF
--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -117,12 +117,17 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// * 21. The amount of reputation that the child reputation for the user being updated is in the agree state
   /// * 22. The UID of the child reputation for the user being updated in the agree state 
   /// * 23. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code.
+  /// * 24. The branchMask of the proof that the reputation adjacent to the new reputation being inserted is in the agree state 
+  /// * 25. The amount of reputation that the reputation adjacent to a new reputation being inserted has in the agree state
+  /// * 26. The UID of the reputation adjacent to the new reputation being inserted 
+  /// * 27. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code.
 
   /// @param b A `bytes[4]` array. The elements of this arry, in order are:
   /// * 1. Reputation key The key of the reputation being changed that the disagreement is over.
   /// * 2. previousNewReputationKey The key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
   /// * 3. originReputationKey Nonzero for child updates only. The key of the origin skill reputation added to the reputation tree in the last reputation state the submitted hashes agree on
   /// * 4. childReputationKey Required for child updates of a colony-wide global skill. The key corresponding to the child skill of the user in this case
+  /// * 5. adjacentReputationKey Key for a reputation already in the tree adjacent to the new reputation being inserted, if required.
 
   /// @param reputationSiblings The siblings of the Merkle proof that the reputation corresponding to `_reputationKey` is in the reputation state before and after the disagreement
   /// @param agreeStateSiblings The siblings of the Merkle proof that the last reputation state the submitted hashes agreed on is in this submitted hash's justification tree
@@ -130,17 +135,19 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @param previousNewReputationSiblings The siblings of the Merkle proof of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
   /// @param originReputationSiblings Nonzero for child updates only. The siblings of the Merkle proof of the origin skill reputation added to the reputation tree in the last reputation state the submitted hashes agree on
   /// @param childReputationSiblings Nonzero for child updates of a colony-wide global skill. The siblings of the Merkle proof of the child skill reputation of the user in the same skill this global update is for
+  /// @param adjacentReputationSiblings Nonzero for updates involving insertion of a new skill. The siblings of the Merkle proof of a reputation in the agree state that ends adjacent to the new reputation
   /// @dev If you know that the disagreement doesn't involve a new reputation being added, the arguments corresponding to the previous new reputation can be zeroed, as they will not be used. You must be sure
   /// that this is the case, however, otherwise you risk being found incorrect. Zeroed arguments will result in a cheaper call to this function.
   function respondToChallenge(
-    uint256[23] memory u, //An array of 23 UINT Params, ordered as given above.
-    bytes[4] memory b,
+    uint256[27] memory u, //An array of 27 UINT Params, ordered as given above.
+    bytes[5] memory b,
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings,
     bytes32[] memory previousNewReputationSiblings,
     bytes32[] memory originReputationSiblings,
-    bytes32[] memory childReputationSiblings) public;
+    bytes32[] memory childReputationSiblings,
+    bytes32[] memory adjacentReputationSiblings) public;
 
   /// @notice Verify the Justification Root Hash (JRH) for a submitted reputation hash is plausible
   /// @param round The round that the hash is currently in.

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -118,27 +118,28 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// * 22. The UID of the child reputation for the user being updated in the agree state 
   /// * 23. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code.
 
-  /// @param _reputationKey The key of the reputation being changed that the disagreement is over.
+  /// @param b A `bytes[4]` array. The elements of this arry, in order are:
+  /// * 1. Reputation key The key of the reputation being changed that the disagreement is over.
+  /// * 2. previousNewReputationKey The key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
+  /// * 3. originReputationKey Nonzero for child updates only. The key of the origin skill reputation added to the reputation tree in the last reputation state the submitted hashes agree on
+  /// * 4. childReputationKey Required for child updates of a colony-wide global skill. The key corresponding to the child skill of the user in this case
+
   /// @param reputationSiblings The siblings of the Merkle proof that the reputation corresponding to `_reputationKey` is in the reputation state before and after the disagreement
   /// @param agreeStateSiblings The siblings of the Merkle proof that the last reputation state the submitted hashes agreed on is in this submitted hash's justification tree
   /// @param disagreeStateSiblings The siblings of the Merkle proof that the first reputation state the submitted hashes disagreed on is in this submitted hash's justification tree
-  /// @param previousNewReputationKey The key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
   /// @param previousNewReputationSiblings The siblings of the Merkle proof of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
-  /// @param originReputationKey Nonzero for child updates only. The key of the origin skill reputation added to the reputation tree in the last reputation state the submitted hashes agree on
   /// @param originReputationSiblings Nonzero for child updates only. The siblings of the Merkle proof of the origin skill reputation added to the reputation tree in the last reputation state the submitted hashes agree on
+  /// @param childReputationSiblings Nonzero for child updates of a colony-wide global skill. The siblings of the Merkle proof of the child skill reputation of the user in the same skill this global update is for
   /// @dev If you know that the disagreement doesn't involve a new reputation being added, the arguments corresponding to the previous new reputation can be zeroed, as they will not be used. You must be sure
   /// that this is the case, however, otherwise you risk being found incorrect. Zeroed arguments will result in a cheaper call to this function.
   function respondToChallenge(
     uint256[23] memory u, //An array of 23 UINT Params, ordered as given above.
-    bytes memory _reputationKey,
+    bytes[4] memory b,
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings,
-    bytes memory previousNewReputationKey,
     bytes32[] memory previousNewReputationSiblings,
-    bytes memory originReputationKey,
     bytes32[] memory originReputationSiblings,
-    bytes memory childReputationKey,
     bytes32[] memory childReputationSiblings) public;
 
   /// @notice Verify the Justification Root Hash (JRH) for a submitted reputation hash is plausible

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -91,7 +91,7 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
     bytes32[] memory siblings) public;
 
   /// @notice Respond to challenge, to establish which (if either) of the two submissions facing off are correct.
-  /// @param u A `uint256[23]` array. The elements of this array, in order are:
+  /// @param u A `uint256[27]` array. The elements of this array, in order are:
   /// * 1. The current round of the hash being responded on behalf of
   /// * 2. The current index in the round of the hash being responded on behalf of
   /// * 3. The branchMask of the proof that the reputation is in the reputation state tree for the reputation with the disputed change
@@ -122,7 +122,7 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// * 26. The UID of the reputation adjacent to the new reputation being inserted 
   /// * 27. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code.
 
-  /// @param b A `bytes[4]` array. The elements of this arry, in order are:
+  /// @param b A `bytes[5]` array. The elements of this array, in order are:
   /// * 1. Reputation key The key of the reputation being changed that the disagreement is over.
   /// * 2. previousNewReputationKey The key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
   /// * 3. originReputationKey Nonzero for child updates only. The key of the origin skill reputation added to the reputation tree in the last reputation state the submitted hashes agree on

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -195,6 +195,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     // The bit added to the branchmask is based on where the (hashes of the) two keys first differ.
     uint256 firstDifferenceBit = Bits.highestBitSet(uint256(keccak256(b[B_ADJACENT_REPUTATION_KEY]) ^ keccak256(b[B_REPUTATION_KEY])));
     uint256 afterInsertionBranchMask = u[U_ADJACENT_REPUTATION_BRANCH_MASK] | uint256(2**firstDifferenceBit);
+    // If a key that exists in the lastAgreeState has been passed in as the reputationKey, the adjacent key will already have a branch at the
+    // first difference bit, and this check will fail.
     require(afterInsertionBranchMask != u[U_ADJACENT_REPUTATION_BRANCH_MASK], "colony-reputation-mining-adjacent-branchmask-incorrect");
 
     bytes32[] memory afterInsertionAdjacentReputationSiblings = new bytes32[](adjacentReputationSiblings.length + 1);

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -193,7 +193,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     require(impliedRoot == disputeRounds[u[U_ROUND]][u[U_IDX]].jrh, "colony-reputation-mining-adjacent-agree-state-disagreement");
 
     // The bit added to the branchmask is based on where the (hashes of the) two keys first differ.
-    uint256 firstDifferenceBit = Bits.highestBitSet(uint256(keccak256(b[B_ADJACENT_REPUTATION_KEY]) ^ keccak256(b[B_REPUTATION_KEY])));
+    uint256 firstDifferenceBit = uint256(Bits.highestBitSet(uint256(keccak256(b[B_ADJACENT_REPUTATION_KEY]) ^ keccak256(b[B_REPUTATION_KEY]))));
     uint256 afterInsertionBranchMask = u[U_ADJACENT_REPUTATION_BRANCH_MASK] | uint256(2**firstDifferenceBit);
     // If a key that exists in the lastAgreeState has been passed in as the reputationKey, the adjacent key will already have a branch at the
     // first difference bit, and this check will fail.

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -177,7 +177,12 @@ export async function checkErrorRevertEthers(promise, errorMessage) {
 }
 
 export async function checkSuccessEthers(promise, errorMessage) {
-  const receipt = await promise;
+  let receipt;
+  try {
+    receipt = await promise;
+  } catch (err) {
+    receipt = err;
+  }
 
   if (receipt.status === 1) {
     return;

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -169,7 +169,6 @@ class ReputationMiner {
    * @param  {string}  key The key we wish to find the adjacentKey for
    * @return {String}
    */
-
   getAdjacentKey(key) {
     const sortedHashes = Object.keys(this.reverseReputationHashLookup).sort();
     const keyPosition = sortedHashes.indexOf(web3Utils.soliditySha3(key));

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -176,7 +176,7 @@ class ReputationMiner {
     let jhLeafValue;
     let justUpdatedProof;
     let originReputationProof;
-    let childReputationProof = await this.getReputationProofObject("0x00")
+    let childReputationProof = await this.getReputationProofObject("0x00");
     let logEntry;
     let amount;
 
@@ -848,15 +848,17 @@ class ReputationMiner {
         this.justificationHashes[lastAgreeKey].childReputationProof.uid,
         "0"
       ],
-      reputationKey,
+      [
+        reputationKey,
+        this.justificationHashes[lastAgreeKey].newestReputationProof.key,
+        this.justificationHashes[lastAgreeKey].originReputationProof.key,
+        this.justificationHashes[lastAgreeKey].childReputationProof.key,
+      ],
       this.justificationHashes[firstDisagreeKey].justUpdatedProof.siblings,
       agreeStateSiblings,
       disagreeStateSiblings,
-      this.justificationHashes[lastAgreeKey].newestReputationProof.key,
       this.justificationHashes[lastAgreeKey].newestReputationProof.siblings,
-      this.justificationHashes[lastAgreeKey].originReputationProof.key,
       this.justificationHashes[lastAgreeKey].originReputationProof.siblings,
-      this.justificationHashes[lastAgreeKey].childReputationProof.key,
       this.justificationHashes[lastAgreeKey].childReputationProof.siblings,
       { gasLimit: 4000000 }
     );

--- a/packages/reputation-miner/test/MaliciousReputationMinerAddNewReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerAddNewReputation.js
@@ -1,0 +1,20 @@
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
+
+class MaliciousReputationMinerAddNewReputation extends ReputationMinerTestWrapper {
+  // This will add a new reputation as well as adding entryToFalsify correctly.
+  constructor(opts, entryToFalsify) {
+    super(opts);
+    this.entryToFalsify = entryToFalsify.toString();
+  }
+
+  async addSingleReputationUpdate(updateNumber, repCycle, blockNumber) {
+    await super.addSingleReputationUpdate(updateNumber, repCycle, blockNumber);
+    // Add a new reputation in the tree if this is when we've been told to do it.
+    if (updateNumber.toString() === this.entryToFalsify) {
+      const key = MaliciousReputationMinerAddNewReputation.getKey(0xdeadbeef, 0xdeadbeef, 0xdeadbeef);
+      await this.reputationTree.insert(key, 0xdeadbeef, { gasLimit: 4000000 });
+    }
+  }
+}
+
+export default MaliciousReputationMinerAddNewReputation;

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimNew.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimNew.js
@@ -9,6 +9,7 @@ class MaliciousReputationMinerClaimNew extends ReputationMinerTestWrapper {
   }
 
   async addSingleReputationUpdate(updateNumber, repCycle, blockNumber) {
+    let adjacentReputationProof;
     if (updateNumber.toString() === this.entryToFalsify) {
       let key;
       if (updateNumber.lt(this.nReputationsBeforeLatestLog)) {
@@ -18,6 +19,8 @@ class MaliciousReputationMinerClaimNew extends ReputationMinerTestWrapper {
       }
       delete this.reputations[key];
       this.beWrongThisCycle = true;
+      const adjacentKey = await this.getAdjacentKey(key);
+      adjacentReputationProof = await this.getReputationProofObject(adjacentKey);
       // Note that this won't remove it from the PatriciaTree - which is what we want
     }
     await super.addSingleReputationUpdate(updateNumber, repCycle, blockNumber);
@@ -25,6 +28,9 @@ class MaliciousReputationMinerClaimNew extends ReputationMinerTestWrapper {
       this.justificationHashes[
         ReputationMinerTestWrapper.getHexString(updateNumber.sub(1), 64)
       ].nextUpdateProof = await this.getReputationProofObject("0");
+      this.justificationHashes[
+        ReputationMinerTestWrapper.getHexString(updateNumber.sub(1), 64)
+      ].adjacentReputationProof = adjacentReputationProof;
     }
     this.beWrongThisCycle = false;
   }

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
@@ -130,6 +130,10 @@ class MaliciousReputationMiningNoOriginReputation extends ReputationMinerTestWra
         this.justificationHashes[lastAgreeKey].childReputationProof.branchMask,
         this.justificationHashes[lastAgreeKey].childReputationProof.reputation,
         this.justificationHashes[lastAgreeKey].childReputationProof.uid,
+        "0",
+        this.justificationHashes[lastAgreeKey].adjacentReputationProof.branchMask,
+        this.justificationHashes[lastAgreeKey].adjacentReputationProof.reputation,
+        this.justificationHashes[lastAgreeKey].adjacentReputationProof.uid,
         "0"
       ],
       [
@@ -137,6 +141,7 @@ class MaliciousReputationMiningNoOriginReputation extends ReputationMinerTestWra
         this.justificationHashes[lastAgreeKey].newestReputationProof.key,
         this.justificationHashes[lastAgreeKey].originReputationProof.key,
         this.justificationHashes[lastAgreeKey].childReputationProof.key,
+        this.justificationHashes[lastAgreeKey].adjacentReputationProof.key
       ],
       this.justificationHashes[firstDisagreeKey].justUpdatedProof.siblings,
       agreeStateSiblings,
@@ -144,6 +149,7 @@ class MaliciousReputationMiningNoOriginReputation extends ReputationMinerTestWra
       this.justificationHashes[lastAgreeKey].newestReputationProof.siblings,
       this.justificationHashes[lastAgreeKey].originReputationProof.siblings,
       this.justificationHashes[lastAgreeKey].childReputationProof.siblings,
+      this.justificationHashes[lastAgreeKey].adjacentReputationProof.siblings,
       { gasLimit: 4000000 }
     );
     return tx.wait();

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
@@ -77,35 +77,6 @@ class MaliciousReputationMiningNoOriginReputation extends ReputationMinerTestWra
       logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(lastAgreeIdx.sub(this.nReputationsBeforeLatestLog));
     }
 
-    // console.log([
-    //   round,
-    //   index,
-    //   this.justificationHashes[firstDisagreeKey].justUpdatedProof.branchMask,
-    //   this.justificationHashes[lastAgreeKey].nextUpdateProof.nNodes,
-    //   ReputationMinerTestWrapper.getHexString(agreeStateBranchMask),
-    //   this.justificationHashes[firstDisagreeKey].justUpdatedProof.nNodes,
-    //   ReputationMinerTestWrapper.getHexString(disagreeStateBranchMask),
-    //   this.justificationHashes[lastAgreeKey].newestReputationProof.branchMask,
-    //   logEntryNumber,
-    //   "0",
-    //   this.justificationHashes[lastAgreeKey].originReputationProof.branchMask,
-    //   this.justificationHashes[lastAgreeKey].nextUpdateProof.reputation,
-    //   this.justificationHashes[lastAgreeKey].nextUpdateProof.uid,
-    //   this.justificationHashes[firstDisagreeKey].justUpdatedProof.reputation,
-    //   this.justificationHashes[firstDisagreeKey].justUpdatedProof.uid,
-    //   this.justificationHashes[lastAgreeKey].newestReputationProof.reputation,
-    //   this.justificationHashes[lastAgreeKey].newestReputationProof.uid,
-    //   "0x0",
-    //   "0x0"
-    // ],
-    //   reputationKey,
-    //   this.justificationHashes[firstDisagreeKey].justUpdatedProof.siblings,
-    //   agreeStateSiblings,
-    //   disagreeStateSiblings,
-    //   this.justificationHashes[lastAgreeKey].newestReputationProof.key,
-    //   this.justificationHashes[lastAgreeKey].newestReputationProof.siblings,
-    //   this.justificationHashes[lastAgreeKey].originReputationProof.key,
-    //   this.justificationHashes[lastAgreeKey].originReputationProof.siblings,);
     const tx = await repCycle.respondToChallenge(
       [
         round,

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
@@ -132,15 +132,17 @@ class MaliciousReputationMiningNoOriginReputation extends ReputationMinerTestWra
         this.justificationHashes[lastAgreeKey].childReputationProof.uid,
         "0"
       ],
-      reputationKey,
+      [
+        reputationKey,
+        this.justificationHashes[lastAgreeKey].newestReputationProof.key,
+        this.justificationHashes[lastAgreeKey].originReputationProof.key,
+        this.justificationHashes[lastAgreeKey].childReputationProof.key,
+      ],
       this.justificationHashes[firstDisagreeKey].justUpdatedProof.siblings,
       agreeStateSiblings,
       disagreeStateSiblings,
-      this.justificationHashes[lastAgreeKey].newestReputationProof.key,
       this.justificationHashes[lastAgreeKey].newestReputationProof.siblings,
-      this.justificationHashes[lastAgreeKey].originReputationProof.key,
       this.justificationHashes[lastAgreeKey].originReputationProof.siblings,
-      this.justificationHashes[lastAgreeKey].childReputationProof.key,
       this.justificationHashes[lastAgreeKey].childReputationProof.siblings,
       { gasLimit: 4000000 }
     );

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -54,15 +54,17 @@ class MaliciousReputationMiningWrongProofLogEntry extends ReputationMinerTestWra
         this.justificationHashes[lastAgreeKey].childReputationProof.uid,
         "0"
       ],
-      reputationKey,
+      [
+        reputationKey,
+        this.justificationHashes[lastAgreeKey].newestReputationProof.key,
+        this.justificationHashes[lastAgreeKey].originReputationProof.key,
+        this.justificationHashes[lastAgreeKey].childReputationProof.key,
+      ],
       this.justificationHashes[firstDisagreeKey].justUpdatedProof.siblings,
       agreeStateSiblings,
       disagreeStateSiblings,
-      this.justificationHashes[lastAgreeKey].newestReputationProof.key,
       this.justificationHashes[lastAgreeKey].newestReputationProof.siblings,
-      this.justificationHashes[lastAgreeKey].originReputationProof.key,
       this.justificationHashes[lastAgreeKey].originReputationProof.siblings,
-      this.justificationHashes[lastAgreeKey].childReputationProof.key,
       this.justificationHashes[lastAgreeKey].childReputationProof.siblings,
       { gasLimit: 4000000 }
     );

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -52,6 +52,10 @@ class MaliciousReputationMiningWrongProofLogEntry extends ReputationMinerTestWra
         this.justificationHashes[lastAgreeKey].childReputationProof.branchMask,
         this.justificationHashes[lastAgreeKey].childReputationProof.reputation,
         this.justificationHashes[lastAgreeKey].childReputationProof.uid,
+        "0",
+        this.justificationHashes[lastAgreeKey].adjacentReputationProof.branchMask,
+        this.justificationHashes[lastAgreeKey].adjacentReputationProof.reputation,
+        this.justificationHashes[lastAgreeKey].adjacentReputationProof.uid,
         "0"
       ],
       [
@@ -59,6 +63,7 @@ class MaliciousReputationMiningWrongProofLogEntry extends ReputationMinerTestWra
         this.justificationHashes[lastAgreeKey].newestReputationProof.key,
         this.justificationHashes[lastAgreeKey].originReputationProof.key,
         this.justificationHashes[lastAgreeKey].childReputationProof.key,
+        this.justificationHashes[lastAgreeKey].adjacentReputationProof.key
       ],
       this.justificationHashes[firstDisagreeKey].justUpdatedProof.siblings,
       agreeStateSiblings,
@@ -66,6 +71,7 @@ class MaliciousReputationMiningWrongProofLogEntry extends ReputationMinerTestWra
       this.justificationHashes[lastAgreeKey].newestReputationProof.siblings,
       this.justificationHashes[lastAgreeKey].originReputationProof.siblings,
       this.justificationHashes[lastAgreeKey].childReputationProof.siblings,
+      this.justificationHashes[lastAgreeKey].adjacentReputationProof.siblings,
       { gasLimit: 4000000 }
     );
 

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -518,18 +518,26 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.branchMask,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.reputation,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.uid,
+            0,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.branchMask,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.reputation,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.uid,
             0
           ],
-          reputationKey,
+          [
+            reputationKey,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
+          ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
           agreeStateSiblings,
           disagreeStateSiblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.siblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.siblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.siblings
+          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.siblings,
+          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.siblings
         ),
         "colony-reputation-mining-last-state-disagreement"
       );
@@ -636,18 +644,26 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.branchMask,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.reputation,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.uid,
+            0,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.branchMask,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.reputation,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.uid,
             0
           ],
-          reputationKey,
+          [
+            reputationKey,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
+          ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
           agreeStateSiblings,
           disagreeStateSiblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.siblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.siblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.siblings
+          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.siblings,
+          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.siblings
         ),
         "colony-reputation-mining-origin-skill-state-disagreement"
       );
@@ -680,18 +696,26 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
             // goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.branchMask,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.reputation,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.uid,
+            0,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.branchMask,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.reputation,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.uid,
             0
           ],
-          reputationKey,
+          [
+            reputationKey,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
+          ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
           agreeStateSiblings,
           disagreeStateSiblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.siblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.siblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.siblings
+          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.siblings,
+          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.siblings
         ),
         "colony-reputation-mining-child-skill-state-disagreement"
       );
@@ -774,18 +798,26 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.branchMask,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.reputation,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.uid,
+            0,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.branchMask,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.reputation,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.uid,
             0
           ],
-          reputationKey,
+          [
+            reputationKey,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
+          ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
           agreeStateSiblings,
           disagreeStateSiblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.siblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.siblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.siblings
+          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.siblings,
+          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.siblings
         ),
         "colony-reputation-mining-uid-not-decay"
       );
@@ -860,18 +892,26 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.branchMask,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.uid,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.reputation,
+            0,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.branchMask,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.reputation,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.uid,
             0
           ],
-          reputationKey,
+          [
+            reputationKey,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
+          ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
           agreeStateSiblings,
           disagreeStateSiblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.siblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.siblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.siblings
+          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.siblings,
+          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.siblings
         ),
         "colony-reputation-mining-invalid-before-reputation-proof"
       );
@@ -905,18 +945,26 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.branchMask,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.uid,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.reputation,
+            0,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.branchMask,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.reputation,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.uid,
             0
           ],
-          reputationKey,
+          [
+            reputationKey,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
+          ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
           agreeStateSiblings,
           disagreeStateSiblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.siblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.siblings,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
-          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.siblings
+          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.siblings,
+          goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.siblings
         ),
         "colony-reputation-mining-invalid-after-reputation-proof"
       );
@@ -968,16 +1016,14 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
 
       await checkErrorRevert(
         repCycle.respondToChallenge(
-          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          wrongColonyKey,
+          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          [wrongColonyKey, "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],
-          "0x00",
           [],
-          "0x00",
           [],
-          "0x00",
+          [],
           []
         ),
         "colony-reputation-mining-colony-address-mismatch"
@@ -985,16 +1031,14 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
 
       await checkErrorRevert(
         repCycle.respondToChallenge(
-          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          wrongReputationKey,
+          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          [wrongReputationKey, "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],
-          "0x00",
           [],
-          "0x00",
           [],
-          "0x00",
+          [],
           []
         ),
         "colony-reputation-mining-skill-id-mismatch"
@@ -1002,16 +1046,14 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
 
       await checkErrorRevert(
         repCycle.respondToChallenge(
-          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          wrongUserKey,
+          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          [wrongUserKey, "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],
-          "0x00",
           [],
-          "0x00",
           [],
-          "0x00",
+          [],
           []
         ),
         "colony-reputation-mining-user-address-mismatch"
@@ -1041,16 +1083,14 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
 
       await checkErrorRevert(
         repCycle.respondToChallenge(
-          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          "0x00",
+          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          ["0x00", "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],
-          "0x00",
           [],
-          "0x00",
           [],
-          "0x00",
+          [],
           []
         ),
         "colony-reputation-binary-search-incomplete"

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -987,16 +987,30 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
         0,
         // This is the right line.
         // goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].originReputationProof.reputation,
-        goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].originReputationProof.uid
+        goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].originReputationProof.uid,
+        goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].childReputationProof.branchMask,
+        goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].childReputationProof.reputation,
+        goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].childReputationProof.uid,
+        "0",
+        goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].adjacentReputationProof.branchMask,
+        goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].adjacentReputationProof.reputation,
+        goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].adjacentReputationProof.uid,
+        "0"
       ],
-      reputationKey,
+      [
+        reputationKey,
+        goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.key,
+        goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].originReputationProof.key,
+        goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].childReputationProof.key,
+        goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].adjacentReputationProof.key
+      ],
       goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.siblings,
       agreeStateSiblings,
       disagreeStateSiblings,
-      goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.key,
       goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.siblings,
-      goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].originReputationProof.key,
       goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].originReputationProof.siblings,
+      goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].childReputationProof.siblings,
+      goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].adjacentReputationProof.siblings,
       { gasLimit: 4000000 }
     );
 

--- a/test/reputation-mining/types-of-disagreement.js
+++ b/test/reputation-mining/types-of-disagreement.js
@@ -97,7 +97,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
   });
 
   describe("when there is a dispute over reputation root hash", () => {
-    it.skip("should cope when a new reputation is correctly added and an extra reputation is added elsewhere at the same time", async () => {
+    it("should cope when a new reputation is correctly added and an extra reputation is added elsewhere at the same time", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
       await fundColonyWithTokens(metaColony, clnyToken);
@@ -113,11 +113,12 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const righthash = await goodClient.getRootHash();
       const wronghash = await badClient.getRootHash();
       assert.notEqual(righthash, wronghash, "Hashes from clients are equal, surprisingly");
-      console.log("accommodate");
-      await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient);
+      await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
+        client2: { respondToChallenge: "colony-reputation-mining-adjacent-disagree-state-disagreement" }
+      });
       await repCycle.confirmNewHash(1);
     });
-
+    
     it("should allow a user to confirm a submitted JRH with proofs for a submission", async () => {
       const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 1, 0xfffffffff);
       await badClient.initialise(colonyNetwork.address);

--- a/test/reputation-mining/types-of-disagreement.js
+++ b/test/reputation-mining/types-of-disagreement.js
@@ -46,8 +46,8 @@ const loader = new TruffleLoader({
 const useJsTree = true;
 
 contract("Reputation Mining - types of disagreement", accounts => {
-  const MAIN_ACCOUNT = accounts[5];
-  const OTHER_ACCOUNT = accounts[6];
+  const MINER1 = accounts[5];
+  const MINER2 = accounts[6];
 
   let metaColony;
   let colonyNetwork;
@@ -66,7 +66,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
     const clnyAddress = await metaColony.getToken();
     clnyToken = await Token.at(clnyAddress);
 
-    goodClient = new ReputationMinerTestWrapper({ loader, realProviderPort, useJsTree, minerAddress: MAIN_ACCOUNT });
+    goodClient = new ReputationMinerTestWrapper({ loader, realProviderPort, useJsTree, minerAddress: MINER1 });
   });
 
   beforeEach(async () => {
@@ -74,7 +74,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
     await goodClient.initialise(colonyNetwork.address);
 
     // Kick off reputation mining.
-    const lock = await tokenLocking.getUserLock(clnyToken.address, MAIN_ACCOUNT);
+    const lock = await tokenLocking.getUserLock(clnyToken.address, MINER1);
     assert.equal(lock.balance, DEFAULT_STAKE.toString());
 
     // Advance two cycles to clear active and inactive state.
@@ -87,9 +87,9 @@ contract("Reputation Mining - types of disagreement", accounts => {
     const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
     assert.equal(nInactiveLogEntries.toNumber(), 1);
 
-    // Burn MAIN_ACCOUNTS accumulated mining rewards.
-    const userBalance = await clnyToken.balanceOf(MAIN_ACCOUNT);
-    await clnyToken.burn(userBalance, { from: MAIN_ACCOUNT });
+    // Burn MINER1S accumulated mining rewards.
+    const userBalance = await clnyToken.balanceOf(MINER1);
+    await clnyToken.burn(userBalance, { from: MINER1 });
   });
 
   afterEach(async () => {
@@ -98,10 +98,10 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
   describe("when there is a dispute over reputation root hash", () => {
     it("should cope when a new reputation is correctly added and an extra reputation is added elsewhere at the same time", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MAIN_ACCOUNT, DEFAULT_STAKE);
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await fundColonyWithTokens(metaColony, clnyToken);
-      const badClient = new MaliciousReputationMinerAddNewReputation({ loader, minerAddress: OTHER_ACCOUNT, realProviderPort, useJsTree }, 3);
+      const badClient = new MaliciousReputationMinerAddNewReputation({ loader, minerAddress: MINER2, realProviderPort, useJsTree }, 3);
       await badClient.initialise(colonyNetwork.address);
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
@@ -120,10 +120,10 @@ contract("Reputation Mining - types of disagreement", accounts => {
     });
 
     it("should allow a user to confirm a submitted JRH with proofs for a submission", async () => {
-      const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 1, 0xfffffffff);
+      const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 1, 0xfffffffff);
       await badClient.initialise(colonyNetwork.address);
 
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       await fundColonyWithTokens(metaColony, clnyToken);
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -169,11 +169,11 @@ contract("Reputation Mining - types of disagreement", accounts => {
     });
 
     it("should cope if the wrong reputation transition is the first transition", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
       await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
 
-      const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 0, 0xfffffffff);
+      const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 0, 0xfffffffff);
       await badClient.initialise(colonyNetwork.address);
 
       await goodClient.saveCurrentState();
@@ -198,15 +198,11 @@ contract("Reputation Mining - types of disagreement", accounts => {
     // correctly. Unsure if I should force them to be run every time.
     [0, 1, 2, 3, 4, 5, 6, 7].forEach(async badIndex => {
       it.skip(`should cope if wrong reputation transition is transition ${badIndex}`, async function advancingTest() {
-        await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+        await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
         await advanceMiningCycleNoContest({ colonyNetwork, test: this });
         await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
 
-        const badClient = new MaliciousReputationMinerExtraRep(
-          { loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT },
-          badIndex,
-          0xfffffffff
-        );
+        const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, badIndex, 0xfffffffff);
         await badClient.initialise(colonyNetwork.address);
 
         await goodClient.saveCurrentState();
@@ -235,7 +231,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
     });
 
     it("should allow a binary search between opponents to take place to find their first disagreement", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(3));
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -249,7 +245,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 13);
 
-      const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 12, 0xfffffffff);
+      const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 12, 0xfffffffff);
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -355,7 +351,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
     });
 
     it("if respondToChallenge is attempted to be called multiple times, it should fail", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(3));
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -370,7 +366,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 13);
 
-      const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 27, 0xfffffffff);
+      const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 27, 0xfffffffff);
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -401,7 +397,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
     });
 
     it("if someone tries to insert a second copy of an existing reputation as a new one, it should fail", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(3));
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -415,7 +411,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 13);
 
-      const badClient = new MaliciousReputationMinerClaimNew({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 20);
+      const badClient = new MaliciousReputationMinerClaimNew({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 20);
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -433,7 +429,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
   describe("should correctly resolve dispute over nNodes", () => {
     it("where the submitted nNodes is lied about", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING);
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -445,7 +441,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 5);
 
-      const badClient = new MaliciousReputationMinerWrongNNodes({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 8);
+      const badClient = new MaliciousReputationMinerWrongNNodes({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 8);
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -458,10 +454,10 @@ contract("Reputation Mining - types of disagreement", accounts => {
     });
 
     it("where the number of nodes has been incremented incorrectly when adding a new reputation", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
-      const badClient = new MaliciousReputationMinerWrongNNodes2({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 3, 1);
+      const badClient = new MaliciousReputationMinerWrongNNodes2({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 3, 1);
       await badClient.initialise(colonyNetwork.address);
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
@@ -475,7 +471,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
     });
 
     it("where the number of nodes has been incremented during an update of an existing reputation", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING);
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -487,7 +483,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 5);
 
-      const badClient = new MaliciousReputationMinerWrongNNodes2({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 8, 1);
+      const badClient = new MaliciousReputationMinerWrongNNodes2({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 8, 1);
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -501,7 +497,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
   describe("should correctly resolve dispute over JRH", () => {
     it("because a leaf in the JT is wrong", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING);
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -513,7 +509,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 5);
 
-      const badClient = new MaliciousReputationMinerWrongJRH({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 8);
+      const badClient = new MaliciousReputationMinerWrongJRH({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 8);
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -526,7 +522,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
     });
 
     it("with an extra leaf causing proof 1 to be too long", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING);
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -538,7 +534,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 5);
 
-      const badClient = new MaliciousReputationMinerWrongJRH({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 500000);
+      const badClient = new MaliciousReputationMinerWrongJRH({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 500000);
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -552,7 +548,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
     });
 
     it("with an extra leaf causing proof 2 to be too long", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(3));
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -568,7 +564,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 13);
 
-      const badClient = new MaliciousReputationMinerWrongJRH({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 30);
+      const badClient = new MaliciousReputationMinerWrongJRH({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 30);
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -580,7 +576,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
   describe("should correctly resolve dispute over reputation UID", () => {
     it("if an existing reputation's uniqueID is changed", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(3));
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -594,7 +590,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 13);
 
-      const badClient = new MaliciousReputationMinerWrongUID({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 12, 0xfffffffff);
+      const badClient = new MaliciousReputationMinerWrongUID({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 12, 0xfffffffff);
       await badClient.initialise(colonyNetwork.address);
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
@@ -639,7 +635,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       // This doesn't quite hold if the two submissions are both malicious, and agreed on an invliad state for the lastAgreeState.
       // However, only one will still be able to be 'right', and so the dispute resoultion will continue as intended with at least
       // one of those submissions being eliminated.
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(3));
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -654,7 +650,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 13);
 
-      const badClient = new MaliciousReputationMinerReuseUID({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 3, 1);
+      const badClient = new MaliciousReputationMinerReuseUID({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 3, 1);
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -692,7 +688,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
     });
 
     it("if a new reputation's uniqueID is not proved right because a too-old previous ID is proved", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(3));
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -701,13 +697,13 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
-      const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 27, 0xfffffffff);
+      const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 27, 0xfffffffff);
       await badClient.initialise(colonyNetwork.address);
 
       // This client gets the same root hash as goodClient, but will submit the wrong newest reputation hash when
       // it calls respondToChallenge.
       const badClient2 = new MaliciousReputationMinerWrongNewestReputation(
-        { loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT },
+        { loader, realProviderPort, useJsTree, minerAddress: MINER2 },
         27,
         0xfffffffff
       );
@@ -747,7 +743,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       // is added or not.
       // So skipping this test, and leaving in the require for now in case I am wrong. This seems like a _very_ good candidate for an experimentation
       // with formal proofs, though....
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(3));
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -762,7 +758,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
       assert.equal(nInactiveLogEntries.toNumber(), 13);
 
-      const badClient = new MaliciousReputationMinerUnsure({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 20, 0xffff);
+      const badClient = new MaliciousReputationMinerUnsure({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 20, 0xffff);
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -795,12 +791,12 @@ contract("Reputation Mining - types of disagreement", accounts => {
     });
 
     it("if a reputation decay calculation is wrong", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       let repCycle = await getActiveRepCycle(colonyNetwork);
 
-      const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 1, 0xfffffffff);
+      const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 1, 0xfffffffff);
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -843,7 +839,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
     });
 
     it("if an update makes reputation amount go over the max, in a dispute, it should be limited to the max value", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, OTHER_ACCOUNT, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       const fundsRequired = INT128_MAX.add(new BN(1000000000000).muln(2)).add(new BN(1000000000).muln(2));
       await fundColonyWithTokens(metaColony, clnyToken, fundsRequired);
@@ -888,7 +884,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       assert.equal(nLogEntries.toNumber(), 5);
 
       const badClient = new MaliciousReputationMinerExtraRep(
-        { loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT },
+        { loader, realProviderPort, useJsTree, minerAddress: MINER2 },
         17,
         toBN("170141183460469231731687302715884105727").mul(toBN(-1))
       );

--- a/test/reputation-mining/types-of-disagreement.js
+++ b/test/reputation-mining/types-of-disagreement.js
@@ -118,7 +118,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       });
       await repCycle.confirmNewHash(1);
     });
-    
+
     it("should allow a user to confirm a submitted JRH with proofs for a submission", async () => {
       const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: OTHER_ACCOUNT }, 1, 0xfffffffff);
       await badClient.initialise(colonyNetwork.address);


### PR DESCRIPTION
Closes #420.

Consider a reputation tree that looks like the following as the `lastAgreeState` in a dispute

```
      .
     / \
    .   C
   / \
  A   B
```

The two `firstDisagreeStates` could be

```
      .                           .
     / \                         / \  
    .    .                      .    .      
   / \  / \                    / \  / \                         
  A  B  D  C                  A' B  D  C             
```

Let's assume the first one is correct. The client that submits the second one has inserted `D` correctly, but modified `A` to `A'` simultaneously. Without this PR, both miners can prove the same things about their new reputation state (i.e. nothing about D in `lastAgreeState` because it doesn't exist, that `D` is in their `firstDisagreeState`, as well as the ID assigned to `D` being correct based on an ID proved to be in `lastAgreeState` and the value of `D` being correct based on the log). In that scenario, both submissions are eliminated (which is obviously incorrect if we assume the first tree is the one that should be winning all disputes).

This PR solves this problem by adding a new check that uses what it refers to as the 'adjacent' reputation to ensure this has not happened. The 'adjacent' reputation is the reputation already in the tree that has the key with the most number of bits at the start the same as the key of the new reputation being added. This is reputation `C` in the example above. There is always one extra sibling added to the proof of the adjacent reputation after an insertion, and the `branchmask` correspondingly has an extra bit set.

The extra checks and calculations done (if necessary) are:

* Make sure that provided reputation `C` is in the `lastAgreeState` via a merkle proof - using the `key`, `value`, `branchMask` and `siblings` as normal
* Based on the key and proposed value of `D`, work out what the branchMask and extra sibling for the proof of C should be in the `firstDisagreeState`, and where the extra sibling should be in the `siblings` array for the proof of C in `firstDisagreeState`.
* Check that C can be proved to be in the `firstDisagreeState` with this generated `branchMask` and `siblings`. If a reputation has been altered elsewhere in the tree, the siblings will be wrong and the proof will fail.

If a reputation that is not-adjacent is attempted to be used, this check will fail as either the generated `branchMask` and/or `siblings` will be wrong, as they assume that the adjacent reputation has been used.

~Not quite ready for a real review yet (I need to fix other tests/clients to include the new parameters to `respondToChallenge` at the very least), and I also want to put some more tests in, which I probably want to wait for #501 to go in before doing - and also come up with a solution to the issue below.~

### Test reproducibility
There is an issue around the tests, in that tests for this are tricky to write, which is part of the reason why I've held off writing more. In the example above, D could be inserted anywhere: 

```
      .                           .
     / \                         / \  
    .    .                      .    .      
   / \  / \                    / \  / \                         
  A  B  D  C                  A  B  C  D    


      .                           .
     / \                         / \  
    .    C                      .   C      
   / \                         / \                           
  .   B                       .   D
 / \                         / \
 A  D                       A   B         
```

> Educational aside: The adjacent reputations to D used by the mining client in these states are C, C, A and B respectively. While not used by the mining client, in the fourth state, a submission could also use reputation A in place of B and pass `respondToChallenge` successfully, assuming the appropriate `branchmask` and `siblings` were used. This does not pose an issue however - this proves exactly the same things about the state, just showing different workings.

Where `D` is located is based on the hashes of the keys of the reputations, which in turn is dependent on the colony address, which in turn is dependent on the number of transactions that the addresses in question have done on the network. So a test that checks when D is inserted in one place above when run with `it.only` will likely insert D elsewhere when run in the full body of tests. Ideally, we would test D being inserted in all locations (or at least, in situations where the new sibling for the adjacent reputation should be first, last, or somewhere in the middle).

My best idea is manually set a state on-chain (essentially, populate the reputation log deterministically with recovery mode) and go from there, but that does seem a bit tedious. Any better suggestions are welcome!

**Followup**: Looking at coverage, our test suite appears to be expansive enough already that those lines are hit, though more by luck than judgment (see lines 252 to 261 in a [run](https://5949-89702863-gh.circle-artifacts.com/0/home/circleci/colonyNetwork/coverage/contracts/ReputationMiningCycleRespond.sol.html)), which makes me happier about merging this without taking the time to write those tests.