### PR TITLE
Remove redundant global skill creation

### DIFF
--- a/test/reputation-mining/happy-paths.js
+++ b/test/reputation-mining/happy-paths.js
@@ -680,16 +680,6 @@ contract("Reputation Mining - happy paths", accounts => {
     });
 
     it("should cope if the wrong reputation transition is a distant parent", async () => {
-      await metaColony.addGlobalSkill(1);
-      await metaColony.addGlobalSkill(4);
-      await metaColony.addGlobalSkill(5);
-      await metaColony.addGlobalSkill(6);
-      await metaColony.addGlobalSkill(7);
-      await metaColony.addGlobalSkill(8);
-      await metaColony.addGlobalSkill(9);
-
-      // 1 -> 4 -> 5 -> 6 -> 7 -> 8 -> 9 -> 10
-
       await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(3));


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Implements part of #317

<!--- Summary of changes including design decisions -->

As the ColonyNetwork is not re-deployed within reputation mining test files, all global skills created in these tests persist for the duration of the file. As such, global skill definitions really should occur in the first `before` block only to avoid creating hidden dependencies between test blocks. This was a bigger issue before @elenadimitrova's #501 , now it only crops up in one test so that's good :)

Specifically here, the calls to `addGlobalSkill` which we remove were actually doing nothing -- the skills we are testing are created in the first `before` block.