### PR TITLE
Throw error for insufficient miner stake

### DIFF
--- a/test/reputation-mining/root-hash-submissions.js
+++ b/test/reputation-mining/root-hash-submissions.js
@@ -98,7 +98,6 @@ contract("Reputation mining - root hash submissions", accounts => {
 
   describe("when determining submission eligibility", () => {
     it("should allow a new reputation hash to be submitted", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION, this);
       await repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MINER1 });


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Implements part of #317 

<!--- Summary of changes including design decisions -->

Currently, an insufficient stake leads the miner to `return` an Error in `submitRootHash`, due to the loop not finding a valid index. This leads to an odd behavior where the actual error which appears to the developer is a `missing method for tx.wait()`; and further, the return value for `miner.submitRootHash` is ambiguous (an Error or a Tx). We should throw the error so that the miner knows what's gone wrong, and so the method always returns a Tx.