### PR TITLE
Enable mythril nightlies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ workflows:
     jobs:
       - lint-and-unit-test
       - test-coverage
-nightly:
+  nightly:
     triggers:
       - schedule:
           cron: "0 1 * * *" # 1am UTC


### PR DESCRIPTION
The nightly didn't run, and we think it's because we got the indentation wrong in the circle.yml, [judging from the docs](https://circleci.com/docs/2.0/workflows/#nightly-example). Let's take another crack at it!