### PR TITLE
Fix issue around origin reputation

### DIFF
--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -122,11 +122,10 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// * 26. The UID of the reputation adjacent to the new reputation being inserted 
   /// * 27. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code.
 
-  /// @param b A `bytes[4]` array. The elements of this array, in order are:
+  /// @param b A `bytes[3]` array. The elements of this array, in order are:
   /// * 1. Reputation key The key of the reputation being changed that the disagreement is over.
   /// * 2. previousNewReputationKey The key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
-  /// * 3. childReputationKey Required for child updates of a colony-wide global skill. The key corresponding to the child skill of the user in this case
-  /// * 4. adjacentReputationKey Key for a reputation already in the tree adjacent to the new reputation being inserted, if required.
+  /// * 3. adjacentReputationKey Key for a reputation already in the tree adjacent to the new reputation being inserted, if required.
 
   /// @param reputationSiblings The siblings of the Merkle proof that the reputation corresponding to `_reputationKey` is in the reputation state before and after the disagreement
   /// @param agreeStateSiblings The siblings of the Merkle proof that the last reputation state the submitted hashes agreed on is in this submitted hash's justification tree
@@ -139,7 +138,7 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// that this is the case, however, otherwise you risk being found incorrect. Zeroed arguments will result in a cheaper call to this function.
   function respondToChallenge(
     uint256[27] memory u, //An array of 27 UINT Params, ordered as given above.
-    bytes[4] memory b,
+    bytes[3] memory b,
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings,

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -122,12 +122,11 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// * 26. The UID of the reputation adjacent to the new reputation being inserted 
   /// * 27. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code.
 
-  /// @param b A `bytes[5]` array. The elements of this array, in order are:
+  /// @param b A `bytes[4]` array. The elements of this array, in order are:
   /// * 1. Reputation key The key of the reputation being changed that the disagreement is over.
   /// * 2. previousNewReputationKey The key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
-  /// * 3. userOriginReputationKey Nonzero for child updates only. The key of the user's origin skill reputation added to the reputation tree in the last reputation state the submitted hashes agree on
-  /// * 4. childReputationKey Required for child updates of a colony-wide global skill. The key corresponding to the child skill of the user in this case
-  /// * 5. adjacentReputationKey Key for a reputation already in the tree adjacent to the new reputation being inserted, if required.
+  /// * 3. childReputationKey Required for child updates of a colony-wide global skill. The key corresponding to the child skill of the user in this case
+  /// * 4. adjacentReputationKey Key for a reputation already in the tree adjacent to the new reputation being inserted, if required.
 
   /// @param reputationSiblings The siblings of the Merkle proof that the reputation corresponding to `_reputationKey` is in the reputation state before and after the disagreement
   /// @param agreeStateSiblings The siblings of the Merkle proof that the last reputation state the submitted hashes agreed on is in this submitted hash's justification tree
@@ -140,7 +139,7 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// that this is the case, however, otherwise you risk being found incorrect. Zeroed arguments will result in a cheaper call to this function.
   function respondToChallenge(
     uint256[27] memory u, //An array of 27 UINT Params, ordered as given above.
-    bytes[5] memory b,
+    bytes[4] memory b,
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings,

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -111,8 +111,8 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// * 15. The UID that the entry in the tree under dispute has in the disagree state
   /// * 16. The amount of reputation that the most recently added entry in the tree has in the state being disputed
   /// * 17. The UID that the most recently added entry in the tree has in the state being disputed
-  /// * 18. The amount of reputation that the origin reputation entry in the tree has in the state being disputed
-  /// * 19. The UID that the origin reputation entry in the tree has in the state being disputed
+  /// * 18. The amount of reputation that the user's origin reputation entry in the tree has in the state being disputed
+  /// * 19. The UID that the user's origin reputation entry in the tree has in the state being disputed
   /// * 20. The branchMask of the proof that the child reputation for the user being updated is in the agree state 
   /// * 21. The amount of reputation that the child reputation for the user being updated is in the agree state
   /// * 22. The UID of the child reputation for the user being updated in the agree state 
@@ -125,7 +125,7 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @param b A `bytes[5]` array. The elements of this array, in order are:
   /// * 1. Reputation key The key of the reputation being changed that the disagreement is over.
   /// * 2. previousNewReputationKey The key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
-  /// * 3. originReputationKey Nonzero for child updates only. The key of the origin skill reputation added to the reputation tree in the last reputation state the submitted hashes agree on
+  /// * 3. userOriginReputationKey Nonzero for child updates only. The key of the user's origin skill reputation added to the reputation tree in the last reputation state the submitted hashes agree on
   /// * 4. childReputationKey Required for child updates of a colony-wide global skill. The key corresponding to the child skill of the user in this case
   /// * 5. adjacentReputationKey Key for a reputation already in the tree adjacent to the new reputation being inserted, if required.
 
@@ -133,7 +133,7 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @param agreeStateSiblings The siblings of the Merkle proof that the last reputation state the submitted hashes agreed on is in this submitted hash's justification tree
   /// @param disagreeStateSiblings The siblings of the Merkle proof that the first reputation state the submitted hashes disagreed on is in this submitted hash's justification tree
   /// @param previousNewReputationSiblings The siblings of the Merkle proof of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
-  /// @param originReputationSiblings Nonzero for child updates only. The siblings of the Merkle proof of the origin skill reputation added to the reputation tree in the last reputation state the submitted hashes agree on
+  /// @param userOriginReputationSiblings Nonzero for child updates only. The siblings of the Merkle proof of the user's origin skill reputation added to the reputation tree in the last reputation state the submitted hashes agree on
   /// @param childReputationSiblings Nonzero for child updates of a colony-wide global skill. The siblings of the Merkle proof of the child skill reputation of the user in the same skill this global update is for
   /// @param adjacentReputationSiblings Nonzero for updates involving insertion of a new skill. The siblings of the Merkle proof of a reputation in the agree state that ends adjacent to the new reputation
   /// @dev If you know that the disagreement doesn't involve a new reputation being added, the arguments corresponding to the previous new reputation can be zeroed, as they will not be used. You must be sure
@@ -145,7 +145,7 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings,
     bytes32[] memory previousNewReputationSiblings,
-    bytes32[] memory originReputationSiblings,
+    bytes32[] memory userOriginReputationSiblings,
     bytes32[] memory childReputationSiblings,
     bytes32[] memory adjacentReputationSiblings) public;
 

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -82,16 +82,15 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
   uint constant B_REPUTATION_KEY = 0;
   uint constant B_PREVIOUS_NEW_REPUTATION_KEY = 1;
-  uint constant B_ORIGIN_REPUTATION_KEY = 2;
-  uint constant B_CHILD_REPUTATION_KEY = 3;
-  uint constant B_ADJACENT_REPUTATION_KEY = 4;
+  uint constant B_CHILD_REPUTATION_KEY = 2;
+  uint constant B_ADJACENT_REPUTATION_KEY = 3;
 
   uint constant DECAY_NUMERATOR =    992327946262944; // 24-hr mining cycles
   uint constant DECAY_DENOMINATOR = 1000000000000000;
 
   function respondToChallenge(
     uint256[27] memory u, //An array of 27 UINT Params, ordered as given above.
-    bytes[5] memory b, // An array of 5 bytes params, ordered as given above
+    bytes[4] memory b, // An array of 5 bytes params, ordered as given above
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings,
@@ -169,7 +168,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   
   function checkAdjacentReputation(
     uint256[27] memory u,
-    bytes[5] memory b,
+    bytes[4] memory b,
     bytes32[] memory adjacentReputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings
@@ -217,7 +216,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
   function buildNewSiblingsArray(
     uint256[27] memory u, 
-    bytes[5] memory b, 
+    bytes[4] memory b, 
     uint256 firstDifferenceBit, 
     bytes32[] memory adjacentReputationSiblings
     ) internal returns (bytes32[] memory) 
@@ -267,7 +266,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
   function checkUserOriginReputation(
     uint256[27] memory u,
-    bytes[5] memory b,
+    bytes[4] memory b,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory userOriginReputationSiblings) internal 
   {
@@ -277,8 +276,6 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     }
 
     bytes memory reputationKey = b[B_REPUTATION_KEY];
-    bytes memory userOriginReputationKey = b[B_ORIGIN_REPUTATION_KEY];
-
     uint256 relativeUpdateNumber = getRelativeUpdateNumber(u, logEntry);
     uint256 nChildUpdates;
     (nChildUpdates, ) = getChildAndParentNUpdatesForLogEntry(u);
@@ -286,30 +283,18 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     // Skip origin reputation checks for anything but child reputation updates
     if (relativeUpdateNumber % (logEntry.nUpdates/2) < nChildUpdates) {
       // Check the user origin reputation key matches the colony, user address and skill id of the log
-      address colonyAddressOriginRep;
-      address userAddressOriginRep;
-      uint256 skillIdOriginRep;
-      assembly {
-          colonyAddressOriginRep := mload(add(userOriginReputationKey,20))
-          skillIdOriginRep := mload(add(userOriginReputationKey, 52))
-          userAddressOriginRep := mload(add(userOriginReputationKey,72))
-      }
-
-      require(colonyAddressOriginRep == logEntry.colony, "colony-reputation-mining-origin-colony-incorrect");
-      require(skillIdOriginRep == logEntry.skillId, "colony-reputation-mining-origin-skill-incorrect");
-      require(userAddressOriginRep == logEntry.user, "colony-reputation-mining-origin-user-incorrect");
-      
+      bytes memory userOriginReputationKeyBytes = abi.encodePacked(logEntry.colony, logEntry.skillId, logEntry.user);
       checkUserOriginReputationInState(
         u,
         agreeStateSiblings,
-        userOriginReputationKey,
+        userOriginReputationKeyBytes,
         userOriginReputationSiblings);
     }
   }
 
   function checkChildReputation(
     uint256[27] memory u,
-    bytes[5] memory b,
+    bytes[4] memory b,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory childReputationSiblings) internal 
   {
@@ -348,7 +333,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     disputeRounds[u[U_ROUND]][u[U_IDX]].lastResponseTimestamp = now;
   }
 
-  function checkKey(uint256[27] memory u, bytes[5] memory b) internal view {
+  function checkKey(uint256[27] memory u, bytes[4] memory b) internal view {
     // If the state transition we're checking is less than the number of nodes in the currently accepted state, it's a decay transition
     // Otherwise, look up the corresponding entry in the reputation log.
     uint256 updateNumber = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1;
@@ -367,7 +352,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     require(u[U_AGREE_STATE_REPUTATION_UID]-1 == _updateNumber, "colony-reputation-mining-uid-not-decay");
   }
 
-  function checkKeyLogEntry(uint256[27] memory u, bytes[5] memory b) internal view {
+  function checkKeyLogEntry(uint256[27] memory u, bytes[4] memory b) internal view {
     ReputationLogEntry storage logEntry = reputationUpdateLog[u[U_LOG_ENTRY_NUMBER]];
 
     uint256 expectedSkillId;
@@ -424,7 +409,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
   function proveBeforeReputationValue(
     uint256[27] memory u,
-    bytes[5] memory b,
+    bytes[4] memory b,
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings
   ) internal
@@ -469,7 +454,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
   function proveAfterReputationValue(
     uint256[27] memory u,
-    bytes[5] memory b,
+    bytes[4] memory b,
     bytes32[] memory reputationSiblings,
     bytes32[] memory disagreeStateSiblings
   ) internal view
@@ -633,7 +618,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
   function checkPreviousReputationInState(
     uint256[27] memory u,
-    bytes[5] memory b,
+    bytes[4] memory b,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory previousNewReputationSiblings
     ) internal view
@@ -659,7 +644,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   function checkUserOriginReputationInState(
     uint256[27] memory u,
     bytes32[] memory agreeStateSiblings,
-    bytes memory userOriginReputationKey,
+    bytes memory userOriginReputationKeyBytes,
     bytes32[] memory userOriginReputationStateSiblings
     ) internal
   {
@@ -669,7 +654,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     bytes memory userOriginReputationValueBytes = abi.encodePacked(u[U_USER_ORIGIN_REPUTATION_VALUE], u[U_USER_ORIGIN_REPUTATION_UID]);
 
     bytes32 reputationRootHash = getImpliedRootHashKey(
-      userOriginReputationKey,
+      userOriginReputationKeyBytes,
       userOriginReputationValueBytes,
       u[U_USER_ORIGIN_SKILL_REPUTATION_BRANCH_MASK],
       userOriginReputationStateSiblings

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -897,7 +897,6 @@ class ReputationMiner {
       [
         reputationKey,
         this.justificationHashes[lastAgreeKey].newestReputationProof.key,
-        this.justificationHashes[lastAgreeKey].originReputationProof.key,
         this.justificationHashes[lastAgreeKey].childReputationProof.key,
         this.justificationHashes[lastAgreeKey].adjacentReputationProof.key
       ],

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -897,7 +897,6 @@ class ReputationMiner {
       [
         reputationKey,
         this.justificationHashes[lastAgreeKey].newestReputationProof.key,
-        this.justificationHashes[lastAgreeKey].childReputationProof.key,
         this.justificationHashes[lastAgreeKey].adjacentReputationProof.key
       ],
       this.justificationHashes[firstDisagreeKey].justUpdatedProof.siblings,

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
@@ -110,7 +110,6 @@ class MaliciousReputationMiningNoOriginReputation extends ReputationMinerTestWra
       [
         reputationKey,
         this.justificationHashes[lastAgreeKey].newestReputationProof.key,
-        this.justificationHashes[lastAgreeKey].originReputationProof.key,
         this.justificationHashes[lastAgreeKey].childReputationProof.key,
         this.justificationHashes[lastAgreeKey].adjacentReputationProof.key
       ],

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
@@ -110,7 +110,6 @@ class MaliciousReputationMiningNoOriginReputation extends ReputationMinerTestWra
       [
         reputationKey,
         this.justificationHashes[lastAgreeKey].newestReputationProof.key,
-        this.justificationHashes[lastAgreeKey].childReputationProof.key,
         this.justificationHashes[lastAgreeKey].adjacentReputationProof.key
       ],
       this.justificationHashes[firstDisagreeKey].justUpdatedProof.siblings,

--- a/packages/reputation-miner/test/MaliciousReputationMinerGlobalOriginNotChildOrigin.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerGlobalOriginNotChildOrigin.js
@@ -1,0 +1,37 @@
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
+
+const WRONG_ADDRESS = "0000000000000000000000000000000000000000";
+
+class MaliciousReputationMinerGlobalOriginNotChildOrigin extends ReputationMinerTestWrapper {
+  // This client will calculate with the global origin skill, rather than the child origin skill, whend doing a child reputation update.
+  // It will also provide it as the origin reputation skill when respondingToChallenge
+  constructor(opts, entryToFalsify) {
+    super(opts);
+    this.entryToFalsify = entryToFalsify;
+  }
+
+  async addSingleReputationUpdate(updateNumber, repCycle, blockNumber, checkForReplacement) {
+    if (updateNumber.toNumber() === this.entryToFalsify){
+      this.alterThisEntry = true;
+    }
+    await super.addSingleReputationUpdate(updateNumber, repCycle, blockNumber, checkForReplacement)
+  }
+
+  async getKeyForUpdateNumber(updateNumber){
+    const correctKey = await super.getKeyForUpdateNumber(updateNumber);
+    if (this.alterThisEntry){
+      if (updateNumber.toNumber() > this.entryToFalsify){
+        // Then we're trying to look up an origin skill
+        // Provide the global origin skill
+        const wrongKey = `${correctKey.slice(0, WRONG_ADDRESS.length + 2 + 64)}${WRONG_ADDRESS}`;
+        // We only return the wrongkey the first time this function is called in the update in question.
+        this.alterThisEntry = false;
+        return wrongKey;
+      }
+    }
+    return correctKey
+  }
+
+}
+
+export default MaliciousReputationMinerGlobalOriginNotChildOrigin;

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -61,7 +61,6 @@ class MaliciousReputationMiningWrongProofLogEntry extends ReputationMinerTestWra
       [
         reputationKey,
         this.justificationHashes[lastAgreeKey].newestReputationProof.key,
-        this.justificationHashes[lastAgreeKey].childReputationProof.key,
         this.justificationHashes[lastAgreeKey].adjacentReputationProof.key
       ],
       this.justificationHashes[firstDisagreeKey].justUpdatedProof.siblings,

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -61,7 +61,6 @@ class MaliciousReputationMiningWrongProofLogEntry extends ReputationMinerTestWra
       [
         reputationKey,
         this.justificationHashes[lastAgreeKey].newestReputationProof.key,
-        this.justificationHashes[lastAgreeKey].originReputationProof.key,
         this.justificationHashes[lastAgreeKey].childReputationProof.key,
         this.justificationHashes[lastAgreeKey].adjacentReputationProof.key
       ],

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -527,7 +527,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
           ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
@@ -652,7 +651,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
           ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
@@ -703,7 +701,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
           ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
@@ -804,7 +801,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
           ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
@@ -897,7 +893,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
           ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
@@ -949,7 +944,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
           ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
@@ -1011,7 +1005,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          [wrongColonyKey, "0x00", "0x00", "0x00"],
+          [wrongColonyKey, "0x00", "0x00"],
           [],
           [],
           [],
@@ -1026,7 +1020,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          [wrongReputationKey, "0x00", "0x00", "0x00"],
+          [wrongReputationKey, "0x00", "0x00"],
           [],
           [],
           [],
@@ -1041,7 +1035,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          [wrongUserKey, "0x00", "0x00", "0x00"],
+          [wrongUserKey, "0x00", "0x00"],
           [],
           [],
           [],
@@ -1078,7 +1072,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          ["0x00", "0x00", "0x00", "0x00", "0x00"],
+          ["0x00", "0x00", "0x00"],
           [],
           [],
           [],

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -527,7 +527,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
           ],
@@ -653,7 +652,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
           ],
@@ -705,7 +703,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
           ],
@@ -807,7 +804,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
           ],
@@ -901,7 +897,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
           ],
@@ -954,7 +949,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.key,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
           ],
@@ -1017,7 +1011,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          [wrongColonyKey, "0x00", "0x00", "0x00", "0x00"],
+          [wrongColonyKey, "0x00", "0x00", "0x00"],
           [],
           [],
           [],
@@ -1032,7 +1026,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          [wrongReputationKey, "0x00", "0x00", "0x00", "0x00"],
+          [wrongReputationKey, "0x00", "0x00", "0x00"],
           [],
           [],
           [],
@@ -1047,7 +1041,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          [wrongUserKey, "0x00", "0x00", "0x00", "0x00"],
+          [wrongUserKey, "0x00", "0x00", "0x00"],
           [],
           [],
           [],

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -701,7 +701,8 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       await repCycle.confirmNewHash(1);
     });
 
-    it("if one person lies about what the child skill is", async () => {
+    it.skip("if one person lies about what the child skill is", async () => {
+      // We deduce the child reputation key from the logEntry on chain now so the client cannot lie about it
       await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
@@ -1074,7 +1075,6 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       [
         reputationKey,
         goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.key,
-        goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].childReputationProof.key,
         goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].adjacentReputationProof.key
       ],
       goodClient.justificationHashes[`0x${new BN(firstDisagreeIdx).toString(16, 64)}`].justUpdatedProof.siblings,

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -31,6 +31,7 @@ import MaliciousReputationMinerClaimNew from "../../packages/reputation-miner/te
 import MaliciousReputationMinerClaimNoOriginReputation from "../../packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation";
 import MaliciousReputationMinerClaimWrongOriginReputation from "../../packages/reputation-miner/test/MaliciousReputationMinerClaimWrongOriginReputation"; // eslint-disable-line max-len
 import MaliciousReputationMinerClaimWrongChildReputation from "../../packages/reputation-miner/test/MaliciousReputationMinerClaimWrongChildReputation"; // eslint-disable-line max-len
+import MaliciousReputationMinerGlobalOriginNotChildOrigin from "../../packages/reputation-miner/test/MaliciousReputationMinerGlobalOriginNotChildOrigin"; // eslint-disable-line max-len
 
 const EtherRouter = artifacts.require("EtherRouter");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
@@ -340,6 +341,77 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
   });
 
   describe("should correctly resolve a dispute over child skill", () => {
+    it("if the global origin skill is provided instead of the child origin skill", async () => {
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 5,
+        managerPayout: 5000000000000,
+        evaluatorPayout: 5000000000000,
+        workerPayout: 5000000000000,
+        managerRating: 3,
+        workerRating: 3,
+        worker: MINER2
+      });
+
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 5,
+        managerPayout: 5000000000000,
+        evaluatorPayout: 5000000000000,
+        workerPayout: 5000000000000,
+        managerRating: 3,
+        workerRating: 3,
+        worker: MINER1
+      });
+
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this });
+
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 4,
+        managerPayout: 1000000000,
+        evaluatorPayout: 1000000000,
+        workerPayout: 1000000000,
+        managerRating: 1,
+        workerRating: 1,
+        worker: MINER2
+      });
+
+      await goodClient.resetDB();
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
+      await goodClient.saveCurrentState();
+
+      // The update log should contain the person being rewarded for the previous
+      // update cycle, and reputation update for one task completion (manager, worker, evaluator);
+      // That's five in total.
+      const repCycle = await getActiveRepCycle(colonyNetwork);
+      const nLogEntries = await repCycle.getReputationUpdateLogLength();
+      assert.equal(nLogEntries.toNumber(), 5);
+
+      const badClient = new MaliciousReputationMinerGlobalOriginNotChildOrigin(
+        { loader, minerAddress: MINER2, realProviderPort, useJsTree },
+        29 // Passing in update number for skillId: 5, user: 0000000000000000000000000000000000000000
+      );
+
+      // Moving the state to the bad client
+      await badClient.initialise(colonyNetwork.address);
+      const currentGoodClientState = await goodClient.getRootHash();
+      await badClient.loadState(currentGoodClientState);
+
+      await submitAndForwardTimeToDispute([goodClient, badClient], this);
+      const righthash = await goodClient.getRootHash();
+      const wronghash = await badClient.getRootHash();
+      assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
+
+      await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
+        client2: { respondToChallenge: "colony-reputation-mining-origin-user-incorrect" }
+      });
+      await repCycle.confirmNewHash(1);
+    });
+
     it("if child skill reputation calculation is wrong", async () => {
       await setupFinalizedTask({
         colonyNetwork,

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -174,7 +174,8 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       assert.equal(righthash, acceptedHash, "The correct hash was not accepted");
     });
 
-    it("if one person lies about what the origin skill is when there is an origin skill for a user update", async () => {
+    it.skip("if one person lies about what the origin skill is when there is an origin skill for a user update", async () => {
+      // We deduce the origin reputation key from the logEntry on chain now so the client cannot lie about it
       await giveUserCLNYTokensAndStake(colonyNetwork, MINER3, DEFAULT_STAKE);
       await giveUserCLNYTokensAndStake(colonyNetwork, MINER4, DEFAULT_STAKE);
 
@@ -341,7 +342,8 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
   });
 
   describe("should correctly resolve a dispute over child skill", () => {
-    it("if the global origin skill is provided instead of the child origin skill", async () => {
+    it.skip("if the global origin skill is provided instead of the child origin skill", async () => {
+      // We deduce the origin reputation key from the logEntry on chain now so the client cannot lie about it
       await setupFinalizedTask({
         colonyNetwork,
         colony: metaColony,
@@ -1072,7 +1074,6 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       [
         reputationKey,
         goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].newestReputationProof.key,
-        goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].originReputationProof.key,
         goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].childReputationProof.key,
         goodClient.justificationHashes[`0x${new BN(lastAgreeIdx).toString(16, 64)}`].adjacentReputationProof.key
       ],


### PR DESCRIPTION
We had, at some point, implicitly assumed that `originReputationValue` could be either the colony-wide origin reputation, or the user-specific origin reputation, and tried to accommodate that in the `checkOriginReputation` function. However, we ultimately only use the origin reputation around [this line](https://github.com/JoinColony/colonyNetwork/blob/f8d7721a29bdd6519a3449be2fdd0efb9aab5f48/contracts/ReputationMiningCycleRespond.sol#L595), where it must be the user origin reputation.

The reputation miner correctly [only ever supplies the user's origin reputation](https://github.com/JoinColony/colonyNetwork/blob/f8d7721a29bdd6519a3449be2fdd0efb9aab5f48/packages/reputation-miner/ReputationMiner.js#L266). However, a malicious miner could instead use the colony-wide origin reputation in its calculations, and pass it here during a dispute over the colony-wide total. This would cause such a submission to be able to tie the correct new reputation state, allowing any other to be set 'by default' if judiciously submitted alongside.

The first commit introduces a test that demonstrates the issue around being able to unexpectedly tie the good submission, and the second commit fixes it by making the checks around origin reputation stricter, now we have clarity of mind to realise we're only expecting the user's origin reputation to be passed in. I have also renamed variables to make it more obvious that we are only expecting the user's origin reputation.

We could, of course, now just build the originKey we're expecting from the log, and not have it passed in at all... worth doing that refactoring here, too?