### PR TITLE
Correctly cap reputation changes when log value zeros user reputation

### DIFF
--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -270,7 +270,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     bytes32[] memory userOriginReputationSiblings) internal 
   {
     ReputationLogEntry storage logEntry = reputationUpdateLog[u[U_LOG_ENTRY_NUMBER]];
-    if (logEntry.amount > 0) {
+    if (logEntry.amount >= 0) {
       return;
     }
 
@@ -279,16 +279,14 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     uint256 nChildUpdates;
     (nChildUpdates, ) = getChildAndParentNUpdatesForLogEntry(u);
 
-    // Skip origin reputation checks for anything but child reputation updates
-    if (relativeUpdateNumber % (logEntry.nUpdates/2) < nChildUpdates) {
-      // Check the user origin reputation key matches the colony, user address and skill id of the log
-      bytes memory userOriginReputationKeyBytes = abi.encodePacked(logEntry.colony, logEntry.skillId, logEntry.user);
-      checkUserOriginReputationInState(
-        u,
-        agreeStateSiblings,
-        userOriginReputationKeyBytes,
-        userOriginReputationSiblings);
-    }
+    // Check the user origin reputation key matches the colony, user address and skill id of the log
+    bytes memory userOriginReputationKeyBytes = abi.encodePacked(logEntry.colony, logEntry.skillId, logEntry.user);
+
+    checkUserOriginReputationInState(
+      u,
+      agreeStateSiblings,
+      userOriginReputationKeyBytes,
+      userOriginReputationSiblings);
   }
 
   function checkChildReputation(
@@ -549,17 +547,28 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
             // Calculate the proportional change expected
             childReputationChange = logEntry.amount * userChildReputationValue / userOriginReputationValue;
           }
+
+          // Cap change based on current value of the user's child reputation.
+          if (userChildReputationValue < (childReputationChange * -1)) {
+            childReputationChange = userChildReputationValue * -1;
+          }
+
           // Don't allow reputation to become negative
-          if (_agreeStateReputationValue + logEntry.amount < 0) {
+          if (_agreeStateReputationValue + childReputationChange < 0) {
+            // I think this is impossible, now.
             require(_disagreeStateReputationValue == 0, "colony-reputation-mining-child-reputation-value-non-zero");
           } else {
             require(_agreeStateReputationValue + childReputationChange == _disagreeStateReputationValue, "colony-reputation-mining-child-reputation-value-incorrect");
           }
 
         } else {
-          // Don't allow reputation to become negative
-          if (_agreeStateReputationValue + logEntry.amount < 0) {
-            require(_disagreeStateReputationValue == 0, "colony-reputation-mining-reputation-value-non-zero");
+          // Cap change based on origin reputation value
+          // Note we are not worried about underflows here; colony-wide totals for origin skill and all parents are greater than or equal to a user's origin skill.
+          // If we're subtracting the origin reputation value, we therefore can't underflow, and if we're subtracting the logEntryAmount, it was absolutely smaller than
+          // the origin reputation value, and so can't underflow either.
+
+          if (int256(u[U_USER_ORIGIN_REPUTATION_VALUE]) + logEntry.amount < 0) {
+            reputationChange = -1 * int256(u[U_USER_ORIGIN_REPUTATION_VALUE]);
           } else {
             require(_agreeStateReputationValue + logEntry.amount == _disagreeStateReputationValue, "colony-reputation-mining-decreased-reputation-value-incorrect");
           }

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -383,7 +383,7 @@ class ReputationMiner {
     return { branchMask: `${branchMask.toString(16)}`, siblings, key, value, reputation, uid, nNodes: this.nReputations.toString() };
   }
 
-  static async getKey(_colonyAddress, _skillId, _userAddress) {
+  static getKey(_colonyAddress, _skillId, _userAddress) {
     let colonyAddress = _colonyAddress;
     let userAddress = _userAddress;
 

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -542,7 +542,7 @@ class ReputationMiner {
       // Then the skill being update is the skill itself - not a parent or child
       skillId = logEntry.skillId; // eslint-disable-line prefer-destructuring
     }
-    const key = await ReputationMiner.getKey(logEntry.colony, skillId, skillAddress);
+    const key = ReputationMiner.getKey(logEntry.colony, skillId, skillAddress);
     return key;
   }
 
@@ -700,7 +700,7 @@ class ReputationMiner {
     }
     for (let i = 0; i < res.length; i += 1) {
       const row = res[i];
-      const rowKey = await ReputationMiner.getKey(row.colony_address, row.skill_id, row.user_address);
+      const rowKey = ReputationMiner.getKey(row.colony_address, row.skill_id, row.user_address);
       await tree.insert(rowKey, row.value);
     }
 
@@ -1086,7 +1086,7 @@ class ReputationMiner {
     this.nReputations = ethers.utils.bigNumberify(res.length);
     for (let i = 0; i < res.length; i += 1) {
       const row = res[i];
-      const key = await ReputationMiner.getKey(row.colony_address, row.skill_id, row.user_address);
+      const key = ReputationMiner.getKey(row.colony_address, row.skill_id, row.user_address);
       await this.reputationTree.insert(key, row.value, { gasLimit: 4000000 });
       this.reputations[key] = row.value;
     }

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -246,7 +246,7 @@ class ReputationMiner {
       const reputationChange = ethers.utils.bigNumberify(logEntry.amount);
       amount = this.getAmount(updateNumber, reputationChange);
 
-      // When reputation amount update is negative, adjust its value for child reputation updates
+      // When reputation amount update is negative, adjust its value for child reputation updates and parent updates
       // We update colonywide sums first (children, parents, skill)
       // Then the user-specifc sums in the order children, parents, skill.
       if (amount.lt(0)) {
@@ -256,15 +256,26 @@ class ReputationMiner {
         const relativeUpdateNumber = updateNumber.sub(logEntry.nPreviousUpdates).sub(this.nReputationsBeforeLatestLog);
         // Child updates are two sets: colonywide sums for children - located in the first nChildUpdates,
         // and user-specific updates located in the first nChildUpdates of the second half of the nUpdates set.
+        
+        // Get current reputation amount of the origin skill, which is positioned at the end of the current logEntry nUpdates.
+        const originSkillUpdateNumber = updateNumber.sub(relativeUpdateNumber).add(nUpdates).sub(1);
+        const originSkillKey = await this.getKeyForUpdateNumber(originSkillUpdateNumber);
+        originReputationProof = await this.getReputationProofObject(originSkillKey);
+        const originSkillKeyExists = this.reputations[originSkillKey] !== undefined;
+
+        let originReputation;
+        if (originSkillKeyExists) {
+          // Look up value from our JSON.
+          const originReputationValueBytes = this.reputations[originSkillKey];
+          originReputation = ethers.utils.bigNumberify(`0x${originReputationValueBytes.slice(2, 66)}`);
+        } else {
+          originReputation = ethers.utils.bigNumberify("0");
+        }
+
         if (
           relativeUpdateNumber.lt(nChildUpdates) ||
           (relativeUpdateNumber.gte(nUpdates.div(2)) && relativeUpdateNumber.lt(nUpdates.div(2).add(nChildUpdates)))
         ) {
-          // Get current reputation amount of the origin skill, which is positioned at the end of the current logEntry nUpdates.
-          const originSkillUpdateNumber = updateNumber.sub(relativeUpdateNumber).add(nUpdates).sub(1);
-          const originSkillKey = await this.getKeyForUpdateNumber(originSkillUpdateNumber);
-          originReputationProof = await this.getReputationProofObject(originSkillKey);
-
           // Get the user-specific child reputation key.
           let keyUsedInCalculations;
           if (relativeUpdateNumber.lt(nChildUpdates)) {
@@ -275,37 +286,28 @@ class ReputationMiner {
           }
           childReputationProof = await this.getReputationProofObject(keyUsedInCalculations);
 
-          const originSkillKeyExists = this.reputations[originSkillKey] !== undefined;
-          if (originSkillKeyExists) {
-            // Look up value from our JSON.
-            const originReputationValueBytes = this.reputations[originSkillKey];
-            const originReputation = ethers.utils.bigNumberify(`0x${originReputationValueBytes.slice(2, 66)}`);
 
-            let targetAmount;
-            if (originReputation.add(amount).lt(0)) {        // Origin reputation cannot become negative
-              targetAmount = originReputation.mul(-1);
-            } else if (originReputation.isZero()) {          // If origin reputation is zero, then the rest reputation updates will be zero
-              targetAmount = ethers.utils.bigNumberify("0");
-            } else {
-
-              const keyExists = this.reputations[keyUsedInCalculations] !== undefined;
-              if (keyExists) {
-                const reputation = ethers.utils.bigNumberify(`0x${this.reputations[keyUsedInCalculations].slice(2, 66)}`);
-                targetAmount = reputation.mul(amount).div(originReputation);
-
-                // Ensure the child reputation update doesn't underflow
-                targetAmount = reputation.add(targetAmount).lt(0) ? reputation.mul(-1) : targetAmount;
-              } else {
-                // Set to 0, if the child skill does not exist yet, as that cannot go negative
-                targetAmount = ethers.utils.bigNumberify("0");
-              }
-            }
-
-            amount = targetAmount;
+          const keyExists = this.reputations[keyUsedInCalculations] !== undefined;
+          let reputation;
+          if (keyExists) {
+            reputation = ethers.utils.bigNumberify(`0x${this.reputations[keyUsedInCalculations].slice(2, 66)}`);
           } else {
-            // Set to 0, if the origin skill does not exist yet and therefore has no value that can be used in calulations
-            amount = ethers.utils.bigNumberify("0");
+            reputation = ethers.utils.bigNumberify("0");
           }
+          if (originReputation.eq(0)) {
+            amount = ethers.utils.bigNumberify("0");
+          } else {
+            amount = amount.mul(reputation).div(originReputation);
+          }
+          // We can't lose more reputation than we have in this reputation
+          if (reputation.lt(amount.mul(-1))) {
+            amount = reputation.mul(-1);
+          }
+        }
+        // We can't lose more reputation in any skill than we have in the origin skill. 
+        // Cap change based on origin skill 
+        if (originReputation.lt(amount.mul(-1))) {
+          amount = originReputation.mul(-1)
         }
       }
     }

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -21,7 +21,7 @@ class ReputationMinerClient {
 
     this._app = express();
     this._app.get("/:rootHash/:colonyAddress/:skillId/:userAddress", async (req, res) => {
-      const key = await ReputationMiner.getKey(req.params.colonyAddress, req.params.skillId, req.params.userAddress);
+      const key = ReputationMiner.getKey(req.params.colonyAddress, req.params.skillId, req.params.userAddress);
       const currentHash = await this._miner.getRootHash();
       if (currentHash === req.params.rootHash) {
         if (this._miner.reputations[key]) {

--- a/test/colony-reward-payouts.js
+++ b/test/colony-reward-payouts.js
@@ -150,7 +150,7 @@ contract("Colony Reward Payouts", accounts => {
 
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
-      const globalKey = await ReputationMinerTestWrapper.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
+      const globalKey = ReputationMinerTestWrapper.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
       await client.insert(globalKey, new BN(10), 0);
 
       await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
@@ -325,7 +325,7 @@ contract("Colony Reward Payouts", accounts => {
       const result = await newColony.getDomain(1);
       const rootDomainSkill = result.skillId;
 
-      const globalKey = await ReputationMinerTestWrapper.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
+      const globalKey = ReputationMinerTestWrapper.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
       await client.insert(globalKey, new BN(0), 0);
 
       await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
@@ -385,7 +385,7 @@ contract("Colony Reward Payouts", accounts => {
 
       await colony.bootstrapColony([userAddress1], [userTokens3]);
 
-      const userKey = await ReputationMinerTestWrapper.getKey(colony.address, rootDomainSkill, userAddress3);
+      const userKey = ReputationMinerTestWrapper.getKey(colony.address, rootDomainSkill, userAddress3);
       await client.insert(userKey, new BN(0), 0);
 
       await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });

--- a/test/reputation-mining/client-calculations.js
+++ b/test/reputation-mining/client-calculations.js
@@ -1,6 +1,8 @@
 /* globals artifacts */
 import path from "path";
 import BN from "bn.js";
+import chai from "chai";
+import bnChai from "bn-chai";
 
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
@@ -18,6 +20,9 @@ import {
 
 const useJsTree = true;
 
+const { expect } = chai;
+chai.use(bnChai(web3.utils.BN));
+
 const EtherRouter = artifacts.require("EtherRouter");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const ITokenLocking = artifacts.require("ITokenLocking");
@@ -28,263 +33,283 @@ const loader = new TruffleLoader({
 
 const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
 
-contract("Reputation mining - client reputation calculations", accounts => {
-  const MINER1 = accounts[5];
-  const MINER2 = accounts[6];
+process.env.SOLIDITY_COVERAGE
+  ? contract.skip
+  : contract("Reputation mining - client reputation calculations", accounts => {
+      const MINER1 = accounts[5];
+      const MINER2 = accounts[6];
 
-  let colonyNetwork;
-  let tokenLocking;
-  let metaColony;
-  let clnyToken;
-  let goodClient;
+      let colonyNetwork;
+      let tokenLocking;
+      let metaColony;
+      let clnyToken;
+      let goodClient;
 
-  before(async () => {
-    // Get the address of the token locking contract from the existing colony Network
-    const etherRouter = await EtherRouter.deployed();
-    const colonyNetworkDeployed = await IColonyNetwork.at(etherRouter.address);
-    const tokenLockingAddress = await colonyNetworkDeployed.getTokenLocking();
-    tokenLocking = await ITokenLocking.at(tokenLockingAddress);
+      before(async () => {
+        // Get the address of the token locking contract from the existing colony Network
+        const etherRouter = await EtherRouter.deployed();
+        const colonyNetworkDeployed = await IColonyNetwork.at(etherRouter.address);
+        const tokenLockingAddress = await colonyNetworkDeployed.getTokenLocking();
+        tokenLocking = await ITokenLocking.at(tokenLockingAddress);
 
-    // Setup a new network instance as we'll be modifying the global skills tree
-    colonyNetwork = await setupColonyNetwork();
-    await colonyNetwork.setTokenLocking(tokenLockingAddress);
-    await tokenLocking.setColonyNetwork(colonyNetwork.address);
-    ({ metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
+        // Setup a new network instance as we'll be modifying the global skills tree
+        colonyNetwork = await setupColonyNetwork();
+        await colonyNetwork.setTokenLocking(tokenLockingAddress);
+        await tokenLocking.setColonyNetwork(colonyNetwork.address);
+        ({ metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
 
-    // Initialise global skills tree: 1 -> 4 -> 5, local skills tree 2 -> 3
-    await metaColony.addGlobalSkill(1);
-    await metaColony.addGlobalSkill(4);
+        // Initialise global skills tree: 1 -> 4 -> 5, local skills tree 2 -> 3
+        await metaColony.addGlobalSkill(1);
+        await metaColony.addGlobalSkill(4);
 
-    await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
-    await colonyNetwork.initialiseReputationMining();
-    await colonyNetwork.startNextCycle();
+        await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
+        await colonyNetwork.initialiseReputationMining();
+        await colonyNetwork.startNextCycle();
 
-    goodClient = new ReputationMinerTestWrapper({ loader, realProviderPort, useJsTree, minerAddress: MINER1 });
-  });
-
-  beforeEach(async () => {
-    await goodClient.resetDB();
-    await goodClient.initialise(colonyNetwork.address);
-
-    // Advance two cycles to clear active and inactive state.
-    await advanceMiningCycleNoContest({ colonyNetwork, test: this });
-    await advanceMiningCycleNoContest({ colonyNetwork, test: this });
-
-    // The inactive reputation log now has the reward for this miner, and the accepted state is empty.
-    // This is the same starting point for all tests.
-    const repCycle = await getActiveRepCycle(colonyNetwork);
-    const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
-    assert.equal(nInactiveLogEntries.toNumber(), 1);
-
-    // Burn MAIN_ACCOUNTS accumulated mining rewards.
-    const userBalance = await clnyToken.balanceOf(MINER1);
-    await clnyToken.burn(userBalance, { from: MINER1 });
-
-    await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
-    await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
-    await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(4));
-  });
-
-  afterEach(async () => {
-    await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
-  });
-
-  describe("core functionality", () => {
-    it("should correctly calculate increments and decrements in parent reputations", async () => {
-      await setupFinalizedTask({
-        colonyNetwork,
-        colony: metaColony,
-        skillId: 5,
-        workerPayout: 100,
-        worker: MINER2
+        goodClient = new ReputationMinerTestWrapper({ loader, realProviderPort, useJsTree, minerAddress: MINER1 });
       });
-      // Skills in 1 / 4 / 5
-      // Miner 2: (100 / 100 / 100)
 
-      await setupFinalizedTask({
-        colonyNetwork,
-        colony: metaColony,
-        skillId: 5,
-        workerPayout: 100,
-        worker: MINER1
+      beforeEach(async () => {
+        await goodClient.resetDB();
+        await goodClient.initialise(colonyNetwork.address);
+
+        // Advance two cycles to clear active and inactive state.
+        await advanceMiningCycleNoContest({ colonyNetwork, test: this });
+        await advanceMiningCycleNoContest({ colonyNetwork, test: this });
+
+        // The inactive reputation log now has the reward for this miner, and the accepted state is empty.
+        // This is the same starting point for all tests.
+        const repCycle = await getActiveRepCycle(colonyNetwork);
+        const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
+        expect(nInactiveLogEntries).to.eq.BN(1);
+
+        // Burn MAIN_ACCOUNTS accumulated mining rewards.
+        const userBalance = await clnyToken.balanceOf(MINER1);
+        await clnyToken.burn(userBalance, { from: MINER1 });
+
+        await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
+        await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
+        await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(4));
       });
-      // Miner 1: (100 / 100 / 100)
-      // Miner 2: (100 / 100 / 100)
 
-      await setupFinalizedTask({
-        colonyNetwork,
-        colony: metaColony,
-        skillId: 4,
-        workerPayout: 900,
-        worker: MINER2
+      afterEach(async () => {
+        await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
       });
-      // Miner 1: (100 / 100 / 100)
-      // Miner 2: (1000 / 1000 / 100)
 
-      await setupFinalizedTask({
-        colonyNetwork,
-        colony: metaColony,
-        skillId: 1,
-        workerPayout: 1000,
-        worker: MINER2
+      describe("core functionality", () => {
+        it("should correctly calculate increments and decrements in parent reputations", async () => {
+          await setupFinalizedTask({
+            colonyNetwork,
+            colony: metaColony,
+            skillId: 5,
+            workerPayout: 100,
+            worker: MINER2
+          });
+          // Skills in 1 / 4 / 5
+          // Miner 2: (100 / 100 / 100)
+
+          await setupFinalizedTask({
+            colonyNetwork,
+            colony: metaColony,
+            skillId: 5,
+            workerPayout: 100,
+            worker: MINER1
+          });
+          // Miner 1: (100 / 100 / 100)
+          // Miner 2: (100 / 100 / 100)
+
+          await setupFinalizedTask({
+            colonyNetwork,
+            colony: metaColony,
+            skillId: 4,
+            workerPayout: 900,
+            worker: MINER2
+          });
+          // Miner 1: (100 / 100 / 100)
+          // Miner 2: (1000 / 1000 / 100)
+
+          await setupFinalizedTask({
+            colonyNetwork,
+            colony: metaColony,
+            skillId: 1,
+            workerPayout: 1000,
+            worker: MINER2
+          });
+          // Miner 1: (100 / 100 / 100)
+          // Miner 2: (2000 / 1000 / 100)
+
+          await setupFinalizedTask({
+            colonyNetwork,
+            colony: metaColony,
+            skillId: 5,
+            workerPayout: 200,
+            workerRating: 1,
+            worker: MINER2
+          });
+          // Miner 1: (100 / 100 / 100)
+          // Miner 2: (1900 / 900 / 0)
+
+          await goodClient.resetDB();
+          await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
+          await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
+
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER1)].slice(2, 66), 16)).to.eq.BN(100);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER1)].slice(2, 66), 16)).to.eq.BN(100);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER1)].slice(2, 66), 16)).to.eq.BN(100);
+
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER2)].slice(2, 66), 16)).to.eq.BN(0);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER2)].slice(2, 66), 16)).to.eq.BN(900);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER2)].slice(2, 66), 16)).to.eq.BN(1900);
+
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+            100
+          );
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+            1000
+          );
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+            2000
+          );
+        });
+
+        it("should correctly calculate decrements in child reputations", async () => {
+          await setupFinalizedTask({
+            colonyNetwork,
+            colony: metaColony,
+            skillId: 5,
+            workerPayout: 100,
+            worker: MINER2
+          });
+          // Skills in 1 / 4 / 5
+          // Miner 2: (100 / 100 / 100)
+
+          await setupFinalizedTask({
+            colonyNetwork,
+            colony: metaColony,
+            skillId: 5,
+            workerPayout: 100,
+            worker: MINER1
+          });
+          // Miner 1: (100 / 100 / 100)
+          // Miner 2: (100 / 100 / 100)
+
+          await setupFinalizedTask({
+            colonyNetwork,
+            colony: metaColony,
+            skillId: 4,
+            workerPayout: 900,
+            worker: MINER2
+          });
+          // Miner 1: (100 / 100 / 100)
+          // Miner 2: (1000 / 1000 / 100)
+
+          await setupFinalizedTask({
+            colonyNetwork,
+            colony: metaColony,
+            skillId: 4,
+            workerPayout: 200,
+            workerRating: 1,
+            worker: MINER2
+          });
+          // Miner 1: (100 / 100 / 100)
+          // Miner 2: (800 / 800 / 80)
+
+          await goodClient.resetDB();
+          await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
+          await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
+
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER1)].slice(2, 66), 16)).to.eq.BN(100);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER1)].slice(2, 66), 16)).to.eq.BN(100);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER1)].slice(2, 66), 16)).to.eq.BN(100);
+
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER2)].slice(2, 66), 16)).to.eq.BN(80);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER2)].slice(2, 66), 16)).to.eq.BN(800);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER2)].slice(2, 66), 16)).to.eq.BN(800);
+
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+            180
+          );
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+            900
+          );
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+            900
+          );
+        });
+
+        it("should correctly calculate decrements in child reputations if the user loses all reputation", async () => {
+          await setupFinalizedTask({
+            colonyNetwork,
+            colony: metaColony,
+            skillId: 5,
+            workerPayout: 100,
+            worker: MINER2
+          });
+          // Skills in 1 / 4 / 5
+          // Miner 2: (100 / 100 / 100)
+
+          await setupFinalizedTask({
+            colonyNetwork,
+            colony: metaColony,
+            skillId: 5,
+            workerPayout: 100,
+            worker: MINER1
+          });
+          // Miner 1: (100 / 100 / 100)
+          // Miner 2: (100 / 100 / 100)
+
+          await setupFinalizedTask({
+            colonyNetwork,
+            colony: metaColony,
+            skillId: 4,
+            workerPayout: 900,
+            worker: MINER2
+          });
+          // Miner 1: (100 / 100 / 100)
+          // Miner 2: (1000 / 1000 / 100)
+
+          await setupFinalizedTask({
+            colonyNetwork,
+            colony: metaColony,
+            skillId: 1,
+            workerPayout: 500,
+            worker: MINER2
+          });
+          // Miner 1: (100 / 100 / 100)
+          // Miner 2: (1500 / 1000 / 100)
+
+          await setupFinalizedTask({
+            colonyNetwork,
+            colony: metaColony,
+            skillId: 4,
+            workerPayout: 100000000,
+            workerRating: 1,
+            worker: MINER2
+          });
+          // Miner 1: (100 / 100 / 100)
+          // Miner 2: (500 / 0 / 0)
+
+          await goodClient.resetDB();
+          await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
+          await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
+
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER1)].slice(2, 66), 16)).to.eq.BN(100);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER1)].slice(2, 66), 16)).to.eq.BN(100);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER1)].slice(2, 66), 16)).to.eq.BN(100);
+
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER2)].slice(2, 66), 16)).to.eq.BN(0);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER2)].slice(2, 66), 16)).to.eq.BN(0);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER2)].slice(2, 66), 16)).to.eq.BN(500);
+
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+            100
+          );
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+            100
+          );
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+            600
+          );
+        });
       });
-      // Miner 1: (100 / 100 / 100)
-      // Miner 2: (2000 / 1000 / 100)
-
-      await setupFinalizedTask({
-        colonyNetwork,
-        colony: metaColony,
-        skillId: 5,
-        workerPayout: 200,
-        workerRating: 1,
-        worker: MINER2
-      });
-      // Miner 1: (100 / 100 / 100)
-      // Miner 2: (1900 / 900 / 0)
-
-      await goodClient.resetDB();
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
-
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER1)].slice(2, 66), 16), 100);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER1)].slice(2, 66), 16), 100);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER1)].slice(2, 66), 16), 100);
-
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER2)].slice(2, 66), 16), 0);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER2)].slice(2, 66), 16), 900);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER2)].slice(2, 66), 16), 1900);
-
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ZERO_ADDRESS)].slice(2, 66), 16), 100);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ZERO_ADDRESS)].slice(2, 66), 16), 1000);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ZERO_ADDRESS)].slice(2, 66), 16), 2000);
     });
-
-    it("should correctly calculate decrements in child reputations", async () => {
-      await setupFinalizedTask({
-        colonyNetwork,
-        colony: metaColony,
-        skillId: 5,
-        workerPayout: 100,
-        worker: MINER2
-      });
-      // Skills in 1 / 4 / 5
-      // Miner 2: (100 / 100 / 100)
-
-      await setupFinalizedTask({
-        colonyNetwork,
-        colony: metaColony,
-        skillId: 5,
-        workerPayout: 100,
-        worker: MINER1
-      });
-      // Miner 1: (100 / 100 / 100)
-      // Miner 2: (100 / 100 / 100)
-
-      await setupFinalizedTask({
-        colonyNetwork,
-        colony: metaColony,
-        skillId: 4,
-        workerPayout: 900,
-        worker: MINER2
-      });
-      // Miner 1: (100 / 100 / 100)
-      // Miner 2: (1000 / 1000 / 100)
-
-      await setupFinalizedTask({
-        colonyNetwork,
-        colony: metaColony,
-        skillId: 4,
-        workerPayout: 200,
-        workerRating: 1,
-        worker: MINER2
-      });
-      // Miner 1: (100 / 100 / 100)
-      // Miner 2: (800 / 800 / 80)
-
-      await goodClient.resetDB();
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
-
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER1)].slice(2, 66), 16), 100);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER1)].slice(2, 66), 16), 100);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER1)].slice(2, 66), 16), 100);
-
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER2)].slice(2, 66), 16), 80);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER2)].slice(2, 66), 16), 800);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER2)].slice(2, 66), 16), 800);
-
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ZERO_ADDRESS)].slice(2, 66), 16), 180);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ZERO_ADDRESS)].slice(2, 66), 16), 900);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ZERO_ADDRESS)].slice(2, 66), 16), 900);
-    });
-
-    it("should correctly calculate decrements in child reputations if the user loses all reputation", async () => {
-      await setupFinalizedTask({
-        colonyNetwork,
-        colony: metaColony,
-        skillId: 5,
-        workerPayout: 100,
-        worker: MINER2
-      });
-      // Skills in 1 / 4 / 5
-      // Miner 2: (100 / 100 / 100)
-
-      await setupFinalizedTask({
-        colonyNetwork,
-        colony: metaColony,
-        skillId: 5,
-        workerPayout: 100,
-        worker: MINER1
-      });
-      // Miner 1: (100 / 100 / 100)
-      // Miner 2: (100 / 100 / 100)
-
-      await setupFinalizedTask({
-        colonyNetwork,
-        colony: metaColony,
-        skillId: 4,
-        workerPayout: 900,
-        worker: MINER2
-      });
-      // Miner 1: (100 / 100 / 100)
-      // Miner 2: (1000 / 1000 / 100)
-
-      await setupFinalizedTask({
-        colonyNetwork,
-        colony: metaColony,
-        skillId: 1,
-        workerPayout: 500,
-        worker: MINER2
-      });
-      // Miner 1: (100 / 100 / 100)
-      // Miner 2: (1500 / 1000 / 100)
-
-      await setupFinalizedTask({
-        colonyNetwork,
-        colony: metaColony,
-        skillId: 4,
-        workerPayout: 100000000,
-        workerRating: 1,
-        worker: MINER2
-      });
-      // Miner 1: (100 / 100 / 100)
-      // Miner 2: (500 / 0 / 0)
-
-      await goodClient.resetDB();
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
-
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER1)].slice(2, 66), 16), 100);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER1)].slice(2, 66), 16), 100);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER1)].slice(2, 66), 16), 100);
-
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER2)].slice(2, 66), 16), 0);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER2)].slice(2, 66), 16), 0);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER2)].slice(2, 66), 16), 500);
-
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ZERO_ADDRESS)].slice(2, 66), 16), 100);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ZERO_ADDRESS)].slice(2, 66), 16), 100);
-      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ZERO_ADDRESS)].slice(2, 66), 16), 600);
-    });
-  });
-});

--- a/test/reputation-mining/client-calculations.js
+++ b/test/reputation-mining/client-calculations.js
@@ -95,11 +95,7 @@ contract("Reputation mining - client reputation calculations", accounts => {
         colonyNetwork,
         colony: metaColony,
         skillId: 5,
-        managerPayout: 1000000000000,
-        evaluatorPayout: 1000000000,
         workerPayout: 100,
-        managerRating: 2,
-        workerRating: 2,
         worker: MINER2
       });
       // Skills in 1 / 4 / 5
@@ -109,11 +105,7 @@ contract("Reputation mining - client reputation calculations", accounts => {
         colonyNetwork,
         colony: metaColony,
         skillId: 5,
-        managerPayout: 1000000000000,
-        evaluatorPayout: 1000000000,
         workerPayout: 100,
-        managerRating: 2,
-        workerRating: 2,
         worker: MINER1
       });
       // Miner 1: (100 / 100 / 100)
@@ -123,11 +115,7 @@ contract("Reputation mining - client reputation calculations", accounts => {
         colonyNetwork,
         colony: metaColony,
         skillId: 4,
-        managerPayout: 1000000000000,
-        evaluatorPayout: 1000000000,
         workerPayout: 900,
-        managerRating: 2,
-        workerRating: 2,
         worker: MINER2
       });
       // Miner 1: (100 / 100 / 100)
@@ -137,11 +125,7 @@ contract("Reputation mining - client reputation calculations", accounts => {
         colonyNetwork,
         colony: metaColony,
         skillId: 1,
-        managerPayout: 1000000000000,
-        evaluatorPayout: 1000000000,
         workerPayout: 1000,
-        managerRating: 2,
-        workerRating: 2,
         worker: MINER2
       });
       // Miner 1: (100 / 100 / 100)
@@ -151,8 +135,6 @@ contract("Reputation mining - client reputation calculations", accounts => {
         colonyNetwork,
         colony: metaColony,
         skillId: 5,
-        managerPayout: 100000000000,
-        evaluatorPayout: 100000000,
         workerPayout: 200,
         workerRating: 1,
         worker: MINER2
@@ -182,11 +164,7 @@ contract("Reputation mining - client reputation calculations", accounts => {
         colonyNetwork,
         colony: metaColony,
         skillId: 5,
-        managerPayout: 1000000000000,
-        evaluatorPayout: 1000000000,
         workerPayout: 100,
-        managerRating: 2,
-        workerRating: 2,
         worker: MINER2
       });
       // Skills in 1 / 4 / 5
@@ -196,11 +174,7 @@ contract("Reputation mining - client reputation calculations", accounts => {
         colonyNetwork,
         colony: metaColony,
         skillId: 5,
-        managerPayout: 1000000000000,
-        evaluatorPayout: 1000000000,
         workerPayout: 100,
-        managerRating: 2,
-        workerRating: 2,
         worker: MINER1
       });
       // Miner 1: (100 / 100 / 100)
@@ -210,11 +184,7 @@ contract("Reputation mining - client reputation calculations", accounts => {
         colonyNetwork,
         colony: metaColony,
         skillId: 4,
-        managerPayout: 1000000000000,
-        evaluatorPayout: 1000000000,
         workerPayout: 900,
-        managerRating: 2,
-        workerRating: 2,
         worker: MINER2
       });
       // Miner 1: (100 / 100 / 100)
@@ -224,8 +194,6 @@ contract("Reputation mining - client reputation calculations", accounts => {
         colonyNetwork,
         colony: metaColony,
         skillId: 4,
-        managerPayout: 100000000000,
-        evaluatorPayout: 100000000,
         workerPayout: 200,
         workerRating: 1,
         worker: MINER2
@@ -255,11 +223,7 @@ contract("Reputation mining - client reputation calculations", accounts => {
         colonyNetwork,
         colony: metaColony,
         skillId: 5,
-        managerPayout: 1000000000000,
-        evaluatorPayout: 1000000000,
         workerPayout: 100,
-        managerRating: 2,
-        workerRating: 2,
         worker: MINER2
       });
       // Skills in 1 / 4 / 5
@@ -269,11 +233,7 @@ contract("Reputation mining - client reputation calculations", accounts => {
         colonyNetwork,
         colony: metaColony,
         skillId: 5,
-        managerPayout: 1000000000000,
-        evaluatorPayout: 1000000000,
         workerPayout: 100,
-        managerRating: 2,
-        workerRating: 2,
         worker: MINER1
       });
       // Miner 1: (100 / 100 / 100)
@@ -283,11 +243,7 @@ contract("Reputation mining - client reputation calculations", accounts => {
         colonyNetwork,
         colony: metaColony,
         skillId: 4,
-        managerPayout: 1000000000000,
-        evaluatorPayout: 1000000000,
         workerPayout: 900,
-        managerRating: 2,
-        workerRating: 2,
         worker: MINER2
       });
       // Miner 1: (100 / 100 / 100)
@@ -297,11 +253,7 @@ contract("Reputation mining - client reputation calculations", accounts => {
         colonyNetwork,
         colony: metaColony,
         skillId: 1,
-        managerPayout: 1000000000000,
-        evaluatorPayout: 1000000000,
         workerPayout: 500,
-        managerRating: 2,
-        workerRating: 2,
         worker: MINER2
       });
       // Miner 1: (100 / 100 / 100)
@@ -311,8 +263,6 @@ contract("Reputation mining - client reputation calculations", accounts => {
         colonyNetwork,
         colony: metaColony,
         skillId: 4,
-        managerPayout: 100000000000,
-        evaluatorPayout: 100000000,
         workerPayout: 100000000,
         workerRating: 1,
         worker: MINER2

--- a/test/reputation-mining/client-calculations.js
+++ b/test/reputation-mining/client-calculations.js
@@ -1,0 +1,340 @@
+/* globals artifacts */
+import path from "path";
+import BN from "bn.js";
+
+import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
+
+import { DEFAULT_STAKE, INITIAL_FUNDING, ZERO_ADDRESS } from "../../helpers/constants";
+import { advanceMiningCycleNoContest, getActiveRepCycle, finishReputationMiningCycleAndWithdrawAllMinerStakes } from "../../helpers/test-helper";
+import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
+
+import {
+  setupColonyNetwork,
+  setupMetaColonyWithLockedCLNYToken,
+  giveUserCLNYTokensAndStake,
+  setupFinalizedTask,
+  fundColonyWithTokens
+} from "../../helpers/test-data-generator";
+
+const useJsTree = true;
+
+const EtherRouter = artifacts.require("EtherRouter");
+const IColonyNetwork = artifacts.require("IColonyNetwork");
+const ITokenLocking = artifacts.require("ITokenLocking");
+
+const loader = new TruffleLoader({
+  contractDir: path.resolve(__dirname, "..", "..", "build", "contracts")
+});
+
+const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
+
+contract("Reputation mining - client reputation calculations", accounts => {
+  const MINER1 = accounts[5];
+  const MINER2 = accounts[6];
+
+  let colonyNetwork;
+  let tokenLocking;
+  let metaColony;
+  let clnyToken;
+  let goodClient;
+
+  before(async () => {
+    // Get the address of the token locking contract from the existing colony Network
+    const etherRouter = await EtherRouter.deployed();
+    const colonyNetworkDeployed = await IColonyNetwork.at(etherRouter.address);
+    const tokenLockingAddress = await colonyNetworkDeployed.getTokenLocking();
+    tokenLocking = await ITokenLocking.at(tokenLockingAddress);
+
+    // Setup a new network instance as we'll be modifying the global skills tree
+    colonyNetwork = await setupColonyNetwork();
+    await colonyNetwork.setTokenLocking(tokenLockingAddress);
+    await tokenLocking.setColonyNetwork(colonyNetwork.address);
+    ({ metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
+
+    // Initialise global skills tree: 1 -> 4 -> 5, local skills tree 2 -> 3
+    await metaColony.addGlobalSkill(1);
+    await metaColony.addGlobalSkill(4);
+
+    await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
+    await colonyNetwork.initialiseReputationMining();
+    await colonyNetwork.startNextCycle();
+
+    goodClient = new ReputationMinerTestWrapper({ loader, realProviderPort, useJsTree, minerAddress: MINER1 });
+  });
+
+  beforeEach(async () => {
+    await goodClient.resetDB();
+    await goodClient.initialise(colonyNetwork.address);
+
+    // Advance two cycles to clear active and inactive state.
+    await advanceMiningCycleNoContest({ colonyNetwork, test: this });
+    await advanceMiningCycleNoContest({ colonyNetwork, test: this });
+
+    // The inactive reputation log now has the reward for this miner, and the accepted state is empty.
+    // This is the same starting point for all tests.
+    const repCycle = await getActiveRepCycle(colonyNetwork);
+    const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
+    assert.equal(nInactiveLogEntries.toNumber(), 1);
+
+    // Burn MAIN_ACCOUNTS accumulated mining rewards.
+    const userBalance = await clnyToken.balanceOf(MINER1);
+    await clnyToken.burn(userBalance, { from: MINER1 });
+
+    await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
+    await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
+    await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(4));
+  });
+
+  afterEach(async () => {
+    await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+  });
+
+  describe("core functionality", () => {
+    it("should correctly calculate increments and decrements in parent reputations", async () => {
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 5,
+        managerPayout: 1000000000000,
+        evaluatorPayout: 1000000000,
+        workerPayout: 100,
+        managerRating: 2,
+        workerRating: 2,
+        worker: MINER2
+      });
+      // Skills in 1 / 4 / 5
+      // Miner 2: (100 / 100 / 100)
+
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 5,
+        managerPayout: 1000000000000,
+        evaluatorPayout: 1000000000,
+        workerPayout: 100,
+        managerRating: 2,
+        workerRating: 2,
+        worker: MINER1
+      });
+      // Miner 1: (100 / 100 / 100)
+      // Miner 2: (100 / 100 / 100)
+
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 4,
+        managerPayout: 1000000000000,
+        evaluatorPayout: 1000000000,
+        workerPayout: 900,
+        managerRating: 2,
+        workerRating: 2,
+        worker: MINER2
+      });
+      // Miner 1: (100 / 100 / 100)
+      // Miner 2: (1000 / 1000 / 100)
+
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 1,
+        managerPayout: 1000000000000,
+        evaluatorPayout: 1000000000,
+        workerPayout: 1000,
+        managerRating: 2,
+        workerRating: 2,
+        worker: MINER2
+      });
+      // Miner 1: (100 / 100 / 100)
+      // Miner 2: (2000 / 1000 / 100)
+
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 5,
+        managerPayout: 100000000000,
+        evaluatorPayout: 100000000,
+        workerPayout: 200,
+        workerRating: 1,
+        worker: MINER2
+      });
+      // Miner 1: (100 / 100 / 100)
+      // Miner 2: (1900 / 900 / 0)
+
+      await goodClient.resetDB();
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
+
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER1)].slice(2, 66), 16), 100);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER1)].slice(2, 66), 16), 100);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER1)].slice(2, 66), 16), 100);
+
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER2)].slice(2, 66), 16), 0);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER2)].slice(2, 66), 16), 900);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER2)].slice(2, 66), 16), 1900);
+
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ZERO_ADDRESS)].slice(2, 66), 16), 100);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ZERO_ADDRESS)].slice(2, 66), 16), 1000);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ZERO_ADDRESS)].slice(2, 66), 16), 2000);
+    });
+
+    it("should correctly calculate decrements in child reputations", async () => {
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 5,
+        managerPayout: 1000000000000,
+        evaluatorPayout: 1000000000,
+        workerPayout: 100,
+        managerRating: 2,
+        workerRating: 2,
+        worker: MINER2
+      });
+      // Skills in 1 / 4 / 5
+      // Miner 2: (100 / 100 / 100)
+
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 5,
+        managerPayout: 1000000000000,
+        evaluatorPayout: 1000000000,
+        workerPayout: 100,
+        managerRating: 2,
+        workerRating: 2,
+        worker: MINER1
+      });
+      // Miner 1: (100 / 100 / 100)
+      // Miner 2: (100 / 100 / 100)
+
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 4,
+        managerPayout: 1000000000000,
+        evaluatorPayout: 1000000000,
+        workerPayout: 900,
+        managerRating: 2,
+        workerRating: 2,
+        worker: MINER2
+      });
+      // Miner 1: (100 / 100 / 100)
+      // Miner 2: (1000 / 1000 / 100)
+
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 4,
+        managerPayout: 100000000000,
+        evaluatorPayout: 100000000,
+        workerPayout: 200,
+        workerRating: 1,
+        worker: MINER2
+      });
+      // Miner 1: (100 / 100 / 100)
+      // Miner 2: (800 / 800 / 80)
+
+      await goodClient.resetDB();
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
+
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER1)].slice(2, 66), 16), 100);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER1)].slice(2, 66), 16), 100);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER1)].slice(2, 66), 16), 100);
+
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER2)].slice(2, 66), 16), 80);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER2)].slice(2, 66), 16), 800);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER2)].slice(2, 66), 16), 800);
+
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ZERO_ADDRESS)].slice(2, 66), 16), 180);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ZERO_ADDRESS)].slice(2, 66), 16), 900);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ZERO_ADDRESS)].slice(2, 66), 16), 900);
+    });
+
+    it("should correctly calculate decrements in child reputations if the user loses all reputation", async () => {
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 5,
+        managerPayout: 1000000000000,
+        evaluatorPayout: 1000000000,
+        workerPayout: 100,
+        managerRating: 2,
+        workerRating: 2,
+        worker: MINER2
+      });
+      // Skills in 1 / 4 / 5
+      // Miner 2: (100 / 100 / 100)
+
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 5,
+        managerPayout: 1000000000000,
+        evaluatorPayout: 1000000000,
+        workerPayout: 100,
+        managerRating: 2,
+        workerRating: 2,
+        worker: MINER1
+      });
+      // Miner 1: (100 / 100 / 100)
+      // Miner 2: (100 / 100 / 100)
+
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 4,
+        managerPayout: 1000000000000,
+        evaluatorPayout: 1000000000,
+        workerPayout: 900,
+        managerRating: 2,
+        workerRating: 2,
+        worker: MINER2
+      });
+      // Miner 1: (100 / 100 / 100)
+      // Miner 2: (1000 / 1000 / 100)
+
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 1,
+        managerPayout: 1000000000000,
+        evaluatorPayout: 1000000000,
+        workerPayout: 500,
+        managerRating: 2,
+        workerRating: 2,
+        worker: MINER2
+      });
+      // Miner 1: (100 / 100 / 100)
+      // Miner 2: (1500 / 1000 / 100)
+
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 4,
+        managerPayout: 100000000000,
+        evaluatorPayout: 100000000,
+        workerPayout: 100000000,
+        workerRating: 1,
+        worker: MINER2
+      });
+      // Miner 1: (100 / 100 / 100)
+      // Miner 2: (500 / 0 / 0)
+
+      await goodClient.resetDB();
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
+
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER1)].slice(2, 66), 16), 100);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER1)].slice(2, 66), 16), 100);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER1)].slice(2, 66), 16), 100);
+
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, MINER2)].slice(2, 66), 16), 0);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER2)].slice(2, 66), 16), 0);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER2)].slice(2, 66), 16), 500);
+
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ZERO_ADDRESS)].slice(2, 66), 16), 100);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ZERO_ADDRESS)].slice(2, 66), 16), 100);
+      assert.equal(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ZERO_ADDRESS)].slice(2, 66), 16), 600);
+    });
+  });
+});

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -474,7 +474,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-incorrect" }
+        client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
       });
       await repCycle.confirmNewHash(1);
     });
@@ -533,7 +533,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-incorrect" }
+        client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
       });
       await repCycle.confirmNewHash(1);
     });
@@ -580,7 +580,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-incorrect" }
+        client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
       });
       await repCycle.confirmNewHash(1);
     });
@@ -701,7 +701,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-incorrect" }
+        client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
       });
       await repCycle.confirmNewHash(1);
     });
@@ -773,7 +773,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-incorrect" }
+        client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
       });
       await repCycle.confirmNewHash(1);
     });
@@ -935,7 +935,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-incorrect" }
+        client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
       });
       await repCycle.confirmNewHash(1);
     });
@@ -1015,11 +1015,11 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-decreased-capped-reputation-value-incorrect" }
+        client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
       });
       await repCycle.invalidateHash(0, 3);
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient2, {
-        client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-incorrect" }
+        client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
       });
       await repCycle.confirmNewHash(2);
     });

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -580,7 +580,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-non-zero" }
+        client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-incorrect" }
       });
       await repCycle.confirmNewHash(1);
     });
@@ -699,6 +699,78 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       const righthash = await goodClient.getRootHash();
       const wronghash = await badClient.getRootHash();
       expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
+
+      await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
+        client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-incorrect" }
+      });
+      await repCycle.confirmNewHash(1);
+    });
+
+    it("if a colony-wide child skill is wrong, and the log .amount is larger than the colony total, but the correct change is not", async () => {
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 5,
+        managerPayout: 1000000000000,
+        evaluatorPayout: 1000000000,
+        workerPayout: 1000000000000,
+        managerRating: 3,
+        workerRating: 3,
+        worker: MINER2
+      });
+
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 5,
+        managerPayout: 1000000000000,
+        evaluatorPayout: 1000000000,
+        workerPayout: 1000000000000,
+        managerRating: 3,
+        workerRating: 3,
+        worker: MINER1
+      });
+
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this });
+
+      await setupFinalizedTask({
+        colonyNetwork,
+        colony: metaColony,
+        skillId: 4,
+        managerPayout: 1000000000000,
+        evaluatorPayout: 1000000000,
+        workerPayout: 1000000000000000,
+        managerRating: 1,
+        workerRating: 1,
+        worker: MINER2
+      });
+
+      await goodClient.resetDB();
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
+      await goodClient.saveCurrentState();
+
+      const repCycle = await getActiveRepCycle(colonyNetwork);
+
+      // The update log should contain the person being rewarded for the previous
+      // update cycle, and reputation update for one task completion (manager, worker, evaluator);
+      // That's five in total.
+      const nLogEntries = await repCycle.getReputationUpdateLogLength();
+      assert.equal(nLogEntries.toNumber(), 5);
+
+      const badClient = new MaliciousReputationMinerExtraRep(
+        { loader, minerAddress: MINER2, realProviderPort, useJsTree },
+        29, // Passing in update number for skillId: 5, user: 0
+        "0xfffffffffffffffffffffff"
+      );
+      // Moving the state to the bad client
+      await badClient.initialise(colonyNetwork.address);
+      const currentGoodClientState = await goodClient.getRootHash();
+      await badClient.loadState(currentGoodClientState);
+
+      await submitAndForwardTimeToDispute([goodClient, badClient], this);
+      const righthash = await goodClient.getRootHash();
+      const wronghash = await badClient.getRootHash();
+      assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-incorrect" }
@@ -863,7 +935,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-non-zero" }
+        client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-incorrect" }
       });
       await repCycle.confirmNewHash(1);
     });
@@ -943,7 +1015,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
+        client2: { respondToChallenge: "colony-reputation-mining-decreased-capped-reputation-value-incorrect" }
       });
       await repCycle.invalidateHash(0, 3);
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient2, {

--- a/test/reputation-mining/happy-paths.js
+++ b/test/reputation-mining/happy-paths.js
@@ -276,7 +276,7 @@ contract("Reputation Mining - happy paths", accounts => {
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-reputation-value-non-zero" }
+        client2: { respondToChallenge: "colony-reputation-mining-decreased-capped-reputation-value-incorrect" }
       });
       await repCycle.confirmNewHash(1);
     });
@@ -308,7 +308,7 @@ contract("Reputation Mining - happy paths", accounts => {
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-non-zero" }
+        client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-incorrect" }
       });
       await repCycle.confirmNewHash(1);
     });
@@ -469,8 +469,8 @@ contract("Reputation Mining - happy paths", accounts => {
       const META_ROOT_SKILL_TOTAL = REWARD // eslint-disable-line prettier/prettier
         .add(MANAGER_PAYOUT.add(EVALUATOR_PAYOUT).add(WORKER_PAYOUT).muln(3)) // eslint-disable-line prettier/prettier
         .add(new BN(1000000000))
-        .sub(new BN(1000000000000))
-        .sub(new BN(5000000000000));
+        .sub(new BN(1000000000000));
+      // .sub(new BN(5000000000000)); // Worker cannot lose skill they never had
 
       const reputationProps = [
         { id: 1, skill: META_ROOT_SKILL, account: undefined, value: META_ROOT_SKILL_TOTAL },
@@ -485,9 +485,7 @@ contract("Reputation Mining - happy paths", accounts => {
           value: MANAGER_PAYOUT.add(EVALUATOR_PAYOUT).muln(3).sub(new BN(1000000000000)) // eslint-disable-line prettier/prettier
         },
         { id: 6, skill: META_ROOT_SKILL, account: WORKER, value: WORKER_PAYOUT.muln(3) },
-        // TODO: This next check needs to be updated once colony wide reputation is fixed for child updates
-        // It needs to NOT deduct anything from the global skill rep as the user had 0 rep in the child skill
-        { id: 7, skill: GLOBAL_SKILL, account: undefined, value: WORKER_PAYOUT.muln(3).sub(new BN(5000000000000)) },
+        { id: 7, skill: GLOBAL_SKILL, account: undefined, value: WORKER_PAYOUT.muln(3) },
         { id: 8, skill: GLOBAL_SKILL, account: WORKER, value: WORKER_PAYOUT.muln(3) },
         // Completing a task in skill 4
         { id: 9, skill: MINING_SKILL, account: MANAGER, value: new BN(0) },
@@ -515,7 +513,7 @@ contract("Reputation Mining - happy paths", accounts => {
         const key = makeReputationKey(metaColony.address, reputationProp.skill, reputationProp.account);
         const value = makeReputationValue(reputationProp.value, reputationProp.id);
         const decimalValue = new BN(goodClient.reputations[key].slice(2, 66), 16);
-        expect(goodClient.reputations[key], `${reputationProp.id} failed. Actual value is ${decimalValue}`).to.eq.BN(value);
+        expect(goodClient.reputations[key], `${reputationProp.id} failed. Actual value is ${decimalValue}, and expected ${reputationProp.value}`).to.eq.BN(value);
       });
     });
 

--- a/test/reputation-mining/happy-paths.js
+++ b/test/reputation-mining/happy-paths.js
@@ -513,7 +513,10 @@ contract("Reputation Mining - happy paths", accounts => {
         const key = makeReputationKey(metaColony.address, reputationProp.skill, reputationProp.account);
         const value = makeReputationValue(reputationProp.value, reputationProp.id);
         const decimalValue = new BN(goodClient.reputations[key].slice(2, 66), 16);
-        expect(goodClient.reputations[key], `${reputationProp.id} failed. Actual value is ${decimalValue}, and expected ${reputationProp.value}`).to.eq.BN(value);
+        expect(
+          goodClient.reputations[key],
+          `${reputationProp.id} failed. Actual value is ${decimalValue}, and expected ${reputationProp.value}`
+        ).to.eq.BN(value);
       });
     });
 

--- a/test/reputation-mining/happy-paths.js
+++ b/test/reputation-mining/happy-paths.js
@@ -332,8 +332,8 @@ contract("Reputation Mining - happy paths", accounts => {
 
       let repCycle = await getActiveRepCycle(colonyNetwork);
       const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId();
-      const globalKey = await ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, ZERO_ADDRESS);
-      const userKey = await ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, MINER1);
+      const globalKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, ZERO_ADDRESS);
+      const userKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, MINER1);
 
       await goodClient.insert(globalKey, INT128_MAX.subn(1), 0);
       await goodClient.insert(userKey, INT128_MAX.subn(1), 0);
@@ -373,8 +373,8 @@ contract("Reputation Mining - happy paths", accounts => {
       await badClient.initialise(colonyNetwork.address);
 
       const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId();
-      const globalKey = await ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, ZERO_ADDRESS);
-      const userKey = await ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, MINER1);
+      const globalKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, ZERO_ADDRESS);
+      const userKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, MINER1);
 
       await goodClient.insert(globalKey, INT128_MAX.subn(1), 0);
       await goodClient.insert(userKey, INT128_MAX.subn(1), 0);
@@ -397,7 +397,7 @@ contract("Reputation Mining - happy paths", accounts => {
       const largeCalculationResult = INT128_MAX.subn(1)
         .mul(DECAY_RATE.NUMERATOR)
         .div(DECAY_RATE.DENOMINATOR);
-      const decayKey = await ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, MINER1);
+      const decayKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, MINER1);
       const decimalValueDecay = new BN(goodClient.reputations[decayKey].slice(2, 66), 16);
 
       expect(largeCalculationResult.toString(16, 64), `Incorrect decay. Actual value is ${decimalValueDecay}`).to.equal(
@@ -733,8 +733,8 @@ contract("Reputation Mining - happy paths", accounts => {
       await badClient.initialise(colonyNetwork.address);
 
       const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId();
-      const globalKey = await ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, ZERO_ADDRESS);
-      const userKey = await ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, MINER1);
+      const globalKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, ZERO_ADDRESS);
+      const userKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, MINER1);
 
       await goodClient.insert(globalKey, new BN("1"), 0);
       await goodClient.insert(userKey, new BN("1"), 0);
@@ -748,7 +748,7 @@ contract("Reputation Mining - happy paths", accounts => {
       await repCycle.submitRootHash(rootHash, 2, "0x00", 10, { from: MINER1 });
       await repCycle.confirmNewHash(0);
 
-      const decayKey = await ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, MINER1);
+      const decayKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, MINER1);
 
       // Check we have exactly one reputation.
       expect(

--- a/test/reputation-mining/happy-paths.js
+++ b/test/reputation-mining/happy-paths.js
@@ -276,7 +276,7 @@ contract("Reputation Mining - happy paths", accounts => {
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-decreased-capped-reputation-value-incorrect" }
+        client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
       });
       await repCycle.confirmNewHash(1);
     });
@@ -308,7 +308,7 @@ contract("Reputation Mining - happy paths", accounts => {
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-child-reputation-value-incorrect" }
+        client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
       });
       await repCycle.confirmNewHash(1);
     });


### PR DESCRIPTION
Closes #519 

Includes tests to explicitly check the miner is getting the answers we expect (at last!), plus some refactoring of the `require`s in `ReputationMiningCycleRespond` to try and simplify that logic.