### PR TITLE
Transparently add the Payment struct

### DIFF
--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -57,6 +57,9 @@ contract ColonyAuthority is CommonAuthority {
     // Add domain
     setAdminRoleCapability(colony, "addDomain(uint256)");
     setFounderRoleCapability(colony, "addDomain(uint256)");
+    // Add payment
+    setAdminRoleCapability(colony, "makePayment(uint256)");
+    setFounderRoleCapability(colony, "makePayment(uint256)");
     // Add task
     setAdminRoleCapability(colony, "makeTask(bytes32,uint256,uint256,uint256)");
     setFounderRoleCapability(colony, "makeTask(bytes32,uint256,uint256,uint256)");

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -81,6 +81,10 @@ contract ColonyDataTypes {
   /// @param rewardInverse The reward inverse value
   event ColonyRewardInverseSet(uint256 rewardInverse);
 
+  /// @notice Event logged when a new payment is added
+  /// @param paymentId The newly added payment id
+  event PaymentAdded(uint256 paymentId);
+
   /// @notice Event logged when a new task is added
   /// @param taskId The newly added task id
   event TaskAdded(uint256 taskId);
@@ -172,20 +176,23 @@ contract ColonyDataTypes {
     uint256 blockTimestamp;
   }
 
-  struct Task {
-    bytes32 specificationHash;
-    bytes32 deliverableHash;
+  struct Payment {
     TaskStatus status;
-    uint256 dueDate;
-    uint256 payoutsWeCannotMake;
-    uint256 fundingPotId;
-    uint256 completionTimestamp;
     uint256 domainId;
+    uint256 fundingPotId;
+    uint256 payoutsWeCannotMake;
     uint256[] skills;
 
     mapping (uint8 => Role) roles;
     // Maps task role ids (0,1,2..) to a token amount to be paid on task completion
     mapping (uint8 => mapping (address => uint256)) payouts;
+  }
+
+  struct Task {
+    bytes32 specificationHash;
+    bytes32 deliverableHash;
+    uint256 dueDate;
+    uint256 completionTimestamp;
   }
 
   enum TaskRatings { None, Unsatisfactory, Satisfactory, Excellent }

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -47,6 +47,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   )
   public
   stoppable
+  taskExists(_id)
   confirmTaskRoleIdentity(_id, TaskRole.Manager)
   {
     Payment storage payment = payments[_id];
@@ -414,7 +415,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   uint256 constant MAX_PAYOUT = 2**254 - 1; // Up to 254 bits to account for sign and payout modifiers.
 
   function setTaskPayout(uint256 _id, TaskRole _role, address _token, uint256 _amount) private
-  taskExists(_id)
+  paymentExists(_id)
   taskNotComplete(_id)
   taskNotFinalized(_id)
   {

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -23,19 +23,19 @@ import "./ITokenLocking.sol";
 
 
 contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
-  function setTaskManagerPayout(uint256 _id, address _token, uint256 _amount) public stoppable self {
+  function setTaskManagerPayout(uint256 _id, address _token, uint256 _amount) public stoppable paymentManagerOrSelf(_id) {
     setTaskPayout(_id, TaskRole.Manager, _token, _amount);
     emit TaskPayoutSet(_id, TaskRole.Manager, _token, _amount);
+  }
+
+  function setTaskWorkerPayout(uint256 _id, address _token, uint256 _amount) public stoppable paymentManagerOrSelf(_id) {
+    setTaskPayout(_id, TaskRole.Worker, _token, _amount);
+    emit TaskPayoutSet(_id, TaskRole.Worker, _token, _amount);
   }
 
   function setTaskEvaluatorPayout(uint256 _id, address _token, uint256 _amount) public stoppable self {
     setTaskPayout(_id, TaskRole.Evaluator, _token, _amount);
     emit TaskPayoutSet(_id, TaskRole.Evaluator, _token, _amount);
-  }
-
-  function setTaskWorkerPayout(uint256 _id, address _token, uint256 _amount) public stoppable self {
-    setTaskPayout(_id, TaskRole.Worker, _token, _amount);
-    emit TaskPayoutSet(_id, TaskRole.Worker, _token, _amount);
   }
 
   function setAllTaskPayouts(

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -23,7 +23,7 @@ import "./ITokenLocking.sol";
 
 
 contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
-  function setTaskManagerPayout(uint256 _id, address _token, uint256 _amount) public stoppable paymentManagerOrSelf(_id) {
+  function setTaskManagerPayout(uint256 _id, address _token, uint256 _amount) public stoppable self {
     setTaskPayout(_id, TaskRole.Manager, _token, _amount);
     emit TaskPayoutSet(_id, TaskRole.Manager, _token, _amount);
   }
@@ -416,6 +416,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   function setTaskPayout(uint256 _id, TaskRole _role, address _token, uint256 _amount) private
   taskExists(_id)
   taskNotComplete(_id)
+  taskNotFinalized(_id)
   {
     require(_amount <= MAX_PAYOUT, "colony-funding-payout-too-large");
 

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -74,7 +74,7 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, DSMath {
   mapping (uint256 => uint256) taskChangeNonces; // Storage slot 22
 
   modifier confirmTaskRoleIdentity(uint256 _id, TaskRole _role) {
-    require(hasTaskRole(_id, _role), "colony-task-role-identity-mismatch");
+    require(hasTaskRole(_id, _role, msg.sender), "colony-task-role-identity-mismatch");
     _;
   }
 
@@ -137,20 +137,20 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, DSMath {
   }
 
   modifier paymentManagerOrSelf(uint256 _id) {
-    require((isPayment(_id) && hasTaskRole(_id, TaskRole.Manager)) || isSelf(), "colony-not-payment-manager-or-self");
+    require((isPayment(_id) && hasTaskRole(_id, TaskRole.Manager, msg.sender)) || isSelf(), "colony-not-payment-manager-or-self");
     _;
+  }
+
+  function isPayment(uint256 _id) public view returns (bool) {
+    return payments[_id].roles[uint8(TaskRole.Evaluator)].user == address(0x0);
   }
 
   function isSelf() internal view returns (bool) {
     return address(this) == msg.sender;
   }
 
-  function isPayment(uint256 _id) internal view returns (bool) {
-    return payments[_id].roles[uint8(TaskRole.Evaluator)].user == address(0x0);
-  }
-
-  function hasTaskRole(uint256 _id, TaskRole _role) internal view returns (bool) {
-    return msg.sender == payments[_id].roles[uint8(_role)].user;
+  function hasTaskRole(uint256 _id, TaskRole _role, address _user) internal view returns (bool) {
+    return _user == payments[_id].roles[uint8(_role)].user;
   }
 
 }

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -78,8 +78,14 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, DSMath {
     _;
   }
 
+  modifier paymentExists(uint256 _id) {
+    require(_id > 0 && _id <= paymentCount, "colony-task-does-not-exist");
+    _;
+  }
+
   modifier taskExists(uint256 _id) {
     require(_id > 0 && _id <= paymentCount, "colony-task-does-not-exist");
+    require(!isPayment(_id), "colony-task-is-payment");
     _;
   }
 

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -136,6 +136,10 @@ contract IColony is ColonyDataTypes, IRecovery {
     public view returns (bool isValid);
 
   // Implemented in ColonyTask.sol
+  /// @notice Make a new payment in the colony. Secured function to authorised members
+  /// @param _domainId The domain where the payment belongs
+  function makePayment(uint256 _domainId) public;
+
   /// @notice Make a new task in the colony. Secured function to authorised members
   /// @param _specificationHash Database identifier where the task specification is stored
   /// @param _domainId The domain where the task belongs
@@ -302,6 +306,11 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _ratingSecret Rating secret for manager
   function submitTaskDeliverableAndRating(uint256 _id, bytes32 _deliverableHash, bytes32 _ratingSecret) public;
 
+  /// @notice Called after the recipients and amounts have been set
+  /// @dev Set the `payment.finalized` property to true
+  /// @param _id Id of the payment
+  function finalizePayment(uint256 _id) public;
+
   /// @notice Called after task work rating is complete which closes the task and logs the respective reputation log updates
   /// Allowed to be called once per task. Secured function to authorised members
   /// @dev Set the `task.finalized` property to true
@@ -320,6 +329,19 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _id Id of the task
   function completeTask(uint256 _id) public;
 
+  /// @notice Get a payment with id `_id`
+  /// @param _id Id of the payment
+  /// @return status TaskStatus property. 0 - Active. 1 - Cancelled. 2 - Finalized
+  /// @return domainId Payment domain id, default is root colony domain with id 1
+  /// @return fundingPotId Id of funding pot for payment
+  /// @return payoutsWeCannotMake Number of payouts that cannot be completed with the current payment funding
+  function getPayment(uint256 _id) public view returns (
+    TaskStatus status,
+    uint256 domainId,
+    uint256 fundingPotId,
+    uint256 payoutsWeCannotMake
+    );
+
   /// @notice Get a task with id `_id`
   /// @param _id Id of the task
   /// @return specificationHash Task brief hash
@@ -331,7 +353,7 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @return completionTimestamp Task completion timestamp
   /// @return domainId Task domain id, default is root colony domain with id 1
   /// @return skillIds Array of global skill ids assigned to task
-  function getTask(uint256 _id) public view returns ( 
+  function getTask(uint256 _id) public view returns (
     bytes32 specificationHash,
     bytes32 deliverableHash,
     TaskStatus status,

--- a/contracts/modules/OneClick.sol
+++ b/contracts/modules/OneClick.sol
@@ -1,0 +1,50 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity >=0.4.23 <0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "../IColony.sol";
+
+
+contract OneClick {
+  IColony colony;
+
+  constructor(address _colony) public {
+    colony = IColony(_colony);
+  }
+
+  event PaymentMade(uint256 paymentId);
+
+  function makePayment(address _recipient, uint256 _domainId, address _token, uint256 _amount) public {
+    colony.makePayment(_domainId);
+    uint256 paymentId = colony.getTaskCount();
+
+    colony.setTaskWorkerPayout(paymentId, _token, _amount);
+    colony.setTaskWorkerRole(paymentId, _recipient);
+
+    var (, , paymentFundingPotId, ) = colony.getPayment(paymentId);
+    uint256 domainFundingPotId = colony.getDomain(_domainId).fundingPotId;
+    colony.moveFundsBetweenPots(domainFundingPotId, uint256(paymentFundingPotId), _amount, _token);
+
+    colony.finalizePayment(paymentId);
+    colony.claimPayout(paymentId, 2, _token);
+
+    emit PaymentMade(paymentId);
+  }
+
+}

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -37,6 +37,17 @@ const ColonyTask = artifacts.require("ColonyTask");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const ContractRecovery = artifacts.require("ContractRecovery");
 
+export async function makePayment({ colony, domainId = 1, manager }) {
+  const accounts = await web3GetAccounts();
+  manager = manager || accounts[0]; // eslint-disable-line no-param-reassign
+  // Only Colony admins are allowed to make Payments, make the account an admin
+  await colony.setAdminRole(manager);
+  const { logs } = await colony.makePayment(domainId, { from: manager });
+
+  // Reading the ID out of the event triggered by our transaction will allow us to make multiple payments in parallel in the future.
+  return logs.filter(log => log.event === "PaymentAdded")[0].args.paymentId;
+}
+
 export async function makeTask({ colony, hash = SPECIFICATION_HASH, domainId = 1, skillId = 1, dueDate = 0, manager }) {
   const accounts = await web3GetAccounts();
   manager = manager || accounts[0]; // eslint-disable-line no-param-reassign

--- a/scripts/check-recovery.js
+++ b/scripts/check-recovery.js
@@ -27,6 +27,7 @@ walkSync("./contracts/").forEach(contractName => {
       "contracts/ens/ENS.sol",
       "contracts/ens/ENSRegistry.sol",
       "contracts/gnosis/MultiSigWallet.sol",
+      "contracts/modules/OneClick.sol",
       "contracts/PatriciaTree/Bits.sol",
       "contracts/PatriciaTree/Data.sol",
       "contracts/PatriciaTree/IPatriciaTree.sol",

--- a/scripts/check-storage.js
+++ b/scripts/check-storage.js
@@ -15,6 +15,10 @@ walkSync("./contracts/").forEach(contractName => {
   // Contracts listed here are allowed to have storage variables
   if (
     [
+      "contracts/ens/ENSRegistry.sol", // Not directly used by any colony contracts
+      "contracts/gnosis/MultiSigWallet.sol", // Not directly used by any colony contracts
+      "contracts/modules/OneClick.sol", // An external module
+      "contracts/PatriciaTree/PatriciaTreeBase.sol", // Only used by mining clients
       "contracts/CommonAuthority.sol",
       "contracts/ColonyAuthority.sol",
       "contracts/ColonyNetworkAuthority.sol",
@@ -23,14 +27,11 @@ walkSync("./contracts/").forEach(contractName => {
       "contracts/CommonStorage.sol",
       "contracts/EtherRouter.sol",
       "contracts/Migrations.sol",
-      "contracts/Resolver.sol",
-      "contracts/TokenLockingStorage.sol",
-      "contracts/PatriciaTree/PatriciaTreeBase.sol", // Only used by mining clients
-      "contracts/gnosis/MultiSigWallet.sol", // Not directly used by any colony contracts
-      "contracts/ens/ENSRegistry.sol", // Not directly used by any colony contracts
       "contracts/ReputationMiningCycleStorage.sol",
+      "contracts/Resolver.sol",
       "contracts/Token.sol", // Imported from colonyToken repo
-      "contracts/TokenAuthority.sol" // Imported from colonyToken repo
+      "contracts/TokenAuthority.sol", // Imported from colonyToken repo
+      "contracts/TokenLockingStorage.sol"
     ].indexOf(contractName) > -1
   ) {
     return;

--- a/test/colony.js
+++ b/test/colony.js
@@ -15,7 +15,7 @@ import {
   WAD
 } from "../helpers/constants";
 import { getTokenArgs, web3GetBalance, checkErrorRevert, expectAllEvents, getFunctionSignature } from "../helpers/test-helper";
-import { makeTask, setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony } from "../helpers/test-data-generator";
+import { makePayment, setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony } from "../helpers/test-data-generator";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
@@ -111,11 +111,11 @@ contract("Colony", accounts => {
     });
 
     it("should let funding pot information be read", async () => {
-      const taskId = await makeTask({ colony });
-      const taskInfo = await colony.getTask(taskId);
-      let potInfo = await colony.getFundingPot(taskInfo.fundingPotId);
+      const paymentId = await makePayment({ colony });
+      const paymentInfo = await colony.getTask(paymentId);
+      let potInfo = await colony.getFundingPot(paymentInfo.fundingPotId);
       expect(potInfo.associatedType).to.eq.BN(2);
-      expect(potInfo.associatedTypeId).to.eq.BN(taskId);
+      expect(potInfo.associatedTypeId).to.eq.BN(paymentId);
 
       // Read pot info about a pot in a domain
       const domainInfo = await colony.getDomain(1);
@@ -314,7 +314,7 @@ contract("Colony", accounts => {
 
     it("should not allow bootstrapping if colony is not in bootstrap state", async () => {
       await colony.mintTokens(WAD.muln(14));
-      await makeTask({ colony });
+      await makePayment({ colony });
       await checkErrorRevert(colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS), "colony-not-in-bootstrap-mode");
     });
   });

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -468,7 +468,7 @@ contract("Meta Colony", accounts => {
       await metaColony.addGlobalSkill(5);
 
       const taskId = await makeTask({ colony, skillId: 0 });
-      await checkErrorRevert(colony.setTaskSkill(taskId, 5, { from: OTHER_ACCOUNT }), "colony-not-self");
+      await checkErrorRevert(colony.setTaskSkill(taskId, 5, { from: OTHER_ACCOUNT }), "colony-not-payment-manager-or-self");
 
       const task = await colony.getTask(taskId);
       expect(task[8][0]).to.be.zero;

--- a/test/modules.js
+++ b/test/modules.js
@@ -21,6 +21,7 @@ contract("OneClick", accounts => {
   before(async () => {
     colonyNetwork = await setupColonyNetwork();
     await setupMetaColonyWithLockedCLNYToken(colonyNetwork);
+    await colonyNetwork.initialiseReputationMining();
   });
 
   beforeEach(async () => {

--- a/test/modules.js
+++ b/test/modules.js
@@ -1,0 +1,42 @@
+/* globals artifacts */
+
+import chai from "chai";
+import bnChai from "bn-chai";
+
+import { WAD, INITIAL_FUNDING } from "../helpers/constants";
+import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony, fundColonyWithTokens } from "../helpers/test-data-generator";
+
+const { expect } = chai;
+chai.use(bnChai(web3.utils.BN));
+
+const OneClick = artifacts.require("OneClick");
+
+contract("OneClick", accounts => {
+  const USER = accounts[1];
+
+  let colonyNetwork;
+  let colony;
+  let token;
+
+  before(async () => {
+    colonyNetwork = await setupColonyNetwork();
+    await setupMetaColonyWithLockedCLNYToken(colonyNetwork);
+  });
+
+  beforeEach(async () => {
+    ({ colony, token } = await setupRandomColony(colonyNetwork));
+    await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+  });
+
+  describe("One-click functionality", () => {
+    it("should send a payment with one tx", async () => {
+      const oneClick = await OneClick.new(colony.address);
+      await colony.setAdminRole(oneClick.address);
+
+      await oneClick.makePayment(USER, 1, token.address, WAD);
+
+      const userBalance = await token.balanceOf(USER);
+      expect(userBalance).to.eq.BN(WAD.divn(100).muln(99).subn(1)); // eslint-disable-line prettier/prettier
+    });
+  });
+});


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
For real this time.

<!--- Summary of changes including design decisions -->

- Separate the existing `Task` struct into a `Payment` and `Task` struct, with the same identifier.
- Allow the Payment manager to make changes to the struct unilaterally.
- Allow a one-way "upgrade" from Payment to Task by assigning an evaluator.
- Tasks continue to require multisig for changes.
