### PR TITLE
Take bootstrapped tokens from claimed funds only

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -105,8 +105,11 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
     for (uint i = 0; i < _users.length; i++) {
       require(_amounts[i] >= 0, "colony-bootstrap-bad-amount-input");
-      
-      ERC20Extended(token).transfer(_users[i], uint(_amounts[i]));
+      require(uint256(_amounts[i]) <= pots[1].balance[token], "colony-bootstrap-not-enough-tokens");
+      pots[1].balance[token] = sub(pots[1].balance[token], uint256(_amounts[i]));
+      nonRewardPotsTotal[token] = sub(nonRewardPotsTotal[token], uint256(_amounts[i]));
+
+      ERC20Extended(token).transfer(_users[i], uint256(_amounts[i]));
       IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_users[i], _amounts[i], domains[1].skillId);
     }
 

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -267,6 +267,7 @@ contract("All", function(accounts) {
 
       await fundColonyWithTokens(newColony, otherToken, initialFunding);
       await newColony.mintTokens(workerReputation.add(managerReputation));
+      await newColony.claimColonyFunds(newToken.address);
       await newColony.bootstrapColony([WORKER, MANAGER], [workerReputation, managerReputation]);
 
       await giveUserCLNYTokensAndStake(colonyNetwork, accounts[8], DEFAULT_STAKE);

--- a/test/colony-network-recovery.js
+++ b/test/colony-network-recovery.js
@@ -275,8 +275,9 @@ contract("Colony Network Recovery", accounts => {
           });
           await newClient.initialise(colonyNetwork.address);
 
-          const { colony } = await setupRandomColony(colonyNetwork);
+          const { colony, token } = await setupRandomColony(colonyNetwork);
           await colony.mintTokens(1000000000000000);
+          await colony.claimColonyFunds(token.address);
           await colony.bootstrapColony([accounts[5]], [1000000000000000]);
 
           await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
@@ -346,8 +347,10 @@ contract("Colony Network Recovery", accounts => {
           });
           await ignorantclient.initialise(colonyNetwork.address);
 
-          const { colony } = await setupRandomColony(colonyNetwork);
+          const { colony, token } = await setupRandomColony(colonyNetwork);
           await colony.mintTokens(1000000000000000);
+          await colony.claimColonyFunds(token.address);
+
           await colony.bootstrapColony([accounts[0]], [1000000000000000]);
 
           // A well intentioned miner makes a submission

--- a/test/colony.js
+++ b/test/colony.js
@@ -244,6 +244,7 @@ contract("Colony", accounts => {
       const skillCount = await colonyNetwork.getSkillCount();
 
       await colony.mintTokens(WAD.muln(14));
+      await colony.claimColonyFunds(token.address);
       await colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS);
       const inactiveReputationMiningCycleAddress = await colonyNetwork.getReputationMiningCycle(false);
       const inactiveReputationMiningCycle = await IReputationMiningCycle.at(inactiveReputationMiningCycleAddress);
@@ -257,7 +258,6 @@ contract("Colony", accounts => {
 
     it("should assign tokens correctly when bootstrapping the colony", async () => {
       await colony.mintTokens(WAD.muln(14));
-
       await checkErrorRevert(colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS), "colony-bootstrap-not-enough-tokens");
 
       await colony.claimColonyFunds(token.address);
@@ -274,6 +274,8 @@ contract("Colony", accounts => {
 
     it("should be able to bootstrap colony more than once", async () => {
       await colony.mintTokens(WAD.muln(10));
+      await colony.claimColonyFunds(token.address);
+
       await colony.bootstrapColony([INITIAL_ADDRESSES[0]], [INITIAL_REPUTATIONS[0]]);
       await colony.bootstrapColony([INITIAL_ADDRESSES[0]], [INITIAL_REPUTATIONS[0]]);
 
@@ -294,7 +296,7 @@ contract("Colony", accounts => {
 
     it("should throw if there is not enough funds to send", async () => {
       await colony.mintTokens(WAD.muln(10));
-      await checkErrorRevert(colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS), "ds-token-insufficient-balance");
+      await checkErrorRevert(colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS), "colony-bootstrap-not-enough-tokens");
 
       const balance = await token.balanceOf(INITIAL_ADDRESSES[0]);
       expect(balance).to.be.zero;

--- a/test/colony.js
+++ b/test/colony.js
@@ -257,10 +257,19 @@ contract("Colony", accounts => {
 
     it("should assign tokens correctly when bootstrapping the colony", async () => {
       await colony.mintTokens(WAD.muln(14));
-      await colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS);
 
+      await checkErrorRevert(colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS), "colony-bootstrap-not-enough-tokens");
+
+      await colony.claimColonyFunds(token.address);
+      const potBalanceBefore = await colony.getPotBalance(1, token.address);
+      expect(potBalanceBefore).to.eq.BN(WAD.muln(14));
+
+      await colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS);
       const balance = await token.balanceOf(INITIAL_ADDRESSES[0]);
       expect(balance).to.eq.BN(INITIAL_REPUTATIONS[0]);
+
+      const potBalanceAfter = await colony.getPotBalance(1, token.address);
+      expect(potBalanceAfter).to.be.zero;
     });
 
     it("should be able to bootstrap colony more than once", async () => {

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -44,7 +44,8 @@ contract("Token Locking", addresses => {
 
   beforeEach(async () => {
     ({ colony, token } = await setupRandomColony(colonyNetwork));
-    await colony.mintTokens(usersTokens + otherUserTokens);
+    await colony.mintTokens(Math.ceil(((usersTokens + otherUserTokens) * 100) / 99));
+    await colony.claimColonyFunds(token.address);
     await colony.bootstrapColony([userAddress], [usersTokens]);
 
     const tokenArgs = getTokenArgs();
@@ -124,6 +125,7 @@ contract("Token Locking", addresses => {
     });
 
     it("should not be able to withdraw if specified amount is greated than deposited", async () => {
+      await colony.claimColonyFunds(token.address);
       await colony.bootstrapColony([addresses[0]], [otherUserTokens]);
       await token.approve(tokenLocking.address, otherUserTokens);
       await tokenLocking.deposit(token.address, otherUserTokens);


### PR DESCRIPTION
Closes #502 

Implemented the fix suggested, which was that tokens distributed during bootstrapping have to come from the claimed funds pot. Strictly, we don't need the `not-enough-tokens` require and could just let `sub` error with `ds-math-sub-underflow`, but I thought it better to have a more explicit error.