### PR TITLE
Allow anyone to claim payout on Task Role's behalf

### DIFF
--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -89,13 +89,12 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   taskFinalized(_id)
   {
     Task storage task = tasks[_id];
-    require(task.roles[_role].user == msg.sender, "colony-claim-payout-access-denied");
+    uint payout = task.payouts[_role][_token];
 
-    if (task.roles[_role].rating == TaskRatings.Unsatisfactory) {
+    if (task.roles[_role].rating == TaskRatings.Unsatisfactory || payout == 0) {
       return;
     }
 
-    uint payout = task.payouts[_role][_token];
     task.payouts[_role][_token] = 0;
 
     fundingPots[task.fundingPotId].balance[_token] = sub(fundingPots[task.fundingPotId].balance[_token], payout);
@@ -106,7 +105,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
 
     if (_token == address(0x0)) {
       // Payout ether
-      msg.sender.transfer(remainder);
+      task.roles[_role].user.transfer(remainder);
       // Fee goes directly to Meta Colony
       IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
       address metaColonyAddress = colonyNetworkContract.getMetaColony();

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -89,6 +89,8 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   taskFinalized(_id)
   {
     Task storage task = tasks[_id];
+    assert(task.roles[_role].user != address(0x0));
+
     uint payout = task.payouts[_role][_token];
 
     if (task.roles[_role].rating == TaskRatings.Unsatisfactory || payout == 0) {

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -34,7 +34,6 @@ const DSToken = artifacts.require("DSToken");
 
 contract("Colony Funding", accounts => {
   const MANAGER = accounts[0];
-  const EVALUATOR = MANAGER;
   const WORKER = accounts[2];
 
   let colony;
@@ -463,8 +462,8 @@ contract("Colony Funding", accounts => {
       const taskId = await setupFinalizedTask({ colonyNetwork, colony, token: otherToken });
       await colony.moveFundsBetweenPots(1, 2, 10, otherToken.address);
       await colony.claimPayout(taskId, MANAGER_ROLE, otherToken.address);
-      await colony.claimPayout(taskId, WORKER_ROLE, otherToken.address, { from: WORKER });
-      await colony.claimPayout(taskId, EVALUATOR_ROLE, otherToken.address, { from: EVALUATOR });
+      await colony.claimPayout(taskId, WORKER_ROLE, otherToken.address);
+      await colony.claimPayout(taskId, EVALUATOR_ROLE, otherToken.address);
       await colony.moveFundsBetweenPots(2, 1, 10, otherToken.address);
 
       const colonyPotBalance = await colony.getPotBalance(2, otherToken.address);
@@ -481,8 +480,8 @@ contract("Colony Funding", accounts => {
       });
 
       await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
-      await colony.claimPayout(taskId, EVALUATOR_ROLE, token.address, { from: EVALUATOR });
-      await colony.claimPayout(taskId, WORKER_ROLE, token.address, { from: WORKER });
+      await colony.claimPayout(taskId, EVALUATOR_ROLE, token.address);
+      await colony.claimPayout(taskId, WORKER_ROLE, token.address);
 
       const taskInfo = await colony.getTask(taskId);
       const taskPotId = taskInfo[5];

--- a/test/colony-reward-payouts.js
+++ b/test/colony-reward-payouts.js
@@ -243,7 +243,7 @@ contract("Colony Reward Payouts", accounts => {
         domainId: domainCount
       });
 
-      await newColony.claimPayout(taskId, MANAGER_ROLE, newToken.address, { from: userAddress1 });
+      await newColony.claimPayout(taskId, MANAGER_ROLE, newToken.address);
 
       await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
       await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -1796,13 +1796,6 @@ contract("ColonyTask", accounts => {
       await checkErrorRevert(colony.claimPayout(taskId, MANAGER_ROLE, token.address), "colony-task-not-finalized");
     });
 
-    it("should return error when called by account that doesn't match the role", async () => {
-      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      const taskId = await setupFinalizedTask({ colonyNetwork, colony, token });
-
-      await checkErrorRevert(colony.claimPayout(taskId, MANAGER_ROLE, token.address, { from: OTHER }), "colony-claim-payout-access-denied");
-    });
-
     it("should payout correct rounded up network fees, for small task payouts", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupFinalizedTask({

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -1710,7 +1710,7 @@ contract("ColonyTask", accounts => {
       const workerBalanceBefore = await web3GetBalance(WORKER);
       const metaBalanceBefore = await web3GetBalance(metaColony.address);
 
-      await colony.claimPayout(taskId, WORKER_ROLE, ZERO_ADDRESS, { from: WORKER, gasPrice: 0 });
+      await colony.claimPayout(taskId, WORKER_ROLE, ZERO_ADDRESS, { gasPrice: 0 });
 
       const workerBalanceAfter = await web3GetBalance(WORKER);
       expect(new BN(workerBalanceAfter).sub(new BN(workerBalanceBefore))).to.eq.BN(new BN(197));
@@ -1739,8 +1739,8 @@ contract("ColonyTask", accounts => {
       });
 
       await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
-      await colony.claimPayout(taskId, WORKER_ROLE, token.address, { from: WORKER });
-      await colony.claimPayout(taskId, EVALUATOR_ROLE, token.address, { from: evaluator });
+      await colony.claimPayout(taskId, WORKER_ROLE, token.address);
+      await colony.claimPayout(taskId, EVALUATOR_ROLE, token.address);
 
       const managerBalanceAfter = await token.balanceOf(MANAGER);
       expect(managerBalanceAfter.sub(managerBalanceBefore)).to.be.zero;
@@ -1771,8 +1771,8 @@ contract("ColonyTask", accounts => {
       await colony.finalizeTask(taskId);
 
       await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
-      await colony.claimPayout(taskId, WORKER_ROLE, token.address, { from: WORKER });
-      await colony.claimPayout(taskId, EVALUATOR_ROLE, token.address, { from: evaluator });
+      await colony.claimPayout(taskId, WORKER_ROLE, token.address);
+      await colony.claimPayout(taskId, EVALUATOR_ROLE, token.address);
 
       const managerBalanceAfter = await token.balanceOf(MANAGER);
       const managerPayout = MANAGER_PAYOUT.divn(100)
@@ -1818,7 +1818,7 @@ contract("ColonyTask", accounts => {
 
       const workerBalanceBefore = await token.balanceOf(WORKER);
 
-      await colony.claimPayout(taskId, WORKER_ROLE, token.address, { from: WORKER });
+      await colony.claimPayout(taskId, WORKER_ROLE, token.address);
       const networkBalance3 = await token.balanceOf(colonyNetwork.address);
       const workerBalanceAfter = await token.balanceOf(WORKER);
       expect(networkBalance3.sub(networkBalance2)).to.eq.BN(1);
@@ -1849,7 +1849,7 @@ contract("ColonyTask", accounts => {
 
       const workerBalanceBefore = await token.balanceOf(WORKER);
 
-      await colony.claimPayout(taskId, WORKER_ROLE, token.address, { from: WORKER });
+      await colony.claimPayout(taskId, WORKER_ROLE, token.address);
       const networkBalance3 = await token.balanceOf(colonyNetwork.address);
       const workerBalanceAfter = await token.balanceOf(WORKER);
       expect(networkBalance3.sub(networkBalance2)).to.eq.BN(1);
@@ -1870,7 +1870,7 @@ contract("ColonyTask", accounts => {
       const networkBalanceBefore = await token.balanceOf(colonyNetwork.address);
       const workerBalanceBefore = await token.balanceOf(WORKER);
 
-      await colony.claimPayout(taskId, WORKER_ROLE, token.address, { from: WORKER });
+      await colony.claimPayout(taskId, WORKER_ROLE, token.address);
 
       const networkBalanceAfter = await token.balanceOf(colonyNetwork.address);
       const workerBalanceAfter = await token.balanceOf(WORKER);


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Implements part of #527

<!--- Summary of changes including design decisions -->

- Remove `require` which allows anyone to call `claimPayout` on behalf of the user (funds go to the user still!).
- Update tests to de-specify the address when calling `claimPayout`. 
- Add guard against sending funds to the null address.