### PR TITLE
Rename Pot to FundingPot

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -273,6 +273,6 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     pots[potCount].domainId = domainCount;
 
     emit DomainAdded(domainCount);
-    emit PotAdded(potCount);
+    emit FundingPotAdded(potCount);
   }
 }

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -105,8 +105,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
     for (uint i = 0; i < _users.length; i++) {
       require(_amounts[i] >= 0, "colony-bootstrap-bad-amount-input");
-      require(uint256(_amounts[i]) <= pots[1].balance[token], "colony-bootstrap-not-enough-tokens");
-      pots[1].balance[token] = sub(pots[1].balance[token], uint256(_amounts[i]));
+      require(uint256(_amounts[i]) <= fundingPots[1].balance[token], "colony-bootstrap-not-enough-tokens");
+      fundingPots[1].balance[token] = sub(fundingPots[1].balance[token], uint256(_amounts[i]));
       nonRewardPotsTotal[token] = sub(nonRewardPotsTotal[token], uint256(_amounts[i]));
 
       ERC20Extended(token).transfer(_users[i], uint256(_amounts[i]));
@@ -270,7 +270,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
       fundingPotId: potCount
     });
 
-    pots[potCount].domainId = domainCount;
+    fundingPots[potCount].domainId = domainCount;
 
     emit DomainAdded(domainCount);
     emit FundingPotAdded(potCount);

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -261,18 +261,18 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
   function initialiseDomain(uint256 _skillId) private skillExists(_skillId) {
     // Create a new pot
-    potCount += 1;
+    fundingPotCount += 1;
 
     // Create a new domain with the given skill and new pot
     domainCount += 1;
     domains[domainCount] = Domain({
       skillId: _skillId,
-      fundingPotId: potCount
+      fundingPotId: fundingPotCount
     });
 
-    fundingPots[potCount].domainId = domainCount;
+    fundingPots[fundingPotCount].domainId = domainCount;
 
     emit DomainAdded(domainCount);
-    emit FundingPotAdded(potCount);
+    emit FundingPotAdded(fundingPotCount);
   }
 }

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -267,7 +267,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     domainCount += 1;
     domains[domainCount] = Domain({
       skillId: _skillId,
-      potId: potCount
+      fundingPotId: potCount
     });
 
     pots[potCount].domainId = domainCount;

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -155,7 +155,7 @@ contract ColonyDataTypes {
 
   /// @notice Event logged when a new FundingPot is added
   /// @param potId Id of the newly-created FundingPot
-  event PotAdded(uint256 potId);
+  event FundingPotAdded(uint256 potId);
 
   struct RewardPayoutCycle {
     // Reputation root hash at the time of reward payout creation

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -153,8 +153,8 @@ contract ColonyDataTypes {
   /// @param domainId Id of the newly-created Domain
   event DomainAdded(uint256 domainId);
 
-  /// @notice Event logged when a new Pot is added
-  /// @param potId Id of the newly-created Pot
+  /// @notice Event logged when a new FundingPot is added
+  /// @param potId Id of the newly-created FundingPot
   event PotAdded(uint256 potId);
 
   struct RewardPayoutCycle {
@@ -211,7 +211,7 @@ contract ColonyDataTypes {
     mapping (uint8 => bytes32) secret;
   }
 
-  struct Pot {
+  struct FundingPot {
     mapping (address => uint256) balance;
     uint256 taskId;
     uint256 domainId;

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -154,8 +154,8 @@ contract ColonyDataTypes {
   event DomainAdded(uint256 domainId);
 
   /// @notice Event logged when a new FundingPot is added
-  /// @param potId Id of the newly-created FundingPot
-  event FundingPotAdded(uint256 potId);
+  /// @param fundingPotId Id of the newly-created FundingPot
+  event FundingPotAdded(uint256 fundingPotId);
 
   struct RewardPayoutCycle {
     // Reputation root hash at the time of reward payout creation
@@ -178,7 +178,7 @@ contract ColonyDataTypes {
     TaskStatus status;
     uint256 dueDate;
     uint256 payoutsWeCannotMake;
-    uint256 potId;
+    uint256 fundingPotId;
     uint256 completionTimestamp;
     uint256 domainId;
     uint256[] skills;
@@ -219,6 +219,6 @@ contract ColonyDataTypes {
 
   struct Domain {
     uint256 skillId;
-    uint256 potId;
+    uint256 fundingPotId;
   }
 }

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -123,8 +123,8 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     emit TaskPayoutClaimed(_id, _role, _token, remainder);
   }
 
-  function getPotCount() public view returns (uint256 count) {
-    return potCount;
+  function getFundingPotCount() public view returns (uint256 count) {
+    return fundingPotCount;
   }
 
   function getPotBalance(uint256 _potId, address _token) public view returns (uint256) {
@@ -150,8 +150,8 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
 
     // Preventing sending from non-existent funding pots is not strictly necessary (if a pot doesn't exist, it can't have any funds if we
     // prevent sending to nonexistent funding pots) but doing this check explicitly gives us the error message for clients.
-    require(_fromPot <= potCount, "colony-funding-from-nonexistent-pot"); // Only allow sending from created pots
-    require(_toPot <= potCount, "colony-funding-nonexistent-pot"); // Only allow sending to created funding pots
+    require(_fromPot <= fundingPotCount, "colony-funding-from-nonexistent-pot"); // Only allow sending from created pots
+    require(_toPot <= fundingPotCount, "colony-funding-nonexistent-pot"); // Only allow sending to created funding pots
 
     uint fromTaskId = fundingPots[_fromPot].taskId;
     uint toTaskId = fundingPots[_toPot].taskId;

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -132,7 +132,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   }
 
   function getPotInformation(uint256 _potId) public view returns (uint256 taskId, uint256 domainId) {
-    Pot storage pot = pots[_potId];
+    FundingPot storage pot = pots[_potId];
     taskId = pot.taskId;
     domainId = pot.domainId;
   }

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -98,7 +98,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     uint payout = task.payouts[_role][_token];
     task.payouts[_role][_token] = 0;
 
-    pots[task.fundingPotId].balance[_token] = sub(pots[task.fundingPotId].balance[_token], payout);
+    fundingPots[task.fundingPotId].balance[_token] = sub(fundingPots[task.fundingPotId].balance[_token], payout);
     nonRewardPotsTotal[_token] = sub(nonRewardPotsTotal[_token], payout);
 
     uint fee = calculateNetworkFeeForPayout(payout);
@@ -128,11 +128,11 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   }
 
   function getPotBalance(uint256 _potId, address _token) public view returns (uint256) {
-    return pots[_potId].balance[_token];
+    return fundingPots[_potId].balance[_token];
   }
 
   function getPotInformation(uint256 _potId) public view returns (uint256 taskId, uint256 domainId) {
-    FundingPot storage pot = pots[_potId];
+    FundingPot storage pot = fundingPots[_potId];
     taskId = pot.taskId;
     domainId = pot.domainId;
   }
@@ -148,16 +148,16 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     // Prevent people moving funds from the pot for paying out token holders
     require(_fromPot > 0, "colony-funding-cannot-move-funds-from-rewards-pot");
 
-    // Preventing sending from non-existent pots is not strictly necessary (if a pot doesn't exist, it can't have any funds if we
-    // prevent sending to nonexistent pots) but doing this check explicitly gives us the error message for clients.
+    // Preventing sending from non-existent funding pots is not strictly necessary (if a pot doesn't exist, it can't have any funds if we
+    // prevent sending to nonexistent funding pots) but doing this check explicitly gives us the error message for clients.
     require(_fromPot <= potCount, "colony-funding-from-nonexistent-pot"); // Only allow sending from created pots
-    require(_toPot <= potCount, "colony-funding-nonexistent-pot"); // Only allow sending to created pots
+    require(_toPot <= potCount, "colony-funding-nonexistent-pot"); // Only allow sending to created funding pots
 
-    uint fromTaskId = pots[_fromPot].taskId;
-    uint toTaskId = pots[_toPot].taskId;
+    uint fromTaskId = fundingPots[_fromPot].taskId;
+    uint toTaskId = fundingPots[_toPot].taskId;
 
-    uint fromPotPreviousAmount = pots[_fromPot].balance[_token];
-    uint toPotPreviousAmount = pots[_toPot].balance[_token];
+    uint fromPotPreviousAmount = fundingPots[_fromPot].balance[_token];
+    uint toPotPreviousAmount = fundingPots[_toPot].balance[_token];
 
     // If this pot is associated with a task, prevent money being taken from the pot
     // if the remaining balance is less than the amount needed for payouts,
@@ -169,8 +169,8 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
       require(task.status == TaskStatus.Cancelled || surplus >= _amount, "colony-funding-task-bad-state");
     }
 
-    pots[_fromPot].balance[_token] = sub(fromPotPreviousAmount, _amount);
-    pots[_toPot].balance[_token] = add(toPotPreviousAmount, _amount);
+    fundingPots[_fromPot].balance[_token] = sub(fromPotPreviousAmount, _amount);
+    fundingPots[_toPot].balance[_token] = add(toPotPreviousAmount, _amount);
     updateTaskPayoutsWeCannotMakeAfterPotChange(toTaskId, _token, toPotPreviousAmount);
     updateTaskPayoutsWeCannotMakeAfterPotChange(fromTaskId, _token, fromPotPreviousAmount);
 
@@ -183,18 +183,18 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     uint remainder;
     if (_token == address(0x0)) {
       // It's ether
-      toClaim = sub(sub(address(this).balance, nonRewardPotsTotal[_token]), pots[0].balance[_token]);
+      toClaim = sub(sub(address(this).balance, nonRewardPotsTotal[_token]), fundingPots[0].balance[_token]);
     } else {
       // Assume it's an ERC 20 token.
       ERC20Extended targetToken = ERC20Extended(_token);
-      toClaim = sub(sub(targetToken.balanceOf(address(this)), nonRewardPotsTotal[_token]), pots[0].balance[_token]);
+      toClaim = sub(sub(targetToken.balanceOf(address(this)), nonRewardPotsTotal[_token]), fundingPots[0].balance[_token]);
     }
 
     feeToPay = toClaim / getRewardInverse();
     remainder = sub(toClaim, feeToPay);
     nonRewardPotsTotal[_token] = add(nonRewardPotsTotal[_token], remainder);
-    pots[1].balance[_token] = add(pots[1].balance[_token], remainder);
-    pots[0].balance[_token] = add(pots[0].balance[_token], feeToPay);
+    fundingPots[1].balance[_token] = add(fundingPots[1].balance[_token], remainder);
+    fundingPots[0].balance[_token] = add(fundingPots[0].balance[_token], feeToPay);
 
     emit ColonyFundsClaimed(_token, feeToPay, remainder);
   }
@@ -232,7 +232,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
       rootHash,
       colonyWideReputation,
       totalTokens,
-      pots[0].balance[_token],
+      fundingPots[0].balance[_token],
       _token,
       block.timestamp
     );
@@ -266,7 +266,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     uint fee = calculateNetworkFeeForPayout(reward);
     uint remainder = sub(reward, fee);
 
-    pots[0].balance[tokenAddress] = sub(pots[0].balance[tokenAddress], reward);
+    fundingPots[0].balance[tokenAddress] = sub(fundingPots[0].balance[tokenAddress], reward);
 
     ERC20Extended(tokenAddress).transfer(msg.sender, remainder);
     ERC20Extended(tokenAddress).transfer(colonyNetworkAddress, fee);
@@ -378,7 +378,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   function updateTaskPayoutsWeCannotMakeAfterPotChange(uint256 _id, address _token, uint _prev) internal {
     Task storage task = tasks[_id];
     uint totalTokenPayout = getTotalTaskPayout(_id, _token);
-    uint tokenPot = pots[task.fundingPotId].balance[_token];
+    uint tokenPot = fundingPots[task.fundingPotId].balance[_token];
     if (_prev >= totalTokenPayout) {                                  // If the old amount in the pot was enough to pay for the budget
       if (tokenPot < totalTokenPayout) {                              // And the new amount in the pot is not enough to pay for the budget...
         task.payoutsWeCannotMake += 1;                                // Then this is a set of payouts we cannot make that we could before.
@@ -393,7 +393,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   function updateTaskPayoutsWeCannotMakeAfterBudgetChange(uint256 _id, address _token, uint _prev) internal {
     Task storage task = tasks[_id];
     uint totalTokenPayout = getTotalTaskPayout(_id, _token);
-    uint tokenPot = pots[task.fundingPotId].balance[_token];
+    uint tokenPot = fundingPots[task.fundingPotId].balance[_token];
     if (tokenPot >= _prev) {                                          // If the amount in the pot was enough to pay for the old budget...
       if (tokenPot < totalTokenPayout) {                              // And the amount is not enough to pay for the new budget...
         task.payoutsWeCannotMake += 1;                                // Then this is a set of payouts we cannot make that we could before.

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -98,7 +98,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     uint payout = task.payouts[_role][_token];
     task.payouts[_role][_token] = 0;
 
-    pots[task.potId].balance[_token] = sub(pots[task.potId].balance[_token], payout);
+    pots[task.fundingPotId].balance[_token] = sub(pots[task.fundingPotId].balance[_token], payout);
     nonRewardPotsTotal[_token] = sub(nonRewardPotsTotal[_token], payout);
 
     uint fee = calculateNetworkFeeForPayout(payout);
@@ -378,7 +378,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   function updateTaskPayoutsWeCannotMakeAfterPotChange(uint256 _id, address _token, uint _prev) internal {
     Task storage task = tasks[_id];
     uint totalTokenPayout = getTotalTaskPayout(_id, _token);
-    uint tokenPot = pots[task.potId].balance[_token];
+    uint tokenPot = pots[task.fundingPotId].balance[_token];
     if (_prev >= totalTokenPayout) {                                  // If the old amount in the pot was enough to pay for the budget
       if (tokenPot < totalTokenPayout) {                              // And the new amount in the pot is not enough to pay for the budget...
         task.payoutsWeCannotMake += 1;                                // Then this is a set of payouts we cannot make that we could before.
@@ -393,7 +393,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   function updateTaskPayoutsWeCannotMakeAfterBudgetChange(uint256 _id, address _token, uint _prev) internal {
     Task storage task = tasks[_id];
     uint totalTokenPayout = getTotalTaskPayout(_id, _token);
-    uint tokenPot = pots[task.potId].balance[_token];
+    uint tokenPot = pots[task.fundingPotId].balance[_token];
     if (tokenPot >= _prev) {                                          // If the amount in the pot was enough to pay for the old budget...
       if (tokenPot < totalTokenPayout) {                              // And the amount is not enough to pay for the new budget...
         task.payoutsWeCannotMake += 1;                                // Then this is a set of payouts we cannot make that we could before.

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -48,11 +48,11 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, DSMath {
 
   mapping (uint256 => Task) tasks; // Storage slot 14
 
-  // Pots can be tied to tasks or domains, so giving them their own mapping.
-  // Pot 1 can be thought of as the pot belonging to the colony itself that hasn't been assigned
+  // FundingPots can be tied to tasks or domains, so giving them their own mapping.
+  // FundingPot 1 can be thought of as the pot belonging to the colony itself that hasn't been assigned
   // to anything yet, but has had some siphoned off in to the reward pot.
-  // Pot 0 is the 'reward' pot containing funds that can be paid to holders of colony tokens in the future.
-  mapping (uint256 => Pot) pots; // Storage slot 15
+  // FundingPot 0 is the 'reward' pot containing funds that can be paid to holders of colony tokens in the future.
+  mapping (uint256 => FundingPot) pots; // Storage slot 15
 
   // Keeps track of all reward payout cycles
   mapping (uint256 => RewardPayoutCycle) rewardPayoutCycles; // Storage slot 16

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -36,7 +36,7 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, DSMath {
   uint256 rewardInverse; // Storage slot 8
 
   uint256 taskCount; // Storage slot 9
-  uint256 potCount; // Storage slot 10
+  uint256 fundingPotCount; // Storage slot 10
   uint256 domainCount; // Storage slot 11
 
   // Mapping function signature to 2 task roles whose approval is needed to execute

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -52,14 +52,14 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, DSMath {
   // FundingPot 1 can be thought of as the pot belonging to the colony itself that hasn't been assigned
   // to anything yet, but has had some siphoned off in to the reward pot.
   // FundingPot 0 is the 'reward' pot containing funds that can be paid to holders of colony tokens in the future.
-  mapping (uint256 => FundingPot) pots; // Storage slot 15
+  mapping (uint256 => FundingPot) fundingPots; // Storage slot 15
 
   // Keeps track of all reward payout cycles
   mapping (uint256 => RewardPayoutCycle) rewardPayoutCycles; // Storage slot 16
   // Active payouts for particular token address. Assures that one token is used for only one active payout
   mapping (address => bool) activeRewardPayouts; // Storage slot 17
 
-  // This keeps track of how much of the colony's funds that it owns have been moved into pots other than pot 0,
+  // This keeps track of how much of the colony's funds that it owns have been moved into funding pots other than pot 0,
   // which (by definition) have also had the reward amount siphoned off and put in to pot 0.
   // This is decremented whenever a payout occurs and the colony loses control of the funds.
   mapping (address => uint256) nonRewardPotsTotal; // Storage slot 18

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -99,7 +99,7 @@ contract ColonyTask is ColonyStorage {
     tasks[taskCount] = task;
     tasks[taskCount].roles[uint8(TaskRole.Manager)].user = msg.sender;
     tasks[taskCount].roles[uint8(TaskRole.Evaluator)].user = msg.sender;
-    pots[potCount].taskId = taskCount;
+    fundingPots[potCount].taskId = taskCount;
 
     if (_skillId > 0) {
       this.setTaskSkill(taskCount, _skillId);

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -113,7 +113,7 @@ contract ColonyTask is ColonyStorage {
     }
     this.setTaskDueDate(taskCount, dueDate);
 
-    emit PotAdded(potCount);
+    emit FundingPotAdded(potCount);
     emit TaskAdded(taskCount);
   }
 

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -89,17 +89,17 @@ contract ColonyTask is ColonyStorage {
   domainExists(_domainId)
   {
     taskCount += 1;
-    potCount += 1;
+    fundingPotCount += 1;
 
     Task memory task;
     task.specificationHash = _specificationHash;
-    task.fundingPotId = potCount;
+    task.fundingPotId = fundingPotCount;
     task.domainId = _domainId;
     task.skills = new uint256[](1);
     tasks[taskCount] = task;
     tasks[taskCount].roles[uint8(TaskRole.Manager)].user = msg.sender;
     tasks[taskCount].roles[uint8(TaskRole.Evaluator)].user = msg.sender;
-    fundingPots[potCount].taskId = taskCount;
+    fundingPots[fundingPotCount].taskId = taskCount;
 
     if (_skillId > 0) {
       this.setTaskSkill(taskCount, _skillId);
@@ -113,7 +113,7 @@ contract ColonyTask is ColonyStorage {
     }
     this.setTaskDueDate(taskCount, dueDate);
 
-    emit FundingPotAdded(potCount);
+    emit FundingPotAdded(fundingPotCount);
     emit TaskAdded(taskCount);
   }
 

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -93,7 +93,7 @@ contract ColonyTask is ColonyStorage {
 
     Task memory task;
     task.specificationHash = _specificationHash;
-    task.potId = potCount;
+    task.fundingPotId = potCount;
     task.domainId = _domainId;
     task.skills = new uint256[](1);
     tasks[taskCount] = task;
@@ -443,7 +443,7 @@ contract ColonyTask is ColonyStorage {
       t.status,
       t.dueDate,
       t.payoutsWeCannotMake,
-      t.potId,
+      t.fundingPotId,
       t.completionTimestamp,
       t.domainId,
       t.skills

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -482,6 +482,6 @@ contract IColony is ColonyDataTypes, IRecovery {
 
   /// @notice Get the total amount of tokens `_token` minus amount reserved to be paid to the reputation and token holders as rewards
   /// @param _token Address of the token, `0x0` value indicates Ether
-  /// @return amount Total amount of tokens in pots other than the rewards pot (id 0)
+  /// @return amount Total amount of tokens in funding pots other than the rewards pot (id 0)
   function getNonRewardPotsTotal(address _token) public view returns (uint256 amount);
 }

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -328,7 +328,7 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @return status TaskStatus property. 0 - Active. 1 - Cancelled. 2 - Finalized
   /// @return dueDate Due date
   /// @return payoutsWeCannotMake Number of payouts that cannot be completed with the current task funding
-  /// @return potId Id of funding pot for task
+  /// @return fundingPotId Id of funding pot for task
   /// @return completionTimestamp Task completion timestamp
   /// @return domainId Task domain id, default is root colony domain with id 1
   /// @return skillIds Array of global skill ids assigned to task
@@ -338,7 +338,7 @@ contract IColony is ColonyDataTypes, IRecovery {
     TaskStatus status,
     uint256 dueDate,
     uint256 payoutsWeCannotMake,
-    uint256 potId,
+    uint256 fundingPotId,
     uint256 completionTimestamp,
     uint256 domainId,
     uint256[] memory skillIds

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -459,7 +459,7 @@ contract IColony is ColonyDataTypes, IRecovery {
 
   /// @notice Get the number of funding pots in the colony
   /// @return count The funding pots count
-  function getPotCount() public view returns (uint256 count);
+  function getFundingPotCount() public view returns (uint256 count);
 
   /// @notice Get the `_token` balance of pot with id `_potId`
   /// @param _potId Id of the funding pot

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -173,12 +173,12 @@ export async function setupFundedTask({
 
   const taskId = await setupTask({ colonyNetwork, colony, dueDate, domainId, skillId, manager });
   const task = await colony.getTask(taskId);
-  const potId = task[5];
+  const fundingPotId = task[5];
   const managerPayoutBN = new BN(managerPayout);
   const evaluatorPayoutBN = new BN(evaluatorPayout);
   const workerPayoutBN = new BN(workerPayout);
   const totalPayouts = managerPayoutBN.add(workerPayoutBN).add(evaluatorPayoutBN);
-  await colony.moveFundsBetweenPots(1, potId, totalPayouts, tokenAddress);
+  await colony.moveFundsBetweenPots(1, fundingPotId, totalPayouts, tokenAddress);
   await colony.setAllTaskPayouts(taskId, tokenAddress, managerPayout, evaluatorPayout, workerPayout, { from: manager });
   await assignRoles({ colony, taskId, manager, evaluator, worker });
 

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -417,13 +417,13 @@ contract("Colony Funding", accounts => {
     it("should return correct number of funding funding pots", async () => {
       const taskCountBefore = await colony.getTaskCount();
       expect(taskCountBefore).to.be.zero;
-      const potCountBefore = await colony.getPotCount();
+      const potCountBefore = await colony.getFundingPotCount();
       // Expect there to be a single funding pot for the root Domain created.
       // Note that the reward pot with id 0 is NOT included in the Colony Funding funding pots count
       expect(potCountBefore).to.eq.BN(1);
 
       await colony.addDomain(1);
-      const potCountAfterAddingDomain = await colony.getPotCount();
+      const potCountAfterAddingDomain = await colony.getFundingPotCount();
       expect(potCountAfterAddingDomain).to.eq.BN(2);
 
       for (let i = 0; i < 5; i += 1) {
@@ -432,7 +432,7 @@ contract("Colony Funding", accounts => {
 
       const taskCountAfter = await colony.getTaskCount();
       expect(taskCountAfter).to.be.eq.BN(5);
-      const potCountAfter = await colony.getPotCount();
+      const potCountAfter = await colony.getFundingPotCount();
       expect(potCountAfter).to.eq.BN(7);
     });
 

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -414,7 +414,7 @@ contract("Colony Funding", accounts => {
       expect(colonyPotBalance).to.eq.BN(297);
     });
 
-    it("should return correct number of funding funding pots", async () => {
+    it("should return correct number of funding pots", async () => {
       const taskCountBefore = await colony.getTaskCount();
       expect(taskCountBefore).to.be.zero;
       const potCountBefore = await colony.getFundingPotCount();

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -149,15 +149,15 @@ contract("Colony Funding", accounts => {
 
     it("should correctly track if we are able to make token payouts", async () => {
       // There are eighteen scenarios to test here.
-      // Pot was below payout, now equal (1 + 2)
-      // Pot was below payout, now above (3 + 4)
-      // Pot was equal to payout, now above (5 + 6)
-      // Pot was equal to payout, now below (7 + 8)
-      // Pot was above payout, now below (9 + 10)
-      // Pot was above payout, now equal (11 + 12)
-      // Pot was below payout, still below (13 + 14)
-      // Pot was above payout, still above (15 + 16)
-      // Pot was equal to payout, still equal (17 + 18)
+      // FundingPot was below payout, now equal (1 + 2)
+      // FundingPot was below payout, now above (3 + 4)
+      // FundingPot was equal to payout, now above (5 + 6)
+      // FundingPot was equal to payout, now below (7 + 8)
+      // FundingPot was above payout, now below (9 + 10)
+      // FundingPot was above payout, now equal (11 + 12)
+      // FundingPot was below payout, still below (13 + 14)
+      // FundingPot was above payout, still above (15 + 16)
+      // FundingPot was equal to payout, still equal (17 + 18)
       //
       // And, for each of these, we have to check that the update is correctly tracked when
       // the pot changes (odd numbers), and when the payout changes (even numbers)
@@ -178,8 +178,8 @@ contract("Colony Funding", accounts => {
         sigTypes: [0, 0],
         args: [taskId, WORKER]
       });
-      // Pot 0, Payout 0
-      // Pot was equal to payout, transition to pot being equal by changing payout (18)
+      // FundingPot 0, Payout 0
+      // FundingPot was equal to payout, transition to pot being equal by changing payout (18)
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -191,14 +191,14 @@ contract("Colony Funding", accounts => {
       let task = await colony.getTask(taskId);
       expect(task[4]).to.be.zero;
 
-      // Pot 0, Payout 0
-      // Pot was equal to payout, transition to pot being equal by changing pot (17)
+      // FundingPot 0, Payout 0
+      // FundingPot was equal to payout, transition to pot being equal by changing pot (17)
       await colony.moveFundsBetweenPots(1, 2, 0, otherToken.address);
       task = await colony.getTask(taskId);
       expect(task[4]).to.be.zero;
 
-      // Pot 0, Payout 0
-      // Pot was equal to payout, transition to pot being lower by increasing payout (8)
+      // FundingPot 0, Payout 0
+      // FundingPot was equal to payout, transition to pot being lower by increasing payout (8)
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -210,20 +210,20 @@ contract("Colony Funding", accounts => {
       task = await colony.getTask(taskId);
       expect(task[4]).to.eq.BN(1);
 
-      // Pot 0, Payout 40
-      // Pot was below payout, transition to being equal by increasing pot (1)
+      // FundingPot 0, Payout 40
+      // FundingPot was below payout, transition to being equal by increasing pot (1)
       await colony.moveFundsBetweenPots(1, 2, 40, otherToken.address);
       task = await colony.getTask(taskId);
       expect(task[4]).to.be.zero;
 
-      // Pot 40, Payout 40
-      // Pot was equal to payout, transition to being above by increasing pot (5)
+      // FundingPot 40, Payout 40
+      // FundingPot was equal to payout, transition to being above by increasing pot (5)
       await colony.moveFundsBetweenPots(1, 2, 40, otherToken.address);
       task = await colony.getTask(taskId);
       expect(task[4]).to.be.zero;
 
-      // Pot 80, Payout 40
-      // Pot was above payout, transition to being equal by increasing payout (12)
+      // FundingPot 80, Payout 40
+      // FundingPot was above payout, transition to being equal by increasing payout (12)
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -235,8 +235,8 @@ contract("Colony Funding", accounts => {
       task = await colony.getTask(taskId);
       expect(task[4]).to.be.zero;
 
-      // Pot 80, Payout 80
-      // Pot was equal to payout, transition to being above by decreasing payout (6)
+      // FundingPot 80, Payout 80
+      // FundingPot was equal to payout, transition to being above by decreasing payout (6)
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -248,14 +248,14 @@ contract("Colony Funding", accounts => {
       task = await colony.getTask(taskId);
       expect(task[4]).to.be.zero;
 
-      // Pot 80, Payout 40
-      // Pot was above payout, transition to being equal by decreasing pot (11)
+      // FundingPot 80, Payout 40
+      // FundingPot was above payout, transition to being equal by decreasing pot (11)
       await colony.moveFundsBetweenPots(2, 1, 40, otherToken.address);
       task = await colony.getTask(taskId);
       expect(task[4]).to.be.zero;
 
-      // Pot 40, Payout 40
-      // Pot was equal to payout, transition to pot being below payout by changing pot (7)
+      // FundingPot 40, Payout 40
+      // FundingPot was equal to payout, transition to pot being below payout by changing pot (7)
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 20, otherToken.address), "colony-funding-task-bad-state");
 
       // Remove 20 from pot
@@ -277,14 +277,14 @@ contract("Colony Funding", accounts => {
         args: [taskId, otherToken.address, 40]
       });
 
-      // Pot 20, Payout 40
-      // Pot was below payout, change to being above by changing pot (3)
+      // FundingPot 20, Payout 40
+      // FundingPot was below payout, change to being above by changing pot (3)
       await colony.moveFundsBetweenPots(1, 2, 60, otherToken.address);
       task = await colony.getTask(taskId);
       expect(task[4]).to.be.zero;
 
-      // Pot 80, Payout 40
-      // Pot was above payout, change to being below by changing pot (9)
+      // FundingPot 80, Payout 40
+      // FundingPot was above payout, change to being below by changing pot (9)
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 60, otherToken.address), "colony-funding-task-bad-state");
 
       // Remove 60 from pot
@@ -306,8 +306,8 @@ contract("Colony Funding", accounts => {
         args: [taskId, otherToken.address, 40]
       });
 
-      // Pot 20, Payout 40
-      // Pot was below payout, change to being above by changing payout (4)
+      // FundingPot 20, Payout 40
+      // FundingPot was below payout, change to being above by changing payout (4)
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -319,8 +319,8 @@ contract("Colony Funding", accounts => {
       task = await colony.getTask(taskId);
       expect(task[4]).to.be.zero;
 
-      // Pot 20, Payout 10
-      // Pot was above, change to being above by changing payout (16)
+      // FundingPot 20, Payout 10
+      // FundingPot was above, change to being above by changing payout (16)
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -332,14 +332,14 @@ contract("Colony Funding", accounts => {
       task = await colony.getTask(taskId);
       expect(task[4]).to.be.zero;
 
-      // Pot 20, Payout 5
-      // Pot was above, change to being above by changing pot (15)
+      // FundingPot 20, Payout 5
+      // FundingPot was above, change to being above by changing pot (15)
       await colony.moveFundsBetweenPots(2, 1, 10, otherToken.address);
       task = await colony.getTask(taskId);
       expect(task[4]).to.be.zero;
 
-      // Pot 10, Payout 5
-      // Pot was above payout, change to being below by changing payout (10)
+      // FundingPot 10, Payout 5
+      // FundingPot was above payout, change to being below by changing payout (10)
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -351,8 +351,8 @@ contract("Colony Funding", accounts => {
       task = await colony.getTask(taskId);
       expect(task[4]).to.eq.BN(1);
 
-      // Pot 10, Payout 40
-      // Pot was below payout, change to being below by changing payout (14)
+      // FundingPot 10, Payout 40
+      // FundingPot was below payout, change to being below by changing payout (14)
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -364,8 +364,8 @@ contract("Colony Funding", accounts => {
       task = await colony.getTask(taskId);
       expect(task[4]).to.eq.BN(1);
 
-      // Pot 10, Payout 30
-      // Pot was below payout, change to being below by changing pot (13)
+      // FundingPot 10, Payout 30
+      // FundingPot was below payout, change to being below by changing pot (13)
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 5, otherToken.address), "colony-funding-task-bad-state");
 
       // Remove 5 from pot
@@ -387,8 +387,8 @@ contract("Colony Funding", accounts => {
         args: [taskId, otherToken.address, 30]
       });
 
-      // Pot 5, Payout 30
-      // Pot was below payout, change to being equal by changing payout (2)
+      // FundingPot 5, Payout 30
+      // FundingPot was below payout, change to being equal by changing payout (2)
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -400,7 +400,7 @@ contract("Colony Funding", accounts => {
       task = await colony.getTask(taskId);
       expect(task[4]).to.be.zero;
 
-      // Pot 5, Payout 5
+      // FundingPot 5, Payout 5
     });
 
     it("should pay fees on revenue correctly", async () => {

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -84,7 +84,7 @@ contract("Colony Funding", accounts => {
       expect(colonyRewardPotBalance).to.eq.BN(1);
     });
 
-    it("should let tokens be moved between pots", async () => {
+    it("should let tokens be moved between funding pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await makeTask({ colony });
       await colony.moveFundsBetweenPots(1, 2, 51, otherToken.address);
@@ -414,12 +414,12 @@ contract("Colony Funding", accounts => {
       expect(colonyPotBalance).to.eq.BN(297);
     });
 
-    it("should return correct number of funding pots", async () => {
+    it("should return correct number of funding funding pots", async () => {
       const taskCountBefore = await colony.getTaskCount();
       expect(taskCountBefore).to.be.zero;
       const potCountBefore = await colony.getPotCount();
       // Expect there to be a single funding pot for the root Domain created.
-      // Note that the reward pot with id 0 is NOT included in the Colony Funding pots count
+      // Note that the reward pot with id 0 is NOT included in the Colony Funding funding pots count
       expect(potCountBefore).to.eq.BN(1);
 
       await colony.addDomain(1);
@@ -436,14 +436,14 @@ contract("Colony Funding", accounts => {
       expect(potCountAfter).to.eq.BN(7);
     });
 
-    it("should not allow contributions to nonexistent pots", async () => {
+    it("should not allow contributions to nonexistent funding pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await checkErrorRevert(colony.moveFundsBetweenPots(1, 5, 40, otherToken.address), "colony-funding-nonexistent-pot");
       const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
       expect(colonyPotBalance).to.eq.BN(99);
     });
 
-    it("should not allow attempts to move funds from nonexistent pots", async () => {
+    it("should not allow attempts to move funds from nonexistent funding pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await checkErrorRevert(colony.moveFundsBetweenPots(5, 1, 40, otherToken.address), "colony-funding-from-nonexistent-pot");
       const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
@@ -514,7 +514,7 @@ contract("Colony Funding", accounts => {
       expect(colonyPotBalance).to.eq.BN(99);
     });
 
-    it("should let ether be moved between pots", async () => {
+    it("should let ether be moved between funding pots", async () => {
       await colony.send(100);
       await colony.claimColonyFunds(ZERO_ADDRESS);
       await makeTask({ colony });

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -168,7 +168,7 @@ contract("Colony Network", accounts => {
 
       const rootDomain = await colony.getDomain(1);
       expect(rootDomain.skillId).to.eq.BN(4);
-      expect(rootDomain.potId).to.eq.BN(1);
+      expect(rootDomain.fundingPotId).to.eq.BN(1);
 
       const domainCount = await colony.getDomainCount();
       expect(domainCount).to.eq.BN(1);

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -1346,7 +1346,7 @@ contract("ColonyTask", accounts => {
       await colony.claimColonyFunds(otherToken.address);
       await colony.moveFundsBetweenPots(1, taskPotId, 100, otherToken.address);
 
-      // Keep track of original Ether balance in pots
+      // Keep track of original Ether balance in funding pots
       const originalDomainEtherBalance = await colony.getPotBalance(domain.fundingPotId, ZERO_ADDRESS);
       const originalTaskEtherBalance = await colony.getPotBalance(taskPotId, ZERO_ADDRESS);
       // And same for the token
@@ -1356,7 +1356,7 @@ contract("ColonyTask", accounts => {
       const originalDomainOtherTokenBalance = await colony.getPotBalance(domain.fundingPotId, otherToken.address);
       const originalTaskOtherTokenBalance = await colony.getPotBalance(taskPotId, otherToken.address);
 
-      // Now that everything is set up, let's cancel the task, move funds and compare pots afterwards
+      // Now that everything is set up, let's cancel the task, move funds and compare funding pots afterwards
       await executeSignedTaskChange({
         colony,
         taskId,

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -164,8 +164,8 @@ contract("ColonyTask", accounts => {
       expect(task[7]).to.eq.BN(2);
     });
 
-    it("should log TaskAdded and PotAdded events", async () => {
-      await expectAllEvents(colony.makeTask(SPECIFICATION_HASH, 1, 1, 0), ["TaskAdded", "PotAdded"]);
+    it("should log TaskAdded and FundingPotAdded events", async () => {
+      await expectAllEvents(colony.makeTask(SPECIFICATION_HASH, 1, 1, 0), ["TaskAdded", "FundingPotAdded"]);
     });
 
     it("should optionally set the skill and due date", async () => {

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -1347,13 +1347,13 @@ contract("ColonyTask", accounts => {
       await colony.moveFundsBetweenPots(1, taskPotId, 100, otherToken.address);
 
       // Keep track of original Ether balance in pots
-      const originalDomainEtherBalance = await colony.getPotBalance(domain.potId, ZERO_ADDRESS);
+      const originalDomainEtherBalance = await colony.getPotBalance(domain.fundingPotId, ZERO_ADDRESS);
       const originalTaskEtherBalance = await colony.getPotBalance(taskPotId, ZERO_ADDRESS);
       // And same for the token
-      const originalDomainTokenBalance = await colony.getPotBalance(domain.potId, token.address);
+      const originalDomainTokenBalance = await colony.getPotBalance(domain.fundingPotId, token.address);
       const originalTaskTokenBalance = await colony.getPotBalance(taskPotId, token.address);
       // And the other token
-      const originalDomainOtherTokenBalance = await colony.getPotBalance(domain.potId, otherToken.address);
+      const originalDomainOtherTokenBalance = await colony.getPotBalance(domain.fundingPotId, otherToken.address);
       const originalTaskOtherTokenBalance = await colony.getPotBalance(taskPotId, otherToken.address);
 
       // Now that everything is set up, let's cancel the task, move funds and compare pots afterwards
@@ -1366,16 +1366,16 @@ contract("ColonyTask", accounts => {
         args: [taskId]
       });
 
-      await colony.moveFundsBetweenPots(taskPotId, domain.potId, originalTaskEtherBalance, ZERO_ADDRESS);
-      await colony.moveFundsBetweenPots(taskPotId, domain.potId, originalTaskTokenBalance, token.address);
-      await colony.moveFundsBetweenPots(taskPotId, domain.potId, originalTaskOtherTokenBalance, otherToken.address);
+      await colony.moveFundsBetweenPots(taskPotId, domain.fundingPotId, originalTaskEtherBalance, ZERO_ADDRESS);
+      await colony.moveFundsBetweenPots(taskPotId, domain.fundingPotId, originalTaskTokenBalance, token.address);
+      await colony.moveFundsBetweenPots(taskPotId, domain.fundingPotId, originalTaskOtherTokenBalance, otherToken.address);
 
       const cancelledTaskEtherBalance = await colony.getPotBalance(taskPotId, ZERO_ADDRESS);
-      const cancelledDomainEtherBalance = await colony.getPotBalance(domain.potId, ZERO_ADDRESS);
+      const cancelledDomainEtherBalance = await colony.getPotBalance(domain.fundingPotId, ZERO_ADDRESS);
       const cancelledTaskTokenBalance = await colony.getPotBalance(taskPotId, token.address);
-      const cancelledDomainTokenBalance = await colony.getPotBalance(domain.potId, token.address);
+      const cancelledDomainTokenBalance = await colony.getPotBalance(domain.fundingPotId, token.address);
       const cancelledTaskOtherTokenBalance = await colony.getPotBalance(taskPotId, otherToken.address);
-      const cancelledDomainOtherTokenBalance = await colony.getPotBalance(domain.potId, otherToken.address);
+      const cancelledDomainOtherTokenBalance = await colony.getPotBalance(domain.fundingPotId, otherToken.address);
 
       expect(originalTaskEtherBalance).to.not.eq.BN(cancelledTaskEtherBalance);
       expect(originalDomainEtherBalance).to.not.eq.BN(cancelledDomainEtherBalance);

--- a/test/colony.js
+++ b/test/colony.js
@@ -231,8 +231,8 @@ contract("Colony", accounts => {
   });
 
   describe("when adding domains", () => {
-    it("should log DomainAdded and PotAdded events", async () => {
-      await expectAllEvents(colony.addDomain(1), ["DomainAdded", "PotAdded"]);
+    it("should log DomainAdded and FundingPotAdded events", async () => {
+      await expectAllEvents(colony.addDomain(1), ["DomainAdded", "FundingPotAdded"]);
     });
   });
 

--- a/test/colony.js
+++ b/test/colony.js
@@ -103,7 +103,7 @@ contract("Colony", accounts => {
       const domain = await colony.getDomain(domainCount);
 
       // The first pot should have been created and assigned to the domain
-      expect(domain.potId).to.eq.BN(1);
+      expect(domain.fundingPotId).to.eq.BN(1);
 
       // A root skill should have been created for the Colony
       const rootLocalSkillId = await colonyNetwork.getSkillCount();
@@ -113,13 +113,13 @@ contract("Colony", accounts => {
     it("should let pot information be read", async () => {
       const taskId = await makeTask({ colony });
       const taskInfo = await colony.getTask(taskId);
-      let potInfo = await colony.getPotInformation(taskInfo.potId);
+      let potInfo = await colony.getPotInformation(taskInfo.fundingPotId);
       expect(potInfo.taskId).to.eq.BN(taskId);
       expect(potInfo.domainId).to.be.zero;
 
       // Read pot info about a pot in a domain
       const domainInfo = await colony.getDomain(1);
-      potInfo = await colony.getPotInformation(domainInfo.potId);
+      potInfo = await colony.getPotInformation(domainInfo.fundingPotId);
       expect(potInfo.taskId).to.be.zero;
       expect(potInfo.domainId).to.eq.BN(1);
     });

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -262,7 +262,7 @@ contract("Meta Colony", accounts => {
 
       const newDomain = await metaColony.getDomain(1);
       expect(newDomain.skillId).to.eq.BN(2);
-      expect(newDomain.potId).to.eq.BN(1);
+      expect(newDomain.fundingPotId).to.eq.BN(1);
 
       // Check root local skill.nChildren is now 2
       // One special mining skill, and the skill associated with the domain we just added
@@ -306,15 +306,15 @@ contract("Meta Colony", accounts => {
 
       const rootDomain = await colony.getDomain(1);
       expect(rootDomain.skillId).to.eq.BN(4);
-      expect(rootDomain.potId).to.eq.BN(1);
+      expect(rootDomain.fundingPotId).to.eq.BN(1);
 
       const newDomain2 = await colony.getDomain(2);
       expect(newDomain2.skillId).to.eq.BN(5);
-      expect(newDomain2.potId).to.eq.BN(2);
+      expect(newDomain2.fundingPotId).to.eq.BN(2);
 
       const newDomain3 = await colony.getDomain(3);
       expect(newDomain3.skillId).to.eq.BN(6);
-      expect(newDomain3.potId).to.eq.BN(3);
+      expect(newDomain3.fundingPotId).to.eq.BN(3);
 
       // Check root local skill.nChildren is now 3
       const rootLocalSkill = await colonyNetwork.getSkill(4);


### PR DESCRIPTION
This terminology has been bothering me for a year and the time has come to make it better. `FundingPot` better demonstrates the concept intention behind the fund pools these manage and is additionally aligned with white-paper terminology.

I've tried to not be too invasive with the rename so there are still test variables called `pot` but these can be refactored along in time if we want to be perfectly aligned. For now the contracts and natspec comments suffices I think.