### PR TITLE
Improvements of the FundingPot model

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -260,17 +260,19 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   }
 
   function initialiseDomain(uint256 _skillId) private skillExists(_skillId) {
-    // Create a new pot
-    fundingPotCount += 1;
-
-    // Create a new domain with the given skill and new pot
     domainCount += 1;
+    // Create a new funding pot
+    fundingPotCount += 1;
+    fundingPots[fundingPotCount] = FundingPot({
+      associatedType: FundingPotAssociatedType.Domain,
+      associatedTypeId: domainCount
+    });
+
+    // Create a new domain with the given skill and new funding pot
     domains[domainCount] = Domain({
       skillId: _skillId,
       fundingPotId: fundingPotCount
     });
-
-    fundingPots[fundingPotCount].domainId = domainCount;
 
     emit DomainAdded(domainCount);
     emit FundingPotAdded(fundingPotCount);

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -211,10 +211,14 @@ contract ColonyDataTypes {
     mapping (uint8 => bytes32) secret;
   }
 
+  enum FundingPotAssociatedType { Domain, Task }
+
   struct FundingPot {
+    // Funding pots can store multiple token balances, for ETH use 0x0 address
     mapping (address => uint256) balance;
-    uint256 taskId;
-    uint256 domainId;
+    // Funding pots can be associated with different fundable entities, for now these are: payments, tasks and domains.
+    FundingPotAssociatedType associatedType;
+    uint256 associatedTypeId;
   }
 
   struct Domain {

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -211,8 +211,8 @@ contract ColonyDataTypes {
     mapping (uint8 => bytes32) secret;
   }
 
-  // We do have 2 "special" funding pots with id 0 for rewards and id 1 for the colony itself. Those will carry the "Unassigned" type
-  // as they are unrelated to other entities in the Colony the same way the remaining funding pots are releated to domains, tasks etc.
+  // We do have 1 "special" funding pot with id 0 for rewards which will carry the "Unassigned" type.
+  // as they are unrelated to other entities in the Colony the same way the remaining funding pots are releated to domains, tasks and payouts.
   enum FundingPotAssociatedType { Unassigned, Domain, Task }
 
   struct FundingPot {

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -218,7 +218,7 @@ contract ColonyDataTypes {
   struct FundingPot {
     // Funding pots can store multiple token balances, for ETH use 0x0 address
     mapping (address => uint256) balance;
-    // Funding pots can be associated with different fundable entities, for now these are: payments, tasks and domains.
+    // Funding pots can be associated with different fundable entities, for now these are: tasks and domains.
     FundingPotAssociatedType associatedType;
     uint256 associatedTypeId;
   }

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -211,7 +211,9 @@ contract ColonyDataTypes {
     mapping (uint8 => bytes32) secret;
   }
 
-  enum FundingPotAssociatedType { Domain, Task }
+  // We do have 2 "special" funding pots with id 0 for rewards and id 1 for the colony itself. Those will carry the "Unassigned" type
+  // as they are unrelated to other entities in the Colony the same way the remaining funding pots are releated to domains, tasks etc.
+  enum FundingPotAssociatedType { Unassigned, Domain, Task }
 
   struct FundingPot {
     // Funding pots can store multiple token balances, for ETH use 0x0 address

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -132,7 +132,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     return fundingPots[_potId].balance[_token];
   }
 
-  function getPotInformation(uint256 _potId) public view returns (FundingPotAssociatedType associatedType, uint256 associatedTypeId) {
+  function getFundingPot(uint256 _potId) public view returns (FundingPotAssociatedType associatedType, uint256 associatedTypeId) {
     FundingPot storage pot = fundingPots[_potId];
     return (pot.associatedType, pot.associatedTypeId);
   }

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -128,7 +128,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     return fundingPotCount;
   }
 
-  function getPotBalance(uint256 _potId, address _token) public view returns (uint256) {
+  function getFundingPotBalance(uint256 _potId, address _token) public view returns (uint256) {
     return fundingPots[_potId].balance[_token];
   }
 

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -89,7 +89,12 @@ contract ColonyTask is ColonyStorage {
   domainExists(_domainId)
   {
     taskCount += 1;
+    
     fundingPotCount += 1;
+    fundingPots[fundingPotCount] = FundingPot({
+      associatedType: FundingPotAssociatedType.Task,
+      associatedTypeId: taskCount
+    });
 
     Task memory task;
     task.specificationHash = _specificationHash;
@@ -99,7 +104,6 @@ contract ColonyTask is ColonyStorage {
     tasks[taskCount] = task;
     tasks[taskCount].roles[uint8(TaskRole.Manager)].user = msg.sender;
     tasks[taskCount].roles[uint8(TaskRole.Evaluator)].user = msg.sender;
-    fundingPots[fundingPotCount].taskId = taskCount;
 
     if (_skillId > 0) {
       this.setTaskSkill(taskCount, _skillId);

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -83,6 +83,12 @@ contract ColonyTask is ColonyStorage {
     _;
   }
 
+  modifier taskFunded(uint256 _id) {
+    Task storage task = tasks[_id];
+    require(task.payoutsWeCannotMake == 0, "colony-task-not-funded");
+    _;
+  }
+
   function makeTask(bytes32 _specificationHash, uint256 _domainId, uint256 _skillId, uint256 _dueDate) public
   stoppable
   auth
@@ -402,6 +408,7 @@ contract ColonyTask is ColonyStorage {
   stoppable
   taskComplete(_id)
   taskWorkRatingsComplete(_id)
+  taskFunded(_id)
   taskNotFinalized(_id)
   {
     if (!taskWorkRatingsAssigned(_id)) {

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -464,7 +464,7 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _potId Id of the funding pot
   /// @param _token Address of the token, `0x0` value indicates Ether
   /// @return balance Funding pot balance
-  function getPotBalance(uint256 _potId, address _token) public view returns (uint256 balance);
+  function getFundingPotBalance(uint256 _potId, address _token) public view returns (uint256 balance);
 
   /// @notice Move a given amount: `_amount` of `_token` funds from funding pot with id `_fromPot` to one with id `_toPot`.
   /// Secured function to authorised members

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -116,7 +116,7 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @return FundingPotAssociatedType The associated type of the current funding pot, e.g. Domain, Task
   /// @return uint256 Id of the associated type, e.g. if associatedType = FundingPotAssociatedType.Domain, this refers to the domainId
   /// @dev For the reward funding pot (e.g. id: 0) this returns (0, 0)
-  function getPotInformation(uint256 _id) public view returns (FundingPotAssociatedType associatedType, uint256 associatedTypeId);
+  function getFundingPot(uint256 _id) public view returns (FundingPotAssociatedType associatedType, uint256 associatedTypeId);
 
   /// @notice Get the number of domains in the colony
   /// @return count The domain count. Min 1 as the root domain is created at the same time as the colony

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -113,11 +113,10 @@ contract IColony is ColonyDataTypes, IRecovery {
 
   /// @notice Get the non-mapping properties of a pot by id
   /// @param _id Id of the pot which details to get
-  /// @return uint256 The taskId the pot is associated with
-  /// @return uint256 The domainId the pot is associated with
-  /// @dev Exactly one of taskId and domainId should return nonzero, unless _id is 0 (the reward pot, which is 
-  ///      the only pot not associated with a task or a domain), in which case both are.
-  function getPotInformation(uint256 _id) public view returns (uint256 taskId, uint256 domainId);
+  /// @return FundingPotAssociatedType The associated type of the current funding pot, e.g. Domain, Task
+  /// @return uint256 Id of the associated type, e.g. if associatedType = FundingPotAssociatedType.Domain, this refers to the domainId
+  /// @dev For the reward funding pot (e.g. id: 0) this returns (0, 0)
+  function getPotInformation(uint256 _id) public view returns (FundingPotAssociatedType associatedType, uint256 associatedTypeId);
 
   /// @notice Get the number of domains in the colony
   /// @return count The domain count. Min 1 as the root domain is created at the same time as the colony

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -2,7 +2,6 @@
 /* eslint-disable no-undef, no-console */
 
 const ContractRecovery = artifacts.require("./ContractRecovery");
-const ColonyTask = artifacts.require("./ColonyTask");
 const ColonyNetwork = artifacts.require("./ColonyNetwork");
 const ColonyNetworkMining = artifacts.require("./ColonyNetworkMining");
 const ColonyNetworkAuction = artifacts.require("./ColonyNetworkAuction");
@@ -21,7 +20,6 @@ artifacts.require("./ReputationMiningCycle");
 
 module.exports = (deployer, network) => {
   console.log(`## ${network} network ##`);
-  deployer.deploy(ColonyTask);
   deployer.deploy(ColonyNetwork);
   deployer.deploy(ColonyNetworkMining);
   deployer.deploy(ColonyNetworkAuction);

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -309,7 +309,7 @@ contract("All", function(accounts) {
       const numeratorSqrt = bnSqrt(workerReputationSqrt.mul(workerReputationSqrt));
       const denominatorSqrt = bnSqrt(totalReputationSqrt.mul(totalReputationSqrt), true);
 
-      const balance = await newColony.getPotBalance(0, otherToken.address);
+      const balance = await newColony.getFundingPotBalance(0, otherToken.address);
       const amountSqrt = bnSqrt(balance);
 
       const squareRoots = [

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -146,7 +146,7 @@ contract("All", function(accounts) {
       });
 
       // moveFundsBetweenPots
-      await colony.moveFundsBetweenPots(1, 2, 150, token.address);
+      await colony.moveFundsBetweenPots(1, 2, 190, token.address);
 
       // setTaskManagerPayout
       await executeSignedTaskChange({

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -135,7 +135,7 @@ contract("Colony Funding", accounts => {
       await makeTask({ colony });
       await colony.moveFundsBetweenPots(1, 2, 40, otherToken.address);
 
-      await checkErrorRevert(colony.moveFundsBetweenPots(2, 3, 50, otherToken.address), "colony-funding-task-bad-state");
+      await checkErrorRevert(colony.moveFundsBetweenPots(2, 3, 50, otherToken.address), "ds-math-sub-underflow");
       const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
       const pot2Balance = await colony.getPotBalance(2, otherToken.address);
@@ -533,7 +533,7 @@ contract("Colony Funding", accounts => {
       await makeTask({ colony });
       await colony.moveFundsBetweenPots(1, 2, 40, ZERO_ADDRESS);
 
-      await checkErrorRevert(colony.moveFundsBetweenPots(2, 3, 50, ZERO_ADDRESS), "colony-funding-task-bad-state");
+      await checkErrorRevert(colony.moveFundsBetweenPots(2, 3, 50, ZERO_ADDRESS), "ds-math-sub-underflow");
       const colonyEtherBalance = await web3GetBalance(colony.address);
       const colonyPotBalance = await colony.getPotBalance(1, ZERO_ADDRESS);
       const pot2Balance = await colony.getPotBalance(2, ZERO_ADDRESS);

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -58,15 +58,15 @@ contract("Colony Funding", accounts => {
     it("should not put the tokens straight in to the pot", async () => {
       await otherToken.mint(100);
       await otherToken.transfer(colony.address, 100);
-      let colonyRewardPotBalance = await colony.getPotBalance(0, otherToken.address);
-      let colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      let colonyRewardPotBalance = await colony.getFundingPotBalance(0, otherToken.address);
+      let colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       let colonyTokenBalance = await otherToken.balanceOf(colony.address);
       expect(colonyTokenBalance).to.eq.BN(100);
       expect(colonyPotBalance).to.be.zero;
       expect(colonyRewardPotBalance).to.be.zero;
       await colony.claimColonyFunds(otherToken.address);
-      colonyRewardPotBalance = await colony.getPotBalance(0, otherToken.address);
-      colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      colonyRewardPotBalance = await colony.getFundingPotBalance(0, otherToken.address);
+      colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       colonyTokenBalance = await otherToken.balanceOf(colony.address);
       expect(colonyTokenBalance).to.eq.BN(100);
       expect(colonyPotBalance).to.eq.BN(99);
@@ -75,8 +75,8 @@ contract("Colony Funding", accounts => {
 
     it("should syphon off own tokens in to the reward pot", async () => {
       await fundColonyWithTokens(colony, token, 100);
-      const colonyRewardPotBalance = await colony.getPotBalance(0, token.address);
-      const colonyPotBalance = await colony.getPotBalance(1, token.address);
+      const colonyRewardPotBalance = await colony.getFundingPotBalance(0, token.address);
+      const colonyPotBalance = await colony.getFundingPotBalance(1, token.address);
       const colonyTokenBalance = await token.balanceOf(colony.address);
       expect(colonyTokenBalance).to.eq.BN(100);
       expect(colonyPotBalance).to.eq.BN(99);
@@ -87,9 +87,9 @@ contract("Colony Funding", accounts => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await makeTask({ colony });
       await colony.moveFundsBetweenPots(1, 2, 51, otherToken.address);
-      const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
-      const pot2Balance = await colony.getPotBalance(2, otherToken.address);
+      const pot2Balance = await colony.getFundingPotBalance(2, otherToken.address);
       expect(colonyTokenBalance).to.eq.BN(100);
       expect(colonyPotBalance).to.eq.BN(48);
       expect(pot2Balance).to.eq.BN(51);
@@ -98,7 +98,7 @@ contract("Colony Funding", accounts => {
     it("should not let tokens be moved between the same pot", async () => {
       await fundColonyWithTokens(colony, otherToken, 1);
       await checkErrorRevert(colony.moveFundsBetweenPots(1, 1, 1, otherToken.address), "colony-funding-cannot-move-funds-between-the-same-pot");
-      const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       expect(colonyPotBalance).to.eq.BN(1);
     });
 
@@ -107,10 +107,10 @@ contract("Colony Funding", accounts => {
       await makeTask({ colony });
 
       await checkErrorRevert(colony.moveFundsBetweenPots(0, 2, 1, otherToken.address), "colony-funding-cannot-move-funds-from-rewards-pot");
-      const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
-      const colonyRewardPotBalance = await colony.getPotBalance(0, otherToken.address);
+      const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
+      const colonyRewardPotBalance = await colony.getFundingPotBalance(0, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
-      const pot2Balance = await colony.getPotBalance(2, otherToken.address);
+      const pot2Balance = await colony.getFundingPotBalance(2, otherToken.address);
       expect(colonyTokenBalance).to.eq.BN(100);
       expect(colonyPotBalance).to.eq.BN(99);
       expect(pot2Balance).to.be.zero;
@@ -121,9 +121,9 @@ contract("Colony Funding", accounts => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await makeTask({ colony });
       await checkErrorRevert(colony.moveFundsBetweenPots(1, 2, 51, otherToken.address, { from: WORKER }), "ds-auth-unauthorized");
-      const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
-      const pot2Balance = await colony.getPotBalance(2, otherToken.address);
+      const pot2Balance = await colony.getFundingPotBalance(2, otherToken.address);
       expect(colonyTokenBalance).to.eq.BN(100);
       expect(colonyPotBalance).to.eq.BN(99);
       expect(pot2Balance).to.be.zero;
@@ -136,10 +136,10 @@ contract("Colony Funding", accounts => {
       await colony.moveFundsBetweenPots(1, 2, 40, otherToken.address);
 
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 3, 50, otherToken.address), "ds-math-sub-underflow");
-      const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
-      const pot2Balance = await colony.getPotBalance(2, otherToken.address);
-      const pot3Balance = await colony.getPotBalance(3, otherToken.address);
+      const pot2Balance = await colony.getFundingPotBalance(2, otherToken.address);
+      const pot3Balance = await colony.getFundingPotBalance(3, otherToken.address);
       expect(colonyTokenBalance).to.eq.BN(100);
       expect(colonyPotBalance).to.eq.BN(59);
       expect(pot2Balance).to.eq.BN(40);
@@ -405,8 +405,8 @@ contract("Colony Funding", accounts => {
     it("should pay fees on revenue correctly", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await fundColonyWithTokens(colony, otherToken, 200);
-      const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
-      const colonyRewardPotBalance = await colony.getPotBalance(0, otherToken.address);
+      const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
+      const colonyRewardPotBalance = await colony.getFundingPotBalance(0, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
       expect(colonyTokenBalance).to.eq.BN(300);
       expect(colonyRewardPotBalance).to.eq.BN(3);
@@ -438,14 +438,14 @@ contract("Colony Funding", accounts => {
     it("should not allow contributions to nonexistent funding pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await checkErrorRevert(colony.moveFundsBetweenPots(1, 5, 40, otherToken.address), "colony-funding-nonexistent-pot");
-      const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       expect(colonyPotBalance).to.eq.BN(99);
     });
 
     it("should not allow attempts to move funds from nonexistent funding pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await checkErrorRevert(colony.moveFundsBetweenPots(5, 1, 40, otherToken.address), "colony-funding-from-nonexistent-pot");
-      const colonyPotBalance = await colony.getPotBalance(1, otherToken.address);
+      const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       expect(colonyPotBalance).to.eq.BN(99);
     });
 
@@ -453,7 +453,7 @@ contract("Colony Funding", accounts => {
       await fundColonyWithTokens(colony, otherToken, INITIAL_FUNDING);
       await setupFinalizedTask({ colonyNetwork, colony, token: otherToken });
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 40, otherToken.address), "colony-funding-task-bad-state");
-      const colonyPotBalance = await colony.getPotBalance(2, otherToken.address);
+      const colonyPotBalance = await colony.getFundingPotBalance(2, otherToken.address);
       expect(colonyPotBalance).to.eq.BN(MANAGER_PAYOUT.add(EVALUATOR_PAYOUT).add(WORKER_PAYOUT));
     });
 
@@ -466,7 +466,7 @@ contract("Colony Funding", accounts => {
       await colony.claimPayout(taskId, EVALUATOR_ROLE, otherToken.address);
       await colony.moveFundsBetweenPots(2, 1, 10, otherToken.address);
 
-      const colonyPotBalance = await colony.getPotBalance(2, otherToken.address);
+      const colonyPotBalance = await colony.getFundingPotBalance(2, otherToken.address);
       expect(colonyPotBalance).to.be.zero;
     });
 
@@ -485,12 +485,12 @@ contract("Colony Funding", accounts => {
 
       const taskInfo = await colony.getTask(taskId);
       const taskPotId = taskInfo[5];
-      const remainingPotBalance = await colony.getPotBalance(taskPotId, token.address);
+      const remainingPotBalance = await colony.getFundingPotBalance(taskPotId, token.address);
       expect(remainingPotBalance).to.eq.BN(WORKER_PAYOUT);
 
       await colony.moveFundsBetweenPots(taskPotId, 1, remainingPotBalance, token.address);
 
-      const potBalance = await colony.getPotBalance(taskPotId, token.address);
+      const potBalance = await colony.getFundingPotBalance(taskPotId, token.address);
       expect(potBalance).to.be.zero;
     });
   });
@@ -498,16 +498,16 @@ contract("Colony Funding", accounts => {
   describe("when receiving ether", () => {
     it("should not put the ether straight in to the pot", async () => {
       await colony.send(100);
-      let colonyPotBalance = await colony.getPotBalance(1, ZERO_ADDRESS);
+      let colonyPotBalance = await colony.getFundingPotBalance(1, ZERO_ADDRESS);
       let colonyEtherBalance = await web3GetBalance(colony.address);
-      let colonyRewardBalance = await colony.getPotBalance(0, ZERO_ADDRESS);
+      let colonyRewardBalance = await colony.getFundingPotBalance(0, ZERO_ADDRESS);
       expect(colonyEtherBalance).to.eq.BN(100);
       expect(colonyPotBalance).to.be.zero;
 
       await colony.claimColonyFunds(ZERO_ADDRESS);
-      colonyPotBalance = await colony.getPotBalance(1, ZERO_ADDRESS);
+      colonyPotBalance = await colony.getFundingPotBalance(1, ZERO_ADDRESS);
       colonyEtherBalance = await web3GetBalance(colony.address);
-      colonyRewardBalance = await colony.getPotBalance(0, ZERO_ADDRESS);
+      colonyRewardBalance = await colony.getFundingPotBalance(0, ZERO_ADDRESS);
       expect(colonyEtherBalance).to.eq.BN(100);
       expect(colonyRewardBalance).to.eq.BN(1);
       expect(colonyPotBalance).to.eq.BN(99);
@@ -518,9 +518,9 @@ contract("Colony Funding", accounts => {
       await colony.claimColonyFunds(ZERO_ADDRESS);
       await makeTask({ colony });
       await colony.moveFundsBetweenPots(1, 2, 51, ZERO_ADDRESS);
-      const colonyPotBalance = await colony.getPotBalance(1, ZERO_ADDRESS);
+      const colonyPotBalance = await colony.getFundingPotBalance(1, ZERO_ADDRESS);
       const colonyEtherBalance = await web3GetBalance(colony.address);
-      const pot2Balance = await colony.getPotBalance(2, ZERO_ADDRESS);
+      const pot2Balance = await colony.getFundingPotBalance(2, ZERO_ADDRESS);
       expect(colonyEtherBalance).to.eq.BN(100);
       expect(colonyPotBalance).to.eq.BN(48);
       expect(pot2Balance).to.eq.BN(51);
@@ -535,9 +535,9 @@ contract("Colony Funding", accounts => {
 
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 3, 50, ZERO_ADDRESS), "ds-math-sub-underflow");
       const colonyEtherBalance = await web3GetBalance(colony.address);
-      const colonyPotBalance = await colony.getPotBalance(1, ZERO_ADDRESS);
-      const pot2Balance = await colony.getPotBalance(2, ZERO_ADDRESS);
-      const pot3Balance = await colony.getPotBalance(3, ZERO_ADDRESS);
+      const colonyPotBalance = await colony.getFundingPotBalance(1, ZERO_ADDRESS);
+      const pot2Balance = await colony.getFundingPotBalance(2, ZERO_ADDRESS);
+      const pot3Balance = await colony.getFundingPotBalance(3, ZERO_ADDRESS);
       expect(colonyEtherBalance).to.eq.BN(100);
       expect(colonyPotBalance).to.eq.BN(59);
       expect(pot2Balance).to.eq.BN(40);
@@ -608,8 +608,8 @@ contract("Colony Funding", accounts => {
       await colony.claimColonyFunds(ZERO_ADDRESS);
       await colony.send(200);
       await colony.claimColonyFunds(ZERO_ADDRESS);
-      const colonyPotBalance = await colony.getPotBalance(1, ZERO_ADDRESS);
-      const colonyRewardPotBalance = await colony.getPotBalance(0, ZERO_ADDRESS);
+      const colonyPotBalance = await colony.getFundingPotBalance(1, ZERO_ADDRESS);
+      const colonyRewardPotBalance = await colony.getFundingPotBalance(0, ZERO_ADDRESS);
       const colonyEtherBalance = await web3GetBalance(colony.address);
       const nonRewardPotsTotal = await colony.getNonRewardPotsTotal(ZERO_ADDRESS);
       expect(colonyEtherBalance).to.eq.BN(300);

--- a/test/colony-reward-payouts.js
+++ b/test/colony-reward-payouts.js
@@ -94,7 +94,7 @@ contract("Colony Reward Payouts", accounts => {
     const denominatorSqrt = bnSqrt(totalReputationSqrt.mul(totalTokensSqrt), true);
 
     // Total amount that will be paid out
-    const balance = await colony.getPotBalance(0, otherToken.address);
+    const balance = await colony.getFundingPotBalance(0, otherToken.address);
     const totalAmountSqrt = bnSqrt(balance);
 
     initialSquareRoots = [userReputationSqrt, userTokensSqrt, totalReputationSqrt, totalTokensSqrt, numeratorSqrt, denominatorSqrt, totalAmountSqrt];
@@ -366,7 +366,7 @@ contract("Colony Reward Payouts", accounts => {
       const totalTokensSqrt = bnSqrt(totalTokens);
 
       const denominatorSqrt = bnSqrt(userTokens.mul(userReputation.add(userReputation3)));
-      const balance = await colony.getPotBalance(0, otherToken.address);
+      const balance = await colony.getFundingPotBalance(0, otherToken.address);
       const amountAvailableForPayoutSqrt = bnSqrt(balance);
 
       const squareRoots = [userReputation3Sqrt, 0, totalReputationSqrt, totalTokensSqrt, 0, denominatorSqrt, amountAvailableForPayoutSqrt];
@@ -411,7 +411,7 @@ contract("Colony Reward Payouts", accounts => {
       const totalReputationSqrt = bnSqrt(totalReputation.add(userTokens3), true);
       const totalTokensSqrt = bnSqrt(userTokens.add(userTokens3), true);
       const denominatorSqrt = bnSqrt(totalReputationSqrt.mul(totalTokensSqrt), true);
-      const balance = await colony.getPotBalance(0, otherToken.address);
+      const balance = await colony.getFundingPotBalance(0, otherToken.address);
       const amountAvailableForPayoutSqrt = bnSqrt(balance);
 
       const squareRoots = [0, userTokens3Sqrt, totalReputationSqrt, totalTokensSqrt, 0, denominatorSqrt, amountAvailableForPayoutSqrt];
@@ -635,7 +635,7 @@ contract("Colony Reward Payouts", accounts => {
       const totalTokensSqrt = bnSqrt(userReputation.muln(2), true);
       const numeratorSqrt = bnSqrt(userReputationSqrt.mul(userTokensSqrt));
       const denominatorSqrt = bnSqrt(totalReputationSqrt.mul(totalTokensSqrt), true);
-      const balance = await colony.getPotBalance(0, otherToken.address);
+      const balance = await colony.getFundingPotBalance(0, otherToken.address);
       const totalAmountAvailableForPayoutSqrt = bnSqrt(balance);
 
       const squareRoots = [
@@ -663,8 +663,8 @@ contract("Colony Reward Payouts", accounts => {
       rewardPayoutInfo = await colony2.getRewardPayoutInfo(payoutId2);
       const amountAvailableForPayout2 = new BN(rewardPayoutInfo.amount);
 
-      const rewardPotBalanceAfterClaimInPayout1 = await colony1.getPotBalance(0, otherToken.address);
-      const rewardPotBalanceAfterClaimInPayout2 = await colony2.getPotBalance(0, otherToken.address);
+      const rewardPotBalanceAfterClaimInPayout1 = await colony1.getFundingPotBalance(0, otherToken.address);
+      const rewardPotBalanceAfterClaimInPayout2 = await colony2.getFundingPotBalance(0, otherToken.address);
 
       const feeInverse = await colonyNetwork.getFeeInverse();
 
@@ -751,7 +751,7 @@ contract("Colony Reward Payouts", accounts => {
       const totalTokensSqrt = bnSqrt(userReputation.muln(2), true);
       const numeratorSqrt = bnSqrt(userReputationSqrt.mul(userTokensSqrt));
       const denominatorSqrt = bnSqrt(totalReputationSqrt.mul(totalTokensSqrt), true);
-      const balance = await colony.getPotBalance(0, otherToken.address);
+      const balance = await colony.getFundingPotBalance(0, otherToken.address);
       const totalAmountAvailableForPayoutSqrt = bnSqrt(balance);
 
       const squareRoots = [
@@ -778,7 +778,7 @@ contract("Colony Reward Payouts", accounts => {
       const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
 
-      const balance = await colony.getPotBalance(0, otherToken.address);
+      const balance = await colony.getFundingPotBalance(0, otherToken.address);
       const blockTimestamp = await currentBlockTime();
       const reputationRootHash = await colonyNetwork.getReputationRootHash();
 
@@ -870,7 +870,7 @@ contract("Colony Reward Payouts", accounts => {
         const payoutId = logs[0].args.rewardPayoutId;
 
         // Getting total amount available for payout
-        const amountAvailableForPayout = await newColony.getPotBalance(0, payoutToken.address);
+        const amountAvailableForPayout = await newColony.getFundingPotBalance(0, payoutToken.address);
 
         const totalSupply = await newToken.totalSupply();
         const colonyTokens = await newToken.balanceOf(newColony.address);
@@ -920,7 +920,7 @@ contract("Colony Reward Payouts", accounts => {
           from: userAddress1
         });
 
-        const remainingAfterClaim1 = await newColony.getPotBalance(0, payoutToken.address);
+        const remainingAfterClaim1 = await newColony.getFundingPotBalance(0, payoutToken.address);
         const user1BalanceAfterClaim = await payoutToken.balanceOf(userAddress1);
         const colonyNetworkBalanceAfterClaim1 = await payoutToken.balanceOf(colonyNetwork.address);
         const colonyNetworkFeeClaim1 = colonyNetworkBalanceAfterClaim1.sub(colonyNetworkBalanceBeforeClaim1);
@@ -951,7 +951,7 @@ contract("Colony Reward Payouts", accounts => {
         const colonyNetworkBalanceAfterClaim2 = await payoutToken.balanceOf(colonyNetwork.address);
         const colonyNetworkFeeClaim2 = colonyNetworkBalanceAfterClaim2.sub(colonyNetworkBalanceAfterClaim1);
 
-        const remainingAfterClaim2 = await newColony.getPotBalance(0, payoutToken.address);
+        const remainingAfterClaim2 = await newColony.getFundingPotBalance(0, payoutToken.address);
         const user2BalanceAfterClaim = await payoutToken.balanceOf(userAddress1);
         expect(user2BalanceAfterClaim).to.eq.BN(
           amountAvailableForPayout
@@ -974,7 +974,7 @@ contract("Colony Reward Payouts", accounts => {
         const colonyNetworkBalanceAfterClaim3 = await payoutToken.balanceOf(colonyNetwork.address);
         const colonyNetworkFeeClaim3 = colonyNetworkBalanceAfterClaim3.sub(colonyNetworkBalanceAfterClaim2);
 
-        const remainingAfterClaim3 = await newColony.getPotBalance(0, payoutToken.address);
+        const remainingAfterClaim3 = await newColony.getFundingPotBalance(0, payoutToken.address);
         const user3BalanceAfterClaim = await payoutToken.balanceOf(userAddress1);
         expect(user3BalanceAfterClaim).to.eq.BN(
           amountAvailableForPayout

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -1367,14 +1367,14 @@ contract("ColonyTask", accounts => {
       await colony.moveFundsBetweenPots(1, taskPotId, 100, otherToken.address);
 
       // Keep track of original Ether balance in funding pots
-      const originalDomainEtherBalance = await colony.getPotBalance(domain.fundingPotId, ZERO_ADDRESS);
-      const originalTaskEtherBalance = await colony.getPotBalance(taskPotId, ZERO_ADDRESS);
+      const originalDomainEtherBalance = await colony.getFundingPotBalance(domain.fundingPotId, ZERO_ADDRESS);
+      const originalTaskEtherBalance = await colony.getFundingPotBalance(taskPotId, ZERO_ADDRESS);
       // And same for the token
-      const originalDomainTokenBalance = await colony.getPotBalance(domain.fundingPotId, token.address);
-      const originalTaskTokenBalance = await colony.getPotBalance(taskPotId, token.address);
+      const originalDomainTokenBalance = await colony.getFundingPotBalance(domain.fundingPotId, token.address);
+      const originalTaskTokenBalance = await colony.getFundingPotBalance(taskPotId, token.address);
       // And the other token
-      const originalDomainOtherTokenBalance = await colony.getPotBalance(domain.fundingPotId, otherToken.address);
-      const originalTaskOtherTokenBalance = await colony.getPotBalance(taskPotId, otherToken.address);
+      const originalDomainOtherTokenBalance = await colony.getFundingPotBalance(domain.fundingPotId, otherToken.address);
+      const originalTaskOtherTokenBalance = await colony.getFundingPotBalance(taskPotId, otherToken.address);
 
       // Now that everything is set up, let's cancel the task, move funds and compare funding pots afterwards
       await executeSignedTaskChange({
@@ -1390,12 +1390,12 @@ contract("ColonyTask", accounts => {
       await colony.moveFundsBetweenPots(taskPotId, domain.fundingPotId, originalTaskTokenBalance, token.address);
       await colony.moveFundsBetweenPots(taskPotId, domain.fundingPotId, originalTaskOtherTokenBalance, otherToken.address);
 
-      const cancelledTaskEtherBalance = await colony.getPotBalance(taskPotId, ZERO_ADDRESS);
-      const cancelledDomainEtherBalance = await colony.getPotBalance(domain.fundingPotId, ZERO_ADDRESS);
-      const cancelledTaskTokenBalance = await colony.getPotBalance(taskPotId, token.address);
-      const cancelledDomainTokenBalance = await colony.getPotBalance(domain.fundingPotId, token.address);
-      const cancelledTaskOtherTokenBalance = await colony.getPotBalance(taskPotId, otherToken.address);
-      const cancelledDomainOtherTokenBalance = await colony.getPotBalance(domain.fundingPotId, otherToken.address);
+      const cancelledTaskEtherBalance = await colony.getFundingPotBalance(taskPotId, ZERO_ADDRESS);
+      const cancelledDomainEtherBalance = await colony.getFundingPotBalance(domain.fundingPotId, ZERO_ADDRESS);
+      const cancelledTaskTokenBalance = await colony.getFundingPotBalance(taskPotId, token.address);
+      const cancelledDomainTokenBalance = await colony.getFundingPotBalance(domain.fundingPotId, token.address);
+      const cancelledTaskOtherTokenBalance = await colony.getFundingPotBalance(taskPotId, otherToken.address);
+      const cancelledDomainOtherTokenBalance = await colony.getFundingPotBalance(domain.fundingPotId, otherToken.address);
 
       expect(originalTaskEtherBalance).to.not.eq.BN(cancelledTaskEtherBalance);
       expect(originalDomainEtherBalance).to.not.eq.BN(cancelledDomainEtherBalance);
@@ -1693,7 +1693,7 @@ contract("ColonyTask", accounts => {
 
       const networkBalanceBefore = await token.balanceOf(colonyNetwork.address);
       const managerBalanceBefore = await token.balanceOf(MANAGER);
-      const potBalanceBefore = await colony.getPotBalance(taskPotId, token.address);
+      const potBalanceBefore = await colony.getFundingPotBalance(taskPotId, token.address);
 
       await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
 
@@ -1703,7 +1703,7 @@ contract("ColonyTask", accounts => {
       const managerBalanceAfter = await token.balanceOf(MANAGER);
       expect(managerBalanceAfter.sub(managerBalanceBefore)).to.eq.BN(WAD.muln(99).subn(1));
 
-      const potBalanceAfter = await colony.getPotBalance(taskPotId, token.address);
+      const potBalanceAfter = await colony.getFundingPotBalance(taskPotId, token.address);
       expect(potBalanceBefore.sub(potBalanceAfter)).to.eq.BN(WAD.muln(100));
     });
 
@@ -1725,7 +1725,7 @@ contract("ColonyTask", accounts => {
 
       const task = await colony.getTask(taskId);
       const taskPotId = task[5];
-      const potBalanceBefore = await colony.getPotBalance(taskPotId, ZERO_ADDRESS);
+      const potBalanceBefore = await colony.getFundingPotBalance(taskPotId, ZERO_ADDRESS);
 
       const workerBalanceBefore = await web3GetBalance(WORKER);
       const metaBalanceBefore = await web3GetBalance(metaColony.address);
@@ -1738,7 +1738,7 @@ contract("ColonyTask", accounts => {
       const metaBalanceAfter = await web3GetBalance(metaColony.address);
       expect(new BN(metaBalanceAfter).sub(new BN(metaBalanceBefore))).to.eq.BN(3);
 
-      const potBalanceAfter = await colony.getPotBalance(taskPotId, ZERO_ADDRESS);
+      const potBalanceAfter = await colony.getFundingPotBalance(taskPotId, ZERO_ADDRESS);
       expect(potBalanceBefore.sub(potBalanceAfter)).to.eq.BN(new BN(200));
     });
 

--- a/test/colony-token-integrations.js
+++ b/test/colony-token-integrations.js
@@ -33,8 +33,8 @@ contract("Colony Token Integration", () => {
     it("should be able to correctly claim tokens in the colony funding pots", async () => {
       await erc20Mintable.mint(colony.address, 100);
 
-      let colonyRewardPotBalance = await colony.getPotBalance(0, erc20Mintable.address);
-      let colonyPotBalance = await colony.getPotBalance(1, erc20Mintable.address);
+      let colonyRewardPotBalance = await colony.getFundingPotBalance(0, erc20Mintable.address);
+      let colonyPotBalance = await colony.getFundingPotBalance(1, erc20Mintable.address);
       let colonyTokenBalance = await erc20Mintable.balanceOf(colony.address);
       expect(colonyRewardPotBalance).to.be.zero;
       expect(colonyPotBalance).to.be.zero;
@@ -42,8 +42,8 @@ contract("Colony Token Integration", () => {
 
       await colony.claimColonyFunds(erc20Mintable.address);
 
-      colonyRewardPotBalance = await colony.getPotBalance(0, erc20Mintable.address);
-      colonyPotBalance = await colony.getPotBalance(1, erc20Mintable.address);
+      colonyRewardPotBalance = await colony.getFundingPotBalance(0, erc20Mintable.address);
+      colonyPotBalance = await colony.getFundingPotBalance(1, erc20Mintable.address);
       colonyTokenBalance = await erc20Mintable.balanceOf(colony.address);
       expect(colonyRewardPotBalance).to.be.eq.BN(1);
       expect(colonyPotBalance).to.be.eq.BN(99);
@@ -61,8 +61,8 @@ contract("Colony Token Integration", () => {
     it("should be able to correctly claim tokens in the colony funding pots", async () => {
       await colony.mintTokens(100);
 
-      let colonyRewardPotBalance = await colony.getPotBalance(0, erc20Mintable.address);
-      let colonyPotBalance = await colony.getPotBalance(1, erc20Mintable.address);
+      let colonyRewardPotBalance = await colony.getFundingPotBalance(0, erc20Mintable.address);
+      let colonyPotBalance = await colony.getFundingPotBalance(1, erc20Mintable.address);
       let colonyTokenBalance = await erc20Mintable.balanceOf(colony.address);
       expect(colonyRewardPotBalance).to.be.zero;
       expect(colonyPotBalance).to.be.zero;
@@ -70,8 +70,8 @@ contract("Colony Token Integration", () => {
 
       await colony.claimColonyFunds(erc20Mintable.address);
 
-      colonyRewardPotBalance = await colony.getPotBalance(0, erc20Mintable.address);
-      colonyPotBalance = await colony.getPotBalance(1, erc20Mintable.address);
+      colonyRewardPotBalance = await colony.getFundingPotBalance(0, erc20Mintable.address);
+      colonyPotBalance = await colony.getFundingPotBalance(1, erc20Mintable.address);
       colonyTokenBalance = await erc20Mintable.balanceOf(colony.address);
       expect(colonyRewardPotBalance).to.be.eq.BN(1);
       expect(colonyPotBalance).to.be.eq.BN(99);

--- a/test/colony.js
+++ b/test/colony.js
@@ -261,14 +261,14 @@ contract("Colony", accounts => {
       await checkErrorRevert(colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS), "colony-bootstrap-not-enough-tokens");
 
       await colony.claimColonyFunds(token.address);
-      const potBalanceBefore = await colony.getPotBalance(1, token.address);
+      const potBalanceBefore = await colony.getFundingPotBalance(1, token.address);
       expect(potBalanceBefore).to.eq.BN(WAD.muln(14));
 
       await colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS);
       const balance = await token.balanceOf(INITIAL_ADDRESSES[0]);
       expect(balance).to.eq.BN(INITIAL_REPUTATIONS[0]);
 
-      const potBalanceAfter = await colony.getPotBalance(1, token.address);
+      const potBalanceAfter = await colony.getFundingPotBalance(1, token.address);
       expect(potBalanceAfter).to.be.zero;
     });
 

--- a/test/colony.js
+++ b/test/colony.js
@@ -110,18 +110,18 @@ contract("Colony", accounts => {
       expect(domain.skillId).to.eq.BN(rootLocalSkillId);
     });
 
-    it("should let pot information be read", async () => {
+    it("should let funding pot information be read", async () => {
       const taskId = await makeTask({ colony });
       const taskInfo = await colony.getTask(taskId);
       let potInfo = await colony.getPotInformation(taskInfo.fundingPotId);
-      expect(potInfo.taskId).to.eq.BN(taskId);
-      expect(potInfo.domainId).to.be.zero;
+      expect(potInfo.associatedType).to.eq.BN(1);
+      expect(potInfo.associatedTypeId).to.eq.BN(taskId);
 
       // Read pot info about a pot in a domain
       const domainInfo = await colony.getDomain(1);
       potInfo = await colony.getPotInformation(domainInfo.fundingPotId);
-      expect(potInfo.taskId).to.be.zero;
-      expect(potInfo.domainId).to.eq.BN(1);
+      expect(potInfo.associatedType).to.be.zero;
+      expect(potInfo.associatedTypeId).to.eq.BN(1);
     });
   });
 

--- a/test/colony.js
+++ b/test/colony.js
@@ -113,14 +113,14 @@ contract("Colony", accounts => {
     it("should let funding pot information be read", async () => {
       const taskId = await makeTask({ colony });
       const taskInfo = await colony.getTask(taskId);
-      let potInfo = await colony.getPotInformation(taskInfo.fundingPotId);
-      expect(potInfo.associatedType).to.eq.BN(1);
+      let potInfo = await colony.getFundingPot(taskInfo.fundingPotId);
+      expect(potInfo.associatedType).to.eq.BN(2);
       expect(potInfo.associatedTypeId).to.eq.BN(taskId);
 
       // Read pot info about a pot in a domain
       const domainInfo = await colony.getDomain(1);
-      potInfo = await colony.getPotInformation(domainInfo.fundingPotId);
-      expect(potInfo.associatedType).to.be.zero;
+      potInfo = await colony.getFundingPot(domainInfo.fundingPotId);
+      expect(potInfo.associatedType).to.eq.BN(1);
       expect(potInfo.associatedTypeId).to.eq.BN(1);
     });
   });

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -254,15 +254,16 @@ contract("Meta Colony", accounts => {
   describe("when adding domains in the meta colony", () => {
     it("should be able to add new domains as children to the root domain", async () => {
       await metaColony.addDomain(1);
+      const newDomainId = await metaColony.getDomainCount();
 
       const skillCount = await colonyNetwork.getSkillCount();
       expect(skillCount).to.eq.BN(4);
       const domainCount = await metaColony.getDomainCount();
       expect(domainCount).to.eq.BN(2);
 
-      const newDomain = await metaColony.getDomain(1);
-      expect(newDomain.skillId).to.eq.BN(2);
-      expect(newDomain.fundingPotId).to.eq.BN(1);
+      const newDomain = await metaColony.getDomain(newDomainId);
+      expect(newDomain.skillId).to.eq.BN(4);
+      expect(newDomain.fundingPotId).to.eq.BN(2);
 
       // Check root local skill.nChildren is now 2
       // One special mining skill, and the skill associated with the domain we just added


### PR DESCRIPTION
We improve the `FundingPot` model to allow for better extensibility and data consistency by introducing a `FundingPotAssociatedType` property and merging `domainId` and `taskId` pointers into a single `associatedTypeId` property which stores the foreign key reference of the respective type, i.e. if the `FundingPotAssociatedType` is `Task`, `associatedTypeId` will be a `taskId` reference, if the type is a `Domain` it will be a `domainId` reference and we are free to add another identifier type as needed.

Additionally we resolve an issue with the `moveFundsBetweenPots` function which executes on all types of funding pots yet some of the Task specific functionality is run on domain pots. 

We also fix a problem with missing check ensuring a task is funded before it can finalize.