### PR TITLE
Prevent bad actors responding on behalf of good

### DIFF
--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -166,7 +166,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   /////////////////////////
   // Internal functions
   /////////////////////////
-  
+
   function checkAdjacentReputation(
     uint256[27] memory u,
     bytes[3] memory b,
@@ -216,11 +216,11 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function buildNewSiblingsArray(
-    uint256[27] memory u, 
-    bytes[3] memory b, 
-    uint256 firstDifferenceBit, 
+    uint256[27] memory u,
+    bytes[3] memory b,
+    uint256 firstDifferenceBit,
     bytes32[] memory adjacentReputationSiblings
-    ) internal returns (bytes32[] memory) 
+    ) internal returns (bytes32[] memory)
   {
     bytes32 newSibling = keccak256(
       abi.encodePacked(
@@ -242,7 +242,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     // This can be > or >= because the adjacent reputation branchmask will be a 0 in the
     // bit where the two keys first differ.
     while (i > 2**firstDifferenceBit) {
-      if (i & u[U_ADJACENT_REPUTATION_BRANCH_MASK] == i) { 
+      if (i & u[U_ADJACENT_REPUTATION_BRANCH_MASK] == i) {
         insert += 1;
       }
       i >>= 1;
@@ -252,7 +252,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     // Now actually build the new siblings array
     i = 0;
     while (i < afterInsertionAdjacentReputationSiblings.length) {
-      if (i < insert) { 
+      if (i < insert) {
         afterInsertionAdjacentReputationSiblings[i] = adjacentReputationSiblings[i];
       } else if (i == insert) {
         afterInsertionAdjacentReputationSiblings[i] = newSibling;
@@ -269,7 +269,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     uint256[27] memory u,
     bytes[3] memory b,
     bytes32[] memory agreeStateSiblings,
-    bytes32[] memory userOriginReputationSiblings) internal 
+    bytes32[] memory userOriginReputationSiblings) internal
   {
     ReputationLogEntry storage logEntry = reputationUpdateLog[u[U_LOG_ENTRY_NUMBER]];
     if (logEntry.amount >= 0) {
@@ -295,15 +295,15 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     uint256[27] memory u,
     bytes[3] memory b,
     bytes32[] memory agreeStateSiblings,
-    bytes32[] memory childReputationSiblings) internal 
+    bytes32[] memory childReputationSiblings) internal
   {
-    // This function is only called if the dispute is over a child reputation update of a colony-wide reputation total 
+    // This function is only called if the dispute is over a child reputation update of a colony-wide reputation total
     ReputationLogEntry storage logEntry = reputationUpdateLog[u[U_LOG_ENTRY_NUMBER]];
 
     uint256 relativeUpdateNumber = getRelativeUpdateNumber(u, logEntry);
     uint256 expectedSkillId = IColonyNetwork(colonyNetworkAddress).getChildSkillId(logEntry.skillId, relativeUpdateNumber);
     bytes memory childReputationKey = abi.encodePacked(logEntry.colony, expectedSkillId, logEntry.user);
-    
+
     checkChildReputationInState(
       u,
       agreeStateSiblings,
@@ -424,12 +424,12 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
 
     require(impliedRoot == jrh, "colony-reputation-mining-invalid-before-reputation-proof");
-    // Check that they have not changed nNodes from the agree state 
+    // Check that they have not changed nNodes from the agree state
     // There is a check at the very start of RespondToChallenge that this difference is either 0 or 1.
     // There is an 'if' statement above that returns if this difference is 1.
-    // Therefore the difference is 0, and we no longer need this check here.
-    // require(u[U_DISAGREE_STATE_NNODES] == u[U_AGREE_STATE_NNODES], "colony-reputation-mining-nnodes-changed");
-    // They've actually verified whatever they claimed. 
+    // Therefore the difference is 0, and this should always be true.
+    assert(u[U_DISAGREE_STATE_NNODES] == u[U_AGREE_STATE_NNODES]);
+    // They've actually verified whatever they claimed.
     // In the event that our opponent lied about this reputation not existing yet in the tree, they will fail on checkAdjacentReputation,
     // as the branchmask generated will indicate that the node already exists
   }
@@ -577,7 +577,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   // Get the update number relative in the context of the log entry currently considered
-  // e.g. for log entry with 6 updates, the relative update number range is [0 .. 5] (inclusive) 
+  // e.g. for log entry with 6 updates, the relative update number range is [0 .. 5] (inclusive)
   function getRelativeUpdateNumber(uint256[27] memory u, ReputationLogEntry memory logEntry) internal view returns (uint256) {
     uint256 nNodes = IColonyNetwork(colonyNetworkAddress).getReputationRootHashNNodes();
     uint256 updateNumber = sub(sub(disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound, 1), nNodes);
@@ -602,7 +602,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       // NB This is not necessarily the same as nChildren. However, this is the number of child updates
       // that this entry in the log was expecting at the time it was created
     }
-    
+
     return (nChildUpdates, nParents);
   }
 
@@ -649,12 +649,12 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       u[U_USER_ORIGIN_SKILL_REPUTATION_BRANCH_MASK],
       userOriginReputationStateSiblings
     );
-    
+
     bytes memory jhLeafValue = abi.encodePacked(uint256(reputationRootHash), u[U_AGREE_STATE_NNODES]);
 
     // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
     bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
-    
+
     bytes32 jrh = disputeRounds[u[U_ROUND]][u[U_IDX]].jrh;
     if (u[U_USER_ORIGIN_REPUTATION_VALUE] == 0 && impliedRoot != jrh) {
       // This implies they are claiming that this is a new hash.
@@ -685,12 +685,12 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       u[U_CHILD_REPUTATION_BRANCH_MASK],
       childReputationStateSiblings
     );
-    
+
     bytes memory jhLeafValue = abi.encodePacked(uint256(reputationRootHash), u[U_AGREE_STATE_NNODES]);
 
     // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
     bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
-    
+
     bytes32 jrh = disputeRounds[u[U_ROUND]][u[U_IDX]].jrh;
     if (u[U_CHILD_REPUTATION_VALUE] == 0 && impliedRoot != jrh) {
       // This implies they are claiming that this is a new hash.

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -400,8 +400,6 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   {
     if (u[U_DISAGREE_STATE_NNODES] - u[U_AGREE_STATE_NNODES] == 1) {
       // This implies they are claiming that this is a new hash.
-      // Check they have incremented nNodes by one
-      require(u[U_DISAGREE_STATE_NNODES] - u[U_AGREE_STATE_NNODES] == 1, "colony-reputation-mining-nnodes-changed-by-not-1");
       // Flag we need to check the adjacent hash
       u[U_NEW_REPUTATION] = 1;
       return;
@@ -427,7 +425,10 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
     require(impliedRoot == jrh, "colony-reputation-mining-invalid-before-reputation-proof");
     // Check that they have not changed nNodes from the agree state 
-    require(u[U_DISAGREE_STATE_NNODES] == u[U_AGREE_STATE_NNODES], "colony-reputation-mining-nnodes-changed");
+    // There is a check at the very start of RespondToChallenge that this difference is either 0 or 1.
+    // There is an 'if' statement above that returns if this difference is 1.
+    // Therefore the difference is 0, and we no longer need this check here.
+    // require(u[U_DISAGREE_STATE_NNODES] == u[U_AGREE_STATE_NNODES], "colony-reputation-mining-nnodes-changed");
     // They've actually verified whatever they claimed. 
     // In the event that our opponent lied about this reputation not existing yet in the tree, they will fail on checkAdjacentReputation,
     // as the branchmask generated will indicate that the node already exists

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -428,14 +428,9 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     require(impliedRoot == jrh, "colony-reputation-mining-invalid-before-reputation-proof");
     // Check that they have not changed nNodes from the agree state 
     require(u[U_DISAGREE_STATE_NNODES] == u[U_AGREE_STATE_NNODES], "colony-reputation-mining-nnodes-changed");
-    // They've actually verified whatever they claimed. We increment their challengeStepCompleted by one to indicate this.
-    // In the event that our opponent lied about this reputation not existing yet in the tree, they will both complete
-    // a call to respondToChallenge, but we will have a higher challengeStepCompleted value, and so they will be the ones
-    // eliminated.
-    disputeRounds[u[U_ROUND]][u[U_IDX]].challengeStepCompleted += 1;
-    // I think this trick can be used exactly once, and only because this is the last function to be called in the challege,
-    // and I'm choosing to use it here. I *think* this is okay, because the only situation
-    // where we don't prove anything with merkle proofs in this whole dance is here.
+    // They've actually verified whatever they claimed. 
+    // In the event that our opponent lied about this reputation not existing yet in the tree, they will fail on checkAdjacentReputation,
+    // as the branchmask generated will indicate that the node already exists
   }
 
   function proveAfterReputationValue(
@@ -667,6 +662,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
     require(impliedRoot == jrh, "colony-reputation-mining-origin-skill-state-disagreement");
     disputeRounds[u[U_ROUND]][u[U_IDX]].challengeStepCompleted += 1;
+    // If the submission has proved that the reputation already exists in the tree, we give it extra 'challengeStepCompleted' so that if
+    // its opponent got a different state by ignoring an existing reputation in the tree, we still out-score them.
   }
 
   function checkChildReputationInState(
@@ -701,6 +698,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
     require(impliedRoot == jrh, "colony-reputation-mining-child-skill-state-disagreement");
     disputeRounds[u[U_ROUND]][u[U_IDX]].challengeStepCompleted += 1;
+    // If the submission has proved that the reputation already exists in the tree, we give it extra 'challengeStepCompleted' so that if
+    // its opponent got a different state by ignoring an existing reputation in the tree, we still out-score them.
   }
 
   function saveProvedReputation(uint256[27] memory u) internal {

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
@@ -1,53 +1,47 @@
 import BN from "bn.js";
 import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
-const ethers = require("ethers");
-
 class MaliciousReputationMiningNoOriginReputation extends ReputationMinerTestWrapper {
   // This client will claim there is no originReputationUID, whether there is one or not
   //
-  constructor(opts, entryToFalsify, amountToFalsify) {
+  constructor(opts, entryToFalsify) {
     super(opts);
     this.entryToFalsify = entryToFalsify;
-    this.amountToFalsify = amountToFalsify.toString();
   }
 
   async addSingleReputationUpdate(updateNumber, repCycle, blockNumber, checkForReplacement) {
     if (updateNumber.toNumber() === this.entryToFalsify){
-      console.log('altering')
       this.alterThisEntry = true;
       const reputationKey = await this.getKeyForUpdateNumber(updateNumber);
-      console.log(reputationKey)
-      console.log(this.reputations[reputationKey])
       const reputationValue = new BN(this.reputations[reputationKey].slice(2, 66), 16);
       this.replacementAmount = reputationValue.mul(new BN(-1));
-      console.log(this.replacementAmount.toString())
     }
     await super.addSingleReputationUpdate(updateNumber, repCycle, blockNumber, checkForReplacement)
+    if (updateNumber.toNumber() === this.entryToFalsify){
 
-    // Set the origin skill key
-    const logEntryNumber = this.getLogEntryNumberForLogUpdateNumber(updateNumber.sub(this.nReputationsBeforeLatestLog));
-    const logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber);
-    const originSkillUpdateNumber = logEntry.nUpdates.add(logEntry.nPreviousUpdates).add(this.nReputationsBeforeLatestLog).sub(1);
-    const originReputationKey = await this.getKeyForUpdateNumber(originSkillUpdateNumber);
-    this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].originReputationProof.key = originReputationKey;
+      // Set the origin skill key
+      const logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(updateNumber.sub(this.nReputationsBeforeLatestLog));
+      const logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber);
+      const originSkillUpdateNumber = logEntry.nUpdates.add(logEntry.nPreviousUpdates).add(this.nReputationsBeforeLatestLog).sub(1);
+      const originReputationKey = await this.getKeyForUpdateNumber(originSkillUpdateNumber);
+      this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].originReputationProof.key = originReputationKey;
+      // Set the child skill key
+      const relativeUpdateNumber = updateNumber.sub(this.nReputationsBeforeLatestLog).sub(logEntry.nPreviousUpdates);
+      const {nUpdates} = logEntry;
+      const [nParents] = await this.colonyNetwork.getSkill(logEntry.skillId);
+      const nChildUpdates = nUpdates.div(2).sub(1).sub(nParents);
+      let childKey;
+      if (relativeUpdateNumber.lt(nChildUpdates)) {
+        const childSkillUpdateNumber = updateNumber.add(nUpdates.div(2));
+        childKey = await this.getKeyForUpdateNumber(childSkillUpdateNumber);
+      } else {
+        childKey = await this.getKeyForUpdateNumber(updateNumber);
+      }
+      this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].childReputationProof = 
+        await this.getReputationProofObject(childKey);
 
-    // Set the child skill key
-    const relativeUpdateNumber = updateNumber.sub(this.nReputationsBeforeLatestLog).sub(logEntry.nPreviousUpdates);
-    const {nUpdates} = logEntry;
-    const [nParents] = await this.colonyNetwork.getSkill(logEntry.skillId);
-    const nChildUpdates = nUpdates.div(2).sub(1).sub(nParents);
-    let childKey;
-    if (relativeUpdateNumber.lt(nChildUpdates)) {
-      const childSkillUpdateNumber = updateNumber.add(nUpdates.div(2));
-      childKey = await this.getKeyForUpdateNumber(childSkillUpdateNumber);
-    } else {
-      childKey = await this.getKeyForUpdateNumber(updateNumber);
+      this.alterThisEntry = false;
     }
-    this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].childReputationProof = 
-      await this.getReputationProofObject(childKey);
-
-    this.alterThisEntry = false;
   }
 
 
@@ -57,71 +51,6 @@ class MaliciousReputationMiningNoOriginReputation extends ReputationMinerTestWra
       score = score.sub(score);
     }
     return score;
-  }
-
-  async respondToChallenge() {
-    const [round, index] = await this.getMySubmissionRoundAndIndex();
-    const addr = await this.colonyNetwork.getReputationMiningCycle(true);
-    const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
-    const submission = await repCycle.getDisputeRounds(round, index);
-    const firstDisagreeIdx = submission[8];
-    const lastAgreeIdx = firstDisagreeIdx.sub(1);
-    const reputationKey = await this.getKeyForUpdateNumber(lastAgreeIdx);
-    const lastAgreeKey = ReputationMinerTestWrapper.getHexString(lastAgreeIdx, 64);
-    const firstDisagreeKey = ReputationMinerTestWrapper.getHexString(firstDisagreeIdx, 64);
-
-    const [agreeStateBranchMask, agreeStateSiblings] = await this.justificationTree.getProof(lastAgreeKey);
-    const [disagreeStateBranchMask, disagreeStateSiblings] = await this.justificationTree.getProof(firstDisagreeKey);
-    let logEntryNumber = ethers.utils.bigNumberify(0);
-    if (lastAgreeIdx.gte(this.nReputationsBeforeLatestLog)) {
-      logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(lastAgreeIdx.sub(this.nReputationsBeforeLatestLog));
-    }
-
-    const tx = await repCycle.respondToChallenge(
-      [
-        round,
-        index,
-        this.justificationHashes[firstDisagreeKey].justUpdatedProof.branchMask,
-        this.justificationHashes[lastAgreeKey].nextUpdateProof.nNodes,
-        ReputationMinerTestWrapper.getHexString(agreeStateBranchMask),
-        this.justificationHashes[firstDisagreeKey].justUpdatedProof.nNodes,
-        ReputationMinerTestWrapper.getHexString(disagreeStateBranchMask),
-        this.justificationHashes[lastAgreeKey].newestReputationProof.branchMask,
-        logEntryNumber,
-        "0",
-        this.justificationHashes[lastAgreeKey].originReputationProof.branchMask,
-        this.justificationHashes[lastAgreeKey].nextUpdateProof.reputation,
-        this.justificationHashes[lastAgreeKey].nextUpdateProof.uid,
-        this.justificationHashes[firstDisagreeKey].justUpdatedProof.reputation,
-        this.justificationHashes[firstDisagreeKey].justUpdatedProof.uid,
-        this.justificationHashes[lastAgreeKey].newestReputationProof.reputation,
-        this.justificationHashes[lastAgreeKey].newestReputationProof.uid,
-        "0",
-        "0",
-        this.justificationHashes[lastAgreeKey].childReputationProof.branchMask,
-        this.justificationHashes[lastAgreeKey].childReputationProof.reputation,
-        this.justificationHashes[lastAgreeKey].childReputationProof.uid,
-        "0",
-        this.justificationHashes[lastAgreeKey].adjacentReputationProof.branchMask,
-        this.justificationHashes[lastAgreeKey].adjacentReputationProof.reputation,
-        this.justificationHashes[lastAgreeKey].adjacentReputationProof.uid,
-        "0"
-      ],
-      [
-        reputationKey,
-        this.justificationHashes[lastAgreeKey].newestReputationProof.key,
-        this.justificationHashes[lastAgreeKey].adjacentReputationProof.key
-      ],
-      this.justificationHashes[firstDisagreeKey].justUpdatedProof.siblings,
-      agreeStateSiblings,
-      disagreeStateSiblings,
-      this.justificationHashes[lastAgreeKey].newestReputationProof.siblings,
-      this.justificationHashes[lastAgreeKey].originReputationProof.siblings,
-      this.justificationHashes[lastAgreeKey].childReputationProof.siblings,
-      this.justificationHashes[lastAgreeKey].adjacentReputationProof.siblings,
-      { gasLimit: 4000000 }
-    );
-    return tx.wait();
   }
 }
 

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimNoUserChildReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimNoUserChildReputation.js
@@ -2,8 +2,8 @@ import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
 const ethers = require("ethers");
 
-class MaliciousReputationMiningNoUserChildReputation extends ReputationMinerTestWrapper {
-  // This client will claim there is no originReputationUID, whether there is one or not
+class MaliciousReputationMiningClaimNoUserChildReputation extends ReputationMinerTestWrapper {
+  // This client will claim there is no user child reputation, whether there is one or not
   //
   constructor(opts, entryToFalsify) {
     super(opts);
@@ -26,6 +26,13 @@ class MaliciousReputationMiningNoUserChildReputation extends ReputationMinerTest
     }
     await super.addSingleReputationUpdate(updateNumber, repCycle, blockNumber, checkForReplacement)
     if (updateNumber.toNumber() === this.entryToFalsify){
+
+      // Because the amount is zero (due to our custom getAmount function below), the origin skill proof object and the user child proof object
+      // will have default (zero) values.
+      // We set the origin proof here here, (because we want to be able to prove that value), but set the child skill key
+      // (which is checked) and leave the other values alone.
+      // The amount variable represents the change in the reputation being updated, which for a child update is always zero when there is no user child reputation.
+      // The calculation is therefore self-consistent and will be able to pass respondToChallenge.
 
       // Set the origin proof
       this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].originReputationProof = originProof;
@@ -55,4 +62,4 @@ class MaliciousReputationMiningNoUserChildReputation extends ReputationMinerTest
   }
 }
 
-export default MaliciousReputationMiningNoUserChildReputation;
+export default MaliciousReputationMiningClaimNoUserChildReputation;

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimNoUserChildReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimNoUserChildReputation.js
@@ -1,0 +1,128 @@
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
+
+const ethers = require("ethers");
+
+class MaliciousReputationMiningNoUserChildReputation extends ReputationMinerTestWrapper {
+  // This client will claim there is no originReputationUID, whether there is one or not
+  //
+  constructor(opts, entryToFalsify) {
+    super(opts);
+    this.entryToFalsify = entryToFalsify;
+  }
+
+  async addSingleReputationUpdate(updateNumber, repCycle, blockNumber, checkForReplacement) {
+    let originProof;
+    let logEntry;
+    if (updateNumber.toNumber() === this.entryToFalsify){
+      const logEntryUpdateNumber = updateNumber.sub(this.nReputationsBeforeLatestLog);
+      const logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(logEntryUpdateNumber, blockNumber);
+      logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber, { blockTag: blockNumber });
+      const nUpdates = ethers.utils.bigNumberify(logEntry.nUpdates);
+      const relativeUpdateNumber = updateNumber.sub(logEntry.nPreviousUpdates).sub(this.nReputationsBeforeLatestLog);
+      // Get current reputation amount of the origin skill, which is positioned at the end of the current logEntry nUpdates.
+      const originSkillUpdateNumber = updateNumber.sub(relativeUpdateNumber).add(nUpdates).sub(1);
+      const originSkillKey = await this.getKeyForUpdateNumber(originSkillUpdateNumber);
+      originProof = await this.getReputationProofObject(originSkillKey);
+    }
+    await super.addSingleReputationUpdate(updateNumber, repCycle, blockNumber, checkForReplacement)
+    if (updateNumber.toNumber() === this.entryToFalsify){
+
+      // Set the origin proof
+      this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].originReputationProof = originProof;
+
+      // Set the child skill key
+      const relativeUpdateNumber = updateNumber.sub(this.nReputationsBeforeLatestLog).sub(logEntry.nPreviousUpdates);
+      const {nUpdates} = logEntry;
+      const [nParents] = await this.colonyNetwork.getSkill(logEntry.skillId);
+      const nChildUpdates = nUpdates.div(2).sub(1).sub(nParents);
+      let childKey;
+      if (relativeUpdateNumber.lt(nChildUpdates)) {
+        const childSkillUpdateNumber = updateNumber.add(nUpdates.div(2));
+        childKey = await this.getKeyForUpdateNumber(childSkillUpdateNumber);
+      } else {
+        childKey = await this.getKeyForUpdateNumber(updateNumber);
+      }
+      this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].childReputationProof = 
+        await this.getReputationProofObject(childKey);
+    }
+  }
+
+
+  getAmount(i, _score) {
+    let score = _score;
+    if (i.toString() === this.entryToFalsify.toString()) {
+      score = score.sub(score);
+    }
+    return score;
+  }
+
+  async respondToChallenge() {
+    const [round, index] = await this.getMySubmissionRoundAndIndex();
+    const addr = await this.colonyNetwork.getReputationMiningCycle(true);
+    const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
+    const submission = await repCycle.getDisputeRounds(round, index);
+    const firstDisagreeIdx = submission.lowerBound;
+    const lastAgreeIdx = firstDisagreeIdx.sub(1);
+    const reputationKey = await this.getKeyForUpdateNumber(lastAgreeIdx);
+    const lastAgreeKey = ReputationMinerTestWrapper.getHexString(lastAgreeIdx, 64);
+    const firstDisagreeKey = ReputationMinerTestWrapper.getHexString(firstDisagreeIdx, 64);
+
+    const [agreeStateBranchMask, agreeStateSiblings] = await this.justificationTree.getProof(lastAgreeKey);
+    const [disagreeStateBranchMask, disagreeStateSiblings] = await this.justificationTree.getProof(firstDisagreeKey);
+    let logEntryNumber = ethers.utils.bigNumberify(0);
+    if (lastAgreeIdx.gte(this.nReputationsBeforeLatestLog)) {
+      logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(lastAgreeIdx.sub(this.nReputationsBeforeLatestLog));
+    }
+  
+    const tx = await repCycle.respondToChallenge(
+      [
+        round,
+        index,
+        this.justificationHashes[firstDisagreeKey].justUpdatedProof.branchMask,
+        this.justificationHashes[lastAgreeKey].nextUpdateProof.nNodes,
+        ReputationMinerTestWrapper.getHexString(agreeStateBranchMask),
+        this.justificationHashes[firstDisagreeKey].justUpdatedProof.nNodes,
+        ReputationMinerTestWrapper.getHexString(disagreeStateBranchMask),
+        this.justificationHashes[lastAgreeKey].newestReputationProof.branchMask,
+        logEntryNumber,
+        "0",
+        this.justificationHashes[lastAgreeKey].originReputationProof.branchMask,
+        this.justificationHashes[lastAgreeKey].nextUpdateProof.reputation,
+        this.justificationHashes[lastAgreeKey].nextUpdateProof.uid,
+        this.justificationHashes[firstDisagreeKey].justUpdatedProof.reputation,
+        this.justificationHashes[firstDisagreeKey].justUpdatedProof.uid,
+        this.justificationHashes[lastAgreeKey].newestReputationProof.reputation,
+        this.justificationHashes[lastAgreeKey].newestReputationProof.uid,
+        this.justificationHashes[lastAgreeKey].originReputationProof.reputation,
+        this.justificationHashes[lastAgreeKey].originReputationProof.uid,
+        this.justificationHashes[lastAgreeKey].childReputationProof.branchMask,
+        0,
+        0,
+        "0",
+        this.justificationHashes[lastAgreeKey].adjacentReputationProof.branchMask,
+        this.justificationHashes[lastAgreeKey].adjacentReputationProof.reputation,
+        this.justificationHashes[lastAgreeKey].adjacentReputationProof.uid,
+        "0",
+        "0"
+      ],
+      [
+        reputationKey,
+        this.justificationHashes[lastAgreeKey].newestReputationProof.key,
+        this.justificationHashes[lastAgreeKey].originReputationProof.key,
+        this.justificationHashes[lastAgreeKey].childReputationProof.key,
+        this.justificationHashes[lastAgreeKey].adjacentReputationProof.key
+      ],
+      this.justificationHashes[firstDisagreeKey].justUpdatedProof.siblings,
+      agreeStateSiblings,
+      disagreeStateSiblings,
+      this.justificationHashes[lastAgreeKey].newestReputationProof.siblings,
+      this.justificationHashes[lastAgreeKey].originReputationProof.siblings,
+      this.justificationHashes[lastAgreeKey].childReputationProof.siblings,
+      this.justificationHashes[lastAgreeKey].adjacentReputationProof.siblings,
+      { gasLimit: 4000000 }
+    );
+    return tx.wait();
+  }
+}
+
+export default MaliciousReputationMiningNoUserChildReputation;

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -1042,6 +1042,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
   });
 
   it.skip("dispute should resolve if a bad actor responds on behalf of the good submission omitting some proofs that exist", async () => {
+    // This test is no longer possible to run - see the explanation in the PR 533.
     await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
     // We make two tasks, which guarantees that the origin reputation actually exists if we disagree about

--- a/test/reputation-mining/types-of-disagreement.js
+++ b/test/reputation-mining/types-of-disagreement.js
@@ -330,10 +330,8 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 0);
       const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 1);
       const delta = goodSubmissionAfterResponseToChallenge.challengeStepCompleted - badSubmissionAfterResponseToChallenge.challengeStepCompleted;
-      expect(delta).to.eq.BN(2);
-      // checks that challengeStepCompleted is two more for the good submission than the bad one.
-      // it's two, because we proved the starting reputation was in the starting reputation state, rather than claiming
-      // it was a new reputation not in the tree with value 0.
+      expect(delta).to.eq.BN(1);
+      // checks that challengeStepCompleted is one more for the good submission than the bad one.
 
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
       await repCycle.invalidateHash(0, 1);
@@ -448,7 +446,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-nnodes-changed-by-not-1" }
+        client2: { respondToChallenge: "colony-network-mining-more-than-one-node-added" }
       });
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await repCycle.confirmNewHash(1);
@@ -472,7 +470,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
-        client2: { respondToChallenge: "colony-reputation-mining-nnodes-changed" }
+        client2: { respondToChallenge: "colony-reputation-mining-adjacent-agree-state-disagreement" }
       });
 
       await repCycle.confirmNewHash(1);
@@ -593,10 +591,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 0);
       const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 1);
       const delta = goodSubmissionAfterResponseToChallenge.challengeStepCompleted - badSubmissionAfterResponseToChallenge.challengeStepCompleted;
-      expect(delta).to.eq.BN(2);
-      // checks that challengeStepCompleted is two more for the good submission than the bad one.
-      // it's two, because we proved the starting reputation was in the starting reputation state, rather than claiming
-      // it was a new reputation not in the tree with value 0.
+      expect(delta).to.eq.BN(1);
 
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
       await repCycle.invalidateHash(0, 1);


### PR DESCRIPTION
Closes #410... but not in a very satisfying way?

Firstly, some background. The reason this issue existed was fundamentally because there were two states that could be submitted that had a plausible numerical calculation done - a bad actor could assume a reputation didn't exist, and use a value of zero when doing the calculation, adding a new node. If a good actor proved the reputation existed, and then did the calculation correctly, we would have two submissions that successfully passed, and so had to use a tiebreak to decide between them, which was done with the additional increment of `challengeStepsCompleted` in the case of the submission that proved the reputation already existed. By responding on behalf of the good actor and skipping this proof (and thus the additional increment), the proofs were tied even with the tiebreak, and both would be eliminated.

The issue arose where the reputation existed, but the same answer was arrived at if you assumed a value of 0 for the existing reputation. In that case (which only applied for a negative reputation change), a bad actor could call `respondToChallenge` on behalf of the good actor, successfully pass all the requires, but skip the proof of the fact the reputation already existed (and thus the additional increment of `challengeStepsCompleted`. In that case, both submissions would have the same number of `challengeStepsCompleted`, and both would end up being eliminated.

This is now impossible for two reasons:

1. The introduction of `checkAdjacentReputationHash` in #506 means that, while there are two states that can have a successful calculation, one of them will never reach the calculation and fail earlier in `respondToChallenge`, as claiming a reputation doesn't exist when it actually does is now detectable based on the branchMask of the adjacent hash.

2. The other is the introduction of stricter checks for the values of `agreeStateNNodes` and `disagreeStateNNodes` in this PR. Currently, so long as they differ by either 0 or 1, regardless of the rest of the submission, the `respondToChallenge` call succeeds; this was exploited by the bad actor replying on behalf of the good. Part of this PR makes sure that the choice of 0 or 1 is self-consistent throughout the response.

It was not immediately clear to me why the same attack was not possible on the remaining 'skippable' increments. But it is my belief is that it is now not possible to (productively) respond on behalf of the good submission and bypass the optional proofs. 

Firstly, the remaining skippable increments only apply when considering a negative update. All negative updates check `userOriginReputationValue`. If the update is of a colony-wide total for a child skill, then `userChildReputationValue` is checked as well.

* Any response on behalf of the good submission that successfully calls `respondToChallenge` and skips a proof can only occur when the calculation done with the correct value for `userOriginReputationValue` or `userChildReputationValue` is the same as if the calculation is done with 0 for one of those values (otherwise the value the bad actor proves to be in `disagreeState` won't be consistent with the calculation submitted by the good actor)
* This can only occur if at exactly one of `userOriginReputation` or `userChildReputation` exists, or both exist and at least one has a value of zero, or both exist and logEntry.amount is zero (which can only occur for miners, currently).
* A bad actor can respond for the good response in this scenario and prevent the submission getting some increment(s) that it deserves, but it still gets at least one for a successful call to `respondToChallenge`.
* In this scenario, I believe that the competing state is will not be able to make a successful `respondToChallenge` at all, and will still therefore be eliminated, as I don't think the bad client can have submitted a different state that will be able to be show a plausible calculation. If it skips the proofs for the right `userOriginReputationValue` or `userChildReputationValue`, and thus uses 0 instead of their correct values, it gets the same answer as the good submission, and so would have submitted the same state. To have submitted a different state, it must therefore have submitted an updated value for the reputation under dispute that will fail the calculation check, and so the good client's submission will not be eliminated (because it got one increment for a successful `respondToChallenge`, just not as many as it could have done).

Note that we cannot get rid of the increments in the optional proof paths, in case a bad submission is made that assumes a value of 0 for the calculation, but the reputation actually does exist with some other value - we have to be able to find in favour of the submission that proved an existing reputation value. In this case, `respondToChallenge` requires the proofs to be made to complete successfully, otherwise the calculation for the good client will fail. The tests `if one person claims an origin skill doesn't exist but the other does (and proves such)` and `if one person claims a user's child skill doesn't exist but the other does (and proves such)` demonstrate this, and fail if these increments are removed.

Note that in this scenario, the bad client is _not_ able to respond on behalf of the good client successfully - if it tries to do so by skipping one of the optional reputations, it won't pass the calculation check (which used a nonzero value when the good client submitted it).