### PR TITLE
Move to mythril release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ step_pull_solc_docker: &step_pull_solc_docker
 step_pull_mythril_docker: &step_pull_mythril_docker
     run:
       name: "Pull mythril dev docker image"
-      command: docker pull mythril/myth-dev
+      command: docker pull mythril/myth
 jobs:
   lint-and-unit-test:
     <<: *job_common
@@ -122,7 +122,7 @@ jobs:
           command: | 
             docker create -v "$pwd"/build --name colonynetwork alpine:3.4 /bin/true
             docker cp build/* colonynetwork:/build 
-            docker run --volumes-from colonynetwork mythril/myth-dev myth --truffle --execution-timeout 40 -v 3
+            docker run --volumes-from colonynetwork mythril/myth myth --truffle --execution-timeout 40 -v 3
 workflows:
   version: 2
   commit:


### PR DESCRIPTION
Following the [latest `mythril` release 0.20.0](https://github.com/ConsenSys/mythril-classic/releases/tag/v0.20.0) we can now move away from the dev image we were using. This should also fix the nightly build.
