### PR TITLE
Consolidate root hash submission checks

### DIFF
--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -1,7 +1,7 @@
 /* globals artifacts */
 /* eslint-disable no-console */
 import shortid from "shortid";
-import { assert } from "chai";
+import { assert, chai } from "chai";
 import web3Utils from "web3-utils";
 import ethUtils from "ethereumjs-util";
 import BN from "bn.js";
@@ -14,6 +14,8 @@ const IMetaColony = artifacts.require("IMetaColony");
 const ITokenLocking = artifacts.require("ITokenLocking");
 const Token = artifacts.require("Token");
 const IReputationMiningCycle = artifacts.require("IReputationMiningCycle");
+
+const { expect } = chai;
 
 export function web3GetNetwork() {
   return new Promise((resolve, reject) => {
@@ -435,6 +437,16 @@ export async function submitAndForwardTimeToDispute(clients, test) {
     await clients[i].submitRootHash();
   }
   await forwardTime(MINING_CYCLE_DURATION / 2, test);
+
+  // If there are multiple submissions, ensure they are different
+  if (clients.length > 1) {
+    let previousHash = await clients[0].getRootHash();
+    for (let i = 1; i < clients.length; i += 1) {
+      const currentHash = await clients[i].getRootHash();
+      expect(previousHash, "Hashes from clients are equal, surprisingly").to.not.equal(currentHash);
+      previousHash = currentHash;
+    }
+  }
 }
 
 export async function runBinarySearch(client1, client2) {

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -440,11 +440,18 @@ export async function submitAndForwardTimeToDispute(clients, test) {
 
   // If there are multiple submissions, ensure they are different
   if (clients.length > 1) {
-    let previousHash = await clients[0].getRootHash();
     for (let i = 1; i < clients.length; i += 1) {
+      const previousHash = await clients[i - 1].getRootHash();
+      const previousNReputations = await clients[i - 1].getRootHashNNodes();
+      const previousJRH = await clients[i - 1].justificationTree.getRootHash();
+
       const currentHash = await clients[i].getRootHash();
-      expect(previousHash, "Hashes from clients are equal, surprisingly").to.not.equal(currentHash);
-      previousHash = currentHash;
+      const currentNReputations = await clients[i].getRootHashNNodes();
+      const currentJRH = await clients[i].justificationTree.getRootHash();
+
+      if (previousHash === currentHash && previousNReputations.eq(currentNReputations) && previousJRH === currentJRH) {
+        throw new Error("Submissions from clients are equal, surprisingly");
+      }
     }
   }
 }

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -431,6 +431,9 @@ export async function getValidEntryNumber(colonyNetwork, account, hash, starting
 }
 
 export async function submitAndForwardTimeToDispute(clients, test) {
+  // For there to be a dispute we need at least 2 competing submisssions
+  expect(clients.length).to.be.abovet(1);
+
   await forwardTime(MINING_CYCLE_DURATION / 2, test);
   for (let i = 0; i < clients.length; i += 1) {
     await clients[i].addLogContentsToReputationTree();
@@ -438,7 +441,8 @@ export async function submitAndForwardTimeToDispute(clients, test) {
   }
   await forwardTime(MINING_CYCLE_DURATION / 2, test);
 
-  // If there are multiple submissions, ensure they are different
+  // If there are multiple submissions, ensure they are all different
+
   if (clients.length > 1) {
     for (let i = 1; i < clients.length; i += 1) {
       const previousHash = await clients[i - 1].getRootHash();

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -1,7 +1,7 @@
 /* globals artifacts */
 /* eslint-disable no-console */
 import shortid from "shortid";
-import { assert, chai } from "chai";
+import chai from "chai";
 import web3Utils from "web3-utils";
 import ethUtils from "ethereumjs-util";
 import BN from "bn.js";
@@ -156,10 +156,10 @@ export async function checkErrorRevert(promise, errorMessage) {
     }
   } catch (err) {
     ({ receipt, reason } = err);
-    assert.equal(reason, errorMessage);
+    expect(reason).to.equal(errorMessage);
   }
   // Check the receipt `status` to ensure transaction failed.
-  assert.isFalse(receipt.status, `Transaction succeeded, but expected error ${errorMessage}`);
+  expect(receipt.status, `Transaction succeeded, but expected error ${errorMessage}`).to.be.false;
 }
 
 export async function checkErrorRevertEthers(promise, errorMessage) {
@@ -171,11 +171,11 @@ export async function checkErrorRevertEthers(promise, errorMessage) {
     const tx = await web3GetTransaction(txid);
     const response = await web3GetRawCall({ from: tx.from, to: tx.to, data: tx.input, gas: tx.gas, value: tx.value });
     const reason = extractReasonString(response);
-    assert.equal(reason, errorMessage);
+    expect(reason).to.equal(errorMessage);
     return;
   }
 
-  assert.equal(receipt.status, 0, `Transaction succeeded, but expected to fail with: ${errorMessage}`);
+  expect(receipt.status, `Transaction succeeded, but expected to fail with: ${errorMessage}`).to.be.zero;
 }
 
 export async function checkSuccessEthers(promise, errorMessage) {
@@ -193,7 +193,7 @@ export async function checkSuccessEthers(promise, errorMessage) {
   const tx = await web3GetTransaction(txid);
   const response = await web3GetRawCall({ from: tx.from, to: tx.to, data: tx.input, gas: tx.gas, value: tx.value });
   const reason = extractReasonString(response);
-  assert.equal(receipt.status, 1, `${errorMessage} with error ${reason}`);
+  expect(receipt.status, `${errorMessage} with error ${reason}`).to.equal(1);
 }
 
 export function getRandomString(_length) {
@@ -253,13 +253,13 @@ export async function getBlockTime(blockNumber) {
 export async function expectEvent(tx, eventName) {
   const { logs } = await tx;
   const event = logs.find(e => e.event === eventName);
-  return assert.exists(event);
+  return expect(event).to.exist;
 }
 
 export async function expectAllEvents(tx, eventNames) {
   const { logs } = await tx;
   const events = eventNames.every(eventName => logs.find(e => e.event === eventName));
-  return assert.isTrue(events);
+  return expect(events).to.be.true;
 }
 
 export async function forwardTime(seconds, test) {
@@ -559,12 +559,12 @@ async function navigateChallenge(colonyNetwork, client1, client2, errors) {
   }
 
   const [round2, idx2] = await client2.getMySubmissionRoundAndIndex();
-  assert.isTrue(round1.eq(round2), "Clients do not have submissions in the same round");
+  expect(round1.eq(round2), "Clients do not have submissions in the same round").to.be.true;
   const submission2before = await repCycle.getDisputeRounds(round2, idx2);
-  assert.isTrue(
+  expect(
     idx1.sub(idx2).pow(2).eq(1), // eslint-disable-line prettier/prettier
     "Clients are not facing each other in this round"
-  );
+  ).to.be.true;
 
   if (submission2before.jrhNNodes === "0") {
     if (errors.client2.confirmJustificationRootHash) {
@@ -674,7 +674,7 @@ export async function finishReputationMiningCycleAndWithdrawAllMinerStakes(colon
 
       if (stakedBalance.gt(new BN(0))) {
         if (user === accounts[5]) {
-          assert.isTrue(stakedBalance.gte(DEFAULT_STAKE), "Insufficient stake for MINER1");
+          expect(stakedBalance.gte(DEFAULT_STAKE), "Insufficient stake for MINER1").to.be.true;
           if (stakedBalance.gt(DEFAULT_STAKE)) {
             await tokenLocking.withdraw(clny.address, stakedBalance.sub(DEFAULT_STAKE), { from: user });
           }

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -610,6 +610,7 @@ class ReputationMiner {
    */
   async submitRootHash(startIndex = 1) {
     const hash = await this.getRootHash();
+    const nNodes = await this.getRootHashNNodes();
     const repCycle = await this.getActiveRepCycle();
     // Get how much we've staked, and thefore how many entries we have
     let entryIndex;
@@ -640,7 +641,7 @@ class ReputationMiner {
       if (ethers.utils.bigNumberify(entryHash).lt(target)) {
         // Check we haven't submitted this already
         try {
-          gas = await repCycle.estimate.submitRootHash(hash, this.nReputations, jrh, i);
+          gas = await repCycle.estimate.submitRootHash(hash, nNodes, jrh, i);
           // If that didn't error, then we can submit this
           entryIndex = i;
           break;
@@ -653,7 +654,7 @@ class ReputationMiner {
       throw new Error("No valid entry for submission found.");
     }
     // Submit that entry
-    return repCycle.submitRootHash(hash, this.nReputations, jrh, entryIndex, { gasLimit: `0x${gas.toString(16)}` });
+    return repCycle.submitRootHash(hash, nNodes, jrh, entryIndex, { gasLimit: `0x${gas.toString(16)}` });
   }
 
   /**
@@ -662,6 +663,14 @@ class ReputationMiner {
    */
   async getRootHash() {
     return this.reputationTree.getRootHash();
+  }
+
+  /**
+   * Get what the client believes should be the next reputation state nNodes.
+   * @return {Promise}      Resolves to the nNodes as ethers BigNumber
+   */
+  async getRootHashNNodes() {
+    return this.nReputations;
   }
 
   /**
@@ -757,7 +766,7 @@ class ReputationMiner {
    */
   async getMySubmissionRoundAndIndex() {
     const submittedHash = await this.reputationTree.getRootHash();
-    const submittedNNodes = await this.nReputations;
+    const submittedNNodes = await this.getRootHashNNodes();
     const jrh = await this.justificationTree.getRootHash();
     const repCycle = await this.getActiveRepCycle();
 

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongNNodes.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongNNodes.js
@@ -1,80 +1,14 @@
 import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
-const ethers = require("ethers");
-
 class MaliciousReputationMinerWrongNNodes extends ReputationMinerTestWrapper {
-  // Only difference between this and the 'real' client should be that it submits a bad JRH
 
-  constructor(opts, entryToFalsify) {
+  constructor(opts, amountToFalsifyBy) {
     super(opts);
-    this.entryToFalsify = entryToFalsify.toString();
+    this.amountToFalsifyBy = amountToFalsifyBy.toString();
   }
 
-  async submitRootHash(startIndex = 1) {
-    const hash = await this.getRootHash();
-    const repCycle = await this.getActiveRepCycle();
-    // Get how much we've staked, and thefore how many entries we have
-    let entryIndex;
-    const [, balance] = await this.tokenLocking.getUserLock(this.clnyAddress, this.minerAddress);
-    const reputationMiningWindowOpenTimestamp = await repCycle.getReputationMiningWindowOpenTimestamp();
-    const minStake = ethers.utils.bigNumberify(10).pow(18).mul(2000); // eslint-disable-line prettier/prettier
-    for (let i = ethers.utils.bigNumberify(startIndex); i.lte(balance.div(minStake)); i = i.add(1)) {
-      // Iterate over entries until we find one that passes
-      const entryHash = await repCycle.getEntryHash(this.minerAddress, i, hash);
-
-      const miningCycleDuration = 60 * 60 * 24;
-      const constant = ethers.utils
-        .bigNumberify(2)
-        .pow(256)
-        .sub(1)
-        .div(miningCycleDuration);
-
-      const block = await this.realProvider.getBlock("latest");
-      const { timestamp } = block;
-
-      const target = ethers.utils
-        .bigNumberify(timestamp)
-        .sub(reputationMiningWindowOpenTimestamp)
-        .mul(constant);
-      if (ethers.utils.bigNumberify(entryHash).lt(target)) {
-        entryIndex = i;
-        break;
-      }
-    }
-    if (!entryIndex) {
-      return new Error("No valid entry for submission found");
-    }
-
-    // Get the JRH
-    const jrh = await this.justificationTree.getRootHash();
-    // Submit that entry with the wrong NNodes
-    const gas = await repCycle.estimate.submitRootHash(hash, this.nReputations.add(this.entryToFalsify), jrh, entryIndex);
-
-    const tx = await repCycle.submitRootHash(hash, this.nReputations.add(this.entryToFalsify), jrh, entryIndex, {
-      gasLimit: `0x${gas.toString(16)}`
-    });
-    return tx.wait();
-  }
-
-  async getMySubmissionRoundAndIndex() {
-    const submittedHash = await this.reputationTree.getRootHash();
-    const submittedNNodes = await this.nReputations.add(this.entryToFalsify);
-    const jrh = await this.justificationTree.getRootHash();
-    const repCycle = await this.getActiveRepCycle();
-
-    let index = ethers.utils.bigNumberify(-1);
-    let round = ethers.utils.bigNumberify(0);
-    let submission = [];
-    while (submission[0] !== submittedHash || submission[1].toString() !== submittedNNodes.toString() || submission[4] !== jrh) {
-      try {
-        index = index.add(1);
-        submission = await repCycle.getDisputeRounds(round, index);
-      } catch (err) {
-        round = round.add(1);
-        index = ethers.utils.bigNumberify(-1);
-      }
-    }
-    return [round, index];
+  async getRootHashNNodes() {
+    return this.nReputations.add(this.amountToFalsifyBy);
   }
 }
 

--- a/test/colony-network-recovery.js
+++ b/test/colony-network-recovery.js
@@ -12,7 +12,6 @@ import {
   currentBlock,
   currentBlockTime,
   checkErrorRevert,
-  submitAndForwardTimeToDispute,
   web3GetStorageAt,
   getActiveRepCycle,
   advanceMiningCycleNoContest
@@ -485,12 +484,8 @@ contract("Colony Network Recovery", accounts => {
           await colonyNetwork.exitRecoveryMode();
 
           // Consume these reputation mining cycles.
-          await submitAndForwardTimeToDispute([client], this);
-          await newActiveCycle.confirmNewHash(0);
-
-          newActiveCycle = newInactiveCycle;
-          await submitAndForwardTimeToDispute([client], this);
-          await newActiveCycle.confirmNewHash(0);
+          await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
+          await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
 
           const newClient = new ReputationMinerTestWrapper({
             loader: contractLoader,

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -1124,10 +1124,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
 
           await submitAndForwardTimeToDispute([badClient, badClient2], this);
 
-          const wronghash = await badClient.getRootHash();
-          const wronghash2 = await badClient2.getRootHash();
-          expect(wronghash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash2);
-
           await badClient.confirmJustificationRootHash();
           await badClient2.confirmJustificationRootHash();
 

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -153,14 +153,11 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       await badClient.loadState(currentGoodClientState);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
-
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient);
       await repCycle.confirmNewHash(1);
       const acceptedHash = await colonyNetwork.getReputationRootHash();
+
+      const righthash = await goodClient.getRootHash();
       expect(righthash, "The correct hash was not accepted").to.equal(acceptedHash);
     });
 
@@ -246,9 +243,6 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       await badClientWrongSkill.loadState(currentGoodClientState);
 
       await submitAndForwardTimeToDispute([goodClient, badClientWrongUser, badClientWrongColony, badClientWrongSkill], this);
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClientWrongUser.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       // Run through the dispute until we can call respondToChallenge
       await goodClient.confirmJustificationRootHash();
@@ -320,9 +314,6 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       await badClient.loadState(currentGoodClientState);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
@@ -394,9 +385,6 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       await badClient.loadState(currentGoodClientState);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-origin-user-incorrect" }
@@ -454,9 +442,6 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       await badClient.loadState(currentGoodClientState);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
@@ -513,9 +498,6 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       await badClient.loadState(currentGoodClientState);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
@@ -560,9 +542,6 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       await badClient.loadState(currentGoodClientState);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
@@ -621,9 +600,6 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       await badClient.loadState(currentGoodClientState);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
@@ -681,9 +657,6 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       await badClient.loadState(currentGoodClientState);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
@@ -844,9 +817,6 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       await badClient.loadState(currentGoodClientState);
 
       await submitAndForwardTimeToDispute([goodClient, badClient, badClientWrongUser, badClientWrongColony, badClientWrongSkill], this);
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       // Run through the dispute until we can call respondToChallenge
       await goodClient.confirmJustificationRootHash();
@@ -915,9 +885,6 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       await badClient.loadState(currentGoodClientState);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }
@@ -994,10 +961,6 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
 
       await submitAndForwardTimeToDispute([goodClient, badClient, badClient2], this);
       await metaColony.addGlobalSkill(6);
-
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" }

--- a/test/reputation-mining/happy-paths.js
+++ b/test/reputation-mining/happy-paths.js
@@ -686,11 +686,6 @@ contract("Reputation Mining - happy paths", accounts => {
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.equal(wronghash);
-
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-increased-reputation-value-incorrect" }
       });

--- a/test/reputation-mining/root-hash-submissions.js
+++ b/test/reputation-mining/root-hash-submissions.js
@@ -533,7 +533,16 @@ contract("Reputation mining - root hash submissions", accounts => {
       badClient2 = new MaliciousReputationMinerExtraRep({ loader, minerAddress: MINER3, realProviderPort, useJsTree }, 1, "0xfffffffff");
       badClient2.initialise(colonyNetwork.address);
 
-      await submitAndForwardTimeToDispute([goodClient, badClient, badClient2], this);
+      await forwardTime(MINING_CYCLE_DURATION / 2, this);
+      await goodClient.addLogContentsToReputationTree();
+      await badClient.addLogContentsToReputationTree();
+      await badClient2.addLogContentsToReputationTree();
+
+      await goodClient.submitRootHash();
+      await badClient.submitRootHash();
+      await badClient2.submitRootHash();
+      await forwardTime(MINING_CYCLE_DURATION / 2, this);
+
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-increased-reputation-value-incorrect" }
       });

--- a/test/reputation-mining/types-of-disagreement.js
+++ b/test/reputation-mining/types-of-disagreement.js
@@ -117,10 +117,6 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const repCycle = await getActiveRepCycle(colonyNetwork);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.eq.BN(wronghash);
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-adjacent-disagree-state-disagreement" }
       });
@@ -144,10 +140,6 @@ contract("Reputation Mining - types of disagreement", accounts => {
       expect(nInactiveLogEntries).to.eq.BN(5);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.eq.BN(wronghash);
 
       const nSubmittedHashes = await repCycle.getNSubmittedHashes();
       expect(nSubmittedHashes).to.eq.BN(2);
@@ -191,10 +183,6 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.eq.BN(wronghash);
-
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-decay-incorrect" }
@@ -218,10 +206,6 @@ contract("Reputation Mining - types of disagreement", accounts => {
         await badClient.loadState(savedHash);
 
         await submitAndForwardTimeToDispute([goodClient, badClient], this);
-
-        const righthash = await goodClient.getRootHash();
-        const wronghash = await badClient.getRootHash();
-        expect(righthash, "Hashes from clients are equal, surprisingly").to.not.eq.BN(wronghash);
 
         const repCycle = await getActiveRepCycle(colonyNetwork);
 
@@ -257,10 +241,6 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.eq.BN(wronghash);
 
       const nSubmittedHashes = await repCycle.getNSubmittedHashes();
       expect(nSubmittedHashes).to.eq.BN(2);
@@ -379,9 +359,6 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.eq.BN(wronghash);
 
       await goodClient.confirmJustificationRootHash();
       await badClient.confirmJustificationRootHash();
@@ -401,8 +378,9 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await repCycle.invalidateHash(0, 1);
       await repCycle.confirmNewHash(1);
 
+      const rightHash = await goodClient.getRootHash();
       const confirmedHash = await colonyNetwork.getReputationRootHash();
-      expect(confirmedHash).to.eq.BN(righthash);
+      expect(confirmedHash).to.equal(rightHash);
     });
 
     it("if someone tries to insert a second copy of an existing reputation as a new one, it should fail", async () => {
@@ -424,9 +402,6 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.eq.BN(wronghash);
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-adjacent-branchmask-incorrect" }
       });
@@ -603,10 +578,6 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await badClient.initialise(colonyNetwork.address);
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.eq.BN(wronghash);
-
       await goodClient.confirmJustificationRootHash();
       await badClient.confirmJustificationRootHash();
 
@@ -665,10 +636,6 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.eq.BN(wronghash);
-
       await goodClient.confirmJustificationRootHash();
       await badClient.confirmJustificationRootHash();
 
@@ -694,8 +661,10 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
       await repCycle.invalidateHash(0, 1);
       await repCycle.confirmNewHash(1);
+
+      const rightHash = await goodClient.getRootHash();
       const confirmedHash = await colonyNetwork.getReputationRootHash();
-      expect(confirmedHash).to.eq.BN(righthash);
+      expect(confirmedHash).to.equal(rightHash);
     });
 
     it("if a new reputation's uniqueID is not proved right because a too-old previous ID is proved", async () => {
@@ -774,10 +743,6 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.eq.BN(wronghash);
-
       await goodClient.confirmJustificationRootHash();
       await badClient.confirmJustificationRootHash();
 
@@ -798,8 +763,10 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
       await repCycle.invalidateHash(0, 1);
       await repCycle.confirmNewHash(1);
+
+      const rightHash = await goodClient.getRootHash();
       const confirmedHash = await colonyNetwork.getReputationRootHash();
-      expect(confirmedHash).to.eq.BN(righthash);
+      expect(confirmedHash).to.equal(rightHash);
     });
 
     it("if a reputation decay calculation is wrong", async () => {
@@ -812,10 +779,6 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await badClient.initialise(colonyNetwork.address);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-
-      let righthash = await goodClient.getRootHash();
-      let wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.eq.BN(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-increased-reputation-value-incorrect" }
@@ -833,15 +796,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
         await badClient.insert(key, score, 0);
       }
 
-      righthash = await goodClient.getRootHash();
-      wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are not equal - not starting from the same state").to.eq.BN(wronghash);
-
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-
-      righthash = await goodClient.getRootHash();
-      wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.eq.BN(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-decay-incorrect" }
@@ -907,10 +862,6 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await badClient.loadState(currentGoodClientState);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-
-      const righthash = await goodClient.getRootHash();
-      const wronghash = await badClient.getRootHash();
-      expect(righthash, "Hashes from clients are equal, surprisingly").to.not.eq.BN(wronghash);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-reputation-not-max-int128" }


### PR DESCRIPTION
Following a call to `submitAndForwardTimeToDispute` for a set of clients, we'd normally perform a check that the submitted hashes are different as to establish valid dispute conditions. Here we consolidate these checks in the helper function itself to check consistently and eliminate repeating lines in tests.