### PR TITLE
Reputation mining client fixes and improvements

### DIFF
--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -18,9 +18,9 @@ class ReputationMiner {
    * @param {string} minerAddress            The address that is staking CLNY that will allow the miner to submit reputation hashes
    * @param {Number} [realProviderPort=8545] The port that the RPC node with the ability to sign transactions from `minerAddress` is responding on. The address is assumed to be `localhost`.
    */
-  constructor({ loader, minerAddress, privateKey, provider, realProviderPort = 8545, useJsTree = false, dbPath = "./reputationStates.sqlite" }) {
+  constructor({ loader, minerAddress, privateKey, provider, realProviderPort = 8545, useJsTree = false }) {
     this.loader = loader;
-    this.dbPath = dbPath;
+    this.dbPath = "./reputationStates.sqlite";
 
     this.useJsTree = useJsTree;
     if (!this.useJsTree) {

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -20,7 +20,6 @@ class ReputationMiner {
    */
   constructor({ loader, minerAddress, privateKey, provider, realProviderPort = 8545, useJsTree = false, dbPath = "./reputationStates.sqlite" }) {
     this.loader = loader;
-    this.minerAddress = minerAddress;
     this.dbPath = dbPath;
 
     this.useJsTree = useJsTree;
@@ -53,11 +52,13 @@ class ReputationMiner {
     }
 
     if (minerAddress) {
+      this.minerAddress = minerAddress;
       this.realWallet = this.realProvider.getSigner(minerAddress);
     } else {
       this.realWallet = new ethers.Wallet(privateKey, this.realProvider);
+      this.minerAddress = this.realWallet.address;
       // TODO: Check that this wallet can stake?
-      console.log("Transactions will be signed from ", this.realWallet.address);
+      console.log("Transactions will be signed from ", this.minerAddress);
     }
   }
 

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -1,6 +1,5 @@
 const ethers = require("ethers");
 const express = require("express");
-const BN = require("bn.js");
 
 const ReputationMiner = require("./ReputationMiner");
 
@@ -10,10 +9,9 @@ class ReputationMinerClient {
    * @param {string} minerAddress            The address that is staking CLNY that will allow the miner to submit reputation hashes
    * @param {Number} [realProviderPort=8545] The port that the RPC node with the ability to sign transactions from `minerAddress` is responding on. The address is assumed to be `localhost`.
    */
-  constructor({ file, minerAddress, loader, realProviderPort, seed, privateKey, provider, useJsTree, auto }) {
+  constructor({ minerAddress, loader, realProviderPort, privateKey, provider, useJsTree, auto }) {
     this._loader = loader;
-    this._miner = new ReputationMiner({ minerAddress, loader, provider, privateKey, realProviderPort, dbPath: file, useJsTree });
-    this._seed = seed;
+    this._miner = new ReputationMiner({ minerAddress, loader, provider, privateKey, realProviderPort, useJsTree });
     this._auto = auto;
     if (typeof this._auto === "undefined") {
       this._auto = true;
@@ -64,24 +62,6 @@ class ReputationMinerClient {
     await this._miner.loadState(latestReputationHash);
     if (this._miner.nReputations.eq(0)) {
       console.log("No existing reputations found - starting from scratch");
-      if (this._seed) {
-        // Temporary data if --seed is set and there's nothing to restore from.
-        const ADDRESS1 = "0x309e642dbf573119ca75153b25f5b8462ff1b90b";
-        const ADDRESS2 = "0xbc13dbc1a954b3443d6f75297a232faa513774b3";
-        const ADDRESS3 = "0x2b183746bd1403cdec8e4fe45139339da20bcf3d";
-        const ADDRESS4 = "0xcd0751d4181acda4f8edb2f3b33b915f91abeef0";
-        const ADDRESS0 = "0x0000000000000000000000000000000000000000";
-        await this._miner.insert(ADDRESS1, 1, ADDRESS2, new BN("999999999"));
-        await this._miner.insert(ADDRESS1, 1, ADDRESS0, new BN("999999999"));
-        await this._miner.insert(ADDRESS1, 2, ADDRESS2, new BN("888888888888888"));
-        await this._miner.insert(ADDRESS1, 2, ADDRESS0, new BN("888888888888888"));
-        await this._miner.insert(ADDRESS3, 1, ADDRESS2, new BN("100000000"));
-        await this._miner.insert(ADDRESS3, 1, ADDRESS4, new BN("100000000"));
-        await this._miner.insert(ADDRESS3, 1, ADDRESS0, new BN("200000000"));
-        console.log("💾 Writing initialised state with dummy data to database");
-
-        await this._miner.saveCurrentState();
-      }
     }
 
     console.log("🏁 Initialised");

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -10,7 +10,8 @@ const ethers = require("ethers");
 
 const ReputationMinerClient = require("../ReputationMinerClient");
 
-const { minerAddress, colonyNetworkAddress, rinkeby, privateKey } = argv;
+const supportedInfuraNetworks = ["rinkeby", "ropsten", "kovan", "mainnet"];
+const { minerAddress, privateKey, colonyNetworkAddress, network } = argv;
 
 if ((!minerAddress && !privateKey) || !colonyNetworkAddress) {
   console.log("❗️ You have to specify all of ( --minerAddress or --privateKey ) and --colonyNetworkAddress on the command line!");
@@ -22,8 +23,12 @@ const loader = new TruffleLoader({
 });
 
 let provider;
-if (rinkeby) {
-  provider = new ethers.providers.InfuraProvider("rinkeby");
+if (network) {
+  if (!supportedInfuraNetworks.includes(network)) {
+    console.log(`❗️ "network" option accepts only supported Infura networks: ${supportedInfuraNetworks} !`);
+    process.exit();
+  }
+  provider = new ethers.providers.InfuraProvider(network);
 }
 
 const client = new ReputationMinerClient({ loader, minerAddress, privateKey, provider, useJsTree: true });

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -1,6 +1,7 @@
 require("@babel/register")({
   presets: ["@babel/preset-env"]
 });
+require("@babel/polyfill");
 
 const path = require("path");
 const { argv } = require("yargs");

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -10,10 +10,10 @@ const ethers = require("ethers");
 
 const ReputationMinerClient = require("../ReputationMinerClient");
 
-const { file, minerAddress, colonyNetworkAddress, rinkeby, privateKey, seed } = argv;
+const { minerAddress, colonyNetworkAddress, rinkeby, privateKey, seed } = argv;
 
-if ((!minerAddress && !privateKey) || !colonyNetworkAddress || !file) {
-  console.log("❗️ You have to specify all of ( --minerAddress or --privateKey ), --colonyNetworkAddress and --file on the command line!");
+if ((!minerAddress && !privateKey) || !colonyNetworkAddress) {
+  console.log("❗️ You have to specify all of ( --minerAddress or --privateKey ) and --colonyNetworkAddress on the command line!");
   process.exit();
 }
 
@@ -26,5 +26,5 @@ if (rinkeby) {
   provider = new ethers.providers.InfuraProvider("rinkeby");
 }
 
-const client = new ReputationMinerClient({ file, loader, minerAddress, privateKey, provider, seed, useJsTree: true });
+const client = new ReputationMinerClient({ loader, minerAddress, privateKey, provider, seed, useJsTree: true });
 client.initialise(colonyNetworkAddress);

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -10,7 +10,7 @@ const ethers = require("ethers");
 
 const ReputationMinerClient = require("../ReputationMinerClient");
 
-const { minerAddress, colonyNetworkAddress, rinkeby, privateKey, seed } = argv;
+const { minerAddress, colonyNetworkAddress, rinkeby, privateKey } = argv;
 
 if ((!minerAddress && !privateKey) || !colonyNetworkAddress) {
   console.log("❗️ You have to specify all of ( --minerAddress or --privateKey ) and --colonyNetworkAddress on the command line!");
@@ -26,5 +26,5 @@ if (rinkeby) {
   provider = new ethers.providers.InfuraProvider("rinkeby");
 }
 
-const client = new ReputationMinerClient({ loader, minerAddress, privateKey, provider, seed, useJsTree: true });
+const client = new ReputationMinerClient({ loader, minerAddress, privateKey, provider, useJsTree: true });
 client.initialise(colonyNetworkAddress);

--- a/packages/reputation-miner/package.json
+++ b/packages/reputation-miner/package.json
@@ -24,6 +24,7 @@
     "yargs": "^13.1.0"
   },
   "devDependencies": {
+    "@babel/polyfill": "^7.2.5",
     "@babel/preset-env": "^7.3.1",
     "@babel/register": "^7.0.0"
   }


### PR DESCRIPTION
- Add babel polyfill to reputation client (It appears I broke that with the babel upgrade and reconfiguration work from #510 )
- Sets the local `minerAddress` property when private key is used (as well as when an actual minerAddress is used directly)
- Remove the obsoleted startup options `file` and `seed`
- Allows all Infura supported networks to be used not just `rinkeby`