### PR TITLE
Remove extra increments of challengeStepCompleted in respondToChallenge

### DIFF
--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -121,11 +121,15 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// * 25. The amount of reputation that the reputation adjacent to a new reputation being inserted has in the agree state
   /// * 26. The UID of the reputation adjacent to the new reputation being inserted
   /// * 27. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code.
+  /// * 28. The value of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree
+  /// * 29. The value of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
 
   /// @param b A `bytes[3]` array. The elements of this array, in order are:
   /// * 1. Reputation key The key of the reputation being changed that the disagreement is over.
   /// * 2. previousNewReputationKey The key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
   /// * 3. adjacentReputationKey Key for a reputation already in the tree adjacent to the new reputation being inserted, if required.
+  /// * 4  The key of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree
+  /// * 5. The key of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
 
   /// @param reputationSiblings The siblings of the Merkle proof that the reputation corresponding to `_reputationKey` is in the reputation state before and after the disagreement
   /// @param agreeStateSiblings The siblings of the Merkle proof that the last reputation state the submitted hashes agreed on is in this submitted hash's justification tree

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -137,8 +137,8 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @dev If you know that the disagreement doesn't involve a new reputation being added, the arguments corresponding to the previous new reputation can be zeroed, as they will not be used. You must be sure
   /// that this is the case, however, otherwise you risk being found incorrect. Zeroed arguments will result in a cheaper call to this function.
   function respondToChallenge(
-    uint256[28] memory u, //An array of 28 UINT Params, ordered as given above.
-    bytes[4] memory b,
+    uint256[29] memory u, //An array of 29 UINT Params, ordered as given above.
+    bytes[5] memory b,
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings,

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -113,13 +113,13 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// * 17. The UID that the most recently added entry in the tree has in the state being disputed
   /// * 18. The amount of reputation that the user's origin reputation entry in the tree has in the state being disputed
   /// * 19. The UID that the user's origin reputation entry in the tree has in the state being disputed
-  /// * 20. The branchMask of the proof that the child reputation for the user being updated is in the agree state 
+  /// * 20. The branchMask of the proof that the child reputation for the user being updated is in the agree state
   /// * 21. The amount of reputation that the child reputation for the user being updated is in the agree state
-  /// * 22. The UID of the child reputation for the user being updated in the agree state 
+  /// * 22. The UID of the child reputation for the user being updated in the agree state
   /// * 23. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code.
-  /// * 24. The branchMask of the proof that the reputation adjacent to the new reputation being inserted is in the agree state 
+  /// * 24. The branchMask of the proof that the reputation adjacent to the new reputation being inserted is in the agree state
   /// * 25. The amount of reputation that the reputation adjacent to a new reputation being inserted has in the agree state
-  /// * 26. The UID of the reputation adjacent to the new reputation being inserted 
+  /// * 26. The UID of the reputation adjacent to the new reputation being inserted
   /// * 27. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code.
 
   /// @param b A `bytes[3]` array. The elements of this array, in order are:
@@ -137,8 +137,8 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @dev If you know that the disagreement doesn't involve a new reputation being added, the arguments corresponding to the previous new reputation can be zeroed, as they will not be used. You must be sure
   /// that this is the case, however, otherwise you risk being found incorrect. Zeroed arguments will result in a cheaper call to this function.
   function respondToChallenge(
-    uint256[27] memory u, //An array of 27 UINT Params, ordered as given above.
-    bytes[3] memory b,
+    uint256[28] memory u, //An array of 28 UINT Params, ordered as given above.
+    bytes[4] memory b,
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings,

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -676,6 +676,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       // They successfully proved the user origin value is in the lastAgreeState, so we're done here
       return;
     }
+    require(u[U_USER_ORIGIN_REPUTATION_VALUE] == 0, "colony-reputation-mining-origin-reputation-nonzero");
 
     // Otherwise, maybe the user's origin skill doesn't exist. If that's true, they can prove it.
     // In which case, the proof they supplied should be for a reputation that proves the origin reputation doesn't exist in the tree
@@ -734,6 +735,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       // They successfully proved the user origin value is in the lastAgreeState, so we're done here
       return;
     }
+
+    require(u[U_CHILD_REPUTATION_VALUE] == 0, "colony-reputation-mining-child-reputation-nonzero");
 
     // Otherwise, maybe the child skill doesn't exist. If that's true, they can prove it.
     // In which case, the proof they supplied should be for a reputation that proves the child reputation doesn't exist in the tree

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -79,17 +79,19 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   uint constant U_ADJACENT_REPUTATION_VALUE = 24;
   uint constant U_ADJACENT_REPUTATION_UID = 25;
   uint constant U_NEW_REPUTATION = 26;
+  uint constant U_USER_ORIGIN_ADJACENT_REPUTATION_VALUE = 27;
 
   uint constant B_REPUTATION_KEY = 0;
   uint constant B_PREVIOUS_NEW_REPUTATION_KEY = 1;
   uint constant B_ADJACENT_REPUTATION_KEY = 2;
+  uint constant B_ORIGIN_ADJACENT_REPUTATION_KEY = 3;
 
   uint constant DECAY_NUMERATOR =    992327946262944; // 24-hr mining cycles
   uint constant DECAY_DENOMINATOR = 1000000000000000;
 
   function respondToChallenge(
-    uint256[27] memory u, //An array of 27 UINT Params, ordered as given above.
-    bytes[3] memory b, // An array of 3 bytes params, ordered as given above
+    uint256[28] memory u, //An array of 28 UINT Params, ordered as given above.
+    bytes[4] memory b, // An array of 4 bytes params, ordered as given above
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings,
@@ -168,8 +170,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   /////////////////////////
 
   function checkAdjacentReputation(
-    uint256[27] memory u,
-    bytes[3] memory b,
+    uint256[28] memory u,
+    bytes[4] memory b,
     bytes32[] memory adjacentReputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings
@@ -216,8 +218,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function buildNewSiblingsArray(
-    uint256[27] memory u,
-    bytes[3] memory b,
+    uint256[28] memory u,
+    bytes[4] memory b,
     uint256 firstDifferenceBit,
     bytes32[] memory adjacentReputationSiblings
     ) internal returns (bytes32[] memory)
@@ -266,8 +268,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function checkUserOriginReputation(
-    uint256[27] memory u,
-    bytes[3] memory b,
+    uint256[28] memory u,
+    bytes[4] memory b,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory userOriginReputationSiblings) internal
   {
@@ -288,12 +290,13 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       u,
       agreeStateSiblings,
       userOriginReputationKeyBytes,
-      userOriginReputationSiblings);
+      userOriginReputationSiblings,
+      b[B_ORIGIN_ADJACENT_REPUTATION_KEY]);
   }
 
   function checkChildReputation(
-    uint256[27] memory u,
-    bytes[3] memory b,
+    uint256[28] memory u,
+    bytes[4] memory b,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory childReputationSiblings) internal
   {
@@ -311,13 +314,13 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       childReputationSiblings);
   }
 
-  function confirmChallengeCompleted(uint256[27] memory u) internal {
+  function confirmChallengeCompleted(uint256[28] memory u) internal {
     // If everthing checked out, note that we've responded to the challenge.
     disputeRounds[u[U_ROUND]][u[U_IDX]].challengeStepCompleted += 1;
     disputeRounds[u[U_ROUND]][u[U_IDX]].lastResponseTimestamp = now;
   }
 
-  function checkKey(uint256[27] memory u, bytes[3] memory b) internal view {
+  function checkKey(uint256[28] memory u, bytes[4] memory b) internal view {
     // If the state transition we're checking is less than the number of nodes in the currently accepted state, it's a decay transition
     // Otherwise, look up the corresponding entry in the reputation log.
     uint256 updateNumber = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1;
@@ -329,14 +332,14 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     }
   }
 
-  function checkKeyDecay(uint256[27] memory u, uint256 _updateNumber) internal pure {
+  function checkKeyDecay(uint256[28] memory u, uint256 _updateNumber) internal pure {
     // We check that the reputation UID is right for the decay transition being disputed.
     // The key is then implicitly checked when they prove that the key+value they supplied is in the
     // right intermediate state in their justification tree.
     require(u[U_AGREE_STATE_REPUTATION_UID]-1 == _updateNumber, "colony-reputation-mining-uid-not-decay");
   }
 
-  function checkKeyLogEntry(uint256[27] memory u, bytes[3] memory b) internal view {
+  function checkKeyLogEntry(uint256[28] memory u, bytes[4] memory b) internal view {
     ReputationLogEntry storage logEntry = reputationUpdateLog[u[U_LOG_ENTRY_NUMBER]];
 
     uint256 expectedSkillId;
@@ -361,7 +364,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     require(expectedSkillId == skillId, "colony-reputation-mining-skill-id-mismatch");
   }
 
-  function getExpectedSkillIdAndAddress(uint256[27] memory u, ReputationLogEntry storage logEntry) internal view
+  function getExpectedSkillIdAndAddress(uint256[28] memory u, ReputationLogEntry storage logEntry) internal view
   returns (uint256 expectedSkillId, address expectedAddress)
   {
     uint256 relativeUpdateNumber = getRelativeUpdateNumber(u, logEntry);
@@ -392,8 +395,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function proveBeforeReputationValue(
-    uint256[27] memory u,
-    bytes[3] memory b,
+    uint256[28] memory u,
+    bytes[4] memory b,
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings
   ) internal
@@ -435,8 +438,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function proveAfterReputationValue(
-    uint256[27] memory u,
-    bytes[3] memory b,
+    uint256[28] memory u,
+    bytes[4] memory b,
     bytes32[] memory reputationSiblings,
     bytes32[] memory disagreeStateSiblings
   ) internal view
@@ -465,7 +468,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function performReputationCalculation(
-    uint256[27] memory u
+    uint256[28] memory u
   ) internal
   {
 
@@ -481,7 +484,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function proveUID(
-    uint256[27] memory u,
+    uint256[28] memory u,
     uint256 _agreeStateReputationUID,
     uint256 _disagreeStateReputationUID
   ) internal
@@ -498,7 +501,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function proveValue(
-    uint256[27] memory u,
+    uint256[28] memory u,
     int256 _agreeStateReputationValue,
     int256 _disagreeStateReputationValue
   ) internal
@@ -578,7 +581,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
   // Get the update number relative in the context of the log entry currently considered
   // e.g. for log entry with 6 updates, the relative update number range is [0 .. 5] (inclusive)
-  function getRelativeUpdateNumber(uint256[27] memory u, ReputationLogEntry memory logEntry) internal view returns (uint256) {
+  function getRelativeUpdateNumber(uint256[28] memory u, ReputationLogEntry memory logEntry) internal view returns (uint256) {
     uint256 nNodes = IColonyNetwork(colonyNetworkAddress).getReputationRootHashNNodes();
     uint256 updateNumber = sub(sub(disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound, 1), nNodes);
 
@@ -592,7 +595,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     return relativeUpdateNumber;
   }
 
-  function getChildAndParentNUpdatesForLogEntry(uint256[27] memory u) internal view returns (uint128, uint128) {
+  function getChildAndParentNUpdatesForLogEntry(uint256[28] memory u) internal view returns (uint128, uint128) {
     ReputationLogEntry storage logEntry = reputationUpdateLog[u[U_LOG_ENTRY_NUMBER]];
     uint128 nParents = IColonyNetwork(colonyNetworkAddress).getSkill(logEntry.skillId).nParents;
 
@@ -607,8 +610,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function checkPreviousReputationInState(
-    uint256[27] memory u,
-    bytes[3] memory b,
+    uint256[28] memory u,
+    bytes[4] memory b,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory previousNewReputationSiblings
     ) internal view
@@ -631,11 +634,21 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     require(impliedRoot == disputeRounds[u[U_ROUND]][u[U_IDX]].jrh, "colony-reputation-mining-last-state-disagreement");
   }
 
+  function checkKeysAdjacent(bytes key1, bytes key2, uint256 branchMask) internal returns (bool) {
+    // The bit that would be added to the branchmask is based on where the (hashes of the) two keys first differ.
+    uint256 firstDifferenceBit = uint256(Bits.highestBitSet(uint256(keccak256(key1) ^ keccak256(key2))));
+    uint256 afterInsertionBranchMask = branchMask | uint256(2**firstDifferenceBit);
+    // If key1 and key2 both exist in a tree, there will already be a branch at the first difference bit,
+    // and so the branchmask will be unchanged.
+    return afterInsertionBranchMask != branchMask;
+  }
+
   function checkUserOriginReputationInState(
-    uint256[27] memory u,
+    uint256[28] memory u,
     bytes32[] memory agreeStateSiblings,
     bytes memory userOriginReputationKeyBytes,
-    bytes32[] memory userOriginReputationStateSiblings
+    bytes32[] memory userOriginReputationStateSiblings,
+    bytes memory userOriginAdjacentReputationKeyBytes
     ) internal
   {
     // We binary searched to the first disagreement, so the last agreement is the one before
@@ -657,18 +670,40 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
     bytes32 jrh = disputeRounds[u[U_ROUND]][u[U_IDX]].jrh;
     if (u[U_USER_ORIGIN_REPUTATION_VALUE] == 0 && impliedRoot != jrh) {
-      // This implies they are claiming that this is a new hash.
+      // This implies they are claiming that the origin reputation doesn't exist in the tree
+      // In which case, the proof they supplied should be for a reputation that proves the origin reputation doesn't exist in the tree
+      require(
+        checkKeysAdjacent(userOriginReputationKeyBytes, userOriginAdjacentReputationKeyBytes, u[U_USER_ORIGIN_SKILL_REPUTATION_BRANCH_MASK]),
+        "colony-reputation-mining-adjacent-origin-not-adjacent-or-already-exists"
+      );
+      // We assume that the proof they supplied is for the origin-adjacent reputation, not the origin reputation.
+      // So use the key and value for the origin-adjacent reputation, but uid, branchmask and siblings that were supplied.
+      bytes memory userOriginAdjacentReputationValueBytes = abi.encodePacked(u[U_USER_ORIGIN_ADJACENT_REPUTATION_VALUE], u[U_USER_ORIGIN_REPUTATION_UID]);
+
+      // Check that the key supplied actually exists in the tree
+      reputationRootHash = getImpliedRootHashKey(
+        userOriginAdjacentReputationKeyBytes,
+        userOriginAdjacentReputationValueBytes,
+        u[U_USER_ORIGIN_SKILL_REPUTATION_BRANCH_MASK],
+        userOriginReputationStateSiblings
+      );
+      jhLeafValue = abi.encodePacked(uint256(reputationRootHash), u[U_AGREE_STATE_NNODES]);
+
+      // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
+      impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
+      require(impliedRoot == jrh, "colony-reputation-mining-origin-adjacent-proof-invalid");
+
       return;
     }
 
     require(impliedRoot == jrh, "colony-reputation-mining-origin-skill-state-disagreement");
-    disputeRounds[u[U_ROUND]][u[U_IDX]].challengeStepCompleted += 1;
+    /* disputeRounds[u[U_ROUND]][u[U_IDX]].challengeStepCompleted += 1; */
     // If the submission has proved that the reputation already exists in the tree, we give it extra 'challengeStepCompleted' so that if
     // its opponent got a different state by ignoring an existing reputation in the tree, we still out-score them.
   }
 
   function checkChildReputationInState(
-    uint256[27] memory u,
+    uint256[28] memory u,
     bytes32[] memory agreeStateSiblings,
     bytes memory childReputationKey,
     bytes32[] memory childReputationStateSiblings
@@ -703,7 +738,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     // its opponent got a different state by ignoring an existing reputation in the tree, we still out-score them.
   }
 
-  function saveProvedReputation(uint256[27] memory u) internal {
+  function saveProvedReputation(uint256[28] memory u) internal {
     // Require that it is at least plausible
     uint256 delta = disputeRounds[u[U_ROUND]][u[U_IDX]].intermediateReputationNNodes - u[U_PREVIOUS_NEW_REPUTATION_UID];
     // Could be zero if this is an update to an existing reputation, or it could be 1 if we have just added a new

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -564,13 +564,13 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
               reputationChange = childReputationChange;
             }
           }
-          
+
         } else {
           // Cap change based on origin reputation value
           // Note we are not worried about underflows here; colony-wide totals for origin skill and all parents are greater than or equal to a user's origin skill.
           // If we're subtracting the origin reputation value, we therefore can't underflow, and if we're subtracting the logEntryAmount, it was absolutely smaller than
           // the origin reputation value, and so can't underflow either.
-          if (int256(u[U_USER_ORIGIN_REPUTATION_VALUE]) + logEntry.amount < 0) {
+          if (int256(userOriginReputationValue) + logEntry.amount < 0) {
             reputationChange = -1 * int256(u[U_USER_ORIGIN_REPUTATION_VALUE]);
           } else {
             reputationChange = logEntry.amount;
@@ -639,7 +639,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     require(impliedRoot == disputeRounds[u[U_ROUND]][u[U_IDX]].jrh, "colony-reputation-mining-last-state-disagreement");
   }
 
-  function checkKeysAdjacent(bytes key1, bytes key2, uint256 branchMask) internal returns (bool) {
+  function checkKeysAdjacent(bytes memory key1, bytes memory key2, uint256 branchMask) internal returns (bool) {
     // The bit that would be added to the branchmask is based on where the (hashes of the) two keys first differ.
     uint256 firstDifferenceBit = uint256(Bits.highestBitSet(uint256(keccak256(key1) ^ keccak256(key2))));
     uint256 afterInsertionBranchMask = branchMask | uint256(2**firstDifferenceBit);

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -80,18 +80,20 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   uint constant U_ADJACENT_REPUTATION_UID = 25;
   uint constant U_NEW_REPUTATION = 26;
   uint constant U_USER_ORIGIN_ADJACENT_REPUTATION_VALUE = 27;
+  uint constant U_CHILD_ADJACENT_REPUTATION_VALUE = 28;
 
   uint constant B_REPUTATION_KEY = 0;
   uint constant B_PREVIOUS_NEW_REPUTATION_KEY = 1;
   uint constant B_ADJACENT_REPUTATION_KEY = 2;
   uint constant B_ORIGIN_ADJACENT_REPUTATION_KEY = 3;
+  uint constant B_CHILD_ADJACENT_REPUTATION_KEY = 4;
 
   uint constant DECAY_NUMERATOR =    992327946262944; // 24-hr mining cycles
   uint constant DECAY_DENOMINATOR = 1000000000000000;
 
   function respondToChallenge(
-    uint256[28] memory u, //An array of 28 UINT Params, ordered as given above.
-    bytes[4] memory b, // An array of 4 bytes params, ordered as given above
+    uint256[29] memory u, //An array of 29 UINT Params, ordered as given above.
+    bytes[5] memory b, // An array of 5 bytes params, ordered as given above
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings,
@@ -170,8 +172,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   /////////////////////////
 
   function checkAdjacentReputation(
-    uint256[28] memory u,
-    bytes[4] memory b,
+    uint256[29] memory u,
+    bytes[5] memory b,
     bytes32[] memory adjacentReputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings
@@ -218,8 +220,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function buildNewSiblingsArray(
-    uint256[28] memory u,
-    bytes[4] memory b,
+    uint256[29] memory u,
+    bytes[5] memory b,
     uint256 firstDifferenceBit,
     bytes32[] memory adjacentReputationSiblings
     ) internal returns (bytes32[] memory)
@@ -268,8 +270,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function checkUserOriginReputation(
-    uint256[28] memory u,
-    bytes[4] memory b,
+    uint256[29] memory u,
+    bytes[5] memory b,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory userOriginReputationSiblings) internal
   {
@@ -295,8 +297,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function checkChildReputation(
-    uint256[28] memory u,
-    bytes[4] memory b,
+    uint256[29] memory u,
+    bytes[5] memory b,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory childReputationSiblings) internal
   {
@@ -311,16 +313,17 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       u,
       agreeStateSiblings,
       childReputationKey,
-      childReputationSiblings);
+      childReputationSiblings,
+      b[B_CHILD_ADJACENT_REPUTATION_KEY]);
   }
 
-  function confirmChallengeCompleted(uint256[28] memory u) internal {
+  function confirmChallengeCompleted(uint256[29] memory u) internal {
     // If everthing checked out, note that we've responded to the challenge.
     disputeRounds[u[U_ROUND]][u[U_IDX]].challengeStepCompleted += 1;
     disputeRounds[u[U_ROUND]][u[U_IDX]].lastResponseTimestamp = now;
   }
 
-  function checkKey(uint256[28] memory u, bytes[4] memory b) internal view {
+  function checkKey(uint256[29] memory u, bytes[5] memory b) internal view {
     // If the state transition we're checking is less than the number of nodes in the currently accepted state, it's a decay transition
     // Otherwise, look up the corresponding entry in the reputation log.
     uint256 updateNumber = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1;
@@ -332,14 +335,14 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     }
   }
 
-  function checkKeyDecay(uint256[28] memory u, uint256 _updateNumber) internal pure {
+  function checkKeyDecay(uint256[29] memory u, uint256 _updateNumber) internal pure {
     // We check that the reputation UID is right for the decay transition being disputed.
     // The key is then implicitly checked when they prove that the key+value they supplied is in the
     // right intermediate state in their justification tree.
     require(u[U_AGREE_STATE_REPUTATION_UID]-1 == _updateNumber, "colony-reputation-mining-uid-not-decay");
   }
 
-  function checkKeyLogEntry(uint256[28] memory u, bytes[4] memory b) internal view {
+  function checkKeyLogEntry(uint256[29] memory u, bytes[5] memory b) internal view {
     ReputationLogEntry storage logEntry = reputationUpdateLog[u[U_LOG_ENTRY_NUMBER]];
 
     uint256 expectedSkillId;
@@ -364,7 +367,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     require(expectedSkillId == skillId, "colony-reputation-mining-skill-id-mismatch");
   }
 
-  function getExpectedSkillIdAndAddress(uint256[28] memory u, ReputationLogEntry storage logEntry) internal view
+  function getExpectedSkillIdAndAddress(uint256[29] memory u, ReputationLogEntry storage logEntry) internal view
   returns (uint256 expectedSkillId, address expectedAddress)
   {
     uint256 relativeUpdateNumber = getRelativeUpdateNumber(u, logEntry);
@@ -395,8 +398,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function proveBeforeReputationValue(
-    uint256[28] memory u,
-    bytes[4] memory b,
+    uint256[29] memory u,
+    bytes[5] memory b,
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings
   ) internal
@@ -438,8 +441,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function proveAfterReputationValue(
-    uint256[28] memory u,
-    bytes[4] memory b,
+    uint256[29] memory u,
+    bytes[5] memory b,
     bytes32[] memory reputationSiblings,
     bytes32[] memory disagreeStateSiblings
   ) internal view
@@ -468,7 +471,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function performReputationCalculation(
-    uint256[28] memory u
+    uint256[29] memory u
   ) internal
   {
 
@@ -484,7 +487,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function proveUID(
-    uint256[28] memory u,
+    uint256[29] memory u,
     uint256 _agreeStateReputationUID,
     uint256 _disagreeStateReputationUID
   ) internal
@@ -501,7 +504,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function proveValue(
-    uint256[28] memory u,
+    uint256[29] memory u,
     int256 _agreeStateReputationValue,
     int256 _disagreeStateReputationValue
   ) internal
@@ -581,7 +584,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
   // Get the update number relative in the context of the log entry currently considered
   // e.g. for log entry with 6 updates, the relative update number range is [0 .. 5] (inclusive)
-  function getRelativeUpdateNumber(uint256[28] memory u, ReputationLogEntry memory logEntry) internal view returns (uint256) {
+  function getRelativeUpdateNumber(uint256[29] memory u, ReputationLogEntry memory logEntry) internal view returns (uint256) {
     uint256 nNodes = IColonyNetwork(colonyNetworkAddress).getReputationRootHashNNodes();
     uint256 updateNumber = sub(sub(disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound, 1), nNodes);
 
@@ -595,7 +598,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     return relativeUpdateNumber;
   }
 
-  function getChildAndParentNUpdatesForLogEntry(uint256[28] memory u) internal view returns (uint128, uint128) {
+  function getChildAndParentNUpdatesForLogEntry(uint256[29] memory u) internal view returns (uint128, uint128) {
     ReputationLogEntry storage logEntry = reputationUpdateLog[u[U_LOG_ENTRY_NUMBER]];
     uint128 nParents = IColonyNetwork(colonyNetworkAddress).getSkill(logEntry.skillId).nParents;
 
@@ -610,8 +613,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function checkPreviousReputationInState(
-    uint256[28] memory u,
-    bytes[4] memory b,
+    uint256[29] memory u,
+    bytes[5] memory b,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory previousNewReputationSiblings
     ) internal view
@@ -644,7 +647,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   }
 
   function checkUserOriginReputationInState(
-    uint256[28] memory u,
+    uint256[29] memory u,
     bytes32[] memory agreeStateSiblings,
     bytes memory userOriginReputationKeyBytes,
     bytes32[] memory userOriginReputationStateSiblings,
@@ -669,44 +672,44 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
 
     bytes32 jrh = disputeRounds[u[U_ROUND]][u[U_IDX]].jrh;
-    if (u[U_USER_ORIGIN_REPUTATION_VALUE] == 0 && impliedRoot != jrh) {
-      // This implies they are claiming that the origin reputation doesn't exist in the tree
-      // In which case, the proof they supplied should be for a reputation that proves the origin reputation doesn't exist in the tree
-      require(
-        checkKeysAdjacent(userOriginReputationKeyBytes, userOriginAdjacentReputationKeyBytes, u[U_USER_ORIGIN_SKILL_REPUTATION_BRANCH_MASK]),
-        "colony-reputation-mining-adjacent-origin-not-adjacent-or-already-exists"
-      );
-      // We assume that the proof they supplied is for the origin-adjacent reputation, not the origin reputation.
-      // So use the key and value for the origin-adjacent reputation, but uid, branchmask and siblings that were supplied.
-      bytes memory userOriginAdjacentReputationValueBytes = abi.encodePacked(u[U_USER_ORIGIN_ADJACENT_REPUTATION_VALUE], u[U_USER_ORIGIN_REPUTATION_UID]);
-
-      // Check that the key supplied actually exists in the tree
-      reputationRootHash = getImpliedRootHashKey(
-        userOriginAdjacentReputationKeyBytes,
-        userOriginAdjacentReputationValueBytes,
-        u[U_USER_ORIGIN_SKILL_REPUTATION_BRANCH_MASK],
-        userOriginReputationStateSiblings
-      );
-      jhLeafValue = abi.encodePacked(uint256(reputationRootHash), u[U_AGREE_STATE_NNODES]);
-
-      // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
-      impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
-      require(impliedRoot == jrh, "colony-reputation-mining-origin-adjacent-proof-invalid");
-
+    if (impliedRoot == jrh) {
+      // They successfully proved the user origin value is in the lastAgreeState, so we're done here
       return;
     }
 
-    require(impliedRoot == jrh, "colony-reputation-mining-origin-skill-state-disagreement");
-    /* disputeRounds[u[U_ROUND]][u[U_IDX]].challengeStepCompleted += 1; */
-    // If the submission has proved that the reputation already exists in the tree, we give it extra 'challengeStepCompleted' so that if
-    // its opponent got a different state by ignoring an existing reputation in the tree, we still out-score them.
+    // Otherwise, maybe the user's origin skill doesn't exist. If that's true, they can prove it.
+    // In which case, the proof they supplied should be for a reputation that proves the origin reputation doesn't exist in the tree
+    require(
+      checkKeysAdjacent(userOriginReputationKeyBytes, userOriginAdjacentReputationKeyBytes, u[U_USER_ORIGIN_SKILL_REPUTATION_BRANCH_MASK]),
+      "colony-reputation-mining-adjacent-origin-not-adjacent-or-already-exists"
+    );
+    // We assume that the proof they supplied is for the origin-adjacent reputation, not the origin reputation.
+    // So use the key and value for the origin-adjacent reputation, but uid, branchmask and siblings that were supplied.
+    bytes memory userOriginAdjacentReputationValueBytes = abi.encodePacked(
+      u[U_USER_ORIGIN_ADJACENT_REPUTATION_VALUE],
+      u[U_USER_ORIGIN_REPUTATION_UID]
+    );
+
+    // Check that the key supplied actually exists in the tree
+    reputationRootHash = getImpliedRootHashKey(
+      userOriginAdjacentReputationKeyBytes,
+      userOriginAdjacentReputationValueBytes,
+      u[U_USER_ORIGIN_SKILL_REPUTATION_BRANCH_MASK],
+      userOriginReputationStateSiblings
+    );
+    jhLeafValue = abi.encodePacked(uint256(reputationRootHash), u[U_AGREE_STATE_NNODES]);
+
+    // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
+    impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
+    require(impliedRoot == jrh, "colony-reputation-mining-origin-adjacent-proof-invalid");
   }
 
   function checkChildReputationInState(
-    uint256[28] memory u,
+    uint256[29] memory u,
     bytes32[] memory agreeStateSiblings,
     bytes memory childReputationKey,
-    bytes32[] memory childReputationStateSiblings
+    bytes32[] memory childReputationStateSiblings,
+    bytes memory childAdjacentReputationKey
     ) internal
   {
     // We binary searched to the first disagreement, so the last agreement is the one before
@@ -727,18 +730,36 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
 
     bytes32 jrh = disputeRounds[u[U_ROUND]][u[U_IDX]].jrh;
-    if (u[U_CHILD_REPUTATION_VALUE] == 0 && impliedRoot != jrh) {
-      // This implies they are claiming that this is a new hash.
+    if (impliedRoot == jrh) {
+      // They successfully proved the user origin value is in the lastAgreeState, so we're done here
       return;
     }
 
-    require(impliedRoot == jrh, "colony-reputation-mining-child-skill-state-disagreement");
-    disputeRounds[u[U_ROUND]][u[U_IDX]].challengeStepCompleted += 1;
-    // If the submission has proved that the reputation already exists in the tree, we give it extra 'challengeStepCompleted' so that if
-    // its opponent got a different state by ignoring an existing reputation in the tree, we still out-score them.
+    // Otherwise, maybe the child skill doesn't exist. If that's true, they can prove it.
+    // In which case, the proof they supplied should be for a reputation that proves the child reputation doesn't exist in the tree
+    require(
+      checkKeysAdjacent(childReputationKey, childAdjacentReputationKey, u[U_CHILD_REPUTATION_BRANCH_MASK]),
+      "colony-reputation-mining-adjacent-child-not-adjacent-or-already-exists"
+    );
+    // We assume that the proof they supplied is for the child-adjacent reputation, not the child reputation.
+    // So use the key and value for the child-adjacent reputation, but uid, branchmask and siblings that were supplied.
+    bytes memory childAdjacentReputationValueBytes = abi.encodePacked(u[U_CHILD_ADJACENT_REPUTATION_VALUE], u[U_CHILD_REPUTATION_UID]);
+
+    // Check that the key supplied actually exists in the tree
+    reputationRootHash = getImpliedRootHashKey(
+      childAdjacentReputationKey,
+      childAdjacentReputationValueBytes,
+      u[U_CHILD_REPUTATION_BRANCH_MASK],
+      childReputationStateSiblings
+    );
+    jhLeafValue = abi.encodePacked(uint256(reputationRootHash), u[U_AGREE_STATE_NNODES]);
+
+    // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
+    impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
+    require(impliedRoot == jrh, "colony-reputation-mining-child-adjacent-proof-invalid");
   }
 
-  function saveProvedReputation(uint256[28] memory u) internal {
+  function saveProvedReputation(uint256[29] memory u) internal {
     // Require that it is at least plausible
     uint256 delta = disputeRounds[u[U_ROUND]][u[U_IDX]].intermediateReputationNNodes - u[U_PREVIOUS_NEW_REPUTATION_UID];
     // Could be zero if this is an update to an existing reputation, or it could be 1 if we have just added a new

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -570,8 +570,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
           // Note we are not worried about underflows here; colony-wide totals for origin skill and all parents are greater than or equal to a user's origin skill.
           // If we're subtracting the origin reputation value, we therefore can't underflow, and if we're subtracting the logEntryAmount, it was absolutely smaller than
           // the origin reputation value, and so can't underflow either.
-          if (int256(userOriginReputationValue) + logEntry.amount < 0) {
-            reputationChange = -1 * int256(u[U_USER_ORIGIN_REPUTATION_VALUE]);
+          if (userOriginReputationValue + logEntry.amount < 0) {
+            reputationChange = -1 * userOriginReputationValue;
           } else {
             reputationChange = logEntry.amount;
           }

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -26,7 +26,7 @@ class ReputationMiner {
     this.useJsTree = useJsTree;
     if (!this.useJsTree) {
       // If this require is global, line numbers are broken in all our tests. If we move it here, it's only an issue if we're not
-      // using the JS tree. There is an issue open at ganache-core about this, and this require will have to remain here until it's fixed. 
+      // using the JS tree. There is an issue open at ganache-core about this, and this require will have to remain here until it's fixed.
       // https://github.com/trufflesuite/ganache-core/issues/287
       const ganache = require("ganache-core"); // eslint-disable-line global-require
       const ganacheProvider = ganache.provider({
@@ -211,6 +211,7 @@ class ReputationMiner {
     let jhLeafValue;
     let justUpdatedProof;
     let originReputationProof;
+    let originAdjacentReputationProof = await this.getReputationProofObject("0x00");;
     let childReputationProof = await this.getReputationProofObject("0x00");
     let adjacentReputationProof = await this.getReputationProofObject("0x00");
     let logEntry;
@@ -258,7 +259,7 @@ class ReputationMiner {
         const relativeUpdateNumber = updateNumber.sub(logEntry.nPreviousUpdates).sub(this.nReputationsBeforeLatestLog);
         // Child updates are two sets: colonywide sums for children - located in the first nChildUpdates,
         // and user-specific updates located in the first nChildUpdates of the second half of the nUpdates set.
-        
+
         // Get current reputation amount of the origin skill, which is positioned at the end of the current logEntry nUpdates.
         const originSkillUpdateNumber = updateNumber.sub(relativeUpdateNumber).add(nUpdates).sub(1);
         const originSkillKey = await this.getKeyForUpdateNumber(originSkillUpdateNumber);
@@ -272,6 +273,10 @@ class ReputationMiner {
           originReputation = ethers.utils.bigNumberify(`0x${originReputationValueBytes.slice(2, 66)}`);
         } else {
           originReputation = ethers.utils.bigNumberify("0");
+          // Get the proof for the reputation that exists in the tree that would be the adjacent reputation.
+          // We use this to prove that the origin reputation doesn't exist
+          const originAdjacentKey = await this.getAdjacentKey(originSkillKey);
+          originAdjacentReputationProof = await this.getReputationProofObject(originAdjacentKey);
         }
 
         if (
@@ -305,8 +310,8 @@ class ReputationMiner {
             }
           }
         } else if (originReputation.lt(amount.mul(-1))) {
-          // If the 'if' above didn't match, it's either an origin or a parent skill update. 
-          // We can't lose more reputation in an origin or parent skill than we have in the origin skill. 
+          // If the 'if' above didn't match, it's either an origin or a parent skill update.
+          // We can't lose more reputation in an origin or parent skill than we have in the origin skill.
           // Cap change based on origin skill if needed.
           amount = originReputation.mul(-1);
         }
@@ -350,7 +355,8 @@ class ReputationMiner {
         newestReputationProof,
         originReputationProof,
         childReputationProof,
-        adjacentReputationProof
+        adjacentReputationProof,
+        originAdjacentReputationProof
       })
     );
     // console.log("updateNumber", updateNumber.toString());
@@ -875,49 +881,60 @@ class ReputationMiner {
     if (lastAgreeIdx.gte(this.nReputationsBeforeLatestLog)) {
       logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(lastAgreeIdx.sub(this.nReputationsBeforeLatestLog));
     }
+    const lastAgreeJustifications = this.justificationHashes[lastAgreeKey];
+    const firstDisagreeJustifications = this.justificationHashes[firstDisagreeIdx];
+
+    if (lastAgreeJustifications.originAdjacentReputationProof.key !== "0x00") {
+      // We generated the origin-adjacent reputation proof. We replace the origin proof with the originAdjacentReputationProof
+      lastAgreeJustifications.originReputationProof.uid = lastAgreeJustifications.originAdjacentReputationProof.uid;
+      lastAgreeJustifications.originReputationProof.branchMask = lastAgreeJustifications.originAdjacentReputationProof.branchMask;
+      lastAgreeJustifications.originReputationProof.siblings = lastAgreeJustifications.originAdjacentReputationProof.siblings;
+    }
 
     return repCycle.respondToChallenge(
       [
         round,
         index,
-        this.justificationHashes[firstDisagreeKey].justUpdatedProof.branchMask,
-        this.justificationHashes[lastAgreeKey].nextUpdateProof.nNodes,
+        firstDisagreeJustifications.justUpdatedProof.branchMask,
+        lastAgreeJustifications.nextUpdateProof.nNodes,
         ReputationMiner.getHexString(agreeStateBranchMask),
-        this.justificationHashes[firstDisagreeKey].justUpdatedProof.nNodes,
+        firstDisagreeJustifications.justUpdatedProof.nNodes,
         ReputationMiner.getHexString(disagreeStateBranchMask),
-        this.justificationHashes[lastAgreeKey].newestReputationProof.branchMask,
+        lastAgreeJustifications.newestReputationProof.branchMask,
         logEntryNumber,
         "0",
-        this.justificationHashes[lastAgreeKey].originReputationProof.branchMask,
-        this.justificationHashes[lastAgreeKey].nextUpdateProof.reputation,
-        this.justificationHashes[lastAgreeKey].nextUpdateProof.uid,
-        this.justificationHashes[firstDisagreeKey].justUpdatedProof.reputation,
-        this.justificationHashes[firstDisagreeKey].justUpdatedProof.uid,
-        this.justificationHashes[lastAgreeKey].newestReputationProof.reputation,
-        this.justificationHashes[lastAgreeKey].newestReputationProof.uid,
-        this.justificationHashes[lastAgreeKey].originReputationProof.reputation,
-        this.justificationHashes[lastAgreeKey].originReputationProof.uid,
-        this.justificationHashes[lastAgreeKey].childReputationProof.branchMask,
-        this.justificationHashes[lastAgreeKey].childReputationProof.reputation,
-        this.justificationHashes[lastAgreeKey].childReputationProof.uid,
+        lastAgreeJustifications.originReputationProof.branchMask,
+        lastAgreeJustifications.nextUpdateProof.reputation,
+        lastAgreeJustifications.nextUpdateProof.uid,
+        firstDisagreeJustifications.justUpdatedProof.reputation,
+        firstDisagreeJustifications.justUpdatedProof.uid,
+        lastAgreeJustifications.newestReputationProof.reputation,
+        lastAgreeJustifications.newestReputationProof.uid,
+        lastAgreeJustifications.originReputationProof.reputation,
+        lastAgreeJustifications.originReputationProof.uid,
+        lastAgreeJustifications.childReputationProof.branchMask,
+        lastAgreeJustifications.childReputationProof.reputation,
+        lastAgreeJustifications.childReputationProof.uid,
         "0",
-        this.justificationHashes[lastAgreeKey].adjacentReputationProof.branchMask,
-        this.justificationHashes[lastAgreeKey].adjacentReputationProof.reputation,
-        this.justificationHashes[lastAgreeKey].adjacentReputationProof.uid,
-        "0"
+        lastAgreeJustifications.adjacentReputationProof.branchMask,
+        lastAgreeJustifications.adjacentReputationProof.reputation,
+        lastAgreeJustifications.adjacentReputationProof.uid,
+        "0",
+        lastAgreeJustifications.originAdjacentReputationProof.reputation
       ],
       [
         reputationKey,
-        this.justificationHashes[lastAgreeKey].newestReputationProof.key,
-        this.justificationHashes[lastAgreeKey].adjacentReputationProof.key
+        lastAgreeJustifications.newestReputationProof.key,
+        lastAgreeJustifications.adjacentReputationProof.key,
+        lastAgreeJustifications.originAdjacentReputationProof.key
       ],
-      this.justificationHashes[firstDisagreeKey].justUpdatedProof.siblings,
+      firstDisagreeJustifications.justUpdatedProof.siblings,
       agreeStateSiblings,
       disagreeStateSiblings,
-      this.justificationHashes[lastAgreeKey].newestReputationProof.siblings,
-      this.justificationHashes[lastAgreeKey].originReputationProof.siblings,
-      this.justificationHashes[lastAgreeKey].childReputationProof.siblings,
-      this.justificationHashes[lastAgreeKey].adjacentReputationProof.siblings,
+      lastAgreeJustifications.newestReputationProof.siblings,
+      lastAgreeJustifications.originReputationProof.siblings,
+      lastAgreeJustifications.childReputationProof.siblings,
+      lastAgreeJustifications.adjacentReputationProof.siblings,
       { gasLimit: 4000000 }
     );
   }

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -175,9 +175,9 @@ class ReputationMiner {
     const sortedHashes = Object.keys(this.reverseReputationHashLookup).sort();
     let keyPosition = sortedHashes.indexOf(soliditySha3(key));
     if (keyPosition === -1) {
-      sortedHashes.push(web3Utils.soliditySha3(key))
+      sortedHashes.push(soliditySha3(key))
       sortedHashes.sort()
-      keyPosition = sortedHashes.indexOf(web3Utils.soliditySha3(key));
+      keyPosition = sortedHashes.indexOf(soliditySha3(key));
     }
 
     let adjacentKeyPosition;
@@ -354,6 +354,7 @@ class ReputationMiner {
       const adjacentKey = await this.getAdjacentKey(key);
       adjacentReputationProof = await this.getReputationProofObject(adjacentKey);
     }
+
     this.justificationHashes[ReputationMiner.getHexString(updateNumber, 64)] = JSON.parse(
       JSON.stringify({
         interimHash,
@@ -893,16 +894,15 @@ class ReputationMiner {
     }
     const lastAgreeJustifications = this.justificationHashes[lastAgreeKey];
     const firstDisagreeJustifications = this.justificationHashes[firstDisagreeKey];
-    console.log(lastAgreeJustifications, firstDisagreeJustifications);
 
-    if (lastAgreeJustifications.originAdjacentReputationProof.key !== "0x00") {
+    if (this.justificationHashes[lastAgreeKey].originAdjacentReputationProof.key !== "0x00") {
       // We generated the origin-adjacent reputation proof. We replace the origin proof with the originAdjacentReputationProof
       lastAgreeJustifications.originReputationProof.uid = lastAgreeJustifications.originAdjacentReputationProof.uid;
       lastAgreeJustifications.originReputationProof.branchMask = lastAgreeJustifications.originAdjacentReputationProof.branchMask;
       lastAgreeJustifications.originReputationProof.siblings = lastAgreeJustifications.originAdjacentReputationProof.siblings;
     }
 
-    if (lastAgreeJustifications.childAdjacentReputationProof.key !== "0x00") {
+    if (this.justificationHashes[lastAgreeKey].childAdjacentReputationProof.key !== "0x00") {
       // We generated the child-adjacent reputation proof. We replace the child proof with the childAdjacentReputationProof
       lastAgreeJustifications.childReputationProof.uid = lastAgreeJustifications.childAdjacentReputationProof.uid;
       lastAgreeJustifications.childReputationProof.branchMask = lastAgreeJustifications.childAdjacentReputationProof.branchMask;

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimNoOriginReputation.js
@@ -23,6 +23,13 @@ class MaliciousReputationMinerClaimNoOriginReputation extends ReputationMinerTes
       const originSkillUpdateNumber = logEntry.nUpdates.add(logEntry.nPreviousUpdates).add(this.nReputationsBeforeLatestLog).sub(1);
       const originReputationKey = await this.getKeyForUpdateNumber(originSkillUpdateNumber);
       this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].originReputationProof.key = originReputationKey;
+
+      // Set the origin-adjacent key information, which is expected if we're
+      const originAdjacentKey = await this.getAdjacentKey(originReputationKey);
+      this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].originAdjacentReputationProof =
+        await this.getReputationProofObject(originAdjacentKey);
+      console.log(originAdjacentKey, originReputationKey);
+
       // Set the child skill key
       const relativeUpdateNumber = updateNumber.sub(this.nReputationsBeforeLatestLog).sub(logEntry.nPreviousUpdates);
       const {nUpdates} = logEntry;

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimNoUserChildReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimNoUserChildReputation.js
@@ -12,17 +12,36 @@ class MaliciousReputationMiningClaimNoUserChildReputation extends ReputationMine
 
   async addSingleReputationUpdate(updateNumber, repCycle, blockNumber, checkForReplacement) {
     let originProof;
+    let childAdjacentProof;
     let logEntry;
+    let relativeUpdateNumber;
+    let childKey;
+
     if (updateNumber.toNumber() === this.entryToFalsify){
       const logEntryUpdateNumber = updateNumber.sub(this.nReputationsBeforeLatestLog);
       const logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(logEntryUpdateNumber, blockNumber);
       logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber, { blockTag: blockNumber });
       const nUpdates = ethers.utils.bigNumberify(logEntry.nUpdates);
-      const relativeUpdateNumber = updateNumber.sub(logEntry.nPreviousUpdates).sub(this.nReputationsBeforeLatestLog);
+      relativeUpdateNumber = updateNumber.sub(logEntry.nPreviousUpdates).sub(this.nReputationsBeforeLatestLog);
       // Get current reputation amount of the origin skill, which is positioned at the end of the current logEntry nUpdates.
       const originSkillUpdateNumber = updateNumber.sub(relativeUpdateNumber).add(nUpdates).sub(1);
       const originSkillKey = await this.getKeyForUpdateNumber(originSkillUpdateNumber);
       originProof = await this.getReputationProofObject(originSkillKey);
+
+      // Get the child-adjacent proof
+      // First, get the (user) child skill key
+      const [nParents] = await this.colonyNetwork.getSkill(logEntry.skillId);
+      const nChildUpdates = nUpdates.div(2).sub(1).sub(nParents);
+      relativeUpdateNumber = updateNumber.sub(logEntry.nPreviousUpdates).sub(this.nReputationsBeforeLatestLog);
+      if (relativeUpdateNumber.lt(nChildUpdates)) {
+        const childSkillUpdateNumber = updateNumber.add(nUpdates.div(2));
+        childKey = await this.getKeyForUpdateNumber(childSkillUpdateNumber);
+      } else {
+        childKey = await this.getKeyForUpdateNumber(updateNumber);
+      }
+      const childAdjacentKey = await this.getAdjacentKey(childKey);
+      childAdjacentProof = await this.getReputationProofObject(childAdjacentKey);
+
     }
     await super.addSingleReputationUpdate(updateNumber, repCycle, blockNumber, checkForReplacement)
     if (updateNumber.toNumber() === this.entryToFalsify){
@@ -33,22 +52,13 @@ class MaliciousReputationMiningClaimNoUserChildReputation extends ReputationMine
       // (which is checked) and leave the other values alone.
       // The amount variable represents the change in the reputation being updated, which for a child update is always zero when there is no user child reputation.
       // The calculation is therefore self-consistent and will be able to pass respondToChallenge.
-
       // Set the origin proof
       this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].originReputationProof = originProof;
 
+      // Set the childAdjacentProof
+      this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].childAdjacentReputationProof = childAdjacentProof;
+
       // Set the child skill key
-      const relativeUpdateNumber = updateNumber.sub(this.nReputationsBeforeLatestLog).sub(logEntry.nPreviousUpdates);
-      const {nUpdates} = logEntry;
-      const [nParents] = await this.colonyNetwork.getSkill(logEntry.skillId);
-      const nChildUpdates = nUpdates.div(2).sub(1).sub(nParents);
-      let childKey;
-      if (relativeUpdateNumber.lt(nChildUpdates)) {
-        const childSkillUpdateNumber = updateNumber.add(nUpdates.div(2));
-        childKey = await this.getKeyForUpdateNumber(childSkillUpdateNumber);
-      } else {
-        childKey = await this.getKeyForUpdateNumber(updateNumber);
-      }
       this.justificationHashes[ReputationMinerTestWrapper.getHexString(updateNumber, 64)].childReputationProof.key = childKey;
     }
   }

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimNoUserChildReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimNoUserChildReputation.js
@@ -2,7 +2,7 @@ import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
 const ethers = require("ethers");
 
-class MaliciousReputationMiningClaimNoUserChildReputation extends ReputationMinerTestWrapper {
+class MaliciousReputationMinerClaimNoUserChildReputation extends ReputationMinerTestWrapper {
   // This client will claim there is no user child reputation, whether there is one or not
   //
   constructor(opts, entryToFalsify) {
@@ -72,4 +72,4 @@ class MaliciousReputationMiningClaimNoUserChildReputation extends ReputationMine
   }
 }
 
-export default MaliciousReputationMiningClaimNoUserChildReputation;
+export default MaliciousReputationMinerClaimNoUserChildReputation;

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimWrongChildReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimWrongChildReputation.js
@@ -2,7 +2,7 @@ import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
 const WRONG_ADDRESS = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 
-class MaliciousReputationMiningWrongChildReputation extends ReputationMinerTestWrapper {
+class MaliciousReputationMinerWrongChildReputation extends ReputationMinerTestWrapper {
   // This client will claim there is no originReputationUID, whether there is one or not
   //
   constructor(opts, whatToFalsify) {
@@ -28,4 +28,4 @@ class MaliciousReputationMiningWrongChildReputation extends ReputationMinerTestW
   }
 }
 
-export default MaliciousReputationMiningWrongChildReputation;
+export default MaliciousReputationMinerWrongChildReputation;

--- a/packages/reputation-miner/test/MaliciousReputationMinerClaimWrongOriginReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerClaimWrongOriginReputation.js
@@ -2,7 +2,7 @@ import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
 const WRONG_ADDRESS = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 
-class MaliciousReputationMiningWrongOriginReputation extends ReputationMinerTestWrapper {
+class MaliciousReputationMinerWrongOriginReputation extends ReputationMinerTestWrapper {
   // This client will claim there is no originReputationUID, whether there is one or not
   //
   constructor(opts, entryToFalsify, amountToFalsify, whatToFalsify) {
@@ -45,4 +45,4 @@ class MaliciousReputationMiningWrongOriginReputation extends ReputationMinerTest
 
 }
 
-export default MaliciousReputationMiningWrongOriginReputation;
+export default MaliciousReputationMinerWrongOriginReputation;

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongNewestReputation.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongNewestReputation.js
@@ -1,7 +1,7 @@
 import BN from "bn.js";
 import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
-class MaliciousReputationMiningWrongNewestReputation extends ReputationMinerTestWrapper {
+class MaliciousReputationMinerWrongNewestReputation extends ReputationMinerTestWrapper {
   // This client will supply the wrong newest reputation as part of its proof
   constructor(opts, amountToFalsify) {
     super(opts);
@@ -19,4 +19,4 @@ class MaliciousReputationMiningWrongNewestReputation extends ReputationMinerTest
   }
 }
 
-export default MaliciousReputationMiningWrongNewestReputation;
+export default MaliciousReputationMinerWrongNewestReputation;

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -56,12 +56,16 @@ class MaliciousReputationMiningWrongProofLogEntry extends ReputationMinerTestWra
         this.justificationHashes[lastAgreeKey].adjacentReputationProof.branchMask,
         this.justificationHashes[lastAgreeKey].adjacentReputationProof.reputation,
         this.justificationHashes[lastAgreeKey].adjacentReputationProof.uid,
-        "0"
+        "0",
+        this.justificationHashes[lastAgreeKey].originAdjacentReputationProof.reputation,
+        this.justificationHashes[lastAgreeKey].childAdjacentReputationProof.reputation
       ],
       [
         reputationKey,
         this.justificationHashes[lastAgreeKey].newestReputationProof.key,
-        this.justificationHashes[lastAgreeKey].adjacentReputationProof.key
+        this.justificationHashes[lastAgreeKey].adjacentReputationProof.key,
+        this.justificationHashes[lastAgreeKey].originAdjacentReputationProof.key,
+        this.justificationHashes[lastAgreeKey].childAdjacentReputationProof.key
       ],
       this.justificationHashes[firstDisagreeKey].justUpdatedProof.siblings,
       agreeStateSiblings,

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -2,7 +2,7 @@ import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
 const ethers = require("ethers");
 
-class MaliciousReputationMiningWrongProofLogEntry extends ReputationMinerTestWrapper {
+class MaliciousReputationMinerWrongProofLogEntry extends ReputationMinerTestWrapper {
   // This client will supply the wrong log entry as part of its proof
   constructor(opts, amountToFalsify) {
     super(opts);
@@ -17,8 +17,8 @@ class MaliciousReputationMiningWrongProofLogEntry extends ReputationMinerTestWra
     const firstDisagreeIdx = ethers.utils.bigNumberify(submission.lowerBound);
     const lastAgreeIdx = firstDisagreeIdx.sub(1);
     const reputationKey = await this.getKeyForUpdateNumber(lastAgreeIdx);
-    const lastAgreeKey = MaliciousReputationMiningWrongProofLogEntry.getHexString(lastAgreeIdx, 64);
-    const firstDisagreeKey = MaliciousReputationMiningWrongProofLogEntry.getHexString(firstDisagreeIdx, 64);
+    const lastAgreeKey = MaliciousReputationMinerWrongProofLogEntry.getHexString(lastAgreeIdx, 64);
+    const firstDisagreeKey = MaliciousReputationMinerWrongProofLogEntry.getHexString(firstDisagreeIdx, 64);
 
     const [agreeStateBranchMask, agreeStateSiblings] = await this.justificationTree.getProof(lastAgreeKey);
     const [disagreeStateBranchMask, disagreeStateSiblings] = await this.justificationTree.getProof(firstDisagreeKey);
@@ -34,9 +34,9 @@ class MaliciousReputationMiningWrongProofLogEntry extends ReputationMinerTestWra
         index,
         this.justificationHashes[firstDisagreeKey].justUpdatedProof.branchMask,
         this.justificationHashes[lastAgreeKey].nextUpdateProof.nNodes,
-        MaliciousReputationMiningWrongProofLogEntry.getHexString(agreeStateBranchMask),
+        MaliciousReputationMinerWrongProofLogEntry.getHexString(agreeStateBranchMask),
         this.justificationHashes[firstDisagreeKey].justUpdatedProof.nNodes,
-        MaliciousReputationMiningWrongProofLogEntry.getHexString(disagreeStateBranchMask),
+        MaliciousReputationMinerWrongProofLogEntry.getHexString(disagreeStateBranchMask),
         this.justificationHashes[lastAgreeKey].newestReputationProof.branchMask,
         logEntryNumber,
         "0",
@@ -81,4 +81,4 @@ class MaliciousReputationMiningWrongProofLogEntry extends ReputationMinerTestWra
   }
 }
 
-export default MaliciousReputationMiningWrongProofLogEntry;
+export default MaliciousReputationMinerWrongProofLogEntry;

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongResponse.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongResponse.js
@@ -1,0 +1,106 @@
+import { ethers } from "ethers";
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
+
+class MaliciousReputationMinerWrongResponse extends ReputationMinerTestWrapper {
+  // Only difference between this and the 'real' client should be that it adds some extra
+  // reputation to one entry being parsed.
+  constructor(opts, responseToFalsify, responseValue) {
+    super(opts);
+    this.responseToFalsify = responseToFalsify;
+    this.responseValue = responseValue;
+  }
+
+  async respondToChallenge() {
+    const [round, index] = await this.getMySubmissionRoundAndIndex();
+    const repCycle = await this.getActiveRepCycle();
+    const submission = await repCycle.getDisputeRounds(round, index);
+
+    // console.log(submission);
+    let firstDisagreeIdx = ethers.utils.bigNumberify(submission.lowerBound);
+    let lastAgreeIdx = firstDisagreeIdx.sub(1);
+    // If this is called before the binary search has finished, these would be -1 and 0, respectively, which will throw errors
+    // when we try and pass -ve hex values. Instead, set them to values that will allow us to send a tx that will fail.
+
+    lastAgreeIdx = lastAgreeIdx.lt(0) ? ethers.constants.Zero : lastAgreeIdx;
+    firstDisagreeIdx = firstDisagreeIdx.lt(1) ? ethers.constants.One : firstDisagreeIdx;
+
+    const reputationKey = await this.getKeyForUpdateNumber(lastAgreeIdx);
+    const lastAgreeKey = ReputationMinerTestWrapper.getHexString(lastAgreeIdx, 64);
+    const firstDisagreeKey = ReputationMinerTestWrapper.getHexString(firstDisagreeIdx, 64);
+
+    const [agreeStateBranchMask, agreeStateSiblings] = await this.justificationTree.getProof(lastAgreeKey);
+    const [disagreeStateBranchMask, disagreeStateSiblings] = await this.justificationTree.getProof(firstDisagreeKey);
+    let logEntryNumber = ethers.constants.Zero;
+    if (lastAgreeIdx.gte(this.nReputationsBeforeLatestLog)) {
+      logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(lastAgreeIdx.sub(this.nReputationsBeforeLatestLog));
+    }
+    const lastAgreeJustifications = this.justificationHashes[lastAgreeKey];
+    const firstDisagreeJustifications = this.justificationHashes[firstDisagreeKey];
+
+    if (this.justificationHashes[lastAgreeKey].originAdjacentReputationProof.key !== "0x00") {
+      // We generated the origin-adjacent reputation proof. We replace the origin proof with the originAdjacentReputationProof
+      lastAgreeJustifications.originReputationProof.uid = lastAgreeJustifications.originAdjacentReputationProof.uid;
+      lastAgreeJustifications.originReputationProof.branchMask = lastAgreeJustifications.originAdjacentReputationProof.branchMask;
+      lastAgreeJustifications.originReputationProof.siblings = lastAgreeJustifications.originAdjacentReputationProof.siblings;
+    }
+
+    if (this.justificationHashes[lastAgreeKey].childAdjacentReputationProof.key !== "0x00") {
+      // We generated the child-adjacent reputation proof. We replace the child proof with the childAdjacentReputationProof
+      lastAgreeJustifications.childReputationProof.uid = lastAgreeJustifications.childAdjacentReputationProof.uid;
+      lastAgreeJustifications.childReputationProof.branchMask = lastAgreeJustifications.childAdjacentReputationProof.branchMask;
+      lastAgreeJustifications.childReputationProof.siblings = lastAgreeJustifications.childAdjacentReputationProof.siblings;
+    }
+
+    return repCycle.respondToChallenge(
+      [
+        this.responseToFalsify === 0 ? this.responseValue : round,
+        this.responseToFalsify === 1 ? this.responseValue : index,
+        this.responseToFalsify === 2 ? this.responseValue : firstDisagreeJustifications.justUpdatedProof.branchMask,
+        this.responseToFalsify === 3 ? this.responseValue : lastAgreeJustifications.nextUpdateProof.nNodes,
+        this.responseToFalsify === 4 ? this.responseValue : ReputationMinerTestWrapper.getHexString(agreeStateBranchMask),
+        this.responseToFalsify === 5 ? this.responseValue : firstDisagreeJustifications.justUpdatedProof.nNodes,
+        this.responseToFalsify === 6 ? this.responseValue : ReputationMinerTestWrapper.getHexString(disagreeStateBranchMask),
+        this.responseToFalsify === 7 ? this.responseValue : lastAgreeJustifications.newestReputationProof.branchMask,
+        this.responseToFalsify === 8 ? this.responseValue : logEntryNumber,
+        this.responseToFalsify === 9 ? this.responseValue : "0",
+        this.responseToFalsify === 10 ? this.responseValue : lastAgreeJustifications.originReputationProof.branchMask,
+        this.responseToFalsify === 11 ? this.responseValue : lastAgreeJustifications.nextUpdateProof.reputation,
+        this.responseToFalsify === 12 ? this.responseValue : lastAgreeJustifications.nextUpdateProof.uid,
+        this.responseToFalsify === 13 ? this.responseValue : firstDisagreeJustifications.justUpdatedProof.reputation,
+        this.responseToFalsify === 14 ? this.responseValue : firstDisagreeJustifications.justUpdatedProof.uid,
+        this.responseToFalsify === 15 ? this.responseValue : lastAgreeJustifications.newestReputationProof.reputation,
+        this.responseToFalsify === 16 ? this.responseValue : lastAgreeJustifications.newestReputationProof.uid,
+        this.responseToFalsify === 17 ? this.responseValue : lastAgreeJustifications.originReputationProof.reputation,
+        this.responseToFalsify === 18 ? this.responseValue : lastAgreeJustifications.originReputationProof.uid,
+        this.responseToFalsify === 19 ? this.responseValue : lastAgreeJustifications.childReputationProof.branchMask,
+        this.responseToFalsify === 20 ? this.responseValue : lastAgreeJustifications.childReputationProof.reputation,
+        this.responseToFalsify === 21 ? this.responseValue : lastAgreeJustifications.childReputationProof.uid,
+        this.responseToFalsify === 22 ? this.responseValue : "0",
+        this.responseToFalsify === 23 ? this.responseValue : lastAgreeJustifications.adjacentReputationProof.branchMask,
+        this.responseToFalsify === 24 ? this.responseValue : lastAgreeJustifications.adjacentReputationProof.reputation,
+        this.responseToFalsify === 25 ? this.responseValue : lastAgreeJustifications.adjacentReputationProof.uid,
+        this.responseToFalsify === 26 ? this.responseValue : "0",
+        this.responseToFalsify === 27 ? this.responseValue : lastAgreeJustifications.originAdjacentReputationProof.reputation,
+        this.responseToFalsify === 28 ? this.responseValue : lastAgreeJustifications.childAdjacentReputationProof.reputation
+      ],
+      [
+        this.responseToFalsify === 29 ? this.responseValue : reputationKey,
+        this.responseToFalsify === 30 ? this.responseValue : lastAgreeJustifications.newestReputationProof.key,
+        this.responseToFalsify === 31 ? this.responseValue : lastAgreeJustifications.adjacentReputationProof.key,
+        this.responseToFalsify === 32 ? this.responseValue : lastAgreeJustifications.originAdjacentReputationProof.key,
+        this.responseToFalsify === 33 ? this.responseValue : lastAgreeJustifications.childAdjacentReputationProof.key
+      ],
+      this.responseToFalsify === 34 ? this.responseValue : firstDisagreeJustifications.justUpdatedProof.siblings,
+      this.responseToFalsify === 35 ? this.responseValue : agreeStateSiblings,
+      this.responseToFalsify === 36 ? this.responseValue : disagreeStateSiblings,
+      this.responseToFalsify === 37 ? this.responseValue : lastAgreeJustifications.newestReputationProof.siblings,
+      this.responseToFalsify === 38 ? this.responseValue : lastAgreeJustifications.originReputationProof.siblings,
+      this.responseToFalsify === 39 ? this.responseValue : lastAgreeJustifications.childReputationProof.siblings,
+      this.responseToFalsify === 40 ? this.responseValue : lastAgreeJustifications.adjacentReputationProof.siblings,
+      { gasLimit: 4000000 }
+    );
+  }
+
+}
+
+export default MaliciousReputationMinerWrongResponse;

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongResponse.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongResponse.js
@@ -51,7 +51,7 @@ class MaliciousReputationMinerWrongResponse extends ReputationMinerTestWrapper {
       lastAgreeJustifications.childReputationProof.siblings = lastAgreeJustifications.childAdjacentReputationProof.siblings;
     }
 
-    return repCycle.respondToChallenge(
+    const tx = await repCycle.respondToChallenge(
       [
         this.responseToFalsify === 0 ? this.responseValue : round,
         this.responseToFalsify === 1 ? this.responseValue : index,
@@ -99,6 +99,7 @@ class MaliciousReputationMinerWrongResponse extends ReputationMinerTestWrapper {
       this.responseToFalsify === 40 ? this.responseValue : lastAgreeJustifications.adjacentReputationProof.siblings,
       { gasLimit: 4000000 }
     );
+    return tx.wait();
   }
 
 }

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -515,12 +515,16 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.branchMask,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.reputation,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.uid,
-            0
+            0,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originAdjacentReputationProof.reputation,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childAdjacentReputationProof.reputation
           ],
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originAdjacentReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childAdjacentReputationProof.key
           ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
           agreeStateSiblings,
@@ -639,12 +643,16 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.branchMask,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.reputation,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.uid,
-            0
+            0,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originAdjacentReputationProof.reputation,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childAdjacentReputationProof.reputation
           ],
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originAdjacentReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childAdjacentReputationProof.key
           ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
           agreeStateSiblings,
@@ -654,7 +662,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.siblings,
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.siblings
         ),
-        "colony-reputation-mining-origin-skill-state-disagreement"
+        "colony-reputation-mining-origin-reputation-nonzero"
       );
 
       await checkErrorRevert(
@@ -689,12 +697,16 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.branchMask,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.reputation,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.uid,
-            0
+            0,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originAdjacentReputationProof.reputation,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childAdjacentReputationProof.reputation
           ],
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originAdjacentReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childAdjacentReputationProof.key
           ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
           agreeStateSiblings,
@@ -704,7 +716,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childReputationProof.siblings,
           goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.siblings
         ),
-        "colony-reputation-mining-child-skill-state-disagreement"
+        "colony-reputation-mining-child-reputation-nonzero"
       );
 
       // Cleanup
@@ -789,12 +801,16 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.branchMask,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.reputation,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.uid,
-            0
+            0,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originAdjacentReputationProof.reputation,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childAdjacentReputationProof.reputation
           ],
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originAdjacentReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childAdjacentReputationProof.key
           ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
           agreeStateSiblings,
@@ -881,12 +897,16 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.branchMask,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.reputation,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.uid,
-            0
+            0,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originAdjacentReputationProof.reputation,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childAdjacentReputationProof.reputation
           ],
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originAdjacentReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childAdjacentReputationProof.key
           ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
           agreeStateSiblings,
@@ -932,12 +952,16 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.branchMask,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.reputation,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.uid,
-            0
+            0,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originAdjacentReputationProof.reputation,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childAdjacentReputationProof.reputation
           ],
           [
             reputationKey,
             goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].newestReputationProof.key,
-            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].adjacentReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].originAdjacentReputationProof.key,
+            goodClient.justificationHashes[`0x${lastAgreeIdx.toString(16, 64)}`].childAdjacentReputationProof.key
           ],
           goodClient.justificationHashes[`0x${firstDisagreeIdx.toString(16, 64)}`].justUpdatedProof.siblings,
           agreeStateSiblings,
@@ -997,8 +1021,8 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
 
       await checkErrorRevert(
         repCycle.respondToChallenge(
-          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          [wrongColonyKey, "0x00", "0x00"],
+          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          [wrongColonyKey, "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],
@@ -1012,8 +1036,8 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
 
       await checkErrorRevert(
         repCycle.respondToChallenge(
-          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          [wrongReputationKey, "0x00", "0x00"],
+          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          [wrongReputationKey, "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],
@@ -1027,8 +1051,8 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
 
       await checkErrorRevert(
         repCycle.respondToChallenge(
-          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          [wrongUserKey, "0x00", "0x00"],
+          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          [wrongUserKey, "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],
@@ -1064,8 +1088,8 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
 
       await checkErrorRevert(
         repCycle.respondToChallenge(
-          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          ["0x00", "0x00", "0x00"],
+          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          ["0x00", "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -99,7 +99,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
   });
 
   describe("should correctly resolve a dispute over origin skill", () => {
-    it.only("if one person claims an origin skill doesn't exist but the other does (and proves such)", async () => {
+    it("if one person claims an origin skill doesn't exist but the other does (and proves such)", async () => {
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
@@ -155,6 +155,10 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient);
+
+      await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
+        client2: { respondToChallenge: "colony-reputation-mining-adjacent-origin-not-adjacent-or-already-exists" }
+      });
       await repCycle.confirmNewHash(1);
       const acceptedHash = await colonyNetwork.getReputationRootHash();
 
@@ -222,7 +226,9 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       const wronghash = await badClient.getRootHash();
       assert(righthash !== wronghash, "Hashes from clients are equal, surprisingly");
 
-      await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient);
+      await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
+        client2: { respondToChallenge: "colony-reputation-mining-adjacent-child-not-adjacent-or-already-exists" }
+      });
 
       await repCycle.confirmNewHash(1);
       const acceptedHash = await colonyNetwork.getReputationRootHash();

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -99,7 +99,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
   });
 
   describe("should correctly resolve a dispute over origin skill", () => {
-    it("if one person claims an origin skill doesn't exist but the other does (and proves such)", async () => {
+    it.only("if one person claims an origin skill doesn't exist but the other does (and proves such)", async () => {
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -154,7 +154,6 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
       await badClient.loadState(currentGoodClientState);
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
-      await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-adjacent-origin-not-adjacent-or-already-exists" }


### PR DESCRIPTION
This extends the logic used in #506 and the idea of an 'adjacent' reputation being used to prove that a reputation doesn't already exist in the tree. We incremented `challengeStepCompleted` if a response in `respondToChallenge` was able to prove a reputation existed in the `lastAgreeState`. The alternative was that if they were claiming a value of 0, then we allowed them to do this with an invalid proof (in case the reputation didn't exist in the tree).

In principle, this was okay but it did lead to issues that ended up being incrementally patched (e.g. #410). This PR removes all of these 'optional' skips; the intention is that only the submission that has done the calculation being disputed correctly is able to call `respondToChallenge` without it throwing.

Instead, with this PR, if a user wish to claim that either the user origin or child reputation doesn't exist, they have to provide a proof for a reputation that is in the tree that would be the adjacent reputation of the one that doesn't exist. This is used to prove that the reputation doesn't exist, and a value of zero should be used in the relevant calculations. In order to have as few extra parameters as possible, if this is something they are claiming, the `uid`, `branchMask` and `siblings` of the proof for the adjacent reputation are assumed to have been sent in the appropriate parameters of the reputation that doesn't exist. the `reputation` (value) and `key` are separate fields; it would have been possible to not add the reputation parameter, but I wanted `u[U_USER_ORIGIN_REPUTATION_VALUE]` in the source code to always correspond to the user origin reputation value, rather than (sometimes) being the value of what would be the adjacent proof of the origin reputation. I'm much more blasé about the proofs, because are more self contained (only used in one function), and so it's clear from context / the comments what is going on.

I have also slightly rearranged the calculations in `proveValue` to allow for a short-circuit in `checkChildReputation` if appropriate, which reduces the gas cost to resolve this type of dispute.

