### PR TITLE
Payments implementation

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -265,7 +265,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     fundingPotCount += 1;
     fundingPots[fundingPotCount] = FundingPot({
       associatedType: FundingPotAssociatedType.Domain,
-      associatedTypeId: domainCount
+      associatedTypeId: domainCount,
+      payoutsWeCannotMake: 0
     });
 
     // Create a new domain with the given skill and new funding pot

--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -66,6 +66,9 @@ contract ColonyAuthority is CommonAuthority {
     setAdminRoleCapability(colony, "addPayment(address,address,uint256,uint256,uint256)");
     setFounderRoleCapability(colony, "addPayment(address,address,uint256,uint256,uint256)");
     // Update payments
+    setAdminRoleCapability(colony, "finalizePayment(uint256)");
+    setFounderRoleCapability(colony, "finalizePayment(uint256)");
+
     setAdminRoleCapability(colony, "setPaymentRecipient(uint256,address)");
     setFounderRoleCapability(colony, "setPaymentRecipient(uint256,address)");
     

--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -78,8 +78,8 @@ contract ColonyAuthority is CommonAuthority {
     setAdminRoleCapability(colony, "setPaymentSkill(uint256,uint256)");
     setFounderRoleCapability(colony, "setPaymentSkill(uint256,uint256)");
 
-    setAdminRoleCapability(colony, "setPayout(uint256,address,uint256)");
-    setFounderRoleCapability(colony, "setPayout(uint256,address,uint256)");
+    setAdminRoleCapability(colony, "setPaymentPayout(uint256,address,uint256)");
+    setFounderRoleCapability(colony, "setPaymentPayout(uint256,address,uint256)");
 
     // Start next reward payout
     setAdminRoleCapability(colony, "startNextRewardPayout(address,bytes,bytes,uint256,bytes32[])");

--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -63,8 +63,8 @@ contract ColonyAuthority is CommonAuthority {
     setFounderRoleCapability(colony, "makeTask(bytes32,uint256,uint256,uint256)");
 
     // Add payment
-    setAdminRoleCapability(colony, "addPayment(address,uint256,uint256,address,uint256)");
-    setFounderRoleCapability(colony, "addPayment(address,uint256,uint256,address,uint256)");
+    setAdminRoleCapability(colony, "addPayment(address,address,uint256,uint256,uint256)");
+    setFounderRoleCapability(colony, "addPayment(address,address,uint256,uint256,uint256)");
 
     // Start next reward payout
     setAdminRoleCapability(colony, "startNextRewardPayout(address,bytes,bytes,uint256,bytes32[])");

--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -65,6 +65,18 @@ contract ColonyAuthority is CommonAuthority {
     // Add payment
     setAdminRoleCapability(colony, "addPayment(address,address,uint256,uint256,uint256)");
     setFounderRoleCapability(colony, "addPayment(address,address,uint256,uint256,uint256)");
+    // Update payments
+    setAdminRoleCapability(colony, "setPaymentRecipient(uint256,address)");
+    setFounderRoleCapability(colony, "setPaymentRecipient(uint256,address)");
+    
+    setAdminRoleCapability(colony, "setPaymentDomain(uint256,uint256)");
+    setFounderRoleCapability(colony, "setPaymentDomain(uint256,uint256)");
+
+    setAdminRoleCapability(colony, "setPaymentSkill(uint256,uint256)");
+    setFounderRoleCapability(colony, "setPaymentSkill(uint256,uint256)");
+
+    setAdminRoleCapability(colony, "setPayout(uint256,address,uint256)");
+    setFounderRoleCapability(colony, "setPayout(uint256,address,uint256)");
 
     // Start next reward payout
     setAdminRoleCapability(colony, "startNextRewardPayout(address,bytes,bytes,uint256,bytes32[])");

--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -57,9 +57,15 @@ contract ColonyAuthority is CommonAuthority {
     // Add domain
     setAdminRoleCapability(colony, "addDomain(uint256)");
     setFounderRoleCapability(colony, "addDomain(uint256)");
+    
     // Add task
     setAdminRoleCapability(colony, "makeTask(bytes32,uint256,uint256,uint256)");
     setFounderRoleCapability(colony, "makeTask(bytes32,uint256,uint256,uint256)");
+
+    // Add payment
+    setAdminRoleCapability(colony, "addPayment(address,uint256,uint256,address,uint256)");
+    setFounderRoleCapability(colony, "addPayment(address,uint256,uint256,address,uint256)");
+
     // Start next reward payout
     setAdminRoleCapability(colony, "startNextRewardPayout(address,bytes,bytes,uint256,bytes32[])");
     setFounderRoleCapability(colony, "startNextRewardPayout(address,bytes,bytes,uint256,bytes32[])");

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -177,7 +177,7 @@ contract ColonyDataTypes {
 
   struct Payment {
     address recipient;
-    bool claimed;
+    bool finalized;
     uint256 fundingPotId;
     uint256 domainId;
     uint256[] skills;

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -176,7 +176,7 @@ contract ColonyDataTypes {
   }
 
   struct Payment {
-    address recipient;
+    address payable recipient;
     bool finalized;
     uint256 fundingPotId;
     uint256 domainId;

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -240,4 +240,6 @@ contract ColonyDataTypes {
     uint256 skillId;
     uint256 fundingPotId;
   }
+
+  uint256 constant MAX_PAYOUT = 2**254 - 1; // Up to 254 bits to account for sign and payout modifiers.
 }

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -174,7 +174,7 @@ contract ColonyDataTypes {
 
   struct Payment {
     address recipient;
-    uint256 potId;
+    uint256 fundingPotId;
     uint256 domainId;
     uint256[] skills;
     mapping (address => uint256) payouts;
@@ -221,12 +221,12 @@ contract ColonyDataTypes {
 
   // We do have 1 "special" funding pot with id 0 for rewards which will carry the "Unassigned" type.
   // as they are unrelated to other entities in the Colony the same way the remaining funding pots are releated to domains, tasks and payouts.
-  enum FundingPotAssociatedType { Unassigned, Domain, Task }
+  enum FundingPotAssociatedType { Unassigned, Domain, Task, Payment }
 
   struct FundingPot {
     // Funding pots can store multiple token balances, for ETH use 0x0 address
     mapping (address => uint256) balance;
-    // Funding pots can be associated with different fundable entities, for now these are: tasks and domains.
+    // Funding pots can be associated with different fundable entities, for now these are: tasks, domains and payments.
     FundingPotAssociatedType associatedType;
     uint256 associatedTypeId;
   }

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -172,6 +172,14 @@ contract ColonyDataTypes {
     uint256 blockTimestamp;
   }
 
+  struct Payment {
+    address recipient;
+    uint256 potId;
+    uint256 domainId;
+    uint256[] skills;
+    mapping (address => uint256) payouts;
+  }
+
   struct Task {
     bytes32 specificationHash;
     bytes32 deliverableHash;

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -146,7 +146,7 @@ contract ColonyDataTypes {
   /// @param fundingPotId Id of the funding pot where payout comes from
   /// @param token Token of the payout claim
   /// @param amount Amount of the payout claimed, after network fee was deducted
-  event PayoutClaimed(uint256 fundingPotId, address token, uint256 amount);
+  event PayoutClaimed(uint256 indexed fundingPotId, address token, uint256 amount);
 
   /// @notice Event logged when a task has been canceled
   /// @param taskId Id of the canceled task

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -142,12 +142,11 @@ contract ColonyDataTypes {
   /// @param taskId Id of the finalized task
   event TaskFinalized(uint256 indexed taskId);
 
-  /// @notice Event logged when a task payout is claimed
-  /// @param taskId Id of the task
-  /// @param role Task role for which the payout is being claimed
+  /// @notice Event logged when a payout is claimed, either from a Task or Payment
+  /// @param fundingPotId Id of the funding pot where payout comes from
   /// @param token Token of the payout claim
-  /// @param amount Amount of the payout claim
-  event TaskPayoutClaimed(uint256 indexed taskId, uint256 role, address token, uint256 amount);
+  /// @param amount Amount of the payout claimed, after network fee was deducted
+  event PayoutClaimed(uint256 fundingPotId, address token, uint256 amount);
 
   /// @notice Event logged when a task has been canceled
   /// @param taskId Id of the canceled task
@@ -188,7 +187,6 @@ contract ColonyDataTypes {
     bytes32 deliverableHash;
     TaskStatus status;
     uint256 dueDate;
-    uint256 payoutsWeCannotMake;
     uint256 fundingPotId;
     uint256 completionTimestamp;
     uint256 domainId;
@@ -232,7 +230,7 @@ contract ColonyDataTypes {
     // Funding pots can be associated with different fundable entities, for now these are: tasks, domains and payments.
     FundingPotAssociatedType associatedType;
     uint256 associatedTypeId;
-    // VALIDATE: Consolidate payouts as part of the funding pot, laternative data structure can also be used, e.g. SpendingPot
+    // Map any assigned payouts from this pot, note that in Tasks these are broken down to a more granular level on a per role basis
     mapping (address => uint256) payouts;
     uint256 payoutsWeCannotMake;
   }

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -178,8 +178,6 @@ contract ColonyDataTypes {
 
   struct Payment {
     address recipient;
-    address token;
-    uint256 amount;
     uint256 fundingPotId;
     uint256 domainId;
     uint256[] skills;
@@ -234,6 +232,9 @@ contract ColonyDataTypes {
     // Funding pots can be associated with different fundable entities, for now these are: tasks, domains and payments.
     FundingPotAssociatedType associatedType;
     uint256 associatedTypeId;
+    // VALIDATE: Consolidate payouts as part of the funding pot, laternative data structure can also be used, e.g. SpendingPot
+    mapping (address => uint256) payouts;
+    uint256 payoutsWeCannotMake;
   }
 
   struct Domain {

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -177,6 +177,7 @@ contract ColonyDataTypes {
 
   struct Payment {
     address recipient;
+    bool claimed;
     uint256 fundingPotId;
     uint256 domainId;
     uint256[] skills;

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -81,6 +81,10 @@ contract ColonyDataTypes {
   /// @param rewardInverse The reward inverse value
   event ColonyRewardInverseSet(uint256 rewardInverse);
 
+  /// @notice Event logged when a new payment is added
+  /// @param paymentId The newly added payment id
+  event PaymentAdded(uint256 paymentId);
+
   /// @notice Event logged when a new task is added
   /// @param taskId The newly added task id
   event TaskAdded(uint256 taskId);

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -178,10 +178,11 @@ contract ColonyDataTypes {
 
   struct Payment {
     address recipient;
+    address token;
+    uint256 amount;
     uint256 fundingPotId;
     uint256 domainId;
     uint256[] skills;
-    mapping (address => uint256) payouts;
   }
 
   struct Task {

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -118,7 +118,14 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
 
     uint currentTotalAmount = fundingPot.payouts[_token];
     fundingPot.payouts[_token] = _amount;
+    uint payoutsWeCannotMakePrev = fundingPot.payoutsWeCannotMake;
+
     updatePayoutsWeCannotMakeAfterBudgetChange(_id, _token, currentTotalAmount);
+    
+    // If payoutsWeCannotMake changes from non-zero to zero we have sufficient funding
+    if (payoutsWeCannotMakePrev > 0 && fundingPot.payoutsWeCannotMake == 0) {
+      finalizePayment(fundingPot.associatedTypeId);
+    }
   }
 
   function getFundingPotCount() public view returns (uint256 count) {

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -108,14 +108,12 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     processPayout(payment.fundingPotId, _token, fundingPot.payouts[_token], payment.recipient);
 
     IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
-    // All payments earn domain reputation
-    colonyNetworkContract.appendReputationUpdateLog(payment.recipient, int(fundingPot.payouts[_token]), domains[payment.domainId].skillId);
-
-    // If skill was set, earn reputation in the global skill
+    // All payments in Colony's home token earn domain reputation and if skill was set, earn skill reputation
+    colonyNetworkContract.appendReputationUpdateLog(payment.recipient, int(fundingPot.payouts[token]), domains[payment.domainId].skillId);
     if (payment.skills[0] > 0) {
       // Currently we support at most one skill per Payment, similarly to Task model.
       // This may change in future to allow multiple skills to be set on both Tasks and Payments
-      colonyNetworkContract.appendReputationUpdateLog(payment.recipient, int(fundingPot.payouts[_token]), payment.skills[0]);
+      colonyNetworkContract.appendReputationUpdateLog(payment.recipient, int(fundingPot.payouts[token]), payment.skills[0]);
     }
   }
 

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -114,7 +114,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   {
     Payment storage payment = payments[_id];
     FundingPot storage fundingPot = fundingPots[payment.fundingPotId];
-    require(fundingPot.associatedType == FundingPotAssociatedType.Payment, "colony-funding-pot-associated-with-non-payment");
+    assert(fundingPot.associatedType == FundingPotAssociatedType.Payment);
 
     uint currentTotalAmount = fundingPot.payouts[_token];
     fundingPot.payouts[_token] = _amount;
@@ -409,6 +409,8 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   {
     Task storage task = tasks[_id];
     FundingPot storage fundingPot = fundingPots[task.fundingPotId];
+    assert(fundingPot.associatedType == FundingPotAssociatedType.Task);
+
     uint currentTotalAmount = fundingPot.payouts[_token];
     uint currentTaskRolePayout = task.payouts[uint8(_role)][_token];
     task.payouts[uint8(_role)][_token] = _amount;

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -85,12 +85,13 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     assert(task.roles[_role].user != address(0x0));
 
     uint payout = task.payouts[_role][_token];
-    fundingPot.payouts[_token] = sub(fundingPot.payouts[_token], payout);
     task.payouts[_role][_token] = 0;
 
     bool unsatisfactory = task.roles[_role].rating == TaskRatings.Unsatisfactory;
     if (!unsatisfactory) {
       processPayout(task.fundingPotId, _token, payout, task.roles[_role].user);
+    } else {
+      fundingPot.payouts[_token] = sub(fundingPot.payouts[_token], payout);
     }
   }
 
@@ -440,6 +441,8 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
       payoutToken.transfer(user, remainder);
       payoutToken.transfer(colonyNetworkAddress, fee);
     }
+
+    fundingPots[fundingPotId].payouts[_token] = sub(fundingPots[fundingPotId].payouts[_token], payout);
 
     emit PayoutClaimed(fundingPotId, _token, remainder);
   }

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -141,12 +141,12 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
 
     IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
     // All payments earn domain reputation
-    colonyNetworkContract.appendReputationUpdateLog(payment.recipient, int(payment.amount), payment.domainId);
+    colonyNetworkContract.appendReputationUpdateLog(payment.recipient, int(payment.amount), domains[payment.domainId].skillId);
     // If skill was set, earn reputation there too
     if (payment.skills.length > 0) {
       // Currently we support at most one skill per Payment, similarly to Task model.
       // This may change in future to allow multiple skills to be set on both Tasks and Payments
-      colonyNetworkContract.appendReputationUpdateLog(payment.recipient, int(payment.amount), payment.skills[0]);
+      // TODO colonyNetworkContract.appendReputationUpdateLog(payment.recipient, int(payment.amount), payment.skills[0]);
     }
 
     // TODO emit PaymentClaimed(_id);

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -85,7 +85,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     assert(task.roles[_role].user != address(0x0));
 
     uint payout = task.payouts[_role][_token];
-    fundingPot.payouts[_token] -= payout;
+    fundingPot.payouts[_token] = sub(fundingPot.payouts[_token], payout);
     task.payouts[_role][_token] = 0;
 
     bool unsatisfactory = task.roles[_role].rating == TaskRatings.Unsatisfactory;

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -134,6 +134,9 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     // TODO: Add a requirement for payment to be funded before it can be claimed
     Payment storage payment = payments[_id];
 
+    FundingPot storage fundingPot = fundingPots[payment.fundingPotId];
+    require(fundingPot.balance[payment.token] >= payment.amount, "colony-payment-insufficient-funding");
+
     processPayment(payment.fundingPotId, payment.token, payment.amount, payment.recipient);
 
     IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -107,7 +107,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     processPayout(payment.fundingPotId, _token, fundingPot.payouts[_token], payment.recipient);
   }
 
-  function setPayout(uint256 _id, address _token, uint256 _amount) public
+  function setPaymentPayout(uint256 _id, address _token, uint256 _amount) public
   auth
   stoppable
   validPayoutAmount(_amount)

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -180,7 +180,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     if (fromPotAssociatedType == FundingPotAssociatedType.Task) {
       uint fromPotPreviousPayoutAmount = fundingPots[_fromPot].payouts[_token];
       uint surplus = (fromPotPreviousAmount > fromPotPreviousPayoutAmount) ? sub(fromPotPreviousAmount, fromPotPreviousPayoutAmount) : 0;
-      // TODO 555 This isn't very graceful
+ 
       Task storage task = tasks[fundingPots[_fromPot].associatedTypeId];
       require(task.status == TaskStatus.Cancelled || surplus >= _amount, "colony-funding-task-bad-state");
     }

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -76,80 +76,42 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     return unsatisfactory ? 0 : task.payouts[_role][_token];
   }
 
-  function getTotalTaskPayout(uint256 _id, address _token) public view returns(uint256) {
-    uint totalPayouts;
-    for (uint8 roleId = 0; roleId <= 2; roleId++) {
-      totalPayouts = add(totalPayouts, getTaskPayout(_id, roleId, _token));
-    }
-    return totalPayouts;
-  }
-
-  function claimPayout(uint256 _id, uint8 _role, address _token) public
+  function claimTaskPayout(uint256 _id, uint8 _role, address _token) public
   stoppable
   taskFinalized(_id)
   {
     Task storage task = tasks[_id];
+    FundingPot storage fundingPot = fundingPots[task.fundingPotId];
     assert(task.roles[_role].user != address(0x0));
 
     uint payout = task.payouts[_role][_token];
-
-    if (task.roles[_role].rating == TaskRatings.Unsatisfactory || payout == 0) {
-      return;
-    }
-
+    fundingPot.payouts[_token] -= payout;
     task.payouts[_role][_token] = 0;
 
-    processPayment(task.fundingPotId, _token, payout, task.roles[_role].user);
-
-    // TODO emit TaskPayoutClaimed(_id, _role, _token, remainder);
-  }
-
-  function processPayment(uint256 fundingPotId, address _token, uint256 payout, address user) private {
-    fundingPots[fundingPotId].balance[_token] = sub(fundingPots[fundingPotId].balance[_token], payout);
-    nonRewardPotsTotal[_token] = sub(nonRewardPotsTotal[_token], payout);
-
-    uint fee = calculateNetworkFeeForPayout(payout);
-    uint remainder = sub(payout, fee);
-
-    if (_token == address(0x0)) {
-      // Payout ether
-      user.transfer(remainder);
-      // Fee goes directly to Meta Colony
-      IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
-      address payable metaColonyAddress = colonyNetworkContract.getMetaColony();
-      metaColonyAddress.transfer(fee);
-    } else {
-      // Payout token
-      // TODO: (post CCv1) If it's a whitelisted token, it goes straight to the metaColony
-      // If it's any other token, goes to the colonyNetwork contract first to be auctioned.
-      ERC20Extended payoutToken = ERC20Extended(_token);
-      payoutToken.transfer(user, remainder);
-      payoutToken.transfer(colonyNetworkAddress, fee);
+    bool unsatisfactory = task.roles[_role].rating == TaskRatings.Unsatisfactory;
+    if (!unsatisfactory) {
+      processPayout(task.fundingPotId, _token, payout, task.roles[_role].user);
     }
   }
 
-  function claimPayment(uint256 _id) public
+  function claimPayment(uint256 _id, address _token) public
   stoppable
   {
-    // TODO: Add a requirement for payment to be funded before it can be claimed
     Payment storage payment = payments[_id];
-
     FundingPot storage fundingPot = fundingPots[payment.fundingPotId];
-    require(fundingPot.balance[payment.token] >= payment.amount, "colony-payment-insufficient-funding");
+    require(fundingPot.balance[_token] >= fundingPot.payouts[_token], "colony-payment-insufficient-funding");
 
-    processPayment(payment.fundingPotId, payment.token, payment.amount, payment.recipient);
+    processPayout(payment.fundingPotId, _token, fundingPot.payouts[_token], payment.recipient);
 
     IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
     // All payments earn domain reputation
-    colonyNetworkContract.appendReputationUpdateLog(payment.recipient, int(payment.amount), domains[payment.domainId].skillId);
+    colonyNetworkContract.appendReputationUpdateLog(payment.recipient, int(fundingPot.payouts[_token]), domains[payment.domainId].skillId);
     // If skill was set, earn reputation there too
     if (payment.skills.length > 0) {
       // Currently we support at most one skill per Payment, similarly to Task model.
       // This may change in future to allow multiple skills to be set on both Tasks and Payments
-      // TODO colonyNetworkContract.appendReputationUpdateLog(payment.recipient, int(payment.amount), payment.skills[0]);
+      // TODO colonyNetworkContract.appendReputationUpdateLog(payment.recipient, int(fundingPot.payouts[_token]), payment.skills[0]);
     }
-
-    // TODO emit PaymentClaimed(_id);
   }
 
   function getFundingPotCount() public view returns (uint256 count) {
@@ -160,9 +122,15 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     return fundingPots[_potId].balance[_token];
   }
 
-  function getFundingPot(uint256 _potId) public view returns (FundingPotAssociatedType associatedType, uint256 associatedTypeId) {
-    FundingPot storage pot = fundingPots[_potId];
-    return (pot.associatedType, pot.associatedTypeId);
+  function getFundingPotPayout(uint256 _potId, address _token) public view returns (uint256) {
+    return fundingPots[_potId].payouts[_token];
+  }
+
+  function getFundingPot(uint256 _potId) public view returns
+  (FundingPotAssociatedType associatedType, uint256 associatedTypeId, uint256 payoutsWeCannotMake)
+  {
+    FundingPot storage fundingPot = fundingPots[_potId];
+    return (fundingPot.associatedType, fundingPot.associatedTypeId, fundingPot.payoutsWeCannotMake);
   }
 
   function moveFundsBetweenPots(uint256 _fromPot, uint256 _toPot, uint256 _amount, address _token) public
@@ -193,19 +161,20 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     FundingPotAssociatedType fromPotAssociatedType = fundingPots[_fromPot].associatedType;
 
     if (fromPotAssociatedType == FundingPotAssociatedType.Task) {
-      uint fromTaskId = fundingPots[_fromPot].associatedTypeId;
-      Task storage task = tasks[fromTaskId];
-      uint totalPayout = getTotalTaskPayout(fromTaskId, _token);
-      uint surplus = (fromPotPreviousAmount > totalPayout) ? sub(fromPotPreviousAmount, totalPayout) : 0;
+      uint fromPotPreviousPayoutAmount = fundingPots[_fromPot].payouts[_token];
+      uint surplus = (fromPotPreviousAmount > fromPotPreviousPayoutAmount) ? sub(fromPotPreviousAmount, fromPotPreviousPayoutAmount) : 0;
+      // TODO 555 This isn't very graceful
+      Task storage task = tasks[fundingPots[_fromPot].associatedTypeId];
       require(task.status == TaskStatus.Cancelled || surplus >= _amount, "colony-funding-task-bad-state");
+    }
 
-      updateTaskPayoutsWeCannotMakeAfterPotChange(fromTaskId, _token, fromPotPreviousAmount);
+    if (fromPotAssociatedType == FundingPotAssociatedType.Task || fromPotAssociatedType == FundingPotAssociatedType.Payment) {
+      updatePayoutsWeCannotMakeAfterPotChange(_fromPot, _token, fromPotPreviousAmount);
     }
 
     FundingPotAssociatedType toPotAssociatedType = fundingPots[_toPot].associatedType;
-    if (toPotAssociatedType == FundingPotAssociatedType.Task) {
-      uint toTaskId = fundingPots[_toPot].associatedTypeId;
-      updateTaskPayoutsWeCannotMakeAfterPotChange(toTaskId, _token, toPotPreviousAmount);
+    if (toPotAssociatedType == FundingPotAssociatedType.Task || toPotAssociatedType == FundingPotAssociatedType.Payment) {
+      updatePayoutsWeCannotMakeAfterPotChange(_toPot, _token, toPotPreviousAmount);
     }
 
     emit ColonyFundsMovedBetweenFundingPots(_fromPot, _toPot, _amount, _token);
@@ -409,34 +378,30 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     return (payout.tokenAddress, reward);
   }
 
-  function updateTaskPayoutsWeCannotMakeAfterPotChange(uint256 _id, address _token, uint _prev) internal {
+  function updatePayoutsWeCannotMakeAfterPotChange(uint256 _fundingPotId, address _token, uint _prev) internal {
+    FundingPot storage tokenPot = fundingPots[_fundingPotId];
 
-    Task storage task = tasks[_id];
-    uint totalTokenPayout = getTotalTaskPayout(_id, _token);
-    uint tokenPot = fundingPots[task.fundingPotId].balance[_token];
-
-    if (_prev >= totalTokenPayout) {                  // If the old amount in the pot was enough to pay for the budget
-      if (tokenPot < totalTokenPayout) {              // And the new amount in the pot is not enough to pay for the budget...
-        task.payoutsWeCannotMake += 1;                // Then this is a set of payouts we cannot make that we could before.
+    if (_prev >= tokenPot.payouts[_token]) {                                  // If the old amount in the pot was enough to pay for the budget
+      if (tokenPot.balance[_token] < tokenPot.payouts[_token]) {      // And the new amount in the pot is not enough to pay for the budget...
+        tokenPot.payoutsWeCannotMake += 1;                            // Then this is a set of payouts we cannot make that we could before.
       }
-    } else {                                          // If this 'else' is running, then the old amount in the pot could not pay for the budget
-      if (tokenPot >= totalTokenPayout) {             // And the new amount in the pot can pay for the budget
-        task.payoutsWeCannotMake -= 1;                // Then this is a set of payouts we can make that we could not before.
+    } else {                                                          // If this 'else' is running, then the old amount in the pot could not pay for the budget
+      if (tokenPot.balance[_token] >= tokenPot.payouts[_token]) {     // And the new amount in the pot can pay for the budget
+        tokenPot.payoutsWeCannotMake -= 1;                            // Then this is a set of payouts we can make that we could not before.
       }
     }
   }
 
-  function updateTaskPayoutsWeCannotMakeAfterBudgetChange(uint256 _id, address _token, uint _prev) internal {
-    Task storage task = tasks[_id];
-    uint totalTokenPayout = getTotalTaskPayout(_id, _token);
-    uint tokenPot = fundingPots[task.fundingPotId].balance[_token];
-    if (tokenPot >= _prev) {                                          // If the amount in the pot was enough to pay for the old budget...
-      if (tokenPot < totalTokenPayout) {                              // And the amount is not enough to pay for the new budget...
-        task.payoutsWeCannotMake += 1;                                // Then this is a set of payouts we cannot make that we could before.
+  function updatePayoutsWeCannotMakeAfterBudgetChange(uint256 _fundingPotId, address _token, uint _prev) internal {
+    FundingPot storage tokenPot = fundingPots[_fundingPotId];
+
+    if (tokenPot.balance[_token] >= _prev) {                          // If the amount in the pot was enough to pay for the old budget...
+      if (tokenPot.balance[_token] < tokenPot.payouts[_token]) {      // And the amount is not enough to pay for the new budget...
+        tokenPot.payoutsWeCannotMake += 1;                            // Then this is a set of payouts we cannot make that we could before.
       }
     } else {                                                          // If this 'else' is running, then the amount in the pot was not enough to pay for the old budget
-      if (tokenPot >= totalTokenPayout) {                             // And the amount is enough to pay for the new budget...
-        task.payoutsWeCannotMake -= 1;                                // Then this is a set of payouts we can make that we could not before.
+      if (tokenPot.balance[_token] >= tokenPot.payouts[_token]) {     // And the amount is enough to pay for the new budget...
+        tokenPot.payoutsWeCannotMake -= 1;                            // Then this is a set of payouts we can make that we could not before.
       }
     }
   }
@@ -449,14 +414,54 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   {
     require(_amount <= MAX_PAYOUT, "colony-funding-payout-too-large");
 
-    uint currentTotalAmount = getTotalTaskPayout(_id, _token);
-    tasks[_id].payouts[uint8(_role)][_token] = _amount;
+    Task storage task = tasks[_id];
+    FundingPot storage fundingPot = fundingPots[task.fundingPotId];
+    uint currentTotalAmount = fundingPot.payouts[_token];
+    uint currentTaskRolePayout = task.payouts[uint8(_role)][_token];
+    task.payouts[uint8(_role)][_token] = _amount;
+    
+    fundingPot.payouts[_token] = currentTotalAmount - currentTaskRolePayout + _amount;
 
     // This call functions as a guard to make sure the new total payout doesn't overflow
     // If there is an overflow, the call will revert
-    getTotalTaskPayout(_id, _token);
+    // TODO: getTotalTaskPayout(_id, _token);
+    updatePayoutsWeCannotMakeAfterBudgetChange(task.fundingPotId, _token, currentTotalAmount);
+  }
 
-    updateTaskPayoutsWeCannotMakeAfterBudgetChange(_id, _token, currentTotalAmount);
+  // TODO: 555
+  function setPayout(uint256 _id, address _token, uint256 _amount) public auth stoppable {
+    require(_amount <= MAX_PAYOUT, "colony-funding-payout-too-large");
+
+    FundingPot storage fundingPot = fundingPots[_id];
+    uint currentTotalAmount = fundingPot.payouts[_token];
+    fundingPot.payouts[_token] = _amount;
+    updatePayoutsWeCannotMakeAfterBudgetChange(_id, _token, currentTotalAmount);
+  }
+
+  function processPayout(uint256 fundingPotId, address _token, uint256 payout, address payable user) private {
+    fundingPots[fundingPotId].balance[_token] = sub(fundingPots[fundingPotId].balance[_token], payout);
+    nonRewardPotsTotal[_token] = sub(nonRewardPotsTotal[_token], payout);
+
+    uint fee = calculateNetworkFeeForPayout(payout);
+    uint remainder = sub(payout, fee);
+
+    if (_token == address(0x0)) {
+      // Payout ether
+      user.transfer(remainder);
+      // Fee goes directly to Meta Colony
+      IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
+      address payable metaColonyAddress = colonyNetworkContract.getMetaColony();
+      metaColonyAddress.transfer(fee);
+    } else {
+      // Payout token
+      // TODO: (post CCv1) If it's a whitelisted token, it goes straight to the metaColony
+      // If it's any other token, goes to the colonyNetwork contract first to be auctioned.
+      ERC20Extended payoutToken = ERC20Extended(_token);
+      payoutToken.transfer(user, remainder);
+      payoutToken.transfer(colonyNetworkAddress, fee);
+    }
+
+    emit PayoutClaimed(fundingPotId, _token, remainder);
   }
 
   function calculateNetworkFeeForPayout(uint256 _payout) private view returns (uint256 fee) {

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -112,13 +112,14 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   validPayoutAmount(_amount)
   paymentNotFinalized(_id)
   {
-    FundingPot storage fundingPot = fundingPots[_id];
+    Payment storage payment = payments[_id];
+    FundingPot storage fundingPot = fundingPots[payment.fundingPotId];
     require(fundingPot.associatedType == FundingPotAssociatedType.Payment, "colony-funding-pot-associated-with-non-payment");
 
     uint currentTotalAmount = fundingPot.payouts[_token];
     fundingPot.payouts[_token] = _amount;
 
-    updatePayoutsWeCannotMakeAfterBudgetChange(_id, _token, currentTotalAmount);
+    updatePayoutsWeCannotMakeAfterBudgetChange(payment.fundingPotId, _token, currentTotalAmount);
   }
 
   function getFundingPotCount() public view returns (uint256 count) {

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -101,7 +101,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     require (payment.finalized, "colony-payment-not-finalized");
 
     FundingPot storage fundingPot = fundingPots[payment.fundingPotId];
-    require(fundingPot.balance[_token] >= fundingPot.payouts[_token], "colony-payment-insufficient-funding");
+    assert(fundingPot.balance[_token] >= fundingPot.payouts[_token]);
 
     processPayout(payment.fundingPotId, _token, fundingPot.payouts[_token], payment.recipient);
   }

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -98,7 +98,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   stoppable
   {
     Payment storage payment = payments[_id];
-    require (payment.finalized, "colony-payment-not-finalized");
+    require(payment.finalized, "colony-payment-not-finalized");
 
     FundingPot storage fundingPot = fundingPots[payment.fundingPotId];
     assert(fundingPot.balance[_token] >= fundingPot.payouts[_token]);

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -98,9 +98,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   stoppable
   {
     Payment storage payment = payments[_id];
-
-    require (!payment.claimed, "colony-payment-already-claimed");
-    payment.claimed = true;
+    require (payment.finalized, "colony-payment-not-finalized");
 
     FundingPot storage fundingPot = fundingPots[payment.fundingPotId];
     require(fundingPot.balance[_token] >= fundingPot.payouts[_token], "colony-payment-insufficient-funding");
@@ -150,10 +148,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     return (fundingPot.associatedType, fundingPot.associatedTypeId, fundingPot.payoutsWeCannotMake);
   }
 
-  function moveFundsBetweenPots(uint256 _fromPot, uint256 _toPot, uint256 _amount, address _token) public
-  stoppable
-  auth
-  {
+  modifier test(uint256 _fromPot, uint256 _toPot) {
     // Prevent moving funds from between the same pot, which otherwise would cause the pot balance to
     // increment by _amount.
     require(_fromPot != _toPot, "colony-funding-cannot-move-funds-between-the-same-pot");
@@ -165,7 +160,14 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     // prevent sending to nonexistent funding pots) but doing this check explicitly gives us the error message for clients.
     require(_fromPot <= fundingPotCount, "colony-funding-from-nonexistent-pot"); // Only allow sending from created pots
     require(_toPot <= fundingPotCount, "colony-funding-nonexistent-pot"); // Only allow sending to created funding pots
+    _;
+  }
 
+  function moveFundsBetweenPots(uint256 _fromPot, uint256 _toPot, uint256 _amount, address _token) public
+  stoppable
+  auth
+  test(_fromPot, _toPot)
+  {
     uint fromPotPreviousAmount = fundingPots[_fromPot].balance[_token];
     uint toPotPreviousAmount = fundingPots[_toPot].balance[_token];
 
@@ -175,9 +177,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     // If this pot is associated with a Task, prevent money being taken from the pot
     // if the remaining balance is less than the amount needed for payouts,
     // unless the task was cancelled.
-    FundingPotAssociatedType fromPotAssociatedType = fundingPots[_fromPot].associatedType;
-
-    if (fromPotAssociatedType == FundingPotAssociatedType.Task) {
+    if (fundingPots[_fromPot].associatedType == FundingPotAssociatedType.Task) {
       uint fromPotPreviousPayoutAmount = fundingPots[_fromPot].payouts[_token];
       uint surplus = (fromPotPreviousAmount > fromPotPreviousPayoutAmount) ? sub(fromPotPreviousAmount, fromPotPreviousPayoutAmount) : 0;
  
@@ -185,13 +185,23 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
       require(task.status == TaskStatus.Cancelled || surplus >= _amount, "colony-funding-task-bad-state");
     }
 
-    if (fromPotAssociatedType == FundingPotAssociatedType.Task || fromPotAssociatedType == FundingPotAssociatedType.Payment) {
+    if (fundingPots[_fromPot].associatedType == FundingPotAssociatedType.Task || 
+    fundingPots[_fromPot].associatedType == FundingPotAssociatedType.Payment) {
       updatePayoutsWeCannotMakeAfterPotChange(_fromPot, _token, fromPotPreviousAmount);
     }
 
-    FundingPotAssociatedType toPotAssociatedType = fundingPots[_toPot].associatedType;
-    if (toPotAssociatedType == FundingPotAssociatedType.Task || toPotAssociatedType == FundingPotAssociatedType.Payment) {
+    if (fundingPots[_toPot].associatedType == FundingPotAssociatedType.Task || 
+    fundingPots[_toPot].associatedType == FundingPotAssociatedType.Payment) {
+      uint payoutsWeCannotMakePrev = fundingPots[_toPot].payoutsWeCannotMake;
+
       updatePayoutsWeCannotMakeAfterPotChange(_toPot, _token, toPotPreviousAmount);
+
+      if (fundingPots[_toPot].associatedType == FundingPotAssociatedType.Payment) {
+        // If payoutsWeCannotMake changes from non-zero to zero we have sufficient funding
+        if (payoutsWeCannotMakePrev > 0 && fundingPots[_toPot].payoutsWeCannotMake == 0) {
+          payments[fundingPots[_toPot].associatedTypeId].finalized = true;
+        }
+      }
     }
 
     emit ColonyFundsMovedBetweenFundingPots(_fromPot, _toPot, _amount, _token);
@@ -398,7 +408,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   function updatePayoutsWeCannotMakeAfterPotChange(uint256 _fundingPotId, address _token, uint _prev) internal {
     FundingPot storage tokenPot = fundingPots[_fundingPotId];
 
-    if (_prev >= tokenPot.payouts[_token]) {                                  // If the old amount in the pot was enough to pay for the budget
+    if (_prev >= tokenPot.payouts[_token]) {                          // If the old amount in the pot was enough to pay for the budget
       if (tokenPot.balance[_token] < tokenPot.payouts[_token]) {      // And the new amount in the pot is not enough to pay for the budget...
         tokenPot.payoutsWeCannotMake += 1;                            // Then this is a set of payouts we cannot make that we could before.
       }

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -109,9 +109,8 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   function setPayout(uint256 _id, address _token, uint256 _amount) public
   auth
   stoppable
+  validPayoutAmount(_amount)
   {
-    require(_amount <= MAX_PAYOUT, "colony-funding-payout-too-large");
-
     FundingPot storage fundingPot = fundingPots[_id];
     require(fundingPot.associatedType == FundingPotAssociatedType.Payment, "colony-funding-pot-associated-with-non-payment");
     require(!payments[fundingPot.associatedTypeId].finalized, "colony-funding-payment-finalized");
@@ -431,8 +430,6 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
       }
     }
   }
-
-  uint256 constant MAX_PAYOUT = 2**254 - 1; // Up to 254 bits to account for sign and payout modifiers.
 
   function setTaskPayout(uint256 _id, TaskRole _role, address _token, uint256 _amount) private
   taskExists(_id)

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -97,10 +97,9 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
 
   function claimPayment(uint256 _id, address _token) public
   stoppable
+  paymentFinalized(_id)
   {
     Payment storage payment = payments[_id];
-    require(payment.finalized, "colony-payment-not-finalized");
-
     FundingPot storage fundingPot = fundingPots[payment.fundingPotId];
     assert(fundingPot.balance[_token] >= fundingPot.payouts[_token]);
 
@@ -111,10 +110,10 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   auth
   stoppable
   validPayoutAmount(_amount)
+  paymentNotFinalized(_id)
   {
     FundingPot storage fundingPot = fundingPots[_id];
     require(fundingPot.associatedType == FundingPotAssociatedType.Payment, "colony-funding-pot-associated-with-non-payment");
-    require(!payments[fundingPot.associatedTypeId].finalized, "colony-funding-payment-finalized");
 
     uint currentTotalAmount = fundingPot.payouts[_token];
     fundingPot.payouts[_token] = _amount;
@@ -405,9 +404,8 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
   function setTaskPayout(uint256 _id, TaskRole _role, address _token, uint256 _amount) private
   taskExists(_id)
   taskNotComplete(_id)
+  validPayoutAmount(_amount)
   {
-    require(_amount <= MAX_PAYOUT, "colony-funding-payout-too-large");
-
     Task storage task = tasks[_id];
     FundingPot storage fundingPot = fundingPots[task.fundingPotId];
     uint currentTotalAmount = fundingPot.payouts[_token];

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -123,6 +123,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
 
     FundingPot storage fundingPot = fundingPots[_id];
     require(fundingPot.associatedType == FundingPotAssociatedType.Payment, "colony-funding-pot-associated-with-non-payment");
+    require(!payments[fundingPot.associatedTypeId].finalized, "colony-funding-payment-finalized");
 
     uint currentTotalAmount = fundingPot.payouts[_token];
     fundingPot.payouts[_token] = _amount;

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -94,10 +94,10 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs {
     }
   }
 
-  function claimPayment(uint256 _paymentId, address _token) public
+  function claimPayment(uint256 _id, address _token) public
   stoppable
   {
-    Payment storage payment = payments[_paymentId];
+    Payment storage payment = payments[_id];
 
     require (!payment.claimed, "colony-payment-already-claimed");
     payment.claimed = true;

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -74,8 +74,8 @@ contract ColonyNetwork is ColonyNetworkStorage {
     skill = skills[_skillId];
   }
 
-  function isGlobalSkill(uint256 _skillId) public view returns (bool globalSkill) {
-    globalSkill = skills[_skillId].globalSkill;
+  function isGlobalSkill(uint256 _skillId) public view returns (bool) {
+    return skills[_skillId].globalSkill;
   }
 
   function getReputationRootHash() public view returns (bytes32) {

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -1,0 +1,59 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity >=0.4.23;
+pragma experimental "ABIEncoderV2";
+
+import "./ColonyStorage.sol";
+
+
+contract ColonyPayment is ColonyStorage {
+  function addPayment(address _recipient, uint256 _domainId, uint256 _skillId, address _token, uint256 _amount) public
+  stoppable
+  auth
+  {
+    paymentCount += 1;
+    
+    fundingPotCount += 1;
+    fundingPots[fundingPotCount] = FundingPot({
+      associatedType: FundingPotAssociatedType.Payment,
+      associatedTypeId: paymentCount
+    });
+
+    Payment memory payment = Payment({
+      recipient: _recipient,
+      fundingPotId: fundingPotCount,
+      domainId: _domainId,
+      skills: new uint256[](_skillId)             
+    });
+
+    payments[paymentCount] = payment;
+    payments[paymentCount].payouts[_token] = _amount;
+
+    emit FundingPotAdded(fundingPotCount);
+    emit PaymentAdded(paymentCount);
+  }
+
+  function getPayment(uint256 id) public view returns(address, uint256, uint256, uint256[] memory) {
+    Payment storage payment = payments[id];
+    return (payment.recipient, payment.fundingPotId, payment.domainId, payment.skills);
+  }
+
+  function getPaymentCount() public view returns (uint256) {
+    return paymentCount;
+  }
+}

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -36,7 +36,7 @@ contract ColonyPayment is ColonyStorage {
     fundingPots[fundingPotCount] = FundingPot({
       associatedType: FundingPotAssociatedType.Payment,
       associatedTypeId: paymentCount,
-      payoutsWeCannotMake: 1
+      payoutsWeCannotMake: _amount > 0 ? 1 : 0
     });
 
     fundingPots[fundingPotCount].payouts[_token] = _amount;

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -28,6 +28,7 @@ contract ColonyPayment is ColonyStorage {
   auth
   returns (uint256)
   {
+    require(_recipient != address(0x0), "colony-payment-invalid-recipient");
     paymentCount += 1;
     
     fundingPotCount += 1;
@@ -39,12 +40,15 @@ contract ColonyPayment is ColonyStorage {
 
     fundingPots[fundingPotCount].payouts[_token] = _amount;
 
-    Payment memory payment = Payment({
-      recipient: _recipient,
-      fundingPotId: fundingPotCount,
-      domainId: _domainId,
-      skills: new uint256[](_skillId)
-    });
+    Payment memory payment;
+    payment.recipient = _recipient;
+    payment.fundingPotId = fundingPotCount;
+    payment.domainId = _domainId;
+    payment.skills = new uint256[](1);
+
+    if (_skillId > 0) {
+      setPaymentSkill(paymentCount, _skillId);
+    }
 
     payments[paymentCount] = payment;
 
@@ -52,6 +56,30 @@ contract ColonyPayment is ColonyStorage {
     emit PaymentAdded(paymentCount);
 
     return paymentCount;
+  }
+
+  function setPaymentRecipient(uint256 _id, address _recipient) public 
+  stoppable
+  auth
+  {
+    require(_recipient != address(0x0), "colony-payment-invalid-recipient");
+    payments[_id].recipient = _recipient;
+  }
+
+  function setPaymentDomain(uint256 _id, uint256 _domainId) public
+  domainExists(_domainId)
+  stoppable
+  auth
+  {
+    payments[_id].domainId = _domainId;
+  }
+
+  function setPaymentSkill(uint256 _id, uint256 _skillId) public
+  globalSkill(_skillId)
+  stoppable
+  auth
+  {
+    payments[_id].skills[0] = _skillId;
   }
 
   function getPayment(uint256 id) public view returns(address, uint256, uint256, uint256[] memory) {

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -23,6 +23,7 @@ import "./ColonyStorage.sol";
 
 contract ColonyPayment is ColonyStorage {
   function addPayment(address _recipient, address _token, uint256 _amount, uint256 _domainId, uint256 _skillId) public
+  domainExists(_domainId)
   stoppable
   auth
   returns (uint256)
@@ -41,7 +42,7 @@ contract ColonyPayment is ColonyStorage {
       amount: _amount,
       fundingPotId: fundingPotCount,
       domainId: _domainId,
-      skills: new uint256[](_skillId)             
+      skills: new uint256[](_skillId)
     });
 
     payments[paymentCount] = payment;

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -33,13 +33,14 @@ contract ColonyPayment is ColonyStorage {
     fundingPotCount += 1;
     fundingPots[fundingPotCount] = FundingPot({
       associatedType: FundingPotAssociatedType.Payment,
-      associatedTypeId: paymentCount
+      associatedTypeId: paymentCount,
+      payoutsWeCannotMake: 0
     });
+
+    fundingPots[fundingPotCount].payouts[_token] = _amount;
 
     Payment memory payment = Payment({
       recipient: _recipient,
-      token: _token,
-      amount: _amount,
       fundingPotId: fundingPotCount,
       domainId: _domainId,
       skills: new uint256[](_skillId)
@@ -53,9 +54,14 @@ contract ColonyPayment is ColonyStorage {
     return paymentCount;
   }
 
-  function getPayment(uint256 id) public view returns(Payment memory) {
+  function getPayment(uint256 id) public view returns(address, uint256, uint256, uint256[] memory) {
     Payment storage payment = payments[id];
-    return payment;
+    return (payment.recipient, payment.fundingPotId, payment.domainId, payment.skills);
+  }
+
+  function getPaymentAmountForToken(uint256 id, address token) public view returns(uint256) {
+    Payment storage payment = payments[id];
+    return payment.payouts[token];
   }
 
   function getPaymentCount() public view returns (uint256) {

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity >=0.4.23;
+pragma solidity >=0.5.3;
 pragma experimental "ABIEncoderV2";
 
 import "./ColonyStorage.sol";
@@ -23,10 +23,10 @@ import "./ColonyStorage.sol";
 
 contract ColonyPayment is ColonyStorage {
   function addPayment(address payable _recipient, address _token, uint256 _amount, uint256 _domainId, uint256 _skillId) public
-  domainExists(_domainId)
-  validPayoutAmount(_amount)
   stoppable
   auth
+  domainExists(_domainId)
+  validPayoutAmount(_amount)
   returns (uint256)
   {
     require(_recipient != address(0x0), "colony-payment-invalid-recipient");
@@ -60,10 +60,10 @@ contract ColonyPayment is ColonyStorage {
   }
 
   function finalizePayment(uint256 _id) public 
-  paymentFunded(_id)
-  paymentNotFinalized(_id)
   stoppable
   auth
+  paymentFunded(_id)
+  paymentNotFinalized(_id)
   {
     Payment storage payment = payments[_id];
     payment.finalized = true;
@@ -80,41 +80,30 @@ contract ColonyPayment is ColonyStorage {
     }
   }
 
-  modifier paymentFunded(uint256 _id) {
-    FundingPot storage fundingPot = fundingPots[payments[_id].fundingPotId];
-    require(fundingPot.payoutsWeCannotMake == 0, "colony-payment-not-funded");
-    _;
-  }
-
-  modifier paymentNotFinalized(uint256 _id) {
-    require(!payments[_id].finalized, "colony-payment-finalized");
-    _;
-  }
-
   function setPaymentRecipient(uint256 _id, address payable _recipient) public 
-  paymentNotFinalized(_id)
   stoppable
   auth
+  paymentNotFinalized(_id)
   {
     require(_recipient != address(0x0), "colony-payment-invalid-recipient");
     payments[_id].recipient = _recipient;
   }
 
   function setPaymentDomain(uint256 _id, uint256 _domainId) public
-  paymentNotFinalized(_id)
-  domainExists(_domainId)
   stoppable
   auth
+  paymentNotFinalized(_id)
+  domainExists(_domainId)
   {
     payments[_id].domainId = _domainId;
   }
 
   function setPaymentSkill(uint256 _id, uint256 _skillId) public
+  stoppable
+  auth
   paymentNotFinalized(_id)
   skillExists(_skillId)
   globalSkill(_skillId)
-  stoppable
-  auth
   {
     payments[_id].skills[0] = _skillId;
   }

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -22,7 +22,7 @@ import "./ColonyStorage.sol";
 
 
 contract ColonyPayment is ColonyStorage {
-  function addPayment(address _recipient, address _token, uint256 _amount, uint256 _domainId, uint256 _skillId) public
+  function addPayment(address payable _recipient, address _token, uint256 _amount, uint256 _domainId, uint256 _skillId) public
   domainExists(_domainId)
   validPayoutAmount(_amount)
   stoppable
@@ -64,7 +64,7 @@ contract ColonyPayment is ColonyStorage {
     _;
   }
 
-  function setPaymentRecipient(uint256 _id, address _recipient) public 
+  function setPaymentRecipient(uint256 _id, address payable _recipient) public 
   paymentNotFinalized(_id)
   stoppable
   auth

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -46,11 +46,11 @@ contract ColonyPayment is ColonyStorage {
     payment.domainId = _domainId;
     payment.skills = new uint256[](1);
 
+    payments[paymentCount] = payment;
+
     if (_skillId > 0) {
       setPaymentSkill(paymentCount, _skillId);
     }
-
-    payments[paymentCount] = payment;
 
     emit FundingPotAdded(fundingPotCount);
     emit PaymentAdded(paymentCount);
@@ -75,6 +75,7 @@ contract ColonyPayment is ColonyStorage {
   }
 
   function setPaymentSkill(uint256 _id, uint256 _skillId) public
+  skillExists(_skillId)
   globalSkill(_skillId)
   stoppable
   auth
@@ -82,8 +83,8 @@ contract ColonyPayment is ColonyStorage {
     payments[_id].skills[0] = _skillId;
   }
 
-  function getPayment(uint256 id) public view returns(address, uint256, uint256, uint256[] memory) {
-    Payment storage payment = payments[id];
+  function getPayment(uint256 _id) public view returns(address, uint256, uint256, uint256[] memory) {
+    Payment storage payment = payments[_id];
     return (payment.recipient, payment.fundingPotId, payment.domainId, payment.skills);
   }
 

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -29,13 +29,14 @@ contract ColonyPayment is ColonyStorage {
   returns (uint256)
   {
     require(_recipient != address(0x0), "colony-payment-invalid-recipient");
+    require(_amount > 0, "colony-payment-invalid-amount");
     paymentCount += 1;
-    
+
     fundingPotCount += 1;
     fundingPots[fundingPotCount] = FundingPot({
       associatedType: FundingPotAssociatedType.Payment,
       associatedTypeId: paymentCount,
-      payoutsWeCannotMake: 0
+      payoutsWeCannotMake: 1
     });
 
     fundingPots[fundingPotCount].payouts[_token] = _amount;
@@ -83,9 +84,9 @@ contract ColonyPayment is ColonyStorage {
     payments[_id].skills[0] = _skillId;
   }
 
-  function getPayment(uint256 _id) public view returns(address, uint256, uint256, uint256[] memory) {
+  function getPayment(uint256 _id) public view returns(address, bool, uint256, uint256, uint256[] memory) {
     Payment storage payment = payments[_id];
-    return (payment.recipient, payment.fundingPotId, payment.domainId, payment.skills);
+    return (payment.recipient, payment.finalized, payment.fundingPotId, payment.domainId, payment.skills);
   }
 
   function getPaymentCount() public view returns (uint256) {

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -22,7 +22,7 @@ import "./ColonyStorage.sol";
 
 
 contract ColonyPayment is ColonyStorage {
-  function addPayment(address _recipient, uint256 _domainId, uint256 _skillId, address _token, uint256 _amount) public
+  function addPayment(address _recipient, address _token, uint256 _amount, uint256 _domainId, uint256 _skillId) public
   stoppable
   auth
   {
@@ -36,21 +36,22 @@ contract ColonyPayment is ColonyStorage {
 
     Payment memory payment = Payment({
       recipient: _recipient,
+      token: _token,
+      amount: _amount,
       fundingPotId: fundingPotCount,
       domainId: _domainId,
       skills: new uint256[](_skillId)             
     });
 
     payments[paymentCount] = payment;
-    payments[paymentCount].payouts[_token] = _amount;
 
     emit FundingPotAdded(fundingPotCount);
     emit PaymentAdded(paymentCount);
   }
 
-  function getPayment(uint256 id) public view returns(address, uint256, uint256, uint256[] memory) {
+  function getPayment(uint256 id) public view returns(Payment memory) {
     Payment storage payment = payments[id];
-    return (payment.recipient, payment.fundingPotId, payment.domainId, payment.skills);
+    return payment;
   }
 
   function getPaymentCount() public view returns (uint256) {

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -25,6 +25,7 @@ contract ColonyPayment is ColonyStorage {
   function addPayment(address _recipient, address _token, uint256 _amount, uint256 _domainId, uint256 _skillId) public
   stoppable
   auth
+  returns (uint256)
   {
     paymentCount += 1;
     
@@ -47,6 +48,8 @@ contract ColonyPayment is ColonyStorage {
 
     emit FundingPotAdded(fundingPotCount);
     emit PaymentAdded(paymentCount);
+
+    return paymentCount;
   }
 
   function getPayment(uint256 id) public view returns(Payment memory) {

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -59,7 +59,13 @@ contract ColonyPayment is ColonyStorage {
     return paymentCount;
   }
 
+  modifier paymentNotFinalized(uint256 _id) {
+    require(!payments[_id].finalized, "colony-payment-finalized");
+    _;
+  }
+
   function setPaymentRecipient(uint256 _id, address _recipient) public 
+  paymentNotFinalized(_id)
   stoppable
   auth
   {
@@ -68,6 +74,7 @@ contract ColonyPayment is ColonyStorage {
   }
 
   function setPaymentDomain(uint256 _id, uint256 _domainId) public
+  paymentNotFinalized(_id)
   domainExists(_domainId)
   stoppable
   auth
@@ -76,6 +83,7 @@ contract ColonyPayment is ColonyStorage {
   }
 
   function setPaymentSkill(uint256 _id, uint256 _skillId) public
+  paymentNotFinalized(_id)
   skillExists(_skillId)
   globalSkill(_skillId)
   stoppable

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -108,9 +108,8 @@ contract ColonyPayment is ColonyStorage {
     payments[_id].skills[0] = _skillId;
   }
 
-  function getPayment(uint256 _id) public view returns(address payable, bool, uint256, uint256, uint256[] memory) {
-    Payment storage payment = payments[_id];
-    return (payment.recipient, payment.finalized, payment.fundingPotId, payment.domainId, payment.skills);
+  function getPayment(uint256 _id) public view returns(Payment memory) {
+    return payments[_id];
   }
 
   function getPaymentCount() public view returns (uint256) {

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -24,12 +24,12 @@ import "./ColonyStorage.sol";
 contract ColonyPayment is ColonyStorage {
   function addPayment(address _recipient, address _token, uint256 _amount, uint256 _domainId, uint256 _skillId) public
   domainExists(_domainId)
+  validPayoutAmount(_amount)
   stoppable
   auth
   returns (uint256)
   {
     require(_recipient != address(0x0), "colony-payment-invalid-recipient");
-    require(_amount > 0, "colony-payment-invalid-amount");
     paymentCount += 1;
 
     fundingPotCount += 1;

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -59,11 +59,6 @@ contract ColonyPayment is ColonyStorage {
     return (payment.recipient, payment.fundingPotId, payment.domainId, payment.skills);
   }
 
-  function getPaymentAmountForToken(uint256 id, address token) public view returns(uint256) {
-    Payment storage payment = payments[id];
-    return payment.payouts[token];
-  }
-
   function getPaymentCount() public view returns (uint256) {
     return paymentCount;
   }

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -74,6 +74,12 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, DSMath {
   uint256 paymentCount; // Storage slot 22
   mapping (uint256 => Payment) payments; // Storage slot 23
 
+  modifier validPayoutAmount(uint256 _amount) {
+    require(_amount > 0, "colony-payout-invalid-amount");
+    require(_amount <= MAX_PAYOUT, "colony-payout-too-large");
+    _;
+  }
+
   modifier confirmTaskRoleIdentity(uint256 _id, TaskRole _role) {
     Role storage role = tasks[_id].roles[uint8(_role)];
     require(msg.sender == role.user, "colony-task-role-identity-mismatch");

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -71,7 +71,7 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, DSMath {
   // Mapping task id to current "active" nonce for executing task changes
   mapping (uint256 => uint256) taskChangeNonces; // Storage slot 21
 
-  uint256 paymentsCount; // Storage slot 22
+  uint256 paymentCount; // Storage slot 22
   mapping (uint256 => Payment) payments; // Storage slot 23
 
   modifier confirmTaskRoleIdentity(uint256 _id, TaskRole _role) {

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -75,7 +75,6 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, DSMath {
   mapping (uint256 => Payment) payments; // Storage slot 23
 
   modifier validPayoutAmount(uint256 _amount) {
-    require(_amount > 0, "colony-payout-invalid-amount");
     require(_amount <= MAX_PAYOUT, "colony-payout-too-large");
     _;
   }

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -129,6 +129,20 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, DSMath {
     _;
   }
 
+  modifier validFundingTransfer(uint256 _fromPot, uint256 _toPot) {
+    // Prevent moving funds from between the same pot, which otherwise would cause the pot balance to increment by _amount.
+    require(_fromPot != _toPot, "colony-funding-cannot-move-funds-between-the-same-pot");
+
+    // Prevent people moving funds from the pot designated to paying out token holders
+    require(_fromPot > 0, "colony-funding-cannot-move-funds-from-rewards-pot");
+
+    // Preventing sending from non-existent funding pots is not strictly necessary (if a pot doesn't exist, it can't have any funds if we
+    // prevent sending to nonexistent funding pots) but doing this check explicitly gives us the error message for clients.
+    require(_fromPot <= fundingPotCount, "colony-funding-from-nonexistent-pot"); // Only allow sending from created pots
+    require(_toPot <= fundingPotCount, "colony-funding-nonexistent-pot"); // Only allow sending to created funding pots
+    _;
+  }
+
   modifier isInBootstrapPhase() {
     require(taskCount == 0, "colony-not-in-bootstrap-mode");
     _;

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -79,6 +79,22 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, DSMath {
     _;
   }
 
+  modifier paymentFunded(uint256 _id) {
+    FundingPot storage fundingPot = fundingPots[payments[_id].fundingPotId];
+    require(fundingPot.payoutsWeCannotMake == 0, "colony-payment-not-funded");
+    _;
+  }
+
+  modifier paymentNotFinalized(uint256 _id) {
+    require(!payments[_id].finalized, "colony-payment-finalized");
+    _;
+  }
+
+  modifier paymentFinalized(uint256 _id) {
+    require(payments[_id].finalized, "colony-payment-not-finalized");
+    _;
+  }
+
   modifier confirmTaskRoleIdentity(uint256 _id, TaskRole _role) {
     Role storage role = tasks[_id].roles[uint8(_role)];
     require(msg.sender == role.user, "colony-task-role-identity-mismatch");

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -71,6 +71,9 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, DSMath {
   // Mapping task id to current "active" nonce for executing task changes
   mapping (uint256 => uint256) taskChangeNonces; // Storage slot 21
 
+  uint256 paymentsCount; // Storage slot 22
+  mapping (uint256 => Payment) payments; // Storage slot 23
+
   modifier confirmTaskRoleIdentity(uint256 _id, TaskRole _role) {
     Role storage role = tasks[_id].roles[uint8(_role)];
     require(msg.sender == role.user, "colony-task-role-identity-mismatch");

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -84,8 +84,8 @@ contract ColonyTask is ColonyStorage {
   }
 
   modifier taskFunded(uint256 _id) {
-    Task storage task = tasks[_id];
-    require(task.payoutsWeCannotMake == 0, "colony-task-not-funded");
+    FundingPot storage fundingPot = fundingPots[tasks[_id].fundingPotId];
+    require(fundingPot.payoutsWeCannotMake == 0, "colony-task-not-funded");
     _;
   }
 
@@ -99,7 +99,8 @@ contract ColonyTask is ColonyStorage {
     fundingPotCount += 1;
     fundingPots[fundingPotCount] = FundingPot({
       associatedType: FundingPotAssociatedType.Task,
-      associatedTypeId: taskCount
+      associatedTypeId: taskCount,
+      payoutsWeCannotMake: 0
     });
 
     Task memory task;
@@ -444,7 +445,6 @@ contract ColonyTask is ColonyStorage {
     uint256,
     uint256,
     uint256,
-    uint256,
     uint256[] memory)
   {
     Task storage t = tasks[_id];
@@ -453,7 +453,6 @@ contract ColonyTask is ColonyStorage {
       t.deliverableHash,
       t.status,
       t.dueDate,
-      t.payoutsWeCannotMake,
       t.fundingPotId,
       t.completionTimestamp,
       t.domainId,

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -142,8 +142,8 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _skillId The skill associated with the payment
   /// @param _token Address of the token, `0x0` value indicates Ether
   /// @param _amount Payout amount
-  function addPayment(address _recipient, uint256 _domainId, uint256 _skillId, address _token, uint256 _amount) public;
-  function getPayment(uint256 id) public view returns(address recipient, uint256 fundingPotId, uint256 domainId, uint256[] memory skills);
+  function addPayment(address _recipient, address _token, uint256 _amount, uint256 _domainId, uint256 _skillId) public;
+  function getPayment(uint256 id) public view returns(Payment memory payment);
   function getPaymentCount() public view returns (uint256 count);
 
   // Implemented in ColonyTask.sol

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -131,10 +131,10 @@ contract IColony is ColonyDataTypes, IRecovery {
   // Implemented in ColonyPayment.sol
   /// @notice Add a new payment in the colony. Secured function to authorised members
   /// @param _recipient Address of the payment recipient
-  /// @param _domainId The domain where the payment belongs
-  /// @param _skillId The skill associated with the payment
   /// @param _token Address of the token, `0x0` value indicates Ether
   /// @param _amount Payout amount
+  /// @param _domainId The domain where the payment belongs
+  /// @param _skillId The skill associated with the payment
   /// @return paymentId Identifier of the newly created payment
   function addPayment(
     address payable _recipient,

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -130,7 +130,7 @@ contract IColony is ColonyDataTypes, IRecovery {
 
   // Implemented in ColonyPayment.sol
   /// @notice Add a new payment in the colony. Secured function to authorised members
-  /// @param _recipient Address of the paymnet recipient
+  /// @param _recipient Address of the payment recipient
   /// @param _domainId The domain where the payment belongs
   /// @param _skillId The skill associated with the payment
   /// @param _token Address of the token, `0x0` value indicates Ether
@@ -144,8 +144,43 @@ contract IColony is ColonyDataTypes, IRecovery {
     uint256 _skillId) 
     public returns (uint256 paymentId);
 
+  /// @notice Sets the recipient on an existing payment. Secured function to authorised members
+  /// @param _id Payment identifier
+  /// @param _recipient Address of the payment recipient
+  function setPaymentRecipient(uint256 _id, address _recipient) public;
+
+  /// @notice Sets the domain on an existing payment. Secured function to authorised members
+  /// @param _id Payment identifier
+  /// @param _domainId Id of the new domain to set
+  function setPaymentDomain(uint256 _id, uint256 _domainId) public;
+
+  /// @notice Sets the skill on an existing payment. Secured function to authorised members
+  /// @param _id Payment identifier
+  /// @param _skillId Id of the new skill to set
+  function setPaymentSkill(uint256 _id, uint256 _skillId) public;
+
+  /// @notice Sets the payout for a given token on an existing payment's funding pot. Secured function to authorised members
+  /// @param _id Payment identifier
+  /// @param _token Address of the token, `0x0` value indicates Ether
+  /// @param _amount Payout amount
+  function setPayout(uint256 _id, address _token, uint256 _amount) public;
+
+  /// @notice Returns an exiting payment
+  /// @param _id Payment identifier
+  /// @return recipient Address of the payment recipient
+  /// @return fundingPotId Id of the associated funding pot
+  /// @return domainId The domain where the payment belongs
+  /// @return skills Array of global skill ids assigned to task
   function getPayment(uint256 id) public view returns(address recipient, uint256 fundingPotId, uint256 domainId, uint256[] memory skills);
+  
+  /// @notice Claim the payout in `_token` denomination for payment `_id`. Here the network receives its fee from each payout.
+  /// Same as for tasks, ether fees go straight to the Meta Colony whereas Token fees go to the Network to be auctioned off.
+  /// @param _id Payment identifier
+  /// @param _token Address of the token, `0x0` value indicates Ether
   function claimPayment(uint256 _id, address _token) public;
+  
+  /// @notice Get the number of payments in the colony
+  /// @return count The payment count
   function getPaymentCount() public view returns (uint256 count);
 
   // Implemented in ColonyTask.sol
@@ -403,7 +438,7 @@ contract IColony is ColonyDataTypes, IRecovery {
   function setAllTaskPayouts(uint256 _id, address _token, uint256 _managerAmount, uint256 _evaluatorAmount, uint256 _workerAmount) public;
 
   /// @notice Claim the payout in `_token` denomination for work completed in task `_id` by contributor with role `_role`
-  /// Allowed only by the contributors themselves after task is finalized. Here the network receives its fee from each payout.
+  /// Allowed only after task is finalized. Here the network receives its fee from each payout.
   /// Ether fees go straight to the Meta Colony whereas Token fees go to the Network to be auctioned off.
   /// @param _id Id of the task
   /// @param _role Id of the role, as defined in TaskRole enum

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -144,6 +144,7 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _amount Payout amount
   function addPayment(address _recipient, address _token, uint256 _amount, uint256 _domainId, uint256 _skillId) public;
   function getPayment(uint256 id) public view returns(Payment memory payment);
+  function claimPayment(uint256) public;
   function getPaymentCount() public view returns (uint256 count);
 
   // Implemented in ColonyTask.sol

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -164,7 +164,7 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _skillId Id of the new skill to set
   function setPaymentSkill(uint256 _id, uint256 _skillId) public;
 
-  /// @notice Sets the payout for a given token on an existing payment's funding pot. Secured function to authorised members
+  /// @notice Sets the payout for a given token on an existing payment. Secured function to authorised members
   /// @param _id Payment identifier
   /// @param _token Address of the token, `0x0` value indicates Ether
   /// @param _amount Payout amount

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -135,6 +135,17 @@ contract IColony is ColonyDataTypes, IRecovery {
   function verifyReputationProof(bytes memory key, bytes memory value, uint256 branchMask, bytes32[] memory siblings)
     public view returns (bool isValid);
 
+  // Implemented in ColonyPayment.sol
+  /// @notice Add a new payment in the colony. Secured function to authorised members
+  /// @param _recipient Address of the paymnet recipient
+  /// @param _domainId The domain where the payment belongs
+  /// @param _skillId The skill associated with the payment
+  /// @param _token Address of the token, `0x0` value indicates Ether
+  /// @param _amount Payout amount
+  function addPayment(address _recipient, uint256 _domainId, uint256 _skillId, address _token, uint256 _amount) public;
+  function getPayment(uint256 id) public view returns(address recipient, uint256 fundingPotId, uint256 domainId, uint256[] memory skills);
+  function getPaymentCount() public view returns (uint256 count);
+
   // Implemented in ColonyTask.sol
   /// @notice Make a new task in the colony. Secured function to authorised members
   /// @param _specificationHash Database identifier where the task specification is stored

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -151,7 +151,8 @@ contract IColony is ColonyDataTypes, IRecovery {
     uint256 _skillId) 
     public returns (uint256 paymentId);
 
-  function getPayment(uint256 id) public view returns(Payment memory payment);
+  function getPayment(uint256 id) public view returns(address recipient, uint256 fundingPotId, uint256 domainId, uint256[] memory skills);
+  function getPaymentAmountForToken(uint256 id, address token) public view returns (uint256 amount);
   function claimPayment(uint256) public;
   function getPaymentCount() public view returns (uint256 count);
 

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -137,17 +137,22 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _amount Payout amount
   /// @return paymentId Identifier of the newly created payment
   function addPayment(
-    address _recipient,
+    address payable _recipient,
     address _token,
     uint256 _amount,
     uint256 _domainId,
     uint256 _skillId) 
     public returns (uint256 paymentId);
 
+  /// @notice Finalizes the payment and logs the reputation log updates
+  /// Allowed to be called once after payment is fully funded. Secured function to authorised members
+  /// @param _id Payment identifier
+  function finalizePayment(uint256 _id) public;
+
   /// @notice Sets the recipient on an existing payment. Secured function to authorised members
   /// @param _id Payment identifier
   /// @param _recipient Address of the payment recipient
-  function setPaymentRecipient(uint256 _id, address _recipient) public;
+  function setPaymentRecipient(uint256 _id, address payable _recipient) public;
 
   /// @notice Sets the domain on an existing payment. Secured function to authorised members
   /// @param _id Payment identifier
@@ -173,7 +178,7 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @return domainId The domain where the payment belongs
   /// @return skills Array of global skill ids assigned to task
   function getPayment(uint256 _id) public view returns (
-    address recipient,
+    address payable recipient,
     bool finalized,
     uint256 fundingPotId,
     uint256 domainId,

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -168,10 +168,16 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @notice Returns an exiting payment
   /// @param _id Payment identifier
   /// @return recipient Address of the payment recipient
+  /// @return finalized Boolean indicator turned on when the payment is fully funded
   /// @return fundingPotId Id of the associated funding pot
   /// @return domainId The domain where the payment belongs
   /// @return skills Array of global skill ids assigned to task
-  function getPayment(uint256 _id) public view returns (address recipient, uint256 fundingPotId, uint256 domainId, uint256[] memory skills);
+  function getPayment(uint256 _id) public view returns (
+    address recipient,
+    bool finalized,
+    uint256 fundingPotId,
+    uint256 domainId,
+    uint256[] memory skills);
   
   /// @notice Claim the payout in `_token` denomination for payment `_id`. Here the network receives its fee from each payout.
   /// Same as for tasks, ether fees go straight to the Meta Colony whereas Token fees go to the Network to be auctioned off.

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -168,7 +168,7 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _id Payment identifier
   /// @param _token Address of the token, `0x0` value indicates Ether
   /// @param _amount Payout amount
-  function setPayout(uint256 _id, address _token, uint256 _amount) public;
+  function setPaymentPayout(uint256 _id, address _token, uint256 _amount) public;
 
   /// @notice Returns an exiting payment
   /// @param _id Payment identifier

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -172,17 +172,8 @@ contract IColony is ColonyDataTypes, IRecovery {
 
   /// @notice Returns an exiting payment
   /// @param _id Payment identifier
-  /// @return recipient Address of the payment recipient
-  /// @return finalized Boolean indicator turned on when the payment is fully funded
-  /// @return fundingPotId Id of the associated funding pot
-  /// @return domainId The domain where the payment belongs
-  /// @return skills Array of global skill ids assigned to task
-  function getPayment(uint256 _id) public view returns (
-    address payable recipient,
-    bool finalized,
-    uint256 fundingPotId,
-    uint256 domainId,
-    uint256[] memory skills);
+  /// @return payment The Payment data structure 
+  function getPayment(uint256 _id) public view returns (Payment memory payment);
   
   /// @notice Claim the payout in `_token` denomination for payment `_id`. Here the network receives its fee from each payout.
   /// Same as for tasks, ether fees go straight to the Meta Colony whereas Token fees go to the Network to be auctioned off.

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -142,7 +142,15 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _skillId The skill associated with the payment
   /// @param _token Address of the token, `0x0` value indicates Ether
   /// @param _amount Payout amount
-  function addPayment(address _recipient, address _token, uint256 _amount, uint256 _domainId, uint256 _skillId) public;
+  /// @return paymentId Identifier of the newly created payment
+  function addPayment(
+    address _recipient,
+    address _token,
+    uint256 _amount,
+    uint256 _domainId,
+    uint256 _skillId) 
+    public returns (uint256 paymentId);
+
   function getPayment(uint256 id) public view returns(Payment memory payment);
   function claimPayment(uint256) public;
   function getPaymentCount() public view returns (uint256 count);

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -171,7 +171,7 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @return fundingPotId Id of the associated funding pot
   /// @return domainId The domain where the payment belongs
   /// @return skills Array of global skill ids assigned to task
-  function getPayment(uint256 id) public view returns(address recipient, uint256 fundingPotId, uint256 domainId, uint256[] memory skills);
+  function getPayment(uint256 _id) public view returns (address recipient, uint256 fundingPotId, uint256 domainId, uint256[] memory skills);
   
   /// @notice Claim the payout in `_token` denomination for payment `_id`. Here the network receives its fee from each payout.
   /// Same as for tasks, ether fees go straight to the Meta Colony whereas Token fees go to the Network to be auctioned off.

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -92,16 +92,14 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
 
   /// @notice Get the `nParents` and `nChildren` of skill with id `_skillId`
   /// @param _skillId Id of the skill
-  /// @return nParents uint128`skill.nParents` i.e. the number of parent skills of skill with id `_skillId`
-  /// @return nChildren uint128`skill.nChildren` i.e. the number of child skills of skill with id `_skillId`
-  /// @return isGlobalSkill true if specified skill is a global skill, otherwise false
+  /// @return skill The Skill struct
   function getSkill(uint256 _skillId) public view returns (Skill memory skill);
 
   /// @notice Get whether the skill with id _skillId is public or not.
   /// @param _skillId Id of the skill
-  /// @return isGlobalSkill bool
+  /// @return result bool
   /// @dev Returns false if skill does not exist
-  function isGlobalSkill(uint256 _skillId) public view returns (bool isGlobalSkill);
+  function isGlobalSkill(uint256 _skillId) public view returns (bool result);
 
   /// @notice Adds a reputation update entry to log
   /// @dev Errors if it is called by anyone but a colony or if skill with id `_skillId` does not exist or

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -98,6 +98,7 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   function getSkill(uint256 _skillId) public view returns (Skill memory skill);
 
   /// @notice Get whether the skill with id _skillId is public or not.
+  /// @param _skillId Id of the skill
   /// @return isGlobalSkill bool
   /// @dev Returns false if skill does not exist
   function isGlobalSkill(uint256 _skillId) public view returns (bool isGlobalSkill);

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -19,6 +19,7 @@ pragma solidity >=0.5.3;
 pragma experimental ABIEncoderV2;
 
 import "./../IColony.sol";
+import "./../ColonyDataTypes.sol";
 import "./../../lib/dappsys/roles.sol";
 
 
@@ -46,10 +47,10 @@ contract OneTxPayment {
     // Add a new payment
     uint256 paymentId = colony.addPayment(_worker, _token, _amount, _domainId, _skillId);
     uint fundingPotId;
-    (,,fundingPotId,,) = colony.getPayment(paymentId);
+    ColonyDataTypes.Payment memory payment = colony.getPayment(paymentId);
     ColonyDataTypes.Domain memory domain = colony.getDomain(_domainId);
     // Fund the payment
-    colony.moveFundsBetweenPots(domain.fundingPotId, fundingPotId, _amount, _token);
+    colony.moveFundsBetweenPots(domain.fundingPotId, payment.fundingPotId, _amount, _token);
     colony.finalizePayment(paymentId);
     // Claim payout on behalf of the recipient
     colony.claimPayment(paymentId, _token);

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -34,10 +34,11 @@ contract OneTxPayment {
 
     // Add a new payment
     uint256 paymentId = colony.addPayment(_worker, _token, _amount, _domainId, _skillId);
-    ColonyDataTypes.Payment memory payment = colony.getPayment(paymentId);
+    uint paymentFundingPotId;
+    (,paymentFundingPotId,,) = colony.getPayment(paymentId);
     ColonyDataTypes.Domain memory domain = colony.getDomain(_domainId);
     // Fund the payment
-    colony.moveFundsBetweenPots(domain.fundingPotId, payment.fundingPotId, _amount, _token);
+    colony.moveFundsBetweenPots(domain.fundingPotId, paymentFundingPotId, _amount, _token);
     // Claim payout on behalf of the recipient
     colony.claimPayment(paymentId);
   }

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -25,7 +25,7 @@ import "./../../lib/dappsys/roles.sol";
 contract OneTxPayment {
   function makePayment(
     address _colony,
-    address _worker,
+    address payable _worker,
     address _token,
     uint256 _amount,
     uint256 _domainId,

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -50,6 +50,7 @@ contract OneTxPayment {
     ColonyDataTypes.Domain memory domain = colony.getDomain(_domainId);
     // Fund the payment
     colony.moveFundsBetweenPots(domain.fundingPotId, fundingPotId, _amount, _token);
+    colony.finalizePayment(paymentId);
     // Claim payout on behalf of the recipient
     colony.claimPayment(paymentId, _token);
   }

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity >=0.4.23 <0.5.0;
+pragma solidity >=0.5.3;
 pragma experimental ABIEncoderV2;
 
 import "./../IColony.sol";

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -40,6 +40,6 @@ contract OneTxPayment {
     // Fund the payment
     colony.moveFundsBetweenPots(domain.fundingPotId, paymentFundingPotId, _amount, _token);
     // Claim payout on behalf of the recipient
-    colony.claimPayment(paymentId);
+    colony.claimPayment(paymentId, _token);
   }
 }

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -33,7 +33,6 @@ contract OneTxPayment {
   {
     IColony colony = IColony(_colony);
     // Check caller is able to call makePayment on the colony
-    // msg.sig is the same for this call as it is for the one we make below, so may as well use it here
     DSRoles authority = DSRoles(colony.authority());
     require(
       authority.canCall(

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -47,7 +47,7 @@ contract OneTxPayment {
     // Add a new payment
     uint256 paymentId = colony.addPayment(_worker, _token, _amount, _domainId, _skillId);
     uint fundingPotId;
-    (,fundingPotId,,) = colony.getPayment(paymentId);
+    (,,fundingPotId,,) = colony.getPayment(paymentId);
     ColonyDataTypes.Domain memory domain = colony.getDomain(_domainId);
     // Fund the payment
     colony.moveFundsBetweenPots(domain.fundingPotId, fundingPotId, _amount, _token);

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -1,0 +1,44 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity >=0.4.23 <0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "./../IColony.sol";
+
+
+contract OneTxPayment {
+  function makePayment(
+    address _colony,
+    address _worker,
+    address _token,
+    uint256 _amount,
+    uint256 _domainId,
+    uint256 _skillId) public 
+  {
+    IColony colony = IColony(_colony);
+
+    // Add a new payment
+    uint256 paymentId = colony.addPayment(_worker, _token, _amount, _domainId, _skillId);
+    ColonyDataTypes.Payment memory payment = colony.getPayment(paymentId);
+    ColonyDataTypes.Domain memory domain = colony.getDomain(_domainId);
+    // Fund the payment
+    colony.moveFundsBetweenPots(domain.fundingPotId, payment.fundingPotId, _amount, _token);
+    // Claim payout on behalf of the recipient
+    colony.claimPayment(paymentId);
+  }
+}

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -34,6 +34,7 @@ const Resolver = artifacts.require("Resolver");
 const Colony = artifacts.require("Colony");
 const ColonyFunding = artifacts.require("ColonyFunding");
 const ColonyTask = artifacts.require("ColonyTask");
+const ColonyPayment = artifacts.require("ColonyPayment");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const ContractRecovery = artifacts.require("ContractRecovery");
 
@@ -381,13 +382,14 @@ export async function setupColonyNetwork() {
   const colonyTemplate = await Colony.new();
   const colonyFunding = await ColonyFunding.new();
   const colonyTask = await ColonyTask.new();
+  const colonyPayment = await ColonyPayment.new();
   const resolver = await Resolver.new();
   const contractRecovery = await ContractRecovery.new();
   const etherRouter = await EtherRouter.new();
   await etherRouter.setResolver(resolverColonyNetworkDeployed.address);
 
   const colonyNetwork = await IColonyNetwork.at(etherRouter.address);
-  await setupColonyVersionResolver(colonyTemplate, colonyTask, colonyFunding, contractRecovery, resolver);
+  await setupColonyVersionResolver(colonyTemplate, colonyTask, colonyPayment, colonyFunding, contractRecovery, resolver);
   await colonyNetwork.initialise(resolver.address);
   // Jumping through these hoops to avoid the need to rewire ReputationMiningCycleResolver.
   const deployedColonyNetwork = await IColonyNetwork.at(EtherRouter.address);

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -174,7 +174,7 @@ export async function setupFundedTask({
 
   const taskId = await setupTask({ colonyNetwork, colony, dueDate, domainId, skillId, manager });
   const task = await colony.getTask(taskId);
-  const fundingPotId = task[5];
+  const { fundingPotId } = task;
   const managerPayoutBN = new BN(managerPayout);
   const evaluatorPayoutBN = new BN(evaluatorPayout);
   const workerPayoutBN = new BN(workerPayout);

--- a/helpers/upgradable-contracts.js
+++ b/helpers/upgradable-contracts.js
@@ -67,7 +67,7 @@ export async function setupColonyVersionResolver(colony, colonyTask, colonyPayme
   const deployedImplementations = {};
   deployedImplementations.Colony = colony.address;
   deployedImplementations.ColonyTask = colonyTask.address;
-  deployedImplementations.colonyPayment = colonyPayment.address;
+  deployedImplementations.ColonyPayment = colonyPayment.address;
   deployedImplementations.ColonyFunding = colonyFunding.address;
   deployedImplementations.ContractRecovery = contractRecovery.address;
 

--- a/helpers/upgradable-contracts.js
+++ b/helpers/upgradable-contracts.js
@@ -63,10 +63,11 @@ export async function setupEtherRouter(interfaceContract, deployedImplementation
   }
 }
 
-export async function setupColonyVersionResolver(colony, colonyTask, colonyFunding, contractRecovery, resolver) {
+export async function setupColonyVersionResolver(colony, colonyTask, colonyPayment, colonyFunding, contractRecovery, resolver) {
   const deployedImplementations = {};
   deployedImplementations.Colony = colony.address;
   deployedImplementations.ColonyTask = colonyTask.address;
+  deployedImplementations.colonyPayment = colonyPayment.address;
   deployedImplementations.ColonyFunding = colonyFunding.address;
   deployedImplementations.ContractRecovery = contractRecovery.address;
 

--- a/migrations/4_setup_colony_version_resolver.js
+++ b/migrations/4_setup_colony_version_resolver.js
@@ -6,6 +6,7 @@ const { setupColonyVersionResolver } = require("../helpers/upgradable-contracts"
 const Colony = artifacts.require("./Colony");
 const ColonyFunding = artifacts.require("./ColonyFunding");
 const ColonyTask = artifacts.require("./ColonyTask");
+const ColonyPayment = artifacts.require("./ColonyPayment");
 const ContractRecovery = artifacts.require("./ContractRecovery");
 const EtherRouter = artifacts.require("./EtherRouter");
 const Resolver = artifacts.require("./Resolver");
@@ -17,6 +18,7 @@ module.exports = async function(deployer) {
   const colony = await Colony.new();
   const colonyFunding = await ColonyFunding.new();
   const colonyTask = await ColonyTask.new();
+  const colonyPayment = await ColonyPayment.new();
   const contractRecovery = await ContractRecovery.deployed();
   const version = await colony.version();
   const resolver = await Resolver.new();
@@ -25,7 +27,7 @@ module.exports = async function(deployer) {
   const colonyNetwork = await IColonyNetwork.at(etherRouterDeployed.address);
 
   // Register the new Colony contract version with the newly setup Resolver
-  await setupColonyVersionResolver(colony, colonyTask, colonyFunding, contractRecovery, resolver);
+  await setupColonyVersionResolver(colony, colonyTask, colonyPayment, colonyFunding, contractRecovery, resolver);
   await colonyNetwork.initialise(resolver.address);
 
   console.log("### Colony version", version.toString(), "set to Resolver", resolver.address);

--- a/scripts/check-recovery.js
+++ b/scripts/check-recovery.js
@@ -57,7 +57,8 @@ walkSync("./contracts/").forEach(contractName => {
       "contracts/TokenLocking.sol",
       "contracts/TokenLockingStorage.sol",
       "contracts/Token.sol", // Imported from colonyToken repo
-      "contracts/TokenAuthority.sol" // Imported from colonyToken repo
+      "contracts/TokenAuthority.sol", // Imported from colonyToken repo
+      "contracts/extensions/OneTxPayment.sol"
     ].indexOf(contractName) > -1
   ) {
     return;

--- a/scripts/check-recovery.js
+++ b/scripts/check-recovery.js
@@ -20,7 +20,7 @@ function correctRecoveryModifier(functionDef) {
 
 walkSync("./contracts/").forEach(contractName => {
   // These contracts don't need to be checked, since they're not used in recovery mode
-  // Basically only Colony.sol, ColonyFunding.sol, and ColonyTask.sol are
+  // Basically only Colony.sol, ColonyFunding.sol, ColonyTask.sol and ColonyPayment.sol are
   // ColonyNetwork, ColonyNetworkAuction, ColonyNetworkENS, ColonyNetworkMining
   if (
     [

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -17,7 +17,8 @@ import {
   SPECIFICATION_HASH,
   DELIVERABLE_HASH,
   SECONDS_PER_DAY,
-  DEFAULT_STAKE
+  DEFAULT_STAKE,
+  INITIAL_FUNDING
 } from "../helpers/constants";
 
 import {
@@ -50,6 +51,7 @@ const IMetaColony = artifacts.require("IMetaColony");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const EtherRouter = artifacts.require("EtherRouter");
 const ITokenLocking = artifacts.require("ITokenLocking");
+const OneTxPayment = artifacts.require("OneTxPayment");
 
 const REAL_PROVIDER_PORT = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
 
@@ -63,6 +65,7 @@ contract("All", function(accounts) {
   const MANAGER = accounts[0];
   const EVALUATOR = MANAGER;
   const WORKER = accounts[2];
+  const COLONY_ADMIN = accounts[5];
 
   let colony;
   let token;
@@ -70,6 +73,7 @@ contract("All", function(accounts) {
   let metaColony;
   let colonyNetwork;
   let tokenLocking;
+  let oneTxExtension;
 
   before(async function() {
     const etherRouter = await EtherRouter.deployed();
@@ -86,6 +90,13 @@ contract("All", function(accounts) {
 
     const otherTokenArgs = getTokenArgs();
     otherToken = await DSToken.new(otherTokenArgs[1]);
+
+    oneTxExtension = await OneTxPayment.new();
+    await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+    // Give a use colony admin rights
+    await colony.setAdminRole(COLONY_ADMIN);
+    // Give oneTxExtension admin rights
+    await colony.setAdminRole(oneTxExtension.address);
   });
 
   // We currently only print out gas costs and no assertions are made about what these should be.
@@ -202,6 +213,21 @@ contract("All", function(accounts) {
       await colony.finalizeTask(taskId);
     });
 
+    it("when working with a Payment", async function() {
+      // 4 transactions payment
+      await colony.addPayment(WORKER, token.address, WAD, 1, 0);
+      const paymentId = await colony.getPaymentCount();
+      const payment = await colony.getPayment(paymentId);
+
+      await colony.moveFundsBetweenPots(1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.finalizePayment(paymentId);
+      await colony.claimPayment(paymentId, token.address);
+
+      // 1 transaction payment
+      const globalSkillId = await colonyNetwork.getRootGlobalSkillId();
+      await oneTxExtension.makePayment(colony.address, WORKER, token.address, 10, 1, globalSkillId);
+    });
+
     it("when working with staking", async function() {
       const STAKER1 = accounts[6];
       const STAKER2 = accounts[7];
@@ -256,7 +282,6 @@ contract("All", function(accounts) {
       const totalReputation = WAD.muln(300);
       const workerReputation = WAD.muln(200);
       const managerReputation = WAD.muln(100);
-      const initialFunding = WAD.muln(360);
 
       const tokenArgs = getTokenArgs();
       const newToken = await DSToken.new(tokenArgs[1]);
@@ -265,7 +290,6 @@ contract("All", function(accounts) {
       const newColony = await IColony.at(colonyAddress);
       await newToken.setOwner(colonyAddress);
 
-      await fundColonyWithTokens(newColony, otherToken, initialFunding);
       await newColony.mintTokens(workerReputation.add(managerReputation));
       await newColony.claimColonyFunds(newToken.address);
       await newColony.bootstrapColony([WORKER, MANAGER], [workerReputation, managerReputation]);
@@ -329,7 +353,7 @@ contract("All", function(accounts) {
       await forwardTime(5184001);
       await newColony.finalizeRewardPayout(payoutId);
 
-      await fundColonyWithTokens(newColony, otherToken, initialFunding);
+      await fundColonyWithTokens(newColony, otherToken, INITIAL_FUNDING);
 
       const tx2 = await newColony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId2 = tx2.logs[0].args.rewardPayoutId;

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -93,7 +93,7 @@ contract("All", function(accounts) {
 
     oneTxExtension = await OneTxPayment.new();
     await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-    // Give a use colony admin rights
+    // Give a user colony admin rights
     await colony.setAdminRole(COLONY_ADMIN);
     // Give oneTxExtension admin rights
     await colony.setAdminRole(oneTxExtension.address);

--- a/test-upgrade/colony-upgrade.js
+++ b/test-upgrade/colony-upgrade.js
@@ -11,6 +11,7 @@ const Resolver = artifacts.require("Resolver");
 const IColony = artifacts.require("IColony");
 const IMetaColony = artifacts.require("IMetaColony");
 const ColonyTask = artifacts.require("ColonyTask");
+const ColonyPayment = artifacts.require("ColonyPayment");
 const ColonyFunding = artifacts.require("ColonyFunding");
 const UpdatedColony = artifacts.require("UpdatedColony");
 const IUpdatedColony = artifacts.require("IUpdatedColony");
@@ -23,6 +24,7 @@ contract("Colony contract upgrade", accounts => {
   let metaColony;
   let colony;
   let colonyTask;
+  let colonyPayment;
   let colonyFunding;
   let token;
   let colonyNetwork;
@@ -46,6 +48,7 @@ contract("Colony contract upgrade", accounts => {
     const { colonyAddress } = logs[0].args;
     colony = await IColony.at(colonyAddress);
     colonyTask = await ColonyTask.new();
+    colonyPayment = await ColonyPayment.new();
     colonyFunding = await ColonyFunding.new();
     contractRecovery = await ContractRecovery.new();
     const tokenAddress = await colony.getToken();
@@ -57,7 +60,7 @@ contract("Colony contract upgrade", accounts => {
     const updatedColonyContract = await UpdatedColony.new();
     const resolver = await Resolver.new();
     await resolver.register("isUpdated()", updatedColonyContract.address);
-    await setupColonyVersionResolver(updatedColonyContract, colonyTask, colonyFunding, contractRecovery, resolver);
+    await setupColonyVersionResolver(updatedColonyContract, colonyTask, colonyPayment, colonyFunding, contractRecovery, resolver);
 
     updatedColonyVersion = await updatedColonyContract.version();
     await metaColony.addNetworkColonyVersion(updatedColonyVersion.toNumber(), resolver.address);

--- a/test-upgrade/colony-upgrade.js
+++ b/test-upgrade/colony-upgrade.js
@@ -91,16 +91,16 @@ contract("Colony contract upgrade", accounts => {
 
     it("should return correct tasks after Task struct is extended", async function() {
       const task1 = await updatedColony.getTask(1);
-      assert.equal(task1[0], SPECIFICATION_HASH);
-      assert.equal(task1[2].toNumber(), 0);
-      assert.equal(task1[3].toNumber(), dueDate);
-      assert.equal(task1[4].toNumber(), 0);
+      assert.equal(task1.specificationHash, SPECIFICATION_HASH);
+      assert.equal(task1.status.toNumber(), 0);
+      assert.equal(task1.dueDate.toNumber(), dueDate);
+      assert.equal(task1.domainId.toNumber(), 1);
 
       const task2 = await updatedColony.getTask(2);
-      assert.equal(task2[0], SPECIFICATION_HASH_UPDATED);
-      assert.equal(task2[2].toNumber(), 0);
-      assert.equal(task2[3].toNumber(), dueDate + 1);
-      assert.equal(task2[4].toNumber(), 0);
+      assert.equal(task2.specificationHash, SPECIFICATION_HASH_UPDATED);
+      assert.equal(task2.status.toNumber(), 0);
+      assert.equal(task2.dueDate.toNumber(), dueDate + 1);
+      assert.equal(task2.domainId.toNumber(), 1);
     });
 
     it("should return correct permissions", async function() {

--- a/test/colony-funding.js
+++ b/test/colony-funding.js
@@ -162,7 +162,7 @@ contract("Colony Funding", accounts => {
       // the pot changes (odd numbers), and when the payout changes (even numbers)
       //
       // NB We do not need to be this exhaustive when using ether, because this test is testing
-      // that updateTaskPayoutsWeCannotMakeAfterPotChange and updateTaskPayoutsWeCannotMakeAfterBudgetChange
+      // that updatePayoutsWeCannotMakeAfterPotChange and updatePayoutsWeCannotMakeAfterBudgetChange
       // are correct, which are used in both cases.
       //
       // NB Also that since we can no longer reduce the pot to below the budget,
@@ -187,14 +187,15 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 0]
       });
-      let task = await colony.getTask(taskId);
-      expect(task[4]).to.be.zero;
+      const task = await colony.getTask(taskId);
+      let fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 0, Payout 0
       // FundingPot was equal to payout, transition to pot being equal by changing pot (17)
       await colony.moveFundsBetweenPots(1, 2, 0, otherToken.address);
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.be.zero;
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 0, Payout 0
       // FundingPot was equal to payout, transition to pot being lower by increasing payout (8)
@@ -206,22 +207,22 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 40]
       });
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.eq.BN(1);
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
-      // FundingPot 0, Payout 40
+      // FundingPot Balance: 0, Payout: 40
       // FundingPot was below payout, transition to being equal by increasing pot (1)
       await colony.moveFundsBetweenPots(1, 2, 40, otherToken.address);
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.be.zero;
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
-      // FundingPot 40, Payout 40
+      // FundingPot Balance: 40, Payout 40
       // FundingPot was equal to payout, transition to being above by increasing pot (5)
       await colony.moveFundsBetweenPots(1, 2, 40, otherToken.address);
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.be.zero;
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
-      // FundingPot 80, Payout 40
+      // FundingPot Balance: 80, Payout 40
       // FundingPot was above payout, transition to being equal by increasing payout (12)
       await executeSignedTaskChange({
         colony,
@@ -231,8 +232,8 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 80]
       });
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.be.zero;
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 80, Payout 80
       // FundingPot was equal to payout, transition to being above by decreasing payout (6)
@@ -244,14 +245,14 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 40]
       });
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.be.zero;
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 80, Payout 40
       // FundingPot was above payout, transition to being equal by decreasing pot (11)
       await colony.moveFundsBetweenPots(2, 1, 40, otherToken.address);
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.be.zero;
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 40, Payout 40
       // FundingPot was equal to payout, transition to pot being below payout by changing pot (7)
@@ -279,8 +280,8 @@ contract("Colony Funding", accounts => {
       // FundingPot 20, Payout 40
       // FundingPot was below payout, change to being above by changing pot (3)
       await colony.moveFundsBetweenPots(1, 2, 60, otherToken.address);
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.be.zero;
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 80, Payout 40
       // FundingPot was above payout, change to being below by changing pot (9)
@@ -315,8 +316,8 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 10]
       });
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.be.zero;
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 20, Payout 10
       // FundingPot was above, change to being above by changing payout (16)
@@ -328,14 +329,14 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 5]
       });
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.be.zero;
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 20, Payout 5
       // FundingPot was above, change to being above by changing pot (15)
       await colony.moveFundsBetweenPots(2, 1, 10, otherToken.address);
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.be.zero;
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 10, Payout 5
       // FundingPot was above payout, change to being below by changing payout (10)
@@ -347,8 +348,8 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 40]
       });
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.eq.BN(1);
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
       // FundingPot 10, Payout 40
       // FundingPot was below payout, change to being below by changing payout (14)
@@ -360,8 +361,8 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 30]
       });
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.eq.BN(1);
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
       // FundingPot 10, Payout 30
       // FundingPot was below payout, change to being below by changing pot (13)
@@ -396,8 +397,8 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 5]
       });
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.be.zero;
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 5, Payout 5
     });
@@ -461,9 +462,9 @@ contract("Colony Funding", accounts => {
       await fundColonyWithTokens(colony, otherToken, WAD.muln(363));
       const taskId = await setupFinalizedTask({ colonyNetwork, colony, token: otherToken });
       await colony.moveFundsBetweenPots(1, 2, 10, otherToken.address);
-      await colony.claimPayout(taskId, MANAGER_ROLE, otherToken.address);
-      await colony.claimPayout(taskId, WORKER_ROLE, otherToken.address);
-      await colony.claimPayout(taskId, EVALUATOR_ROLE, otherToken.address);
+      await colony.claimTaskPayout(taskId, MANAGER_ROLE, otherToken.address);
+      await colony.claimTaskPayout(taskId, WORKER_ROLE, otherToken.address);
+      await colony.claimTaskPayout(taskId, EVALUATOR_ROLE, otherToken.address);
       await colony.moveFundsBetweenPots(2, 1, 10, otherToken.address);
 
       const colonyPotBalance = await colony.getFundingPotBalance(2, otherToken.address);
@@ -479,18 +480,17 @@ contract("Colony Funding", accounts => {
         workerRating: 1
       });
 
-      await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
-      await colony.claimPayout(taskId, EVALUATOR_ROLE, token.address);
-      await colony.claimPayout(taskId, WORKER_ROLE, token.address);
+      await colony.claimTaskPayout(taskId, MANAGER_ROLE, token.address);
+      await colony.claimTaskPayout(taskId, EVALUATOR_ROLE, token.address);
+      await colony.claimTaskPayout(taskId, WORKER_ROLE, token.address);
 
-      const taskInfo = await colony.getTask(taskId);
-      const taskPotId = taskInfo[5];
-      const remainingPotBalance = await colony.getFundingPotBalance(taskPotId, token.address);
+      const task = await colony.getTask(taskId);
+      const remainingPotBalance = await colony.getFundingPotBalance(task.fundingPotId, token.address);
       expect(remainingPotBalance).to.eq.BN(WORKER_PAYOUT);
 
-      await colony.moveFundsBetweenPots(taskPotId, 1, remainingPotBalance, token.address);
+      await colony.moveFundsBetweenPots(task.fundingPotId, 1, remainingPotBalance, token.address);
 
-      const potBalance = await colony.getFundingPotBalance(taskPotId, token.address);
+      const potBalance = await colony.getFundingPotBalance(task.fundingPotId, token.address);
       expect(potBalance).to.be.zero;
     });
   });
@@ -566,13 +566,15 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, ZERO_ADDRESS, 40]
       });
-      let task = await colony.getTask(taskId);
-      expect(task[4]).to.eq.BN(1);
+
+      const task = await colony.getTask(taskId);
+      let fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
       // Fund the pot equal to manager payout 40 = 40
       await colony.moveFundsBetweenPots(1, 2, 40, ZERO_ADDRESS);
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.be.zero;
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // Cannot bring pot balance below current payout
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 30, ZERO_ADDRESS), "colony-funding-task-bad-state");
@@ -586,21 +588,21 @@ contract("Colony Funding", accounts => {
         sigTypes: [0],
         args: [taskId, ZERO_ADDRESS, 50]
       });
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.eq.BN(1);
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
       // Fund the pot equal to manager payout, plus 10, 50 < 60
       await colony.moveFundsBetweenPots(1, 2, 20, ZERO_ADDRESS);
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.be.zero;
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // Cannot bring pot balance below current payout
       await checkErrorRevert(colony.moveFundsBetweenPots(2, 1, 30, ZERO_ADDRESS), "colony-funding-task-bad-state");
 
       // Can remove surplus 50 = 50
       await colony.moveFundsBetweenPots(2, 1, 10, ZERO_ADDRESS);
-      task = await colony.getTask(taskId);
-      expect(task[4]).to.be.zero;
+      fundingPot = await colony.getFundingPot(task.fundingPotId);
+      expect(fundingPot.payoutsWeCannotMake).to.be.zero;
     });
 
     it("should pay fees on revenue correctly", async () => {

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -82,5 +82,14 @@ contract("Colony Payment", accounts => {
       expect(recipientBalanceAfter.sub(recipientBalanceBefore)).to.eq.BN(new BN("989999999999999999"));
       expect(networkBalanceAfter.sub(networkBalanceBefore)).to.eq.BN(new BN("10000000000000001"));
     });
+
+    it("should error when payment is insufficiently funded", async () => {
+      await colony.addPayment(RECIPIENT, token.address, 10000, 1, 0);
+      const paymentId = await colony.getPaymentCount();
+      const payment = await colony.getPayment(paymentId);
+
+      await colony.moveFundsBetweenPots(1, payment.fundingPotId, 9999, token.address);
+      await checkErrorRevert(colony.claimPayment(paymentId), "colony-payment-insufficient-funding");
+    });
   });
 });

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -5,7 +5,7 @@ import { BN } from "bn.js";
 
 import { WAD, ZERO_ADDRESS, MAX_PAYOUT } from "../helpers/constants";
 import { checkErrorRevert, getTokenArgs } from "../helpers/test-helper";
-import { fundColonyWithTokens, setupRandomColony } from "../helpers/test-data-generator";
+import { fundColonyWithTokens, setupRandomColony, makeTask } from "../helpers/test-data-generator";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
@@ -180,6 +180,12 @@ contract("Colony Payment", accounts => {
       await colony.moveFundsBetweenPots(1, payment.fundingPotId, 10, token.address);
       payment = await colony.getPayment(paymentId);
       expect(payment.finalized).to.be.true;
+    });
+
+    it("should not allow task payouts to be set via setPayout", async () => {
+      const taskId = await makeTask({ colony });
+      const { fundingPotId } = await colony.getTask(taskId);
+      await checkErrorRevert(colony.setPayout(fundingPotId, token.address, 100), "colony-funding-pot-associated-with-non-payment");
     });
   });
 

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -198,6 +198,10 @@ contract("Colony Payment", accounts => {
     it("should not allow admins to update skill", async () => {
       await checkErrorRevert(colony.setPaymentSkill(paymentId, 1, { from: COLONY_ADMIN }), "colony-payment-finalized");
     });
+
+    it("should not allow admins to update payment", async () => {
+      await checkErrorRevert(colony.setPayout(paymentId, token.address, 1, { from: COLONY_ADMIN }), "colony-funding-payment-finalized");
+    });
   });
 
   describe("when claiming payments", () => {

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -195,13 +195,18 @@ contract("Colony Payment", accounts => {
     });
 
     it("can finalize payment when it is fully funded", async () => {
-      let payment = await colony.getPayment(paymentId);
+      const payment = await colony.getPayment(paymentId);
+      await colony.moveFundsBetweenPots(payment.fundingPotId, 1, 1, token.address);
+      expect(payment.finalized).to.be.false;
+
+      await checkErrorRevert(colony.finalizePayment(paymentId), "colony-payment-not-funded");
+    });
+
+    it("cannnot finalize payment if it is NOT fully funded", async () => {
+      const payment = await colony.getPayment(paymentId);
       expect(payment.finalized).to.be.false;
 
       await colony.finalizePayment(paymentId);
-
-      payment = await colony.getPayment(paymentId);
-      expect(payment.finalized).to.be.true;
     });
 
     it("cannot finalize payment not authorised", async () => {

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -279,6 +279,19 @@ contract("Colony Payment", accounts => {
       expect(networkBalanceAfter.sub(networkBalanceBefore)).to.eq.BN(new BN("10000000000000001"));
     });
 
+    it("after payment is claimed it should set the payout to 0", async () => {
+      await colony.addPayment(RECIPIENT, token.address, WAD, 1, 0);
+      const paymentId = await colony.getPaymentCount();
+      const payment = await colony.getPayment(paymentId);
+
+      await colony.moveFundsBetweenPots(1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.finalizePayment(paymentId);
+      await colony.claimPayment(paymentId, token.address);
+
+      const tokenPayout = await colony.getFundingPotPayout(payment.fundingPotId, token.address);
+      expect(tokenPayout).to.be.zero;
+    });
+
     it("should error when payment is not funded and finalized", async () => {
       await colony.addPayment(RECIPIENT, token.address, 10000, 1, 0);
       const paymentId = await colony.getPaymentCount();

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -49,9 +49,8 @@ contract("Colony Payment", accounts => {
       expect(payment.domainId).to.eq.BN(1);
     });
 
-    // TODO
-    it.skip("should not allow admins to add payment with no domain set", async () => {
-      await checkErrorRevert(colony.addPayment(RECIPIENT, token.address, WAD, 0, 0), "");
+    it("should not allow admins to add payment with no domain set", async () => {
+      await checkErrorRevert(colony.addPayment(RECIPIENT, token.address, WAD, 0, 0), "colony-domain-does-not-exist");
     });
   });
 

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -14,7 +14,7 @@ const EtherRouter = artifacts.require("EtherRouter");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const DSToken = artifacts.require("DSToken");
 
-contract("Colony Payment", accounts => {
+contract.only("Colony Payment", accounts => {
   const RECIPIENT = accounts[3];
   const COLONY_ADMIN = accounts[4];
 

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -14,7 +14,7 @@ const EtherRouter = artifacts.require("EtherRouter");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const DSToken = artifacts.require("DSToken");
 
-contract.only("Colony Payment", accounts => {
+contract("Colony Payment", accounts => {
   const RECIPIENT = accounts[3];
   const COLONY_ADMIN = accounts[4];
 

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -176,6 +176,30 @@ contract("Colony Payment", accounts => {
     });
   });
 
+  describe("when payment is finalized", () => {
+    let paymentId;
+
+    beforeEach(async () => {
+      await colony.addPayment(RECIPIENT, token.address, 40, 1, 0);
+      paymentId = await colony.getPaymentCount();
+      const payment = await colony.getPayment(paymentId);
+      await fundColonyWithTokens(colony, token, 40);
+      await colony.moveFundsBetweenPots(1, payment.fundingPotId, 40, token.address);
+    });
+
+    it("should not allow admins to update recipient", async () => {
+      await checkErrorRevert(colony.setPaymentRecipient(paymentId, accounts[6], { from: COLONY_ADMIN }), "colony-payment-finalized");
+    });
+
+    it("should not allow admins to update to empty domain", async () => {
+      await checkErrorRevert(colony.setPaymentDomain(paymentId, 2, { from: COLONY_ADMIN }), "colony-payment-finalized");
+    });
+
+    it("should not allow admins to update skill", async () => {
+      await checkErrorRevert(colony.setPaymentSkill(paymentId, 1, { from: COLONY_ADMIN }), "colony-payment-finalized");
+    });
+  });
+
   describe("when claiming payments", () => {
     it("should allow recipient to claim their payment and network fee is deducated", async () => {
       await colony.addPayment(RECIPIENT, token.address, WAD, 1, 0);

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -1,0 +1,96 @@
+/* global artifacts */
+import chai from "chai";
+import bnChai from "bn-chai";
+
+import {
+  WAD,
+  ZERO_ADDRESS
+} from "../helpers/constants";
+
+import {
+  getTokenArgs,
+  web3GetBalance,
+  checkErrorRevert,
+  expectEvent,
+  expectAllEvents,
+  forwardTime,
+  currentBlockTime,
+  createSignatures
+} from "../helpers/test-helper";
+
+import {
+  fundColonyWithTokens,
+  setupFinalizedTask,
+  setupRatedTask,
+  setupAssignedTask,
+  setupFundedTask,
+  executeSignedTaskChange,
+  executeSignedRoleAssignment,
+  getSigsAndTransactionData,
+  makeTask,
+  setupRandomColony
+} from "../helpers/test-data-generator";
+
+const ethers = require("ethers");
+
+const { expect } = chai;
+chai.use(bnChai(web3.utils.BN));
+
+const EtherRouter = artifacts.require("EtherRouter");
+const IMetaColony = artifacts.require("IMetaColony");
+const IColonyNetwork = artifacts.require("IColonyNetwork");
+const DSToken = artifacts.require("DSToken");
+
+contract("Colony Payment", accounts => {
+  const PAYMENT_ADMIN = accounts[1];
+  const RECIPIENT = accounts[3];
+  const COLONY_ADMIN = accounts[4];
+
+  let colony;
+  let metaColony;
+  let token;
+  let otherToken;
+  let colonyNetwork;
+
+  before(async () => {
+    const etherRouter = await EtherRouter.deployed();
+    colonyNetwork = await IColonyNetwork.at(etherRouter.address);
+    const metaColonyAddress = await colonyNetwork.getMetaColony();
+    metaColony = await IMetaColony.at(metaColonyAddress);
+
+    ({ colony, token } = await setupRandomColony(colonyNetwork));
+    await colony.setRewardInverse(100);
+    await colony.setAdminRole(COLONY_ADMIN);
+
+    const otherTokenArgs = getTokenArgs();
+    otherToken = await DSToken.new(otherTokenArgs[1]);
+    await fundColonyWithTokens(colony, token, WAD);
+  });
+
+  describe("when adding payments", () => {
+    it("should allow admins to add payment", async () => {
+      const paymentsCountBefore = await colony.getPaymentCount();
+      await colony.addPayment(RECIPIENT, 0, 0, token.address, WAD);
+
+      const paymentsCountAfter = await colony.getPaymentCount();
+      expect(paymentsCountAfter.sub(paymentsCountBefore)).to.eq.BN(1);
+
+      const fundingPotId = await colony.getFundingPotCount();
+      const payment = await colony.getPayment(paymentsCountAfter);
+      expect(payment[0]).to.equal(RECIPIENT);
+      expect(payment[1]).to.eq.BN(fundingPotId);
+      expect(payment[2]).to.be.zero;
+    });
+  });
+
+  describe("when funding payments", () => {
+    it("should allow admins to fund a payment", async () => {
+      await colony.addPayment(RECIPIENT, 0, 0, token.address, WAD);
+      const paymentId = await colony.getPaymentCount();
+      const payment = await colony.getPayment(paymentId);
+      const fundingPotId = payment[1];
+
+      await colony.moveFundsBetweenPots(1, fundingPotId, 40, token.address);
+    });
+  });
+});

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -150,7 +150,6 @@ contract("Colony Payment", accounts => {
 
       await colony.setPaymentPayout(paymentId, otherToken.address, 100);
       const payment = await colony.getPayment(paymentId);
-      console.log("payment.fundingPotId", payment.fundingPotId);
       const fundingPotPayoutForToken = await colony.getFundingPotPayout(payment.fundingPotId, token.address);
       const fundingPotPayoutForOtherToken = await colony.getFundingPotPayout(payment.fundingPotId, otherToken.address);
       expect(fundingPotPayoutForToken).to.eq.BN(WAD);

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -3,8 +3,8 @@ import chai from "chai";
 import bnChai from "bn-chai";
 import { BN } from "bn.js";
 
-import { WAD } from "../helpers/constants";
-import { checkErrorRevert } from "../helpers/test-helper";
+import { WAD, ZERO_ADDRESS } from "../helpers/constants";
+import { checkErrorRevert, getTokenArgs } from "../helpers/test-helper";
 import { fundColonyWithTokens, setupRandomColony } from "../helpers/test-data-generator";
 
 const { expect } = chai;
@@ -12,13 +12,15 @@ chai.use(bnChai(web3.utils.BN));
 
 const EtherRouter = artifacts.require("EtherRouter");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
+const DSToken = artifacts.require("DSToken");
 
-contract.skip("Colony Payment", accounts => {
+contract("Colony Payment", accounts => {
   const RECIPIENT = accounts[3];
   const COLONY_ADMIN = accounts[4];
 
   let colony;
   let token;
+  let otherToken;
   let colonyNetwork;
 
   before(async () => {
@@ -28,13 +30,16 @@ contract.skip("Colony Payment", accounts => {
     ({ colony, token } = await setupRandomColony(colonyNetwork));
     await colony.setRewardInverse(100);
     await colony.setAdminRole(COLONY_ADMIN);
-    await fundColonyWithTokens(colony, token, WAD.muln(2));
+    await fundColonyWithTokens(colony, token, WAD.muln(20));
+
+    const tokenArgs = getTokenArgs();
+    otherToken = await DSToken.new(tokenArgs[1]);
   });
 
   describe("when adding payments", () => {
     it("should allow admins to add payment", async () => {
       const paymentsCountBefore = await colony.getPaymentCount();
-      await colony.addPayment(RECIPIENT, token.address, WAD, 1, 0);
+      await colony.addPayment(RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
 
       const paymentsCountAfter = await colony.getPaymentCount();
       expect(paymentsCountAfter.sub(paymentsCountBefore)).to.eq.BN(1);
@@ -43,24 +48,109 @@ contract.skip("Colony Payment", accounts => {
       const payment = await colony.getPayment(paymentsCountAfter);
 
       expect(payment.recipient).to.equal(RECIPIENT);
-      expect(payment.token).to.equal(token.address);
-      expect(payment.amount).to.eq.BN(WAD);
       expect(payment.fundingPotId).to.eq.BN(fundingPotId);
       expect(payment.domainId).to.eq.BN(1);
+
+      const fundingPot = await colony.getFundingPot(fundingPotId);
+      expect(fundingPot.associatedType).to.eq.BN(3); // 3 = FundingPotAssociatedType.Payment
+      expect(fundingPot.associatedTypeId).to.eq.BN(paymentsCountAfter);
+
+      const payout = await colony.getFundingPotPayout(fundingPotId, token.address);
+      expect(payout).to.eq.BN(WAD);
     });
 
     it("should not allow admins to add payment with no domain set", async () => {
-      await checkErrorRevert(colony.addPayment(RECIPIENT, token.address, WAD, 0, 0), "colony-domain-does-not-exist");
+      await checkErrorRevert(colony.addPayment(RECIPIENT, token.address, WAD, 0, 0, { from: COLONY_ADMIN }), "colony-domain-does-not-exist");
+    });
+
+    it("should not allow admins to add payment with no recipient set", async () => {
+      await checkErrorRevert(colony.addPayment(ZERO_ADDRESS, token.address, WAD, 1, 0, { from: COLONY_ADMIN }), "colony-payment-invalid-recipient");
+    });
+
+    it("should not allow non-admins to add payment", async () => {
+      await checkErrorRevert(colony.addPayment(RECIPIENT, token.address, WAD, 1, 0, { from: accounts[10] }), "ds-auth-unauthorized");
     });
   });
 
-  describe("when funding payments", () => {
+  describe("when updating payments", () => {
+    it("should allow admins to update recipient", async () => {
+      await colony.addPayment(RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      const paymentId = await colony.getPaymentCount();
+
+      await colony.setPaymentRecipient(paymentId, accounts[10], { from: COLONY_ADMIN });
+      const payment = await colony.getPayment(paymentId);
+      expect(payment.recipient).to.equal(accounts[10]);
+    });
+
+    it("should not allow admins to update to empty recipient", async () => {
+      await colony.addPayment(RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      const paymentId = await colony.getPaymentCount();
+
+      await checkErrorRevert(colony.setPaymentRecipient(paymentId, ZERO_ADDRESS, { from: COLONY_ADMIN }), "colony-payment-invalid-recipient");
+    });
+
+    it("should allow admins to update domain", async () => {
+      await colony.addDomain(1);
+      await colony.addPayment(RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      const paymentId = await colony.getPaymentCount();
+
+      let payment = await colony.getPayment(paymentId);
+      expect(payment.domainId).to.eq.BN(1);
+      await colony.setPaymentDomain(paymentId, 2, { from: COLONY_ADMIN });
+      payment = await colony.getPayment(paymentId);
+      expect(payment.domainId).to.eq.BN(2);
+    });
+
+    it("should not allow admins to update to empty domain", async () => {
+      await colony.addPayment(RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      const paymentId = await colony.getPaymentCount();
+
+      const { domainId } = await colony.getPayment(paymentId);
+      expect(domainId).to.eq.BN(1);
+      await checkErrorRevert(colony.setPaymentDomain(paymentId, 10, { from: COLONY_ADMIN }), "colony-domain-does-not-exist");
+    });
+
+    it("should allow admins to update skill", async () => {
+      await colony.addPayment(RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      const paymentId = await colony.getPaymentCount();
+
+      let payment = await colony.getPayment(paymentId);
+      expect(payment.skills[0]).to.eq.BN(0);
+      await colony.setPaymentSkill(paymentId, 1, { from: COLONY_ADMIN });
+      payment = await colony.getPayment(paymentId);
+      expect(payment.skills[0]).to.eq.BN(1);
+    });
+
+    it("should not allow non-admins to update recipient", async () => {
+      await colony.addPayment(RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      const paymentId = await colony.getPaymentCount();
+
+      await checkErrorRevert(colony.setPaymentRecipient(paymentId, accounts[7], { from: accounts[10] }), "ds-auth-unauthorized");
+    });
+
+    it("should be able to add multiple payouts", async () => {
+      await colony.addPayment(RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      const paymentId = await colony.getPaymentCount();
+      const payment = await colony.getPayment(paymentId);
+      await colony.setPayout(payment.fundingPotId, otherToken.address, 100);
+
+      const fundingPotPayoutForToken = await colony.getFundingPotPayout(payment.fundingPotId, token.address);
+      const fundingPotPayoutForOtherToken = await colony.getFundingPotPayout(payment.fundingPotId, otherToken.address);
+      expect(fundingPotPayoutForToken).to.eq.BN(WAD);
+      expect(fundingPotPayoutForOtherToken).to.eq.BN(100);
+    });
+
     it("should allow admins to fund a payment", async () => {
       await colony.addPayment(RECIPIENT, token.address, WAD, 1, 0);
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
+      const fundingPotPayoutForToken = await colony.getFundingPotPayout(payment.fundingPotId, token.address);
+      expect(fundingPotPayoutForToken).to.eq.BN(WAD);
 
+      await fundColonyWithTokens(colony, token, 40);
       await colony.moveFundsBetweenPots(1, payment.fundingPotId, 40, token.address);
+      const fundingPotBalanceForToken = await colony.getFundingPotBalance(payment.fundingPotId, token.address);
+      expect(fundingPotBalanceForToken).to.eq.BN(40);
     });
   });
 
@@ -74,7 +164,24 @@ contract.skip("Colony Payment", accounts => {
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
       const networkBalanceBefore = await token.balanceOf(colonyNetwork.address);
-      await colony.claimPayment(paymentId, { from: RECIPIENT });
+      await colony.claimPayment(paymentId, token.address, { from: RECIPIENT });
+
+      const recipientBalanceAfter = await token.balanceOf(RECIPIENT);
+      const networkBalanceAfter = await token.balanceOf(colonyNetwork.address);
+      expect(recipientBalanceAfter.sub(recipientBalanceBefore)).to.eq.BN(new BN("989999999999999999"));
+      expect(networkBalanceAfter.sub(networkBalanceBefore)).to.eq.BN(new BN("10000000000000001"));
+    });
+
+    it("should allow anyone to claim on behalf of the recipient", async () => {
+      await colony.addPayment(RECIPIENT, token.address, WAD, 1, 0);
+      const paymentId = await colony.getPaymentCount();
+      const payment = await colony.getPayment(paymentId);
+
+      await colony.moveFundsBetweenPots(1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+
+      const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
+      const networkBalanceBefore = await token.balanceOf(colonyNetwork.address);
+      await colony.claimPayment(paymentId, token.address, { from: accounts[10] });
 
       const recipientBalanceAfter = await token.balanceOf(RECIPIENT);
       const networkBalanceAfter = await token.balanceOf(colonyNetwork.address);
@@ -88,7 +195,18 @@ contract.skip("Colony Payment", accounts => {
       const payment = await colony.getPayment(paymentId);
 
       await colony.moveFundsBetweenPots(1, payment.fundingPotId, 9999, token.address);
-      await checkErrorRevert(colony.claimPayment(paymentId), "colony-payment-insufficient-funding");
+      await checkErrorRevert(colony.claimPayment(paymentId, token.address), "colony-payment-insufficient-funding");
+    });
+
+    it("should error if payment already claimed", async () => {
+      await colony.addPayment(RECIPIENT, token.address, WAD, 1, 0);
+      const paymentId = await colony.getPaymentCount();
+      const payment = await colony.getPayment(paymentId);
+
+      await colony.moveFundsBetweenPots(1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+
+      await colony.claimPayment(paymentId, token.address, { from: RECIPIENT });
+      await checkErrorRevert(colony.claimPayment(paymentId, token.address, { from: RECIPIENT }), "colony-payment-already-claimed");
     });
   });
 });

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -195,18 +195,21 @@ contract("Colony Payment", accounts => {
     });
 
     it("can finalize payment when it is fully funded", async () => {
+      let payment = await colony.getPayment(paymentId);
+      expect(payment.finalized).to.be.false;
+
+      await colony.finalizePayment(paymentId);
+
+      payment = await colony.getPayment(paymentId);
+      expect(payment.finalized).to.be.true;
+    });
+
+    it("cannnot finalize payment if it is NOT fully funded", async () => {
       const payment = await colony.getPayment(paymentId);
       await colony.moveFundsBetweenPots(payment.fundingPotId, 1, 1, token.address);
       expect(payment.finalized).to.be.false;
 
       await checkErrorRevert(colony.finalizePayment(paymentId), "colony-payment-not-funded");
-    });
-
-    it("cannnot finalize payment if it is NOT fully funded", async () => {
-      const payment = await colony.getPayment(paymentId);
-      expect(payment.finalized).to.be.false;
-
-      await colony.finalizePayment(paymentId);
     });
 
     it("cannot finalize payment not authorised", async () => {

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -148,7 +148,7 @@ contract("Colony Payment", accounts => {
       await colony.addPayment(RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
-      await colony.setPayout(payment.fundingPotId, otherToken.address, 100);
+      await colony.setPaymentPayout(payment.fundingPotId, otherToken.address, 100);
 
       const fundingPotPayoutForToken = await colony.getFundingPotPayout(payment.fundingPotId, token.address);
       const fundingPotPayoutForOtherToken = await colony.getFundingPotPayout(payment.fundingPotId, otherToken.address);
@@ -169,10 +169,10 @@ contract("Colony Payment", accounts => {
       expect(fundingPotBalanceForToken).to.eq.BN(40);
     });
 
-    it("should not allow task payouts to be set via setPayout", async () => {
+    it("should not allow task payouts to be set via setPaymentPayout", async () => {
       const taskId = await makeTask({ colony });
       const { fundingPotId } = await colony.getTask(taskId);
-      await checkErrorRevert(colony.setPayout(fundingPotId, token.address, 100), "colony-funding-pot-associated-with-non-payment");
+      await checkErrorRevert(colony.setPaymentPayout(fundingPotId, token.address, 100), "colony-funding-pot-associated-with-non-payment");
     });
 
     it("should allow admins to set token payment to zero", async () => {
@@ -182,7 +182,7 @@ contract("Colony Payment", accounts => {
       let fundingPotPayout = await colony.getFundingPotPayout(fundingPotId, token.address);
       expect(fundingPotPayout).to.eq.BN(WAD);
 
-      await colony.setPayout(fundingPotId, token.address, 0);
+      await colony.setPaymentPayout(fundingPotId, token.address, 0);
       fundingPotPayout = await colony.getFundingPotPayout(fundingPotId, token.address);
       expect(fundingPotPayout).to.be.zero;
     });
@@ -233,12 +233,12 @@ contract("Colony Payment", accounts => {
 
     it("should not allow admins to update payment", async () => {
       await colony.finalizePayment(paymentId);
-      await checkErrorRevert(colony.setPayout(paymentId, token.address, 1, { from: COLONY_ADMIN }), "colony-funding-payment-finalized");
+      await checkErrorRevert(colony.setPaymentPayout(paymentId, token.address, 1, { from: COLONY_ADMIN }), "colony-funding-payment-finalized");
     });
 
     it("should not be able to set a payout above the limit", async () => {
       await colony.finalizePayment(paymentId);
-      await checkErrorRevert(colony.setPayout(paymentId, token.address, MAX_PAYOUT.addn(1), { from: COLONY_ADMIN }), "colony-payout-too-large");
+      await checkErrorRevert(colony.setPaymentPayout(paymentId, token.address, MAX_PAYOUT.addn(1), { from: COLONY_ADMIN }), "colony-payout-too-large");
     });
   });
 
@@ -306,7 +306,7 @@ contract("Colony Payment", accounts => {
       const paymentId = await colony.getPaymentCount();
       let payment = await colony.getPayment(paymentId);
 
-      await colony.setPayout(payment.fundingPotId, otherToken.address, 100);
+      await colony.setPaymentPayout(payment.fundingPotId, otherToken.address, 100);
       await fundColonyWithTokens(colony, otherToken, 101);
       let fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(2);
@@ -319,7 +319,7 @@ contract("Colony Payment", accounts => {
       fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
-      await colony.setPayout(payment.fundingPotId, token.address, 199);
+      await colony.setPaymentPayout(payment.fundingPotId, token.address, 199);
       fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -13,7 +13,7 @@ chai.use(bnChai(web3.utils.BN));
 const EtherRouter = artifacts.require("EtherRouter");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 
-contract("Colony Payment", accounts => {
+contract.skip("Colony Payment", accounts => {
   const RECIPIENT = accounts[3];
   const COLONY_ADMIN = accounts[4];
 

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -3,7 +3,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 import { BN } from "bn.js";
 
-import { WAD, ZERO_ADDRESS } from "../helpers/constants";
+import { WAD, ZERO_ADDRESS, MAX_PAYOUT } from "../helpers/constants";
 import { checkErrorRevert, getTokenArgs } from "../helpers/test-helper";
 import { fundColonyWithTokens, setupRandomColony } from "../helpers/test-data-generator";
 
@@ -69,11 +69,18 @@ contract("Colony Payment", accounts => {
     });
 
     it("should not allow admins to add payment with zero token amount set", async () => {
-      await checkErrorRevert(colony.addPayment(RECIPIENT, token.address, 0, 1, 0, { from: COLONY_ADMIN }), "colony-payment-invalid-amount");
+      await checkErrorRevert(colony.addPayment(RECIPIENT, token.address, 0, 1, 0, { from: COLONY_ADMIN }), "colony-payout-invalid-amount");
     });
 
     it("should not allow non-admins to add payment", async () => {
       await checkErrorRevert(colony.addPayment(RECIPIENT, token.address, WAD, 1, 0, { from: accounts[10] }), "ds-auth-unauthorized");
+    });
+
+    it("should not be able to set a payout above the limit", async () => {
+      await checkErrorRevert(
+        colony.addPayment(RECIPIENT, token.address, MAX_PAYOUT.addn(1), 1, 0, { from: COLONY_ADMIN }),
+        "colony-payout-too-large"
+      );
     });
   });
 
@@ -201,6 +208,10 @@ contract("Colony Payment", accounts => {
 
     it("should not allow admins to update payment", async () => {
       await checkErrorRevert(colony.setPayout(paymentId, token.address, 1, { from: COLONY_ADMIN }), "colony-funding-payment-finalized");
+    });
+
+    it("should not be able to set a payout above the limit", async () => {
+      await checkErrorRevert(colony.setPayout(paymentId, token.address, MAX_PAYOUT.addn(1), { from: COLONY_ADMIN }), "colony-payout-too-large");
     });
   });
 

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -289,14 +289,23 @@ contract("Colony Payment", accounts => {
       payment = await colony.getPayment(paymentId);
       expect(payment.finalized).to.be.true;
 
-      const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
-      const networkBalanceBefore = await token.balanceOf(colonyNetwork.address);
+      const recipientBalanceBefore1 = await token.balanceOf(RECIPIENT);
+      const networkBalanceBefore1 = await token.balanceOf(colonyNetwork.address);
       await colony.claimPayment(paymentId, token.address);
 
-      const recipientBalanceAfter = await token.balanceOf(RECIPIENT);
-      const networkBalanceAfter = await token.balanceOf(colonyNetwork.address);
-      expect(recipientBalanceAfter.sub(recipientBalanceBefore)).to.eq.BN(new BN("197"));
-      expect(networkBalanceAfter.sub(networkBalanceBefore)).to.eq.BN(new BN("2"));
+      const recipientBalanceAfter1 = await token.balanceOf(RECIPIENT);
+      const networkBalanceAfter1 = await token.balanceOf(colonyNetwork.address);
+      expect(recipientBalanceAfter1.sub(recipientBalanceBefore1)).to.eq.BN(new BN("197"));
+      expect(networkBalanceAfter1.sub(networkBalanceBefore1)).to.eq.BN(new BN("2"));
+
+      const recipientBalanceBefore2 = await otherToken.balanceOf(RECIPIENT);
+      const networkBalanceBefore2 = await otherToken.balanceOf(colonyNetwork.address);
+      await colony.claimPayment(paymentId, otherToken.address);
+
+      const recipientBalanceAfter2 = await otherToken.balanceOf(RECIPIENT);
+      const networkBalanceAfter2 = await otherToken.balanceOf(colonyNetwork.address);
+      expect(recipientBalanceAfter2.sub(recipientBalanceBefore2)).to.eq.BN(new BN("98"));
+      expect(networkBalanceAfter2.sub(networkBalanceBefore2)).to.eq.BN(new BN("2"));
     });
   });
 });

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -233,12 +233,15 @@ contract("Colony Payment", accounts => {
 
     it("should not allow admins to update payment", async () => {
       await colony.finalizePayment(paymentId);
-      await checkErrorRevert(colony.setPaymentPayout(paymentId, token.address, 1, { from: COLONY_ADMIN }), "colony-funding-payment-finalized");
+      await checkErrorRevert(colony.setPaymentPayout(paymentId, token.address, 1, { from: COLONY_ADMIN }), "colony-payment-finalized");
     });
 
     it("should not be able to set a payout above the limit", async () => {
       await colony.finalizePayment(paymentId);
-      await checkErrorRevert(colony.setPaymentPayout(paymentId, token.address, MAX_PAYOUT.addn(1), { from: COLONY_ADMIN }), "colony-payout-too-large");
+      await checkErrorRevert(
+        colony.setPaymentPayout(paymentId, token.address, MAX_PAYOUT.addn(1), { from: COLONY_ADMIN }),
+        "colony-payout-too-large"
+      );
     });
   });
 

--- a/test/colony-reward-payouts.js
+++ b/test/colony-reward-payouts.js
@@ -243,7 +243,7 @@ contract("Colony Reward Payouts", accounts => {
         domainId: domainCount
       });
 
-      await newColony.claimPayout(taskId, MANAGER_ROLE, newToken.address);
+      await newColony.claimTaskPayout(taskId, MANAGER_ROLE, newToken.address);
 
       await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
       await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -95,11 +95,11 @@ contract("ColonyTask", accounts => {
       const dueDate = await currentBlockTime();
       const taskId = await makeTask({ colony, dueDate });
       const task = await colony.getTask(taskId);
-      expect(task[0]).to.equal(SPECIFICATION_HASH);
-      expect(task[1]).to.equal("0x0000000000000000000000000000000000000000000000000000000000000000");
-      expect(task[2]).to.eq.BN(ACTIVE_TASK_STATE);
-      expect(task[3]).to.eq.BN(dueDate);
-      expect(task[4]).to.be.zero;
+      expect(task.specificationHash).to.equal(SPECIFICATION_HASH);
+      expect(task.deliverableHash).to.equal("0x0000000000000000000000000000000000000000000000000000000000000000");
+      expect(task.status).to.eq.BN(ACTIVE_TASK_STATE);
+      expect(task.dueDate).to.eq.BN(dueDate);
+      expect(task.domainId).to.eq.BN(1);
     });
 
     it("should fail if a non-admin user tries to make a task", async () => {
@@ -168,7 +168,7 @@ contract("ColonyTask", accounts => {
       await colony.addDomain(1);
       const taskId = await makeTask({ colony, domainId: 2 });
       const task = await colony.getTask(taskId);
-      expect(task[7]).to.eq.BN(2);
+      expect(task.domainId).to.eq.BN(2);
     });
 
     it("should log TaskAdded and FundingPotAdded events", async () => {
@@ -182,8 +182,8 @@ contract("ColonyTask", accounts => {
 
       const taskId = await makeTask({ colony, skillId, dueDate });
       const task = await colony.getTask(taskId);
-      expect(task[3]).to.eq.BN(dueDate);
-      expect(task[8][0]).to.eq.BN(skillId);
+      expect(task.dueDate).to.eq.BN(dueDate);
+      expect(task.skillIds[0]).to.eq.BN(skillId);
     });
 
     it("should set the due date to 90 days from now if unspecified", async () => {
@@ -193,7 +193,7 @@ contract("ColonyTask", accounts => {
       const task = await colony.getTask(taskId);
       const currTime = await currentBlockTime();
       const expectedDueDate = currTime + SECONDS_PER_DAY * 90;
-      expect(task[3]).to.eq.BN(expectedDueDate);
+      expect(task.dueDate).to.eq.BN(expectedDueDate);
     });
   });
 
@@ -769,7 +769,7 @@ contract("ColonyTask", accounts => {
       });
 
       const task = await colony.getTask(taskId);
-      expect(task[0]).to.eq.BN(SPECIFICATION_HASH_UPDATED);
+      expect(task.specificationHash).to.eq.BN(SPECIFICATION_HASH_UPDATED);
     });
 
     it("should allow update of task brief signed by manager and worker", async () => {
@@ -794,7 +794,7 @@ contract("ColonyTask", accounts => {
       });
 
       const task = await colony.getTask(taskId);
-      expect(task[0]).to.eq.BN(SPECIFICATION_HASH_UPDATED);
+      expect(task.specificationHash).to.eq.BN(SPECIFICATION_HASH_UPDATED);
     });
 
     it("should allow update of task brief signed by manager and worker using Trezor-style signatures", async () => {
@@ -819,7 +819,7 @@ contract("ColonyTask", accounts => {
       });
 
       const task = await colony.getTask(taskId);
-      expect(task[0]).to.eq.BN(SPECIFICATION_HASH_UPDATED);
+      expect(task.specificationHash).to.eq.BN(SPECIFICATION_HASH_UPDATED);
     });
 
     it("should allow update of task brief signed by manager and worker if one uses Trezor-style signatures and the other does not", async () => {
@@ -844,7 +844,7 @@ contract("ColonyTask", accounts => {
       });
 
       const task = await colony.getTask(taskId);
-      expect(task[0]).to.eq.BN(SPECIFICATION_HASH_UPDATED);
+      expect(task.specificationHash).to.eq.BN(SPECIFICATION_HASH_UPDATED);
     });
 
     it("should not allow update of task brief signed by manager twice, with two different signature styles", async () => {
@@ -872,7 +872,7 @@ contract("ColonyTask", accounts => {
       );
 
       const task = await colony.getTask(taskId);
-      expect(task[0]).to.eq.BN(SPECIFICATION_HASH);
+      expect(task.specificationHash).to.eq.BN(SPECIFICATION_HASH);
     });
 
     it("should allow update of task due date signed by manager and worker", async () => {
@@ -898,7 +898,7 @@ contract("ColonyTask", accounts => {
       });
 
       const task = await colony.getTask(taskId);
-      expect(task[3]).to.eq.BN(dueDate);
+      expect(task.dueDate).to.eq.BN(dueDate);
     });
 
     it("should not allow update of task due if it is trying to be set to 0", async () => {
@@ -911,7 +911,7 @@ contract("ColonyTask", accounts => {
       );
 
       const task = await colony.getTask(taskId);
-      expect(task[3]).to.eq.BN(dueDate);
+      expect(task.dueDate).to.eq.BN(dueDate);
     });
 
     it("should fail if a non-colony call is made to the task update functions", async () => {
@@ -1212,13 +1212,13 @@ contract("ColonyTask", accounts => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
 
       let task = await colony.getTask(taskId);
-      expect(task[1]).to.equal("0x0000000000000000000000000000000000000000000000000000000000000000");
+      expect(task.deliverableHash).to.equal("0x0000000000000000000000000000000000000000000000000000000000000000");
 
       await colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH, { from: WORKER });
       const currentTime = await currentBlockTime();
       task = await colony.getTask(taskId);
-      expect(task[1]).to.equal(DELIVERABLE_HASH);
-      expect(task[6]).to.eq.BN(currentTime);
+      expect(task.deliverableHash).to.equal(DELIVERABLE_HASH);
+      expect(task.completionTimestamp).to.eq.BN(currentTime);
     });
 
     it("should fail if I try to submit work for a task that is complete", async () => {
@@ -1242,7 +1242,7 @@ contract("ColonyTask", accounts => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH, { from: WORKER });
       const task = await colony.getTask(taskId);
-      expect(task[1]).to.equal(DELIVERABLE_HASH);
+      expect(task.deliverableHash).to.equal(DELIVERABLE_HASH);
     });
 
     it("should fail if I try to submit work for a task using an invalid id", async () => {
@@ -1259,7 +1259,7 @@ contract("ColonyTask", accounts => {
 
       await checkErrorRevert(colony.submitTaskDeliverable(taskId, SPECIFICATION_HASH, { from: WORKER }), "colony-task-complete");
       const task = await colony.getTask(taskId);
-      expect(task[1]).to.equal(DELIVERABLE_HASH);
+      expect(task.deliverableHash).to.equal(DELIVERABLE_HASH);
     });
 
     it("should fail if I try to submit work if I'm not the assigned worker", async () => {
@@ -1269,7 +1269,7 @@ contract("ColonyTask", accounts => {
 
       await checkErrorRevert(colony.submitTaskDeliverable(taskId, SPECIFICATION_HASH, { from: OTHER }), "colony-task-role-identity-mismatch");
       const task = await colony.getTask(taskId);
-      expect(task[1]).to.not.equal(DELIVERABLE_HASH);
+      expect(task.deliverableHash).to.not.equal(DELIVERABLE_HASH);
     });
 
     it("should log a TaskDeliverableSubmitted event", async () => {
@@ -1286,7 +1286,7 @@ contract("ColonyTask", accounts => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupFinalizedTask({ colonyNetwork, colony, token });
       const task = await colony.getTask(taskId);
-      expect(task[2]).to.eq.BN(FINALIZED_TASK_STATE);
+      expect(task.status).to.eq.BN(FINALIZED_TASK_STATE);
     });
 
     it("should fail if the task work ratings have not been assigned and they still have time to be", async () => {
@@ -1343,16 +1343,16 @@ contract("ColonyTask", accounts => {
       });
 
       const task = await colony.getTask(taskId);
-      expect(task[2]).to.eq.BN(CANCELLED_TASK_STATE);
+      expect(task.status).to.eq.BN(CANCELLED_TASK_STATE);
     });
 
     it("should be possible to return funds back to the domain", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupFundedTask({ colonyNetwork, colony, token });
       const task = await colony.getTask(taskId);
-      const domainId = task[7];
+      const { domainId } = task;
       const domain = await colony.getDomain(domainId);
-      const taskPotId = task[5];
+      const taskPotId = task.fundingPotId;
 
       // Our test-data-generator already set up some task fund with tokens,
       // but we need some Ether, too
@@ -1651,8 +1651,9 @@ contract("ColonyTask", accounts => {
     it("should correctly return the current total payout", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupFundedTask({ colonyNetwork, colony, token });
+      const { fundingPotId } = await colony.getTask(taskId);
 
-      const totalTokenPayout = await colony.getTotalTaskPayout(taskId, token.address);
+      const totalTokenPayout = await colony.getFundingPotPayout(fundingPotId, token.address);
       const totalTokenPayoutExpected = MANAGER_PAYOUT.add(EVALUATOR_PAYOUT).add(WORKER_PAYOUT);
       expect(totalTokenPayout).to.eq.BN(totalTokenPayoutExpected);
     });
@@ -1689,13 +1690,13 @@ contract("ColonyTask", accounts => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupFinalizedTask({ colonyNetwork, colony, token });
       const task = await colony.getTask(taskId);
-      const taskPotId = task[5];
+      const taskPotId = task.fundingPotId;
 
       const networkBalanceBefore = await token.balanceOf(colonyNetwork.address);
       const managerBalanceBefore = await token.balanceOf(MANAGER);
       const potBalanceBefore = await colony.getFundingPotBalance(taskPotId, token.address);
 
-      await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
+      await colony.claimTaskPayout(taskId, MANAGER_ROLE, token.address);
 
       const networkBalanceAfter = await token.balanceOf(colonyNetwork.address);
       expect(networkBalanceAfter.sub(networkBalanceBefore)).to.eq.BN(WAD.addn(1));
@@ -1724,13 +1725,13 @@ contract("ColonyTask", accounts => {
       });
 
       const task = await colony.getTask(taskId);
-      const taskPotId = task[5];
+      const taskPotId = task.fundingPotId;
       const potBalanceBefore = await colony.getFundingPotBalance(taskPotId, ZERO_ADDRESS);
 
       const workerBalanceBefore = await web3GetBalance(WORKER);
       const metaBalanceBefore = await web3GetBalance(metaColony.address);
 
-      await colony.claimPayout(taskId, WORKER_ROLE, ZERO_ADDRESS, { gasPrice: 0 });
+      await colony.claimTaskPayout(taskId, WORKER_ROLE, ZERO_ADDRESS, { gasPrice: 0 });
 
       const workerBalanceAfter = await web3GetBalance(WORKER);
       expect(new BN(workerBalanceAfter).sub(new BN(workerBalanceBefore))).to.eq.BN(new BN(197));
@@ -1758,9 +1759,9 @@ contract("ColonyTask", accounts => {
         workerRating: 1
       });
 
-      await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
-      await colony.claimPayout(taskId, WORKER_ROLE, token.address);
-      await colony.claimPayout(taskId, EVALUATOR_ROLE, token.address);
+      await colony.claimTaskPayout(taskId, MANAGER_ROLE, token.address);
+      await colony.claimTaskPayout(taskId, WORKER_ROLE, token.address);
+      await colony.claimTaskPayout(taskId, EVALUATOR_ROLE, token.address);
 
       const managerBalanceAfter = await token.balanceOf(MANAGER);
       expect(managerBalanceAfter.sub(managerBalanceBefore)).to.be.zero;
@@ -1790,9 +1791,9 @@ contract("ColonyTask", accounts => {
       await forwardTime(SECONDS_PER_DAY * 10 + 1, this);
       await colony.finalizeTask(taskId);
 
-      await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
-      await colony.claimPayout(taskId, WORKER_ROLE, token.address);
-      await colony.claimPayout(taskId, EVALUATOR_ROLE, token.address);
+      await colony.claimTaskPayout(taskId, MANAGER_ROLE, token.address);
+      await colony.claimTaskPayout(taskId, WORKER_ROLE, token.address);
+      await colony.claimTaskPayout(taskId, EVALUATOR_ROLE, token.address);
 
       const managerBalanceAfter = await token.balanceOf(MANAGER);
       const managerPayout = MANAGER_PAYOUT.divn(100)
@@ -1813,7 +1814,7 @@ contract("ColonyTask", accounts => {
     it("should return error when task is not finalized", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony, token });
-      await checkErrorRevert(colony.claimPayout(taskId, MANAGER_ROLE, token.address), "colony-task-not-finalized");
+      await checkErrorRevert(colony.claimTaskPayout(taskId, MANAGER_ROLE, token.address), "colony-task-not-finalized");
     });
 
     it("should payout correct rounded up network fees, for small task payouts", async () => {
@@ -1830,7 +1831,7 @@ contract("ColonyTask", accounts => {
       const networkBalance1 = await token.balanceOf(colonyNetwork.address);
       const managerBalanceBefore = await token.balanceOf(MANAGER);
 
-      await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
+      await colony.claimTaskPayout(taskId, MANAGER_ROLE, token.address);
       const networkBalance2 = await token.balanceOf(colonyNetwork.address);
       const managerBalanceAfter = await token.balanceOf(MANAGER);
       expect(networkBalance2.sub(networkBalance1)).to.eq.BN(1);
@@ -1838,7 +1839,7 @@ contract("ColonyTask", accounts => {
 
       const workerBalanceBefore = await token.balanceOf(WORKER);
 
-      await colony.claimPayout(taskId, WORKER_ROLE, token.address);
+      await colony.claimTaskPayout(taskId, WORKER_ROLE, token.address);
       const networkBalance3 = await token.balanceOf(colonyNetwork.address);
       const workerBalanceAfter = await token.balanceOf(WORKER);
       expect(networkBalance3.sub(networkBalance2)).to.eq.BN(1);
@@ -1861,7 +1862,7 @@ contract("ColonyTask", accounts => {
       const networkBalance1 = await token.balanceOf(colonyNetwork.address);
       const managerBalanceBefore = await token.balanceOf(MANAGER);
 
-      await colony.claimPayout(taskId, MANAGER_ROLE, token.address);
+      await colony.claimTaskPayout(taskId, MANAGER_ROLE, token.address);
       const networkBalance2 = await token.balanceOf(colonyNetwork.address);
       const managerBalanceAfter = await token.balanceOf(MANAGER);
       expect(networkBalance2.sub(networkBalance1)).to.eq.BN(99);
@@ -1869,7 +1870,7 @@ contract("ColonyTask", accounts => {
 
       const workerBalanceBefore = await token.balanceOf(WORKER);
 
-      await colony.claimPayout(taskId, WORKER_ROLE, token.address);
+      await colony.claimTaskPayout(taskId, WORKER_ROLE, token.address);
       const networkBalance3 = await token.balanceOf(colonyNetwork.address);
       const workerBalanceAfter = await token.balanceOf(WORKER);
       expect(networkBalance3.sub(networkBalance2)).to.eq.BN(1);
@@ -1890,7 +1891,7 @@ contract("ColonyTask", accounts => {
       const networkBalanceBefore = await token.balanceOf(colonyNetwork.address);
       const workerBalanceBefore = await token.balanceOf(WORKER);
 
-      await colony.claimPayout(taskId, WORKER_ROLE, token.address);
+      await colony.claimTaskPayout(taskId, WORKER_ROLE, token.address);
 
       const networkBalanceAfter = await token.balanceOf(colonyNetwork.address);
       const workerBalanceAfter = await token.balanceOf(WORKER);

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -1680,7 +1680,7 @@ contract("ColonyTask", accounts => {
           sigTypes: [0],
           args: [taskId, ZERO_ADDRESS, MAX_PAYOUT.addn(1)]
         }),
-        "colony-task-change-execution-failed" // Should be "colony-funding-payout-too-large"
+        "colony-task-change-execution-failed" // Should be "colony-payout-too-large"
       );
     });
   });

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -25,7 +25,8 @@ import {
   RATING_1_SALT,
   RATING_2_SALT,
   RATING_1_SECRET,
-  RATING_2_SECRET
+  RATING_2_SECRET,
+  MAX_PAYOUT
 } from "../helpers/constants";
 
 import {
@@ -1659,7 +1660,6 @@ contract("ColonyTask", accounts => {
     });
 
     it("should not be able to set a payout above the limit", async () => {
-      const maxPayout = new BN(0).notn(254);
       const taskId = await makeTask({ colony });
 
       await executeSignedTaskChange({
@@ -1668,7 +1668,7 @@ contract("ColonyTask", accounts => {
         functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
-        args: [taskId, ZERO_ADDRESS, maxPayout]
+        args: [taskId, ZERO_ADDRESS, MAX_PAYOUT]
       });
 
       await checkErrorRevert(
@@ -1678,7 +1678,7 @@ contract("ColonyTask", accounts => {
           functionName: "setTaskManagerPayout",
           signers: [MANAGER],
           sigTypes: [0],
-          args: [taskId, ZERO_ADDRESS, maxPayout.addn(1)]
+          args: [taskId, ZERO_ADDRESS, MAX_PAYOUT.addn(1)]
         }),
         "colony-task-change-execution-failed" // Should be "colony-funding-payout-too-large"
       );

--- a/test/colony.js
+++ b/test/colony.js
@@ -116,6 +116,7 @@ contract("Colony", accounts => {
       let potInfo = await colony.getFundingPot(taskInfo.fundingPotId);
       expect(potInfo.associatedType).to.eq.BN(2);
       expect(potInfo.associatedTypeId).to.eq.BN(taskId);
+      expect(potInfo.payoutsWeCannotMake).to.eq.BN(0);
 
       // Read pot info about a pot in a domain
       const domainInfo = await colony.getDomain(1);

--- a/test/colony.js
+++ b/test/colony.js
@@ -116,13 +116,20 @@ contract("Colony", accounts => {
       let potInfo = await colony.getFundingPot(taskInfo.fundingPotId);
       expect(potInfo.associatedType).to.eq.BN(2);
       expect(potInfo.associatedTypeId).to.eq.BN(taskId);
-      expect(potInfo.payoutsWeCannotMake).to.eq.BN(0);
+      expect(potInfo.payoutsWeCannotMake).to.be.zero;
 
       // Read pot info about a pot in a domain
       const domainInfo = await colony.getDomain(1);
       potInfo = await colony.getFundingPot(domainInfo.fundingPotId);
       expect(potInfo.associatedType).to.eq.BN(1);
       expect(potInfo.associatedTypeId).to.eq.BN(1);
+    });
+
+    it("should return the correct payout information about the reward funding pot", async () => {
+      const rewardPotInfo = await colony.getFundingPot(0);
+      expect(rewardPotInfo.associatedType).to.be.zero;
+      expect(rewardPotInfo.associatedTypeId).to.be.zero;
+      expect(rewardPotInfo.payoutsWeCannotMake).to.be.zero;
     });
   });
 

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -33,7 +33,7 @@ contract("One transaction payments", accounts => {
   beforeEach(async () => {
     ({ colony, token } = await setupRandomColony(colonyNetwork));
     await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-    // Give a use colony admin rights
+    // Give a user colony admin rights
     await colony.setAdminRole(COLONY_ADMIN);
     // Give oneTxExtension admin rights
     await colony.setAdminRole(oneTxExtension.address);

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -19,6 +19,7 @@ contract("One transaction payments", accounts => {
   let oneTxExtension;
   let globalSkillId;
   const RECIPIENT = accounts[3];
+  const COLONY_ADMIN = accounts[5];
 
   before(async () => {
     colonyNetwork = await setupColonyNetwork();
@@ -32,17 +33,18 @@ contract("One transaction payments", accounts => {
   beforeEach(async () => {
     ({ colony, token } = await setupRandomColony(colonyNetwork));
     await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-
+    // Give a use colony admin rights
+    await colony.setAdminRole(COLONY_ADMIN);
     // Give oneTxExtension admin rights
     await colony.setAdminRole(oneTxExtension.address);
   });
 
-  describe("Under normal conditions", () => {
+  describe("under normal conditions", () => {
     it("should allow a single transaction payment of tokens to occur", async () => {
       const balanceBefore = await token.balanceOf(RECIPIENT);
       expect(balanceBefore).to.eq.BN(0);
       // This is the one transactions. Those ones above don't count...
-      await oneTxExtension.makePayment(colony.address, RECIPIENT, token.address, 10, 1, globalSkillId);
+      await oneTxExtension.makePayment(colony.address, RECIPIENT, token.address, 10, 1, globalSkillId, { from: COLONY_ADMIN });
       // Check it completed
       const balanceAfter = await token.balanceOf(RECIPIENT);
       expect(balanceAfter).to.eq.BN(9);
@@ -53,33 +55,39 @@ contract("One transaction payments", accounts => {
       await colony.send(10); // NB 10 wei, not ten ether!
       await colony.claimColonyFunds(ZERO_ADDRESS);
       // This is the one transactions. Those ones above don't count...
-      await oneTxExtension.makePayment(colony.address, RECIPIENT, ZERO_ADDRESS, 10, 1, globalSkillId);
+      await oneTxExtension.makePayment(colony.address, RECIPIENT, ZERO_ADDRESS, 10, 1, globalSkillId, { from: COLONY_ADMIN });
       // Check it completed
       const balanceAfter = await web3.eth.getBalance(RECIPIENT);
       // So only 9 here, because of the same rounding errors as applied to the token
       expect(new web3.utils.BN(balanceAfter).sub(new web3.utils.BN(balanceBefore))).to.eq.BN(9);
     });
 
-    it.skip("should not allow a non-admin to make a single-transaction payment", async () => {
+    it("should not allow a non-admin to make a single-transaction payment", async () => {
       await checkErrorRevert(
-        oneTxExtension.makePayment(colony.address, RECIPIENT, token.address, 10, 1, globalSkillId, { from: RECIPIENT }),
+        oneTxExtension.makePayment(colony.address, RECIPIENT, token.address, 10, 1, globalSkillId, { from: accounts[10] }),
         "colony-one-tx-payment-not-authorized"
       );
     });
 
-    it.skip("should not allow an admin to specify a non-global skill", async () => {
-      await checkErrorRevert(oneTxExtension.makePayment(colony.address, RECIPIENT, token.address, 10, 1, 3), "colony-not-global-skill");
+    it("should not allow an admin to specify a non-global skill", async () => {
+      await checkErrorRevert(
+        oneTxExtension.makePayment(colony.address, RECIPIENT, token.address, 10, 1, 3, { from: COLONY_ADMIN }),
+        "colony-not-global-skill"
+      );
     });
 
-    it.skip("should not allow an admin to specify a non-existent domain", async () => {
+    it("should not allow an admin to specify a non-existent domain", async () => {
       await checkErrorRevert(
-        oneTxExtension.makePayment(colony.address, RECIPIENT, token.address, 10, 99, globalSkillId),
+        oneTxExtension.makePayment(colony.address, RECIPIENT, token.address, 10, 99, globalSkillId, { from: COLONY_ADMIN }),
         "colony-domain-does-not-exist"
       );
     });
 
-    it.skip("should not allow an admin to specify a non-existent skill", async () => {
-      await checkErrorRevert(oneTxExtension.makePayment(colony.address, RECIPIENT, token.address, 10, 1, 99), "colony-skill-does-not-exist");
+    it("should not allow an admin to specify a non-existent skill", async () => {
+      await checkErrorRevert(
+        oneTxExtension.makePayment(colony.address, RECIPIENT, token.address, 10, 1, 99, { from: COLONY_ADMIN }),
+        "colony-skill-does-not-exist"
+      );
     });
   });
 });

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -1,0 +1,85 @@
+/* globals artifacts */
+
+import chai from "chai";
+import bnChai from "bn-chai";
+
+import { INITIAL_FUNDING, ZERO_ADDRESS } from "../../helpers/constants";
+import { checkErrorRevert } from "../../helpers/test-helper";
+import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony, fundColonyWithTokens } from "../../helpers/test-data-generator";
+
+const { expect } = chai;
+chai.use(bnChai(web3.utils.BN));
+
+const OneTxPayment = artifacts.require("OneTxPayment");
+
+contract("One transaction payments", accounts => {
+  let colony;
+  let token;
+  let colonyNetwork;
+  let oneTxExtension;
+  let globalSkillId;
+  const RECIPIENT = accounts[3];
+
+  before(async () => {
+    colonyNetwork = await setupColonyNetwork();
+    await setupMetaColonyWithLockedCLNYToken(colonyNetwork);
+    await colonyNetwork.initialiseReputationMining();
+    await colonyNetwork.startNextCycle();
+    oneTxExtension = await OneTxPayment.new();
+    globalSkillId = await colonyNetwork.getRootGlobalSkillId();
+  });
+
+  beforeEach(async () => {
+    ({ colony, token } = await setupRandomColony(colonyNetwork));
+    await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+
+    // Give oneTxExtension admin rights
+    await colony.setAdminRole(oneTxExtension.address);
+  });
+
+  describe("Under normal conditions", () => {
+    it("should allow a single transaction payment of tokens to occur", async () => {
+      const balanceBefore = await token.balanceOf(RECIPIENT);
+      expect(balanceBefore).to.eq.BN(0);
+      // This is the one transactions. Those ones above don't count...
+      await oneTxExtension.makePayment(colony.address, RECIPIENT, token.address, 10, 1, globalSkillId);
+      // Check it completed
+      const balanceAfter = await token.balanceOf(RECIPIENT);
+      expect(balanceAfter).to.eq.BN(9);
+    });
+
+    it("should allow a single transaction payment of ETH to occur", async () => {
+      const balanceBefore = await web3.eth.getBalance(RECIPIENT);
+      await colony.send(10); // NB 10 wei, not ten ether!
+      await colony.claimColonyFunds(ZERO_ADDRESS);
+      // This is the one transactions. Those ones above don't count...
+      await oneTxExtension.makePayment(colony.address, RECIPIENT, ZERO_ADDRESS, 10, 1, globalSkillId);
+      // Check it completed
+      const balanceAfter = await web3.eth.getBalance(RECIPIENT);
+      // So only 9 here, because of the same rounding errors as applied to the token
+      expect(new web3.utils.BN(balanceAfter).sub(new web3.utils.BN(balanceBefore))).to.eq.BN(9);
+    });
+
+    it.skip("should not allow a non-admin to make a single-transaction payment", async () => {
+      await checkErrorRevert(
+        oneTxExtension.makePayment(colony.address, RECIPIENT, token.address, 10, 1, globalSkillId, { from: RECIPIENT }),
+        "colony-one-tx-payment-not-authorized"
+      );
+    });
+
+    it.skip("should not allow an admin to specify a non-global skill", async () => {
+      await checkErrorRevert(oneTxExtension.makePayment(colony.address, RECIPIENT, token.address, 10, 1, 3), "colony-not-global-skill");
+    });
+
+    it.skip("should not allow an admin to specify a non-existent domain", async () => {
+      await checkErrorRevert(
+        oneTxExtension.makePayment(colony.address, RECIPIENT, token.address, 10, 99, globalSkillId),
+        "colony-domain-does-not-exist"
+      );
+    });
+
+    it.skip("should not allow an admin to specify a non-existent skill", async () => {
+      await checkErrorRevert(oneTxExtension.makePayment(colony.address, RECIPIENT, token.address, 10, 1, 99), "colony-skill-does-not-exist");
+    });
+  });
+});

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -368,7 +368,7 @@ contract("Meta Colony", accounts => {
       });
 
       const task = await colony.getTask(taskId);
-      expect(task[7]).to.eq.BN(2);
+      expect(task.domainId).to.eq.BN(2);
     });
 
     it("should NOT allow a non-manager to set domain on task", async () => {
@@ -387,7 +387,7 @@ contract("Meta Colony", accounts => {
       );
 
       const task = await colony.getTask(taskId);
-      expect(task[7]).to.eq.BN(1);
+      expect(task.domainId).to.eq.BN(1);
     });
 
     it("should NOT be able to set a domain on nonexistent task", async () => {
@@ -423,7 +423,7 @@ contract("Meta Colony", accounts => {
       );
 
       const task = await colony.getTask(taskId);
-      expect(task[7]).to.eq.BN(1);
+      expect(task.domainId).to.eq.BN(1);
     });
 
     it("should NOT be able to set a domain on completed task", async () => {
@@ -460,7 +460,7 @@ contract("Meta Colony", accounts => {
       });
 
       const task = await colony.getTask(taskId);
-      expect(task[8][0]).to.eq.BN(6);
+      expect(task.skillIds[0]).to.eq.BN(6);
     });
 
     it("should not allow anyone but the colony to set global skill on task", async () => {
@@ -471,7 +471,7 @@ contract("Meta Colony", accounts => {
       await checkErrorRevert(colony.setTaskSkill(taskId, 5, { from: OTHER_ACCOUNT }), "colony-not-self");
 
       const task = await colony.getTask(taskId);
-      expect(task[8][0]).to.be.zero;
+      expect(task.skillIds[0]).to.be.zero;
     });
 
     it("should NOT be able to set global skill on nonexistent task", async () => {
@@ -486,7 +486,7 @@ contract("Meta Colony", accounts => {
       await checkErrorRevert(colony.setTaskSkill(taskId, 6), "colony-task-complete");
 
       const task = await colony.getTask(taskId);
-      expect(task[8][0]).to.eq.BN(1);
+      expect(task.skillIds[0]).to.eq.BN(1);
     });
 
     it("should NOT be able to set nonexistent skill on task", async () => {

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -336,6 +336,7 @@ contract("Reputation Updates", accounts => {
 
       const payment = await metaColony.getPayment(paymentId);
       await metaColony.moveFundsBetweenPots(1, payment.fundingPotId, WAD.add(WAD.divn(10)), clnyToken.address);
+      await metaColony.finalizePayment(paymentId);
       await metaColony.claimPayment(paymentId, clnyToken.address);
 
       const reputationUpdateLogLength = await inactiveReputationMiningCycle.getReputationUpdateLogLength();
@@ -364,6 +365,7 @@ contract("Reputation Updates", accounts => {
 
       const payment = await metaColony.getPayment(paymentId);
       await metaColony.moveFundsBetweenPots(1, payment.fundingPotId, WAD.add(WAD.divn(10)), otherToken.address);
+      await metaColony.finalizePayment(paymentId);
       await metaColony.claimPayment(paymentId, otherToken.address);
 
       const reputationUpdateLogLength = await inactiveReputationMiningCycle.getReputationUpdateLogLength();

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -256,7 +256,7 @@ contract("Reputation Updates", accounts => {
 
       const payment = await metaColony.getPayment(paymentId);
       await metaColony.moveFundsBetweenPots(1, payment.fundingPotId, WAD.add(WAD.divn(10)), clnyToken.address);
-      await metaColony.claimPayment(paymentId);
+      await metaColony.claimPayment(paymentId, clnyToken.address);
 
       const repLogEntryManager = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(1);
       expect(repLogEntryManager.user).to.equal(RECIPIENT);

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -369,7 +369,7 @@ contract("Reputation Updates", accounts => {
       await metaColony.claimPayment(paymentId, otherToken.address);
 
       const reputationUpdateLogLength = await inactiveReputationMiningCycle.getReputationUpdateLogLength();
-      expect(reputationUpdateLogLength).to.eq.BN(1);
+      expect(reputationUpdateLogLength).to.eq.BN(1); // Just the miner reward
     });
   });
 });

--- a/test/reputation-update.js
+++ b/test/reputation-update.js
@@ -34,12 +34,13 @@ import {
   RATING_2_SECRET
 } from "../helpers/constants";
 
-import { checkErrorRevert, forwardTime, advanceMiningCycleNoContest } from "../helpers/test-helper";
+import { checkErrorRevert, forwardTime, advanceMiningCycleNoContest, getTokenArgs } from "../helpers/test-helper";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
 
 const IReputationMiningCycle = artifacts.require("IReputationMiningCycle");
+const DSToken = artifacts.require("DSToken");
 
 contract("Reputation Updates", accounts => {
   const MANAGER = accounts[0];
@@ -337,6 +338,9 @@ contract("Reputation Updates", accounts => {
       await metaColony.moveFundsBetweenPots(1, payment.fundingPotId, WAD.add(WAD.divn(10)), clnyToken.address);
       await metaColony.claimPayment(paymentId, clnyToken.address);
 
+      const reputationUpdateLogLength = await inactiveReputationMiningCycle.getReputationUpdateLogLength();
+      expect(reputationUpdateLogLength).to.eq.BN(3);
+
       let repLogEntryManager = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(1);
       expect(repLogEntryManager.user).to.equal(RECIPIENT);
       expect(repLogEntryManager.amount).to.eq.BN(WAD);
@@ -347,6 +351,23 @@ contract("Reputation Updates", accounts => {
       expect(repLogEntryManager.user).to.equal(RECIPIENT);
       expect(repLogEntryManager.amount).to.eq.BN(WAD);
       expect(repLogEntryManager.skillId).to.eq.BN(7);
+    });
+
+    it("should not add entries to the reputation log for payments that are not in the colony home token", async () => {
+      const RECIPIENT = accounts[3];
+      const tokenArgs = getTokenArgs();
+      const otherToken = await DSToken.new(tokenArgs[1]);
+      await fundColonyWithTokens(metaColony, otherToken, WAD.muln(2));
+
+      await metaColony.addPayment(RECIPIENT, otherToken.address, WAD, 1, 7);
+      const paymentId = await metaColony.getPaymentCount();
+
+      const payment = await metaColony.getPayment(paymentId);
+      await metaColony.moveFundsBetweenPots(1, payment.fundingPotId, WAD.add(WAD.divn(10)), otherToken.address);
+      await metaColony.claimPayment(paymentId, otherToken.address);
+
+      const reputationUpdateLogLength = await inactiveReputationMiningCycle.getReputationUpdateLogLength();
+      expect(reputationUpdateLogLength).to.eq.BN(1);
     });
   });
 });


### PR DESCRIPTION
Closes #527 

The `Payment` flow (aka 4tx flow) is:
1. Create new payment: 
`addPayment(address recipient,  address token,  uint256 amount, uint256 domainId,  uint256 skillId)` 
2. Fund the payment (same as for Tasks using `moveFundsBetweenPots`).
3. Finalize the payment. When the payment becomes fully funded admins can call `finalizePayment` which marks it finalised and awards reputation.
3. Claim the payment via `claimPayment` (can be called by anyone on behalf of the recipient)

Amending the different elements of a payment can be done via: `setPaymentRecipient`, `setPaymentDomain`, `setPaymentSkill` or `setPayout`. These functions are restricted to the colony admins as is creating a payment. Note that once created any admin can manage any payment in the colony. Payments cannot be amended once finalized.

Note that even though by default a newly created Payment is 1 token amount for the recipient, there is a possibility to add more tokens in the payment for the same recipient, again similarly to tasks.

For the single transaction flow, I've reused the `OneTxPayment` contract and tests from @area 's [branch for eth-denver](https://github.com/JoinColony/colonyNetwork/tree/temp/eth-denver)

In addition to implementing the requirements for `Payment`s we refactor the following common logic between Tasks and Payments:

- Logic around tracking whether a `Task` or `Payment` is sufficiently funded via the `payoutsWeCannotMake` property. This used to be stored in the `Task` itself however it make more sense to abstract as part of the `FundingPot` model. This way `Payment`s can reuse it. A nice side effect from this is that the iterative function `getTotalTaskPayout` is no longer needed as this is kept as part of the `FundingPot.payouts` information.

- Disbursing the payment logic including deducting network fee, updating the funding pot balances and paying the recipient is consolidated in the `processPayout` private function which is reused across both `Task` and `Payment` 