### PR TITLE
Give Colony founder recovery role by default

### DIFF
--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -153,6 +153,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
 
     authority.setOwner(address(etherRouter));
     colony.setFounderRole(msg.sender);
+    colony.setRecoveryRole(msg.sender);
 
     // Colony will not have owner
     dsauth.setOwner(address(0x0));

--- a/test/colony-recovery.js
+++ b/test/colony-recovery.js
@@ -27,9 +27,6 @@ contract("Colony Recovery", accounts => {
 
   describe("when using recovery mode", () => {
     it("should be able to check whether we are in recovery mode", async () => {
-      const founder = accounts[0];
-      await colony.setRecoveryRole(founder);
-
       let recoveryMode = await colony.isInRecoveryMode();
       expect(recoveryMode).to.be.false;
       await colony.enterRecoveryMode();
@@ -39,13 +36,11 @@ contract("Colony Recovery", accounts => {
     });
 
     it("should be able to add and remove recovery roles when not in recovery", async () => {
-      const founder = accounts[0];
       let numRecoveryRoles;
 
       numRecoveryRoles = await colony.numRecoveryRoles();
-      expect(numRecoveryRoles).to.be.zero;
+      expect(numRecoveryRoles).to.eq.BN(1);
 
-      await colony.setRecoveryRole(founder);
       await colony.setRecoveryRole(accounts[1]);
       await colony.setRecoveryRole(accounts[2]);
       numRecoveryRoles = await colony.numRecoveryRoles();
@@ -62,33 +57,28 @@ contract("Colony Recovery", accounts => {
       expect(numRecoveryRoles).to.eq.BN(2);
 
       // Can remove founder
-      await colony.removeRecoveryRole(founder);
+      await colony.removeRecoveryRole(accounts[0]);
       numRecoveryRoles = await colony.numRecoveryRoles();
       expect(numRecoveryRoles).to.eq.BN(1);
     });
 
     it("should not error when adding recovery roles for existing recovery users", async () => {
-      const founder = accounts[0];
       let numRecoveryRoles;
 
       numRecoveryRoles = await colony.numRecoveryRoles();
-      expect(numRecoveryRoles).to.be.zero;
+      expect(numRecoveryRoles).to.eq.BN(1);
 
-      await colony.setRecoveryRole(founder);
       await colony.setRecoveryRole(accounts[1]);
       numRecoveryRoles = await colony.numRecoveryRoles();
       expect(numRecoveryRoles).to.eq.BN(2);
 
       // Can add twice
-      await colony.setRecoveryRole(founder);
       await colony.setRecoveryRole(accounts[1]);
       numRecoveryRoles = await colony.numRecoveryRoles();
       expect(numRecoveryRoles).to.eq.BN(2);
     });
 
     it("should not be able to add and remove roles when in recovery", async () => {
-      const founder = accounts[0];
-      await colony.setRecoveryRole(founder);
       await colony.enterRecoveryMode();
       await checkErrorRevert(colony.setAdminRole(accounts[1]), "colony-in-recovery-mode");
       await checkErrorRevert(colony.removeAdminRole(accounts[1]), "colony-in-recovery-mode");
@@ -98,11 +88,7 @@ contract("Colony Recovery", accounts => {
     });
 
     it("should not be able to call normal functions while in recovery", async () => {
-      const founder = accounts[0];
-      await colony.setRecoveryRole(founder);
       await colony.enterRecoveryMode();
-
-      await metaColony.setRecoveryRole(founder);
       await metaColony.enterRecoveryMode();
 
       await checkErrorRevert(colony.initialiseColony(ZERO_ADDRESS, ZERO_ADDRESS), "colony-in-recovery-mode");
@@ -112,8 +98,6 @@ contract("Colony Recovery", accounts => {
     });
 
     it("should exit recovery mode with sufficient approvals", async () => {
-      const founder = accounts[0];
-      await colony.setRecoveryRole(founder);
       await colony.setRecoveryRole(accounts[1]);
       await colony.setRecoveryRole(accounts[2]);
 
@@ -133,8 +117,6 @@ contract("Colony Recovery", accounts => {
     });
 
     it("recovery users can work in recovery mode", async () => {
-      const founder = accounts[0];
-      await colony.setRecoveryRole(founder);
       await colony.setRecoveryRole(accounts[1]);
 
       await colony.enterRecoveryMode();
@@ -147,8 +129,6 @@ contract("Colony Recovery", accounts => {
     });
 
     it("users cannot approve twice", async () => {
-      const founder = accounts[0];
-      await colony.setRecoveryRole(founder);
       await colony.enterRecoveryMode();
       await colony.setStorageSlotRecovery(5, "0xdeadbeef");
 
@@ -157,15 +137,11 @@ contract("Colony Recovery", accounts => {
     });
 
     it("users cannot approve if unauthorized", async () => {
-      const founder = accounts[0];
-      await colony.setRecoveryRole(founder);
       await colony.enterRecoveryMode();
       await checkErrorRevert(colony.approveExitRecovery({ from: accounts[1] }), "ds-auth-unauthorized");
     });
 
     it("should allow editing of general variables", async () => {
-      const founder = accounts[0];
-      await colony.setRecoveryRole(founder);
       await colony.enterRecoveryMode();
       await colony.setStorageSlotRecovery(5, "0xdeadbeef");
 
@@ -174,9 +150,6 @@ contract("Colony Recovery", accounts => {
     });
 
     it("should not allow editing of protected variables", async () => {
-      const founder = accounts[0];
-
-      await colony.setRecoveryRole(founder);
       await colony.enterRecoveryMode();
       await checkErrorRevert(colony.setStorageSlotRecovery(0, "0xdeadbeef"), "colony-common-protected-variable");
       await checkErrorRevert(colony.setStorageSlotRecovery(1, "0xdeadbeef"), "colony-common-protected-variable");
@@ -186,11 +159,9 @@ contract("Colony Recovery", accounts => {
     });
 
     it("should allow upgrade to be called on a colony in and out of recovery mode", async () => {
-      const founder = accounts[0];
       // Note that we can't upgrade, because we don't have a new version. But this test is still valid, because we're getting the
       // 'version must be newer' error, not a `colony-not-in-recovery-mode` or `colony-in-recovery-mode` error.
       await checkErrorRevert(colony.upgrade(1), "colony-version-must-be-newer");
-      await colony.setRecoveryRole(founder);
       await colony.enterRecoveryMode();
       await checkErrorRevert(colony.upgrade(1), "colony-version-must-be-newer");
     });


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->

<!--- Summary of changes including design decisions -->

Give `msg.sender` the recovery role when creating a new Colony.