### PR TITLE
Remove redundant auth from ReputationMiningCycleStorage

### DIFF
--- a/contracts/ReputationMiningCycleStorage.sol
+++ b/contracts/ReputationMiningCycleStorage.sol
@@ -22,8 +22,11 @@ import "./ReputationMiningCycleDataTypes.sol";
 
 
 contract ReputationMiningCycleStorage is ReputationMiningCycleDataTypes, DSAuth {
+  // From DSAuth there is authority and owner at storage slots 0 and 1 respectively
+  // These are not used but are necessary for alignment when casting from EtherRouter
+
   // Address of the Resolver contract used by EtherRouter for lookups and routing
-  address resolver; // Storage slot 2 (from DSAuth there is authority and owner at storage slots 0 and 1 respectively)
+  address resolver; // Storage slot 2
 
   address payable colonyNetworkAddress; // Storage slot 3
   address tokenLockingAddress; // Storage slot 4


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Follow-on from #553 , looking into whether the `DSAuth` in `ReputationMiningCycleStorage.sol` is redundant.

<!--- Summary of changes including design decisions -->

After doing some investigation, I have found that `DSAuth` is both redundant _and_ not redundant. `DSAuth` is **redundant** because no functions in `ReputationMiningCycle` use the `auth` modifier. However, it is **not redundant** because under-the-hood, we generate a new `EtherRouter` contract and _cast it to_ `ReputationMiningCycle` before use. In that sense, the actual contract has `owner` and `authority` variables from `EtherRouter`, and so we need to reserve the first two storage variables in `ReputationMiningCycle` so that the storage lines up.

My solution is to _remove_ the DSAuth dependency but to _keep_ the `owner` and `authority` storage variables (although to rename them to dummy names for clarity). These storage variables are not meant for use. While having "dummy" variables is a bit awkward, I would suggest that this does provide more clarity overall, specifically by making it clear that we _do not_ authenticate the `ReputationMiningCycle` functions.

Ultimately it's not a big change so I could see arguments for not merging this and leaving things as-are. But I did the investigation and so I figured I should present the change to the team for consideration.