### PR TITLE
Fix token authority instantiation in migrations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "lib/colonyToken"]
 	path = lib/colonyToken
 	url = https://github.com/JoinColony/colonyToken.git
-  branch = feature/upgrade-token-authority-for-colony-network
+  branch = master

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -346,7 +346,8 @@ export async function setupMetaColonyWithLockedCLNYToken(colonyNetwork) {
     metaColonyAddress,
     tokenLockingAddress,
     ZERO_ADDRESS,
-    reputationMinerTestAccounts
+    reputationMinerTestAccounts,
+    ZERO_ADDRESS
   );
 
   await clnyToken.setAuthority(tokenAuthority.address);

--- a/migrations/8_setup_meta_colony.js
+++ b/migrations/8_setup_meta_colony.js
@@ -36,7 +36,8 @@ module.exports = async function(deployer, network, accounts) {
     metaColonyAddress,
     tokenLockingAddress,
     ZERO_ADDRESS,
-    reputationMinerTestAccounts
+    reputationMinerTestAccounts,
+    ZERO_ADDRESS
   );
   await clnyToken.setAuthority(tokenAuthority.address);
   await clnyToken.setOwner(accounts[11]);


### PR DESCRIPTION
Aligns the network with the updated `TokenAuthority` implementation (which now uses 7 constructor parameters) and switches the `colonyToken` git submodule to use the `master` branch.