### PR TITLE
Downgrade eth-gas-reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-prettier": "^3.0.1",
     "eth-ens-namehash": "^2.0.8",
-    "eth-gas-reporter": "0.1.12",
+    "eth-gas-reporter": "0.1.10",
     "ethereumjs-util": "^6.1.0",
     "ethers": "^4.0.27",
     "ethlint": "^1.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2002,7 +2002,7 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-"charenc@>= 0.0.1", charenc@~0.0.1:
+charenc@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
@@ -2331,7 +2331,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-"crypt@>= 0.0.1", crypt@~0.0.1:
+crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
@@ -2993,10 +2993,10 @@ eth-ens-namehash@2.0.8, eth-ens-namehash@^2.0.8:
     idna-uts46-hx "^2.3.1"
     js-sha3 "^0.5.7"
 
-eth-gas-reporter@0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/eth-gas-reporter/-/eth-gas-reporter-0.1.12.tgz#6b761e05c33ae85be47840dd07468ab51d473dd8"
-  integrity sha512-Ao5uiXSA5Ep5fi/YvGCsFJMelMKj0fMJkAvWYzPVe1h3Mg9Z7X3Rs51ovG9izFZH7wSqnqydiC6SKDhZWpxK2g==
+eth-gas-reporter@0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/eth-gas-reporter/-/eth-gas-reporter-0.1.10.tgz#6ac24958f0e018d4729902e802dc8449e8a5ff72"
+  integrity sha512-esVDZWlS+4ByrbHGYHA2sJSevmqBsh7tLTnp7qlc6oJrWqU+SakyTUtHWsUcxhv1SerWEvUl0aRmeytspunmww==
   dependencies:
     abi-decoder "^1.0.8"
     cli-table3 "^0.5.0"
@@ -3006,7 +3006,6 @@ eth-gas-reporter@0.1.12:
     req-cwd "^2.0.0"
     request "^2.83.0"
     request-promise-native "^1.0.5"
-    sha1 "^1.1.1"
     shelljs "^0.7.8"
     solidity-parser-antlr "^0.2.10"
     sync-request "^6.0.0"
@@ -7203,14 +7202,6 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
-
-sha1@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/sha1/-/sha1-1.1.1.tgz#addaa7a93168f393f19eb2b15091618e2700f848"
-  integrity sha1-rdqnqTFo85PxnrKxUJFhjicA+Eg=
-  dependencies:
-    charenc ">= 0.0.1"
-    crypt ">= 0.0.1"
 
 sha3@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
I got a bit overzealous with `yarn upgrade --latest`. Sorry!

Double-check the gas reporter part of the build before merging.