### PR TITLE
Refactor bytes[5] to bytes32[8] in respondToChallenge

### DIFF
--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -124,22 +124,15 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// * 28. The value of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree
   /// * 29. The value of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
 
-  /// @param b32 A `bytes32[15]` array. The elements of this array, in order are:
+  /// @param b32 A `bytes32[8]` array. The elements of this array, in order are:
   /// * 1. The colony address in the key of the reputation being changed that the disagreement is over.
   /// * 2. The skillid in the key of the reputation being changed that the disagreement is over.
   /// * 3. The user address in the key of the reputation being changed that the disagreement is over.
-  /// * 4. The colony address in the key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
-  /// * 5. The skillid in the key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
-  /// * 6. The user address in the key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
-  /// * 7. The colony address in the key for a reputation already in the tree adjacent to the new reputation being inserted, if required.
-  /// * 8. The skillid in the key for a reputation already in the tree adjacent to the new reputation being inserted, if required.
-  /// * 9. The user address in the key for a reputation already in the tree adjacent to the new reputation being inserted, if required.
-  /// * 10. The colony address in the key of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree
-  /// * 11. The skillid in the key of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree
-  /// * 12. The user address in the key of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree
-  /// * 13. The colony address in the key of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
-  /// * 14. The skillid in the key of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
-  /// * 15. The user address in the key of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
+  /// * 4. The keccak256 hash of the key of the reputation being changed that the disagreement is over.
+  /// * 5. The keccak256 hash of the key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
+  /// * 6. The keccak256 hash of the key for a reputation already in the tree adjacent to the new reputation being inserted, if required.
+  /// * 7. The keccak256 hash of the key of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree
+  /// * 8. The keccak256 hash of the key of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
   /// @dev note that these are all bytes32; the address should be left padded from 20 bytes to 32 bytes. Strictly, I do not believe the padding matters, but you should use 0s for your own sanity!
 
   /// @param reputationSiblings The siblings of the Merkle proof that the reputation corresponding to `_reputationKey` is in the reputation state before and after the disagreement

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -153,7 +153,7 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// that this is the case, however, otherwise you risk being found incorrect. Zeroed arguments will result in a cheaper call to this function.
   function respondToChallenge(
     uint256[29] memory u, //An array of 29 UINT Params, ordered as given above.
-    bytes32[15] memory b32,
+    bytes32[8] memory b32,
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings,

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -124,12 +124,23 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// * 28. The value of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree
   /// * 29. The value of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
 
-  /// @param b A `bytes[3]` array. The elements of this array, in order are:
-  /// * 1. Reputation key The key of the reputation being changed that the disagreement is over.
-  /// * 2. previousNewReputationKey The key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
-  /// * 3. adjacentReputationKey Key for a reputation already in the tree adjacent to the new reputation being inserted, if required.
-  /// * 4  The key of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree
-  /// * 5. The key of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
+  /// @param b32 A `bytes32[15]` array. The elements of this array, in order are:
+  /// * 1. The colony address in the key of the reputation being changed that the disagreement is over.
+  /// * 2. The skillid in the key of the reputation being changed that the disagreement is over.
+  /// * 3. The user address in the key of the reputation being changed that the disagreement is over.
+  /// * 4. The colony address in the key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
+  /// * 5. The skillid in the key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
+  /// * 6. The user address in the key of the newest reputation added to the reputation tree in the last reputation state the submitted hashes agree on
+  /// * 7. The colony address in the key for a reputation already in the tree adjacent to the new reputation being inserted, if required.
+  /// * 8. The skillid in the key for a reputation already in the tree adjacent to the new reputation being inserted, if required.
+  /// * 9. The user address in the key for a reputation already in the tree adjacent to the new reputation being inserted, if required.
+  /// * 10. The colony address in the key of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree
+  /// * 11. The skillid in the key of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree
+  /// * 12. The user address in the key of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree
+  /// * 13. The colony address in the key of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
+  /// * 14. The skillid in the key of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
+  /// * 15. The user address in the key of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
+  /// @dev note that these are all bytes32; the address should be left padded from 20 bytes to 32 bytes. Strictly, I do not believe the padding matters, but you should use 0s for your own sanity!
 
   /// @param reputationSiblings The siblings of the Merkle proof that the reputation corresponding to `_reputationKey` is in the reputation state before and after the disagreement
   /// @param agreeStateSiblings The siblings of the Merkle proof that the last reputation state the submitted hashes agreed on is in this submitted hash's justification tree
@@ -142,7 +153,7 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// that this is the case, however, otherwise you risk being found incorrect. Zeroed arguments will result in a cheaper call to this function.
   function respondToChallenge(
     uint256[29] memory u, //An array of 29 UINT Params, ordered as given above.
-    bytes[5] memory b,
+    bytes32[15] memory b32,
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings,

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -322,7 +322,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     require(impliedRoot == targetHashDuringSearch, "colony-reputation-mining-invalid-binary-search-response");
     // If require hasn't thrown, proof is correct.
     // Process the consequences
-    processBinaryChallengeSearchResponse(round, idx, jhIntermediateValue, targetNode, lastSiblings);
+    processBinaryChallengeSearchResponse(round, idx, jhIntermediateValue, lastSiblings);
   }
 
   function confirmBinarySearchResult(
@@ -502,7 +502,6 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     uint256 round,
     uint256 idx,
     bytes memory jhIntermediateValue,
-    uint256 targetNode,
     bytes32[2] memory lastSiblings
   ) internal
   {
@@ -525,11 +524,11 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     if (disputeRounds[round][opponentIdx].challengeStepCompleted == disputeRounds[round][idx].challengeStepCompleted ) {
       // Our opponent answered this challenge already.
       // Compare our intermediateReputationHash to theirs to establish how to move the bounds.
-      processBinaryChallengeSearchStep(round, idx, targetNode);
+      processBinaryChallengeSearchStep(round, idx);
     }
   }
 
-  function processBinaryChallengeSearchStep(uint256 round, uint256 idx, uint256 targetNode) internal {
+  function processBinaryChallengeSearchStep(uint256 round, uint256 idx) internal {
     uint256 opponentIdx = (idx % 2 == 1 ? idx-1 : idx + 1);
     uint256 searchWidth = (disputeRounds[round][idx].upperBound - disputeRounds[round][idx].lowerBound) + 1;
     uint256 searchWidthNextPowerOfTwo = nextPowerOfTwoInclusive(searchWidth);

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -96,7 +96,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
   function respondToChallenge(
     uint256[29] memory u, //An array of 29 UINT Params, ordered as given above.
-    bytes32[8] memory b32, // An array of 8 bytes params, ordered as given above
+    bytes32[8] memory b32, // An array of 8 bytes32 params, ordered as given above
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings,

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -82,12 +82,6 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   uint constant U_USER_ORIGIN_ADJACENT_REPUTATION_VALUE = 27;
   uint constant U_CHILD_ADJACENT_REPUTATION_VALUE = 28;
 
-  uint constant B_REPUTATION_KEY = 0;
-  uint constant B_PREVIOUS_NEW_REPUTATION_KEY = 1;
-  uint constant B_ADJACENT_REPUTATION_KEY = 2;
-  uint constant B_ORIGIN_ADJACENT_REPUTATION_KEY = 3;
-  uint constant B_CHILD_ADJACENT_REPUTATION_KEY = 4;
-
   uint constant B_REPUTATION_KEY_COLONY = 0;
   uint constant B_REPUTATION_KEY_SKILLID = 1;
   uint constant B_REPUTATION_KEY_USER = 2;

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -123,25 +123,25 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     u[U_DECAY_TRANSITION] = 0;
     u[U_GLOBAL_CHILD_UPDATE] = 0;
     u[U_NEW_REPUTATION] = 0;
-    // Temporary transition array.
-    bytes[5] memory b;
-    b[0] = buildReputationKey(b32[B_REPUTATION_KEY_COLONY], b32[B_REPUTATION_KEY_SKILLID], b32[B_REPUTATION_KEY_USER]);
-    b[1] = buildReputationKey(
+    // For functions that want the keys directly, we build them here (once) and then can pass them the array.
+    bytes[5] memory keys;
+    keys[0] = buildReputationKey(b32[B_REPUTATION_KEY_COLONY], b32[B_REPUTATION_KEY_SKILLID], b32[B_REPUTATION_KEY_USER]);
+    keys[1] = buildReputationKey(
       b32[B_PREVIOUS_NEW_REPUTATION_KEY_COLONY],
       b32[B_PREVIOUS_NEW_REPUTATION_KEY_SKILLID],
       b32[B_PREVIOUS_NEW_REPUTATION_KEY_USER]
     );
-    b[2] = buildReputationKey(
+    keys[2] = buildReputationKey(
       b32[B_ADJACENT_REPUTATION_KEY_COLONY], 
       b32[B_ADJACENT_REPUTATION_KEY_SKILLID], 
       b32[B_ADJACENT_REPUTATION_KEY_USER]
     );
-    b[3] = buildReputationKey(
+    keys[3] = buildReputationKey(
       b32[B_ORIGIN_ADJACENT_REPUTATION_KEY_COLONY],
       b32[B_ORIGIN_ADJACENT_REPUTATION_KEY_SKILLID],
       b32[B_ORIGIN_ADJACENT_REPUTATION_KEY_USER]
     );
-    b[4] = buildReputationKey(
+    keys[4] = buildReputationKey(
       b32[B_CHILD_ADJACENT_KEY_COLONY],
       b32[B_CHILD_ADJACENT_KEY_SKILLID],
       b32[B_CHILD_ADJACENT_KEY_USER]
@@ -163,35 +163,35 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     //    that it's a decay calculation - not yet implemented.)
 
     // Check the supplied key is appropriate.
-    checkKey(u, b);
+    checkKey(u, b32);
 
     // Prove the reputation's starting value is in some state, and that state is in the appropriate index in our JRH
-    proveBeforeReputationValue(u, b, reputationSiblings, agreeStateSiblings);
+    proveBeforeReputationValue(u, keys, reputationSiblings, agreeStateSiblings);
 
     // Prove the reputation's final value is in a particular state, and that state is in our JRH in the appropriate index (corresponding to the first disagreement between these miners)
     // By using the same branchMask and siblings, we know that no other changes to the reputation state tree have been slipped in.
-    proveAfterReputationValue(u, b, reputationSiblings, disagreeStateSiblings);
+    proveAfterReputationValue(u, keys, reputationSiblings, disagreeStateSiblings);
 
     // Perform the reputation calculation ourselves.
     performReputationCalculation(u);
 
     if (u[U_DECAY_TRANSITION] == 0) {
-      checkUserOriginReputation(u, b, agreeStateSiblings, userOriginReputationSiblings);
+      checkUserOriginReputation(u, keys, agreeStateSiblings, userOriginReputationSiblings);
     }
 
     if (u[U_GLOBAL_CHILD_UPDATE] == 1) {
-      checkChildReputation(u, b, agreeStateSiblings, childReputationSiblings);
+      checkChildReputation(u, keys, agreeStateSiblings, childReputationSiblings);
     }
 
     if (u[U_NEW_REPUTATION] == 1) {
-      checkAdjacentReputation(u, b, adjacentReputationSiblings, agreeStateSiblings, disagreeStateSiblings);
+      checkAdjacentReputation(u, keys, adjacentReputationSiblings, agreeStateSiblings, disagreeStateSiblings);
     }
 
     // If necessary, check the supplied previousNewRepuation is, in fact, in the same reputation state as the 'agree' state.
     // i.e. the reputation they supplied is in the 'agree' state.
     checkPreviousReputationInState(
       u,
-      b,
+      keys,
       agreeStateSiblings,
       previousNewReputationSiblings);
 
@@ -212,7 +212,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
   function checkAdjacentReputation(
     uint256[29] memory u,
-    bytes[5] memory b,
+    bytes[5] memory keys,
     bytes32[] memory adjacentReputationSiblings,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory disagreeStateSiblings
@@ -225,7 +225,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     bytes memory adjacentReputationValue = abi.encodePacked(u[U_ADJACENT_REPUTATION_VALUE], u[U_ADJACENT_REPUTATION_UID]);
 
     bytes32 reputationRootHash = getImpliedRootHashKey(
-      b[B_ADJACENT_REPUTATION_KEY],
+      keys[B_ADJACENT_REPUTATION_KEY],
       adjacentReputationValue,
       u[U_ADJACENT_REPUTATION_BRANCH_MASK],
       adjacentReputationSiblings
@@ -236,17 +236,19 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     require(impliedRoot == disputeRounds[u[U_ROUND]][u[U_IDX]].jrh, "colony-reputation-mining-adjacent-agree-state-disagreement");
 
     // The bit added to the branchmask is based on where the (hashes of the) two keys first differ.
-    uint256 firstDifferenceBit = uint256(Bits.highestBitSet(uint256(keccak256(b[B_ADJACENT_REPUTATION_KEY]) ^ keccak256(b[B_REPUTATION_KEY]))));
+    uint256 firstDifferenceBit = uint256(
+      Bits.highestBitSet(uint256(keccak256(keys[B_ADJACENT_REPUTATION_KEY]) ^ keccak256(keys[B_REPUTATION_KEY])))
+    );
     uint256 afterInsertionBranchMask = u[U_ADJACENT_REPUTATION_BRANCH_MASK] | uint256(2**firstDifferenceBit);
     // If a key that exists in the lastAgreeState has been passed in as the reputationKey, the adjacent key will already have a branch at the
     // first difference bit, and this check will fail.
     require(afterInsertionBranchMask != u[U_ADJACENT_REPUTATION_BRANCH_MASK], "colony-reputation-mining-adjacent-branchmask-incorrect");
 
     bytes32[] memory afterInsertionAdjacentReputationSiblings = new bytes32[](adjacentReputationSiblings.length + 1);
-    afterInsertionAdjacentReputationSiblings = buildNewSiblingsArray(u, b, firstDifferenceBit, adjacentReputationSiblings);
+    afterInsertionAdjacentReputationSiblings = buildNewSiblingsArray(u, keys, firstDifferenceBit, adjacentReputationSiblings);
 
     reputationRootHash = getImpliedRootHashKey(
-      b[B_ADJACENT_REPUTATION_KEY],
+      keys[B_ADJACENT_REPUTATION_KEY],
       adjacentReputationValue,
       afterInsertionBranchMask,
       afterInsertionAdjacentReputationSiblings
@@ -260,10 +262,10 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
   function buildNewSiblingsArray(
     uint256[29] memory u,
-    bytes[5] memory b,
+    bytes[5] memory keys,
     uint256 firstDifferenceBit,
     bytes32[] memory adjacentReputationSiblings
-    ) internal returns (bytes32[] memory)
+    ) internal pure returns (bytes32[] memory)
   {
     bytes32 newSibling = keccak256(
       abi.encodePacked(
@@ -274,7 +276,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
           )
         ),
         firstDifferenceBit,
-        keccak256(b[B_REPUTATION_KEY]) << (256 - firstDifferenceBit)
+        keccak256(keys[B_REPUTATION_KEY]) << (256 - firstDifferenceBit)
       )
     );
 
@@ -310,7 +312,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
   function checkUserOriginReputation(
     uint256[29] memory u,
-    bytes[5] memory b,
+    bytes[5] memory keys,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory userOriginReputationSiblings) internal
   {
@@ -318,11 +320,6 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     if (logEntry.amount >= 0) {
       return;
     }
-
-    bytes memory reputationKey = b[B_REPUTATION_KEY];
-    uint256 relativeUpdateNumber = getRelativeUpdateNumber(u, logEntry);
-    uint256 nChildUpdates;
-    (nChildUpdates, ) = getChildAndParentNUpdatesForLogEntry(u);
 
     // Check the user origin reputation key matches the colony, user address and skill id of the log
     bytes memory userOriginReputationKeyBytes = abi.encodePacked(logEntry.colony, logEntry.skillId, logEntry.user);
@@ -332,12 +329,12 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       agreeStateSiblings,
       userOriginReputationKeyBytes,
       userOriginReputationSiblings,
-      b[B_ORIGIN_ADJACENT_REPUTATION_KEY]);
+      keys[B_ORIGIN_ADJACENT_REPUTATION_KEY]);
   }
 
   function checkChildReputation(
     uint256[29] memory u,
-    bytes[5] memory b,
+    bytes[5] memory keys,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory childReputationSiblings) internal
   {
@@ -356,7 +353,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       agreeStateSiblings,
       childReputationKey,
       childReputationSiblings,
-      b[B_CHILD_ADJACENT_REPUTATION_KEY]);
+      keys[B_CHILD_ADJACENT_REPUTATION_KEY]);
   }
 
   function confirmChallengeCompleted(uint256[29] memory u) internal {
@@ -365,7 +362,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     disputeRounds[u[U_ROUND]][u[U_IDX]].lastResponseTimestamp = now;
   }
 
-  function checkKey(uint256[29] memory u, bytes[5] memory b) internal view {
+  function checkKey(uint256[29] memory u, bytes32[15] memory b32) internal view {
     // If the state transition we're checking is less than the number of nodes in the currently accepted state, it's a decay transition
     // Otherwise, look up the corresponding entry in the reputation log.
     uint256 updateNumber = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1;
@@ -373,7 +370,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       checkKeyDecay(u, updateNumber);
       u[U_DECAY_TRANSITION] = 1;
     } else {
-      checkKeyLogEntry(u, b);
+      checkKeyLogEntry(u, b32);
     }
   }
 
@@ -384,29 +381,16 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     require(u[U_AGREE_STATE_REPUTATION_UID]-1 == _updateNumber, "colony-reputation-mining-uid-not-decay");
   }
 
-  function checkKeyLogEntry(uint256[29] memory u, bytes[5] memory b) internal view {
+  function checkKeyLogEntry(uint256[29] memory u, bytes32[15] memory b32) internal view {
     ReputationLogEntry storage logEntry = reputationUpdateLog[u[U_LOG_ENTRY_NUMBER]];
 
     uint256 expectedSkillId;
     address expectedAddress;
     (expectedSkillId, expectedAddress) = getExpectedSkillIdAndAddress(u, logEntry);
 
-    bytes memory reputationKey = new bytes(20+32+20);
-    reputationKey = b[B_REPUTATION_KEY];
-    address colonyAddress;
-    address userAddress;
-    uint256 skillId;
-    assembly {
-        colonyAddress := mload(add(reputationKey,20)) // 20, not 32, because we're copying in to a slot that will be interpreted as an address.
-                                              // which will truncate the leftmost 12 bytes
-        skillId := mload(add(reputationKey, 52))
-        userAddress := mload(add(reputationKey,72))   // 72, not 84, for the same reason as above. Is this being too clever? I don't think there are
-                                              // any unintended side effects here, but I'm not quite confortable enough with EVM's stack to be sure.
-                                              // Not sure what the alternative would be anyway.
-    }
-    require(expectedAddress == userAddress, "colony-reputation-mining-user-address-mismatch");
-    require(logEntry.colony == colonyAddress, "colony-reputation-mining-colony-address-mismatch");
-    require(expectedSkillId == skillId, "colony-reputation-mining-skill-id-mismatch");
+    require(expectedAddress == address(uint256(b32[B_REPUTATION_KEY_USER])), "colony-reputation-mining-user-address-mismatch");
+    require(logEntry.colony == address(uint256(b32[B_REPUTATION_KEY_COLONY])), "colony-reputation-mining-colony-address-mismatch");
+    require(expectedSkillId == uint256(b32[B_REPUTATION_KEY_SKILLID]), "colony-reputation-mining-skill-id-mismatch");
   }
 
   function getExpectedSkillIdAndAddress(uint256[29] memory u, ReputationLogEntry storage logEntry) internal view
@@ -441,10 +425,10 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
   function proveBeforeReputationValue(
     uint256[29] memory u,
-    bytes[5] memory b,
+    bytes[5] memory keys,
     bytes32[] memory reputationSiblings,
     bytes32[] memory agreeStateSiblings
-  ) internal
+  ) internal view
   {
     if (u[U_DISAGREE_STATE_NNODES] - u[U_AGREE_STATE_NNODES] == 1) {
       // This implies they are claiming that this is a new hash.
@@ -461,7 +445,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     bytes memory agreeStateReputationValue = abi.encodePacked(u[U_AGREE_STATE_REPUTATION_VALUE], u[U_AGREE_STATE_REPUTATION_UID]);
 
     bytes32 reputationRootHash = getImpliedRootHashKey(
-      b[B_REPUTATION_KEY],
+      keys[B_REPUTATION_KEY],
       agreeStateReputationValue,
       u[U_REPUTATION_BRANCH_MASK],
       reputationSiblings);
@@ -484,7 +468,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
   function proveAfterReputationValue(
     uint256[29] memory u,
-    bytes[5] memory b,
+    bytes[5] memory keys,
     bytes32[] memory reputationSiblings,
     bytes32[] memory disagreeStateSiblings
   ) internal view
@@ -495,7 +479,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     bytes memory disagreeStateReputationValue = abi.encodePacked(u[U_DISAGREE_STATE_REPUTATION_VALUE], u[U_DISAGREE_STATE_REPUTATION_UID]);
 
     bytes32 reputationRootHash = getImpliedRootHashKey(
-      b[B_REPUTATION_KEY],
+      keys[B_REPUTATION_KEY],
       disagreeStateReputationValue,
       u[U_REPUTATION_BRANCH_MASK],
       reputationSiblings
@@ -655,7 +639,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
   function checkPreviousReputationInState(
     uint256[29] memory u,
-    bytes[5] memory b,
+    bytes[5] memory keys,
     bytes32[] memory agreeStateSiblings,
     bytes32[] memory previousNewReputationSiblings
     ) internal view
@@ -663,7 +647,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     // We binary searched to the first disagreement, so the last agreement is the one before
     uint256 lastAgreeIdx = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1;
 
-    bytes memory previousNewReputationKey = b[B_PREVIOUS_NEW_REPUTATION_KEY];
+    bytes memory previousNewReputationKey = keys[B_PREVIOUS_NEW_REPUTATION_KEY];
     bytes memory previousNewReputationValue = abi.encodePacked(u[U_PREVIOUS_NEW_REPUTATION_VALUE], u[U_PREVIOUS_NEW_REPUTATION_UID]);
 
     bytes32 reputationRootHash = getImpliedRootHashKey(
@@ -678,7 +662,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     require(impliedRoot == disputeRounds[u[U_ROUND]][u[U_IDX]].jrh, "colony-reputation-mining-last-state-disagreement");
   }
 
-  function checkKeysAdjacent(bytes memory key1, bytes memory key2, uint256 branchMask) internal returns (bool) {
+  function checkKeysAdjacent(bytes memory key1, bytes memory key2, uint256 branchMask) internal pure returns (bool) {
     // The bit that would be added to the branchmask is based on where the (hashes of the) two keys first differ.
     uint256 firstDifferenceBit = uint256(Bits.highestBitSet(uint256(keccak256(key1) ^ keccak256(key2))));
     uint256 afterInsertionBranchMask = branchMask | uint256(2**firstDifferenceBit);
@@ -814,15 +798,12 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     disputeRounds[u[U_ROUND]][u[U_IDX]].provedPreviousReputationUID = u[U_PREVIOUS_NEW_REPUTATION_UID];
   }
 
-  function buildReputationKey(bytes32 colony, bytes32 skill, bytes32 user) internal returns (bytes memory) {
+  function buildReputationKey(bytes32 colony, bytes32 skill, bytes32 user) internal pure returns (bytes memory) {
     bytes memory reputationKey = new bytes(72);
-    bytes32 rcolony = colony;
-    bytes32 rskill = skill;
-    bytes32 ruser = user;
     assembly {
-        mstore(add(reputationKey, 32), shl(96, rcolony))
-        mstore(add(reputationKey, 72), ruser)
-        mstore(add(reputationKey, 52), rskill)
+        mstore(add(reputationKey, 32), shl(96, colony))
+        mstore(add(reputationKey, 72), user)
+        mstore(add(reputationKey, 52), skill)
     }
     return reputationKey;
   }

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -942,11 +942,11 @@ class ReputationMiner {
         lastAgreeJustifications.childAdjacentReputationProof.reputation
       ],
       [
-        reputationKey,
-        lastAgreeJustifications.newestReputationProof.key,
-        lastAgreeJustifications.adjacentReputationProof.key,
-        lastAgreeJustifications.originAdjacentReputationProof.key,
-        lastAgreeJustifications.childAdjacentReputationProof.key
+        ...ReputationMiner.breakKeyInToElements(reputationKey).map(x => ethers.utils.hexZeroPad(x, 32)),
+        ...ReputationMiner.breakKeyInToElements(lastAgreeJustifications.newestReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)),
+        ...ReputationMiner.breakKeyInToElements(lastAgreeJustifications.adjacentReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)),
+        ...ReputationMiner.breakKeyInToElements(lastAgreeJustifications.originAdjacentReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)),
+        ...ReputationMiner.breakKeyInToElements(lastAgreeJustifications.childAdjacentReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)),
       ],
       firstDisagreeJustifications.justUpdatedProof.siblings,
       agreeStateSiblings,

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -391,11 +391,11 @@ class ReputationMiner {
       value = this.reputations[key];
     } else {
       // Doesn't exist yet.
-      branchMask = 0x0;
+      branchMask = 0x00;
       siblings = [];
       value = this.getValueAsBytes(0, 0);
       if (!key) {
-        key = ReputationMiner.getHexString(0);
+        key = ReputationMiner.getHexString(0, 32);
       }
     }
     const reputation = `0x${value.slice(2,66)}`;
@@ -908,7 +908,6 @@ class ReputationMiner {
       lastAgreeJustifications.childReputationProof.branchMask = lastAgreeJustifications.childAdjacentReputationProof.branchMask;
       lastAgreeJustifications.childReputationProof.siblings = lastAgreeJustifications.childAdjacentReputationProof.siblings;
     }
-
     return repCycle.respondToChallenge(
       [
         round,
@@ -943,10 +942,11 @@ class ReputationMiner {
       ],
       [
         ...ReputationMiner.breakKeyInToElements(reputationKey).map(x => ethers.utils.hexZeroPad(x, 32)),
-        ...ReputationMiner.breakKeyInToElements(lastAgreeJustifications.newestReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)),
-        ...ReputationMiner.breakKeyInToElements(lastAgreeJustifications.adjacentReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)),
-        ...ReputationMiner.breakKeyInToElements(lastAgreeJustifications.originAdjacentReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)),
-        ...ReputationMiner.breakKeyInToElements(lastAgreeJustifications.childAdjacentReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)),
+        soliditySha3(reputationKey),
+        soliditySha3(lastAgreeJustifications.newestReputationProof.key),
+        soliditySha3(lastAgreeJustifications.adjacentReputationProof.key),
+        soliditySha3(lastAgreeJustifications.originAdjacentReputationProof.key),
+        soliditySha3(lastAgreeJustifications.childAdjacentReputationProof.key),
       ],
       firstDisagreeJustifications.justUpdatedProof.siblings,
       agreeStateSiblings,

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -1,3 +1,4 @@
+import { soliditySha3 } from "web3-utils";
 import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
 const ethers = require("ethers");
@@ -62,18 +63,11 @@ class MaliciousReputationMinerWrongProofLogEntry extends ReputationMinerTestWrap
       ],
       [
         ...ReputationMinerTestWrapper.breakKeyInToElements(reputationKey).map(x => ethers.utils.hexZeroPad(x, 32)),
-        ...ReputationMinerTestWrapper.breakKeyInToElements(
-          this.justificationHashes[lastAgreeKey].newestReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)
-        ),
-        ...ReputationMinerTestWrapper.breakKeyInToElements(
-          this.justificationHashes[lastAgreeKey].adjacentReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)
-        ),
-        ...ReputationMinerTestWrapper.breakKeyInToElements(
-          this.justificationHashes[lastAgreeKey].originAdjacentReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)
-        ),
-        ...ReputationMinerTestWrapper.breakKeyInToElements(
-          this.justificationHashes[lastAgreeKey].childAdjacentReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)
-        ),
+        soliditySha3(reputationKey),
+        soliditySha3(this.justificationHashes[lastAgreeKey].newestReputationProof.key),
+        soliditySha3(this.justificationHashes[lastAgreeKey].adjacentReputationProof.key),
+        soliditySha3(this.justificationHashes[lastAgreeKey].originAdjacentReputationProof.key),
+        soliditySha3(this.justificationHashes[lastAgreeKey].childAdjacentReputationProof.key),
       ],
       this.justificationHashes[firstDisagreeKey].justUpdatedProof.siblings,
       agreeStateSiblings,

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -61,11 +61,19 @@ class MaliciousReputationMinerWrongProofLogEntry extends ReputationMinerTestWrap
         this.justificationHashes[lastAgreeKey].childAdjacentReputationProof.reputation
       ],
       [
-        reputationKey,
-        this.justificationHashes[lastAgreeKey].newestReputationProof.key,
-        this.justificationHashes[lastAgreeKey].adjacentReputationProof.key,
-        this.justificationHashes[lastAgreeKey].originAdjacentReputationProof.key,
-        this.justificationHashes[lastAgreeKey].childAdjacentReputationProof.key
+        ...ReputationMinerTestWrapper.breakKeyInToElements(reputationKey).map(x => ethers.utils.hexZeroPad(x, 32)),
+        ...ReputationMinerTestWrapper.breakKeyInToElements(
+          this.justificationHashes[lastAgreeKey].newestReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)
+        ),
+        ...ReputationMinerTestWrapper.breakKeyInToElements(
+          this.justificationHashes[lastAgreeKey].adjacentReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)
+        ),
+        ...ReputationMinerTestWrapper.breakKeyInToElements(
+          this.justificationHashes[lastAgreeKey].originAdjacentReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)
+        ),
+        ...ReputationMinerTestWrapper.breakKeyInToElements(
+          this.justificationHashes[lastAgreeKey].childAdjacentReputationProof.key).map(x => ethers.utils.hexZeroPad(x, 32)
+        ),
       ],
       this.justificationHashes[firstDisagreeKey].justUpdatedProof.siblings,
       agreeStateSiblings,

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongResponse.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongResponse.js
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { soliditySha3 } from "web3-utils";
 import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
 
 class MaliciousReputationMinerWrongResponse extends ReputationMinerTestWrapper {
@@ -95,48 +96,27 @@ class MaliciousReputationMinerWrongResponse extends ReputationMinerTestWrapper {
           ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(reputationKey)[2], 32),
         this.responseToFalsify === 32 ? 
           this.responseValue : 
-            ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.newestReputationProof.key)[0], 32),
+            soliditySha3(reputationKey),
         this.responseToFalsify === 33 ? 
           this.responseValue : 
-            ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.newestReputationProof.key)[1], 32),
+            soliditySha3(lastAgreeJustifications.newestReputationProof.key),
         this.responseToFalsify === 34 ? 
           this.responseValue : 
-          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.newestReputationProof.key)[2], 32),
+            soliditySha3(lastAgreeJustifications.adjacentReputationProof.key),
         this.responseToFalsify === 35 ? 
           this.responseValue : 
-          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.adjacentReputationProof.key)[0], 32),
+          soliditySha3(lastAgreeJustifications.originAdjacentReputationProof.key),
         this.responseToFalsify === 36 ? 
-          this.responseValue :
-          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.adjacentReputationProof.key)[1], 32),
-        this.responseToFalsify === 37 ? 
           this.responseValue : 
-          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.adjacentReputationProof.key)[2], 32),
-        this.responseToFalsify === 38 ? 
-          this.responseValue : 
-          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.originAdjacentReputationProof.key)[0], 32),
-        this.responseToFalsify === 39 ? 
-          this.responseValue : 
-          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.originAdjacentReputationProof.key)[1], 32),
-        this.responseToFalsify === 40 ? 
-          this.responseValue : 
-          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.originAdjacentReputationProof.key)[2], 32),
-        this.responseToFalsify === 41 ? 
-          this.responseValue : 
-          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.childAdjacentReputationProof.key)[0], 32),
-        this.responseToFalsify === 42 ? 
-          this.responseValue : 
-          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.childAdjacentReputationProof.key)[1], 32),
-        this.responseToFalsify === 43 ? 
-          this.responseValue : 
-          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.childAdjacentReputationProof.key)[2], 32),
+          soliditySha3(lastAgreeJustifications.childAdjacentReputationProof.key)
       ],
-      this.responseToFalsify === 44 ? this.responseValue : firstDisagreeJustifications.justUpdatedProof.siblings,
-      this.responseToFalsify === 45 ? this.responseValue : agreeStateSiblings,
-      this.responseToFalsify === 46 ? this.responseValue : disagreeStateSiblings,
-      this.responseToFalsify === 47 ? this.responseValue : lastAgreeJustifications.newestReputationProof.siblings,
-      this.responseToFalsify === 48 ? this.responseValue : lastAgreeJustifications.originReputationProof.siblings,
-      this.responseToFalsify === 49 ? this.responseValue : lastAgreeJustifications.childReputationProof.siblings,
-      this.responseToFalsify === 50 ? this.responseValue : lastAgreeJustifications.adjacentReputationProof.siblings,
+      this.responseToFalsify === 37 ? this.responseValue : firstDisagreeJustifications.justUpdatedProof.siblings,
+      this.responseToFalsify === 38 ? this.responseValue : agreeStateSiblings,
+      this.responseToFalsify === 39 ? this.responseValue : disagreeStateSiblings,
+      this.responseToFalsify === 40 ? this.responseValue : lastAgreeJustifications.newestReputationProof.siblings,
+      this.responseToFalsify === 41 ? this.responseValue : lastAgreeJustifications.originReputationProof.siblings,
+      this.responseToFalsify === 42 ? this.responseValue : lastAgreeJustifications.childReputationProof.siblings,
+      this.responseToFalsify === 43 ? this.responseValue : lastAgreeJustifications.adjacentReputationProof.siblings,
       { gasLimit: 4000000 }
     );
     return tx.wait();

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongResponse.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongResponse.js
@@ -84,19 +84,59 @@ class MaliciousReputationMinerWrongResponse extends ReputationMinerTestWrapper {
         this.responseToFalsify === 28 ? this.responseValue : lastAgreeJustifications.childAdjacentReputationProof.reputation
       ],
       [
-        this.responseToFalsify === 29 ? this.responseValue : reputationKey,
-        this.responseToFalsify === 30 ? this.responseValue : lastAgreeJustifications.newestReputationProof.key,
-        this.responseToFalsify === 31 ? this.responseValue : lastAgreeJustifications.adjacentReputationProof.key,
-        this.responseToFalsify === 32 ? this.responseValue : lastAgreeJustifications.originAdjacentReputationProof.key,
-        this.responseToFalsify === 33 ? this.responseValue : lastAgreeJustifications.childAdjacentReputationProof.key
+        this.responseToFalsify === 29 ? 
+          this.responseValue : 
+          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(reputationKey)[0], 32),
+        this.responseToFalsify === 30 ? 
+          this.responseValue : 
+          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(reputationKey)[1], 32),
+        this.responseToFalsify === 31 ?
+          this.responseValue :
+          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(reputationKey)[2], 32),
+        this.responseToFalsify === 32 ? 
+          this.responseValue : 
+            ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.newestReputationProof.key)[0], 32),
+        this.responseToFalsify === 33 ? 
+          this.responseValue : 
+            ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.newestReputationProof.key)[1], 32),
+        this.responseToFalsify === 34 ? 
+          this.responseValue : 
+          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.newestReputationProof.key)[2], 32),
+        this.responseToFalsify === 35 ? 
+          this.responseValue : 
+          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.adjacentReputationProof.key)[0], 32),
+        this.responseToFalsify === 36 ? 
+          this.responseValue :
+          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.adjacentReputationProof.key)[1], 32),
+        this.responseToFalsify === 37 ? 
+          this.responseValue : 
+          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.adjacentReputationProof.key)[2], 32),
+        this.responseToFalsify === 38 ? 
+          this.responseValue : 
+          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.originAdjacentReputationProof.key)[0], 32),
+        this.responseToFalsify === 39 ? 
+          this.responseValue : 
+          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.originAdjacentReputationProof.key)[1], 32),
+        this.responseToFalsify === 40 ? 
+          this.responseValue : 
+          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.originAdjacentReputationProof.key)[2], 32),
+        this.responseToFalsify === 41 ? 
+          this.responseValue : 
+          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.childAdjacentReputationProof.key)[0], 32),
+        this.responseToFalsify === 42 ? 
+          this.responseValue : 
+          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.childAdjacentReputationProof.key)[1], 32),
+        this.responseToFalsify === 43 ? 
+          this.responseValue : 
+          ethers.utils.hexZeroPad(ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.childAdjacentReputationProof.key)[2], 32),
       ],
-      this.responseToFalsify === 34 ? this.responseValue : firstDisagreeJustifications.justUpdatedProof.siblings,
-      this.responseToFalsify === 35 ? this.responseValue : agreeStateSiblings,
-      this.responseToFalsify === 36 ? this.responseValue : disagreeStateSiblings,
-      this.responseToFalsify === 37 ? this.responseValue : lastAgreeJustifications.newestReputationProof.siblings,
-      this.responseToFalsify === 38 ? this.responseValue : lastAgreeJustifications.originReputationProof.siblings,
-      this.responseToFalsify === 39 ? this.responseValue : lastAgreeJustifications.childReputationProof.siblings,
-      this.responseToFalsify === 40 ? this.responseValue : lastAgreeJustifications.adjacentReputationProof.siblings,
+      this.responseToFalsify === 44 ? this.responseValue : firstDisagreeJustifications.justUpdatedProof.siblings,
+      this.responseToFalsify === 45 ? this.responseValue : agreeStateSiblings,
+      this.responseToFalsify === 46 ? this.responseValue : disagreeStateSiblings,
+      this.responseToFalsify === 47 ? this.responseValue : lastAgreeJustifications.newestReputationProof.siblings,
+      this.responseToFalsify === 48 ? this.responseValue : lastAgreeJustifications.originReputationProof.siblings,
+      this.responseToFalsify === 49 ? this.responseValue : lastAgreeJustifications.childReputationProof.siblings,
+      this.responseToFalsify === 50 ? this.responseValue : lastAgreeJustifications.adjacentReputationProof.siblings,
       { gasLimit: 4000000 }
     );
     return tx.wait();

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -5,6 +5,7 @@ import BN from "bn.js";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 import chai from "chai";
 import bnChai from "bn-chai";
+import { ethers } from "ethers";
 
 import {
   forwardTime,
@@ -688,29 +689,14 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await badClient.confirmBinarySearchResult();
 
       const logEntry = await repCycle.getReputationUpdateLogEntry(0);
-
-      const colonyAddress = logEntry.colony.slice(2);
-      const userAddress = logEntry.user.slice(2);
-      const skillId = new BN(logEntry.skillId);
-
-      // Linter fail
-      const wrongColonyKey = `0x${new BN(0, 16).toString(16, 40)}${new BN(skillId.toString()).toString(16, 64)}${new BN(userAddress, 16).toString(
-        16,
-        40
-      )}`;
-      const wrongReputationKey = `0x${new BN(colonyAddress, 16).toString(16, 40)}${new BN(0).toString(16, 64)}${new BN(userAddress, 16).toString(
-        16,
-        40
-      )}`;
-      const wrongUserKey = `0x${new BN(colonyAddress, 16).toString(16, 40)}${new BN(skillId.toString()).toString(16, 64)}${new BN(0, 16).toString(
-        16,
-        40
-      )}`;
+      const colonyAddress = ethers.utils.hexZeroPad(logEntry.colony, 32);
+      const userAddress = ethers.utils.hexZeroPad(logEntry.user, 32);
+      const skillId = ethers.utils.hexZeroPad(`0x${logEntry.skillId.toString(16)}`);
 
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          [wrongColonyKey, "0x00", "0x00", "0x00", "0x00"],
+          ["0x00", skillId, userAddress, "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],
@@ -725,7 +711,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          [wrongReputationKey, "0x00", "0x00", "0x00", "0x00"],
+          [colonyAddress, "0x00", userAddress, "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],
@@ -740,7 +726,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          [wrongUserKey, "0x00", "0x00", "0x00", "0x00"],
+          [colonyAddress, skillId, "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],
@@ -777,7 +763,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          ["0x00", "0x00", "0x00", "0x00", "0x00"],
+          ["0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -136,7 +136,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
 
       // Check we can't respond to challenge before we've confirmed JRH
       await checkErrorRevertEthers(goodClient.respondToChallenge(), "colony-reputation-mining-binary-search-result-not-confirmed");
-
       await goodClient.confirmJustificationRootHash();
       await badClient.confirmJustificationRootHash();
 
@@ -691,12 +690,12 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       const logEntry = await repCycle.getReputationUpdateLogEntry(0);
       const colonyAddress = ethers.utils.hexZeroPad(logEntry.colony, 32);
       const userAddress = ethers.utils.hexZeroPad(logEntry.user, 32);
-      const skillId = ethers.utils.hexZeroPad(`0x${logEntry.skillId.toString(16)}`);
+      const skillId = ethers.utils.hexZeroPad(ethers.utils.bigNumberify(logEntry.skillId).toHexString(), 32);
 
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          ["0x00", skillId, userAddress, "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00"],
+          ["0x00", skillId, userAddress, "0x00", "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],
@@ -711,7 +710,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          [colonyAddress, "0x00", userAddress, "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00"],
+          [colonyAddress, "0x00", userAddress, "0x00", "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],
@@ -726,7 +725,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          [colonyAddress, skillId, "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00"],
+          [colonyAddress, skillId, "0x00", "0x00", "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],
@@ -763,7 +762,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await checkErrorRevert(
         repCycle.respondToChallenge(
           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          ["0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00"],
+          ["0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00", "0x00"],
           [],
           [],
           [],

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -669,7 +669,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await repCycle.confirmNewHash(1);
     });
 
-    it("should fail to respondToChallenge if any part of the key is wrong", async () => {
+    it("should fail to respondToChallenge if any part of the key or hashedKey is wrong", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
@@ -735,6 +735,21 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
           []
         ),
         "colony-reputation-mining-user-address-mismatch"
+      );
+
+      await checkErrorRevert(
+        repCycle.respondToChallenge(
+          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          [colonyAddress, skillId, userAddress, "0x00", "0x00", "0x00", "0x00", "0x00"],
+          [],
+          [],
+          [],
+          [],
+          [],
+          [],
+          []
+        ),
+        "colony-reputation-mining-reputation-key-and-hash-mismatch"
       );
 
       await forwardTime(MINING_CYCLE_DURATION / 6, this);

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -4,6 +4,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 import { ethers } from "ethers";
+import { soliditySha3 } from "web3-utils";
 
 import {
   forwardTime,
@@ -404,18 +405,11 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
           ],
           [
             ...ReputationMinerTestWrapper.breakKeyInToElements(reputationKey).map(x => ethers.utils.hexZeroPad(x, 32)),
-            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.newestReputationProof.key).map(x =>
-              ethers.utils.hexZeroPad(x, 32)
-            ),
-            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.adjacentReputationProof.key).map(x =>
-              ethers.utils.hexZeroPad(x, 32)
-            ),
-            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.originAdjacentReputationProof.key).map(x =>
-              ethers.utils.hexZeroPad(x, 32)
-            ),
-            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.childAdjacentReputationProof.key).map(x =>
-              ethers.utils.hexZeroPad(x, 32)
-            )
+            soliditySha3(reputationKey),
+            soliditySha3(lastAgreeJustifications.newestReputationProof.key),
+            soliditySha3(lastAgreeJustifications.adjacentReputationProof.key),
+            soliditySha3(lastAgreeJustifications.originAdjacentReputationProof.key),
+            soliditySha3(lastAgreeJustifications.childAdjacentReputationProof.key)
           ],
           firstDisagreeJustifications.justUpdatedProof.siblings,
           agreeStateSiblings,
@@ -552,18 +546,11 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
           ],
           [
             ...ReputationMinerTestWrapper.breakKeyInToElements(reputationKey).map(x => ethers.utils.hexZeroPad(x, 32)),
-            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.newestReputationProof.key).map(x =>
-              ethers.utils.hexZeroPad(x, 32)
-            ),
-            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.adjacentReputationProof.key).map(x =>
-              ethers.utils.hexZeroPad(x, 32)
-            ),
-            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.originAdjacentReputationProof.key).map(x =>
-              ethers.utils.hexZeroPad(x, 32)
-            ),
-            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.childAdjacentReputationProof.key).map(x =>
-              ethers.utils.hexZeroPad(x, 32)
-            )
+            soliditySha3(reputationKey),
+            soliditySha3(lastAgreeJustifications.newestReputationProof.key),
+            soliditySha3(lastAgreeJustifications.adjacentReputationProof.key),
+            soliditySha3(lastAgreeJustifications.originAdjacentReputationProof.key),
+            soliditySha3(lastAgreeJustifications.childAdjacentReputationProof.key)
           ],
           firstDisagreeJustifications.justUpdatedProof.siblings,
           agreeStateSiblings,

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -3,6 +3,7 @@ import BN from "bn.js";
 import chai from "chai";
 import bnChai from "bn-chai";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
+import { ethers } from "ethers";
 
 import {
   forwardTime,
@@ -402,11 +403,19 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
             lastAgreeJustifications.childAdjacentReputationProof.reputation
           ],
           [
-            reputationKey,
-            lastAgreeJustifications.newestReputationProof.key,
-            lastAgreeJustifications.adjacentReputationProof.key,
-            lastAgreeJustifications.originAdjacentReputationProof.key,
-            lastAgreeJustifications.childAdjacentReputationProof.key
+            ...ReputationMinerTestWrapper.breakKeyInToElements(reputationKey).map(x => ethers.utils.hexZeroPad(x, 32)),
+            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.newestReputationProof.key).map(x =>
+              ethers.utils.hexZeroPad(x, 32)
+            ),
+            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.adjacentReputationProof.key).map(x =>
+              ethers.utils.hexZeroPad(x, 32)
+            ),
+            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.originAdjacentReputationProof.key).map(x =>
+              ethers.utils.hexZeroPad(x, 32)
+            ),
+            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.childAdjacentReputationProof.key).map(x =>
+              ethers.utils.hexZeroPad(x, 32)
+            )
           ],
           firstDisagreeJustifications.justUpdatedProof.siblings,
           agreeStateSiblings,
@@ -542,11 +551,19 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
             lastAgreeJustifications.childAdjacentReputationProof.reputation
           ],
           [
-            reputationKey,
-            lastAgreeJustifications.newestReputationProof.key,
-            lastAgreeJustifications.adjacentReputationProof.key,
-            lastAgreeJustifications.originAdjacentReputationProof.key,
-            lastAgreeJustifications.childAdjacentReputationProof.key
+            ...ReputationMinerTestWrapper.breakKeyInToElements(reputationKey).map(x => ethers.utils.hexZeroPad(x, 32)),
+            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.newestReputationProof.key).map(x =>
+              ethers.utils.hexZeroPad(x, 32)
+            ),
+            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.adjacentReputationProof.key).map(x =>
+              ethers.utils.hexZeroPad(x, 32)
+            ),
+            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.originAdjacentReputationProof.key).map(x =>
+              ethers.utils.hexZeroPad(x, 32)
+            ),
+            ...ReputationMinerTestWrapper.breakKeyInToElements(lastAgreeJustifications.childAdjacentReputationProof.key).map(x =>
+              ethers.utils.hexZeroPad(x, 32)
+            )
           ],
           firstDisagreeJustifications.justUpdatedProof.siblings,
           agreeStateSiblings,


### PR DESCRIPTION
Closes #393. Partly done with an eye on #569, but after further exploration (see that issue), we have iceboxed #569.

~~This also currently includes necessary upgrades to move to the `petersburg` hardfork, which means it is treading on the toes of #574. Happy for that to be merged first and then rebase this. I am therefore marking this as 'ready-to-review', but should also not be merged yet 😄~~