### PR TITLE
Fixed Restore good state in reputation mining test.

### DIFF
--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -114,46 +114,6 @@ export function web3GetRawCall(params) {
   });
 }
 
-export function takeSnapshot() {
-  return new Promise((resolve, reject) => {
-    web3.currentProvider.send(
-      {
-        jsonrpc: "2.0",
-        method: "evm_snapshot",
-        params: [],
-        id: new Date().getTime()
-      },
-      (err, result) => {
-        if (err) {
-          return reject(err);
-        }
-
-        return resolve(result.result);
-      }
-    );
-  });
-}
-
-export function revertToSnapshot(snapShotId) {
-  return new Promise((resolve, reject) => {
-    web3.currentProvider.send(
-      {
-        jsonrpc: "2.0",
-        method: "evm_revert",
-        params: [snapShotId],
-        id: new Date().getTime()
-      },
-      err => {
-        if (err) {
-          return reject(err);
-        }
-
-        return resolve();
-      }
-    );
-  });
-}
-
 // Borrowed from `truffle` https://github.com/trufflesuite/truffle/blob/next/packages/truffle-contract/lib/reason.js
 export function extractReasonString(res) {
   if (!res || (!res.error && !res.result)) return "";
@@ -703,7 +663,7 @@ export async function finishReputationMiningCycleAndWithdrawAllMinerStakes(colon
       // We shouldn't get here. If this fires during a test, you haven't finished writing the test.
       console.log("We're mid dispute process, and can't untangle from here"); // eslint-disable-line no-console
       // process.exit(1);
-      return;
+      return false;
     }
   }
 
@@ -738,4 +698,5 @@ export async function finishReputationMiningCycleAndWithdrawAllMinerStakes(colon
       }
     })
   );
+  return true;
 }

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -114,6 +114,46 @@ export function web3GetRawCall(params) {
   });
 }
 
+export function takeSnapshot() {
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_snapshot",
+        params: [],
+        id: new Date().getTime()
+      },
+      (err, result) => {
+        if (err) {
+          return reject(err);
+        }
+
+        return resolve(result.result);
+      }
+    );
+  });
+}
+
+export function revertToSnapshot(snapShotId) {
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_revert",
+        params: [snapShotId],
+        id: new Date().getTime()
+      },
+      err => {
+        if (err) {
+          return reject(err);
+        }
+
+        return resolve();
+      }
+    );
+  });
+}
+
 // Borrowed from `truffle` https://github.com/trufflesuite/truffle/blob/next/packages/truffle-contract/lib/reason.js
 export function extractReasonString(res) {
   if (!res || (!res.error && !res.result)) return "";

--- a/test/reputation-mining/client-calculations.js
+++ b/test/reputation-mining/client-calculations.js
@@ -6,7 +6,13 @@ import bnChai from "bn-chai";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
 import { DEFAULT_STAKE, INITIAL_FUNDING, ZERO_ADDRESS } from "../../helpers/constants";
-import { advanceMiningCycleNoContest, getActiveRepCycle, finishReputationMiningCycleAndWithdrawAllMinerStakes } from "../../helpers/test-helper";
+import {
+  advanceMiningCycleNoContest,
+  getActiveRepCycle,
+  finishReputationMiningCycleAndWithdrawAllMinerStakes,
+  takeSnapshot,
+  revertToSnapshot
+} from "../../helpers/test-helper";
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
 
 import {
@@ -38,6 +44,7 @@ process.env.SOLIDITY_COVERAGE
       let metaColony;
       let clnyToken;
       let goodClient;
+      let latestSnapShotId;
 
       before(async () => {
         // Setup a new network instance as we'll be modifying the global skills tree
@@ -76,10 +83,12 @@ process.env.SOLIDITY_COVERAGE
         await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
         await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
         await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(4));
+        latestSnapShotId = await takeSnapshot();
       });
 
       afterEach(async () => {
-        await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+        const isStateGotReset = await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+        if (!isStateGotReset) await revertToSnapshot(latestSnapShotId);
       });
 
       describe("core functionality", () => {

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -15,7 +15,9 @@ import {
   getActiveRepCycle,
   advanceMiningCycleNoContest,
   accommodateChallengeAndInvalidateHash,
-  finishReputationMiningCycleAndWithdrawAllMinerStakes
+  finishReputationMiningCycleAndWithdrawAllMinerStakes,
+  takeSnapshot,
+  revertToSnapshot
 } from "../../helpers/test-helper";
 
 import {
@@ -53,6 +55,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
   let colonyNetwork;
   let clnyToken;
   let goodClient;
+  let latestSnapShotId;
   const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
 
   before(async () => {
@@ -92,10 +95,12 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
     await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
     await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
     await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(4));
+    latestSnapShotId = await takeSnapshot();
   });
 
   afterEach(async () => {
-    await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+    const isStateGotReset = await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+    if (!isStateGotReset) await revertToSnapshot(latestSnapShotId);
   });
 
   // The dispute resolution flow is as follows:

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -15,9 +15,7 @@ import {
   getActiveRepCycle,
   advanceMiningCycleNoContest,
   accommodateChallengeAndInvalidateHash,
-  finishReputationMiningCycleAndWithdrawAllMinerStakes,
-  takeSnapshot,
-  revertToSnapshot
+  finishReputationMiningCycleAndWithdrawAllMinerStakes
 } from "../../helpers/test-helper";
 
 import {
@@ -46,32 +44,35 @@ const loader = new TruffleLoader({
 
 const useJsTree = true;
 
+let metaColony;
+let colonyNetwork;
+let clnyToken;
+let goodClient;
+const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
+
+const setupNewNetworkInstance = async MINER1 => {
+  colonyNetwork = await setupColonyNetwork();
+  ({ metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
+
+  // Initialise global skills tree: 1 -> 4 -> 5, local skills tree 2 -> 3
+  await metaColony.addGlobalSkill(1);
+  await metaColony.addGlobalSkill(4);
+
+  await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
+  await colonyNetwork.initialiseReputationMining();
+  await colonyNetwork.startNextCycle();
+
+  goodClient = new ReputationMinerTestWrapper({ loader, realProviderPort, useJsTree, minerAddress: MINER1 });
+};
+
 contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
   const MINER1 = accounts[5];
   const MINER2 = accounts[6];
   const MINER3 = accounts[7];
 
-  let metaColony;
-  let colonyNetwork;
-  let clnyToken;
-  let goodClient;
-  let latestSnapShotId;
-  const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
-
   before(async () => {
     // Setup a new network instance as we'll be modifying the global skills tree
-    colonyNetwork = await setupColonyNetwork();
-    ({ metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
-
-    // Initialise global skills tree: 1 -> 4 -> 5, local skills tree 2 -> 3
-    await metaColony.addGlobalSkill(1);
-    await metaColony.addGlobalSkill(4);
-
-    await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
-    await colonyNetwork.initialiseReputationMining();
-    await colonyNetwork.startNextCycle();
-
-    goodClient = new ReputationMinerTestWrapper({ loader, realProviderPort, useJsTree, minerAddress: MINER1 });
+    await setupNewNetworkInstance(MINER1);
   });
 
   beforeEach(async () => {
@@ -95,12 +96,11 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
     await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
     await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
     await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(4));
-    latestSnapShotId = await takeSnapshot();
   });
 
   afterEach(async () => {
-    const isStateGotReset = await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
-    if (!isStateGotReset) await revertToSnapshot(latestSnapShotId);
+    const reputationMiningGotClean = await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+    if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1);
   });
 
   // The dispute resolution flow is as follows:

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -13,7 +13,9 @@ import {
   getActiveRepCycle,
   advanceMiningCycleNoContest,
   accommodateChallengeAndInvalidateHash,
-  finishReputationMiningCycleAndWithdrawAllMinerStakes
+  finishReputationMiningCycleAndWithdrawAllMinerStakes,
+  takeSnapshot,
+  revertToSnapshot
 } from "../../helpers/test-helper";
 
 import {
@@ -54,6 +56,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
   let colonyNetwork;
   let clnyToken;
   let goodClient;
+  let latestSnapShotId;
   const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
 
   before(async () => {
@@ -93,10 +96,12 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
     await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
     await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
     await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(4));
+    latestSnapShotId = await takeSnapshot();
   });
 
   afterEach(async () => {
-    await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+    const isStateGotReset = await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+    if (!isStateGotReset) await revertToSnapshot(latestSnapShotId);
   });
 
   describe("should correctly resolve a dispute over origin skill", () => {

--- a/test/reputation-mining/happy-paths.js
+++ b/test/reputation-mining/happy-paths.js
@@ -14,6 +14,8 @@ import {
   advanceMiningCycleNoContest,
   accommodateChallengeAndInvalidateHash,
   finishReputationMiningCycleAndWithdrawAllMinerStakes,
+  takeSnapshot,
+  revertToSnapshot,
   makeReputationKey,
   makeReputationValue
 } from "../../helpers/test-helper";
@@ -65,6 +67,7 @@ contract("Reputation Mining - happy paths", accounts => {
   let colonyNetwork;
   let clnyToken;
   let goodClient;
+  let latestSnapShotId;
   const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
 
   before(async () => {
@@ -110,10 +113,12 @@ contract("Reputation Mining - happy paths", accounts => {
     await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
     await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
     await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(4));
+    latestSnapShotId = await takeSnapshot();
   });
 
   afterEach(async () => {
-    await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+    const isStateGotReset = await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+    if (!isStateGotReset) await revertToSnapshot(latestSnapShotId);
   });
 
   describe("when executing intended behaviours", () => {

--- a/test/reputation-mining/types-of-disagreement.js
+++ b/test/reputation-mining/types-of-disagreement.js
@@ -16,9 +16,7 @@ import {
   getActiveRepCycle,
   advanceMiningCycleNoContest,
   accommodateChallengeAndInvalidateHash,
-  finishReputationMiningCycleAndWithdrawAllMinerStakes,
-  takeSnapshot,
-  revertToSnapshot
+  finishReputationMiningCycleAndWithdrawAllMinerStakes
 } from "../../helpers/test-helper";
 
 import {
@@ -54,30 +52,32 @@ const loader = new TruffleLoader({
 
 const useJsTree = true;
 
+let metaColony;
+let colonyNetwork;
+let tokenLocking;
+let clnyToken;
+let goodClient;
+const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
+
+const setupNewNetworkInstance = async MINER1 => {
+  colonyNetwork = await setupColonyNetwork();
+  const tokenLockingAddress = await colonyNetwork.getTokenLocking();
+  tokenLocking = await ITokenLocking.at(tokenLockingAddress);
+  ({ metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
+
+  await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
+  await colonyNetwork.initialiseReputationMining();
+  await colonyNetwork.startNextCycle();
+
+  goodClient = new ReputationMinerTestWrapper({ loader, realProviderPort, useJsTree, minerAddress: MINER1 });
+};
 contract("Reputation Mining - types of disagreement", accounts => {
   const MINER1 = accounts[5];
   const MINER2 = accounts[6];
 
-  let metaColony;
-  let colonyNetwork;
-  let tokenLocking;
-  let clnyToken;
-  let goodClient;
-  let latestSnapShotId;
-  const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
-
   before(async () => {
     // Setup a new network instance as we'll be modifying the global skills tree
-    colonyNetwork = await setupColonyNetwork();
-    const tokenLockingAddress = await colonyNetwork.getTokenLocking();
-    tokenLocking = await ITokenLocking.at(tokenLockingAddress);
-    ({ metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
-
-    await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
-    await colonyNetwork.initialiseReputationMining();
-    await colonyNetwork.startNextCycle();
-
-    goodClient = new ReputationMinerTestWrapper({ loader, realProviderPort, useJsTree, minerAddress: MINER1 });
+    await setupNewNetworkInstance(MINER1);
   });
 
   beforeEach(async () => {
@@ -101,12 +101,11 @@ contract("Reputation Mining - types of disagreement", accounts => {
     // Burn MINER1S accumulated mining rewards.
     const userBalance = await clnyToken.balanceOf(MINER1);
     await clnyToken.burn(userBalance, { from: MINER1 });
-    latestSnapShotId = await takeSnapshot();
   });
 
   afterEach(async () => {
-    const isStateGotReset = await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
-    if (!isStateGotReset) await revertToSnapshot(latestSnapShotId);
+    const reputationMiningGotClean = await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+    if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1);
   });
 
   describe("when there is a dispute over reputation root hash", () => {


### PR DESCRIPTION
Moved the logic of `before` block into a function `newNetworkInstance`, if we ever reached to a point from where we can't untangle the disputed states, we will call this function which will reset the network completely. 

<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #524

<!--- Summary of changes including design decisions -->

