### PR TITLE
Assorted cleanups and improvements

### DIFF
--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -296,7 +296,7 @@ contract ColonyTask is ColonyStorage {
     return keccak256(abi.encodePacked(_salt, _value));
   }
 
-  function getTaskWorkRatings(uint256 _id) public view returns (uint256, uint256) {
+  function getTaskWorkRatingSecretsInfo(uint256 _id) public view returns (uint256, uint256) {
     return (taskWorkRatings[_id].count, taskWorkRatings[_id].timestamp);
   }
 

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -309,11 +309,11 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @return secret `keccak256` hash of joint _salt and _value
   function generateSecret(bytes32 _salt, uint256 _value) public pure returns (bytes32 secret);
 
-  /// @notice Get the `ColonyStorage.RatingSecrets` for task `_id`
+  /// @notice Get the `ColonyStorage.RatingSecrets` information for task `_id`
   /// @param _id Id of the task
   /// @return nSecrets Number of secrets
   /// @return lastSubmittedAt Timestamp of the last submitted rating secret
-  function getTaskWorkRatings(uint256 _id) public view returns (uint256 nSecrets, uint256 lastSubmittedAt);
+  function getTaskWorkRatingSecretsInfo(uint256 _id) public view returns (uint256 nSecrets, uint256 lastSubmittedAt);
 
   /// @notice Get the rating secret submitted for role `_role` in task `_id`
   /// @param _id Id of the task

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -27,12 +27,12 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @param _round The dispute round to query
   /// @param _index The index in the dispute round to query
   /// @return The elements of the Submission struct for the submission requested. See ReputationMiningCycleDataTypes for the full description
-  function getDisputeRounds(uint256 _round, uint256 _index) public view returns (Submission memory submission);
+  function getDisputeRoundSubmission(uint256 _round, uint256 _index) public view returns (Submission memory submission);
 
   /// @notice The getter for the hashSubmissions mapping, which keeps track of submissions by user.
   /// @param _user Address of the user
   /// @return submission the Submission struct for the submission requested. See ReputationMiningCycleDataTypes.sol for the full description
-  function getReputationHashSubmissions(address _user) public view returns (Submission memory submission);
+  function getReputationHashSubmission(address _user) public view returns (Submission memory submission);
 
   /// @notice Get the hash for the corresponding entry.
   /// @param submitter The address that submitted the hash

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -445,11 +445,11 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     return reputationUpdateLog[_id];
   }
 
-  function getReputationHashSubmissions(address _user) public view returns (Submission memory) {
+  function getReputationHashSubmission(address _user) public view returns (Submission memory) {
     return reputationHashSubmissions[_user];
   }
 
-  function getDisputeRounds(uint256 _round, uint256 _index) public view returns (Submission memory) {
+  function getDisputeRoundSubmission(uint256 _round, uint256 _index) public view returns (Submission memory) {
     return disputeRounds[_round][_index];
   }
 

--- a/contracts/TokenLocking.sol
+++ b/contracts/TokenLocking.sol
@@ -50,7 +50,7 @@ contract TokenLocking is TokenLockingStorage, DSMath {
   modifier hashNotSubmitted(address _token) {
     address clnyToken = IMetaColony(IColonyNetwork(colonyNetwork).getMetaColony()).getToken();
     if (_token == clnyToken) {
-      bytes32 submissionHash = IReputationMiningCycle(IColonyNetwork(colonyNetwork).getReputationMiningCycle(true)).getReputationHashSubmissions(msg.sender).proposedNewRootHash;
+      bytes32 submissionHash = IReputationMiningCycle(IColonyNetwork(colonyNetwork).getReputationMiningCycle(true)).getReputationHashSubmission(msg.sender).proposedNewRootHash;
       require(submissionHash == 0x0, "colony-token-locking-hash-submitted");
     }
     _;

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -7,8 +7,6 @@ const INT256_MAX = new BN(0).notn(255);
 const INT128_MAX = new BN(2).pow(new BN(127)).sub(new BN(1));
 const INT128_MIN = new BN(2).pow(new BN(127)).mul(new BN(-1));
 
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-
 const RECOVERY_ROLE = 0;
 const ROOT_ROLE = 1;
 const ARBITRATION_ROLE = 2;
@@ -65,7 +63,6 @@ module.exports = {
   INT256_MAX,
   INT128_MAX,
   INT128_MIN,
-  ZERO_ADDRESS,
   RECOVERY_ROLE,
   ROOT_ROLE,
   ARBITRATION_ROLE,

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -1,6 +1,6 @@
 /* globals artifacts */
 import { soliditySha3 } from "web3-utils";
-import { BN } from "bn.js";
+import BN from "bn.js";
 import { ethers } from "ethers";
 
 import {
@@ -15,8 +15,7 @@ import {
   MANAGER_ROLE,
   WORKER_ROLE,
   SPECIFICATION_HASH,
-  DELIVERABLE_HASH,
-  ZERO_ADDRESS
+  DELIVERABLE_HASH
 } from "./constants";
 import { getTokenArgs, createSignatures, createSignaturesTrezor, web3GetAccounts } from "./test-helper";
 
@@ -168,7 +167,7 @@ export async function setupFundedTask({
   if (token === undefined) {
     tokenAddress = await colony.getToken();
   } else {
-    tokenAddress = token === ZERO_ADDRESS ? ZERO_ADDRESS : token.address;
+    tokenAddress = token === ethers.constants.AddressZero ? ethers.constants.AddressZero : token.address;
   }
 
   const taskId = await setupTask({ colonyNetwork, colony, dueDate, domainId, skillId, manager });
@@ -345,9 +344,9 @@ export async function setupMetaColonyWithLockedCLNYToken(colonyNetwork) {
     colonyNetwork.address,
     metaColonyAddress,
     tokenLockingAddress,
-    ZERO_ADDRESS,
+    ethers.constants.AddressZero,
     reputationMinerTestAccounts,
-    ZERO_ADDRESS
+    ethers.constants.AddressZero
   );
 
   await clnyToken.setAuthority(tokenAuthority.address);

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -531,8 +531,8 @@ export async function accommodateChallengeAndInvalidateHash(colonyNetwork, test,
     await navigateChallenge(colonyNetwork, client1, client2, errors);
 
     // Work out which submission is to be invalidated.
-    const submission1 = await repCycle.getDisputeRounds(round1, idx1);
-    const submission2 = await repCycle.getDisputeRounds(round2, idx2);
+    const submission1 = await repCycle.getDisputeRoundSubmission(round1, idx1);
+    const submission2 = await repCycle.getDisputeRoundSubmission(round2, idx2);
 
     if (new BN(submission1.challengeStepCompleted).gt(new BN(submission2.challengeStepCompleted))) {
       toInvalidateIdx = idx2;
@@ -555,7 +555,7 @@ export async function accommodateChallengeAndInvalidateHash(colonyNetwork, test,
 async function navigateChallenge(colonyNetwork, client1, client2, errors) {
   const repCycle = await getActiveRepCycle(colonyNetwork);
   const [round1, idx1] = await client1.getMySubmissionRoundAndIndex();
-  const submission1before = await repCycle.getDisputeRounds(round1, idx1);
+  const submission1before = await repCycle.getDisputeRoundSubmission(round1, idx1);
 
   // Submit JRH for submission 1 if needed
   // We only do this if client2 is defined so that we test JRH submission in rounds other than round 0.
@@ -569,7 +569,7 @@ async function navigateChallenge(colonyNetwork, client1, client2, errors) {
 
   const [round2, idx2] = await client2.getMySubmissionRoundAndIndex();
   expect(round1.eq(round2), "Clients do not have submissions in the same round").to.be.true;
-  const submission2before = await repCycle.getDisputeRounds(round2, idx2);
+  const submission2before = await repCycle.getDisputeRoundSubmission(round2, idx2);
   expect(
     idx1.sub(idx2).pow(2).eq(1), // eslint-disable-line prettier/prettier
     "Clients are not facing each other in this round"
@@ -589,7 +589,7 @@ async function navigateChallenge(colonyNetwork, client1, client2, errors) {
     return;
   }
 
-  let submission1 = await repCycle.getDisputeRounds(round1, idx1);
+  let submission1 = await repCycle.getDisputeRoundSubmission(round1, idx1);
   let binarySearchStep = -1;
   let binarySearchError = false;
   while (submission1.lowerBound !== submission1.upperBound && binarySearchError === false) {
@@ -612,7 +612,7 @@ async function navigateChallenge(colonyNetwork, client1, client2, errors) {
         `Client2 failed unexpectedly on respondToBinarySearchForChallenge${binarySearchStep}`
       );
     }
-    submission1 = await repCycle.getDisputeRounds(round1, idx1);
+    submission1 = await repCycle.getDisputeRoundSubmission(round1, idx1);
   }
 
   if (errors.client1.respondToBinarySearchForChallenge[binarySearchStep] || errors.client2.respondToBinarySearchForChallenge[binarySearchStep]) {

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -649,7 +649,7 @@ async function navigateChallenge(colonyNetwork, client1, client2, errors) {
   }
 }
 
-export async function finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, test) {
+export async function finishReputationMiningCycle(colonyNetwork, test) {
   // Finish the current cycle. Can only do this at the start of a new cycle, if anyone has submitted a hash in this current cycle.
   await forwardTime(MINING_CYCLE_DURATION, test);
   const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -666,8 +666,9 @@ export async function finishReputationMiningCycleAndWithdrawAllMinerStakes(colon
       return false;
     }
   }
+}
 
-  // Actually do the withdrawal.
+export async function withdrawAllMinerStakes(colonyNetwork) {
   const tokenLockingAddress = await colonyNetwork.getTokenLocking();
   const tokenLocking = await ITokenLocking.at(tokenLockingAddress);
   const metaColonyAddress = await colonyNetwork.getMetaColony();

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -666,6 +666,8 @@ export async function finishReputationMiningCycle(colonyNetwork, test) {
       return false;
     }
   }
+
+  return true;
 }
 
 export async function withdrawAllMinerStakes(colonyNetwork) {
@@ -699,5 +701,4 @@ export async function withdrawAllMinerStakes(colonyNetwork) {
       }
     })
   );
-  return true;
 }

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -794,7 +794,7 @@ class ReputationMiner {
     while (submission[0] !== submittedHash || submission[1].toString() !== submittedNNodes.toString() || submission[4] !== jrh) {
       try {
         index = index.add(1);
-        submission = await repCycle.getDisputeRounds(round, index);
+        submission = await repCycle.getDisputeRoundSubmission(round, index);
       } catch (err) {
         round = round.add(1);
         index = ethers.constants.NegativeOne;
@@ -811,7 +811,7 @@ class ReputationMiner {
   async respondToBinarySearchForChallenge() {
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const repCycle = await this.getActiveRepCycle();
-    const submission = await repCycle.getDisputeRounds(round, index);
+    const submission = await repCycle.getDisputeRoundSubmission(round, index);
 
     const targetNode = submission.lowerBound;
     const targetNodeKey = ReputationMiner.getHexString(targetNode, 64);
@@ -852,7 +852,7 @@ class ReputationMiner {
   async confirmBinarySearchResult() {
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const repCycle = await this.getActiveRepCycle();
-    const submission = await repCycle.getDisputeRounds(round, index);
+    const submission = await repCycle.getDisputeRoundSubmission(round, index);
     const targetNode = ethers.utils.bigNumberify(submission.lowerBound);
     const targetNodeKey = ReputationMiner.getHexString(targetNode, 64);
 
@@ -871,7 +871,7 @@ class ReputationMiner {
   async respondToChallenge() {
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const repCycle = await this.getActiveRepCycle();
-    const submission = await repCycle.getDisputeRounds(round, index);
+    const submission = await repCycle.getDisputeRoundSubmission(round, index);
 
     // console.log(submission);
     let firstDisagreeIdx = ethers.utils.bigNumberify(submission.lowerBound);

--- a/packages/reputation-miner/patricia-base.js
+++ b/packages/reputation-miner/patricia-base.js
@@ -1,6 +1,6 @@
-import { BN } from "bn.js";
-import { soliditySha3 } from "web3-utils";
+import BN from "bn.js";
 import { ethers } from "ethers";
+import { soliditySha3 } from "web3-utils";
 
 // //////
 // Patricia Tree

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -14,7 +14,7 @@ class MaliciousReputationMinerWrongProofLogEntry extends ReputationMinerTestWrap
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const addr = await this.colonyNetwork.getReputationMiningCycle(true);
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
-    const submission = await repCycle.getDisputeRounds(round, index);
+    const submission = await repCycle.getDisputeRoundSubmission(round, index);
     const firstDisagreeIdx = ethers.utils.bigNumberify(submission.lowerBound);
     const lastAgreeIdx = firstDisagreeIdx.sub(1);
     const reputationKey = await this.getKeyForUpdateNumber(lastAgreeIdx);

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongResponse.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongResponse.js
@@ -14,7 +14,7 @@ class MaliciousReputationMinerWrongResponse extends ReputationMinerTestWrapper {
   async respondToChallenge() {
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const repCycle = await this.getActiveRepCycle();
-    const submission = await repCycle.getDisputeRounds(round, index);
+    const submission = await repCycle.getDisputeRoundSubmission(round, index);
 
     // console.log(submission);
     let firstDisagreeIdx = ethers.utils.bigNumberify(submission.lowerBound);

--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -1,6 +1,6 @@
 /* globals artifacts */
 import BN from "bn.js";
-import ethers from "ethers";
+import { ethers } from "ethers";
 import chai from "chai";
 import bnChai from "bn-chai";
 

--- a/test/colony-network-auction.js
+++ b/test/colony-network-auction.js
@@ -1,10 +1,11 @@
 /* globals artifacts */
-import { BN } from "bn.js";
+import BN from "bn.js";
+import ethers from "ethers";
 import chai from "chai";
 import bnChai from "bn-chai";
 
 import { getTokenArgs, web3GetTransactionReceipt, web3GetCode, checkErrorRevert, forwardTime, getBlockTime } from "../helpers/test-helper";
-import { ZERO_ADDRESS, WAD, SECONDS_PER_DAY } from "../helpers/constants";
+import { WAD, SECONDS_PER_DAY } from "../helpers/constants";
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, unlockCLNYToken, giveUserCLNYTokens } from "../helpers/test-data-generator";
 
 const { expect } = chai;
@@ -58,7 +59,7 @@ contract("Colony Network Auction", accounts => {
     });
 
     it("should fail with a zero address token", async () => {
-      await checkErrorRevert(colonyNetwork.startTokenAuction(ZERO_ADDRESS), "colony-auction-invalid-token");
+      await checkErrorRevert(colonyNetwork.startTokenAuction(ethers.constants.AddressZero), "colony-auction-invalid-token");
     });
 
     it("should burn tokens if auction is initialised for the CLNY token", async () => {

--- a/test/colony-network-recovery.js
+++ b/test/colony-network-recovery.js
@@ -1,5 +1,6 @@
 /* globals artifacts */
 
+import { ethers } from "ethers";
 import { padLeft, soliditySha3, numberToHex } from "web3-utils";
 import BN from "bn.js";
 import chai from "chai";
@@ -203,7 +204,7 @@ contract("Colony Network Recovery", accounts => {
 
       let rootHash = await colonyNetwork.getReputationRootHash();
       let nNodes = await colonyNetwork.getReputationRootHashNNodes();
-      expect(rootHash).to.equal("0x0000000000000000000000000000000000000000000000000000000000000000");
+      expect(rootHash).to.equal(ethers.constants.HashZero);
       expect(nNodes).to.be.zero;
 
       await colonyNetwork.enterRecoveryMode();

--- a/test/colony-network-recovery.js
+++ b/test/colony-network-recovery.js
@@ -2,7 +2,7 @@
 
 import { padLeft, soliditySha3, numberToHex } from "web3-utils";
 import BN from "bn.js";
-import ethers from "ethers";
+import { ethers } from "ethers";
 import chai from "chai";
 import bnChai from "bn-chai";
 import path from "path";

--- a/test/colony-network-recovery.js
+++ b/test/colony-network-recovery.js
@@ -1,8 +1,8 @@
 /* globals artifacts */
 
-import { ethers } from "ethers";
 import { padLeft, soliditySha3, numberToHex } from "web3-utils";
 import BN from "bn.js";
+import ethers from "ethers";
 import chai from "chai";
 import bnChai from "bn-chai";
 import path from "path";

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -1,9 +1,9 @@
 /* globals artifacts */
 import chai from "chai";
 import bnChai from "bn-chai";
+import ethers from "ethers";
 
 import { getTokenArgs, web3GetNetwork, web3GetBalance, checkErrorRevert, expectEvent } from "../helpers/test-helper";
-import { ZERO_ADDRESS } from "../helpers/constants";
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony } from "../helpers/test-data-generator";
 
 const namehash = require("eth-ens-namehash");
@@ -51,7 +51,7 @@ contract("Colony Network", accounts => {
 
     it("should have the Resolver for current Colony version set", async () => {
       const currentResolver = await colonyNetwork.getColonyVersionResolver(version);
-      expect(currentResolver).to.not.equal(ZERO_ADDRESS);
+      expect(currentResolver).to.not.equal(ethers.constants.AddressZero);
     });
 
     it("should be able to register a higher Colony contract version", async () => {
@@ -74,7 +74,7 @@ contract("Colony Network", accounts => {
     });
 
     it("should not be able to set the token locking contract twice", async () => {
-      await checkErrorRevert(colonyNetwork.setTokenLocking(ZERO_ADDRESS), "colony-token-locking-address-already-set");
+      await checkErrorRevert(colonyNetwork.setTokenLocking(ethers.constants.AddressZero), "colony-token-locking-address-already-set");
     });
 
     it("should not be able to initialise network twice", async () => {
@@ -109,7 +109,7 @@ contract("Colony Network", accounts => {
     it("should allow users to create new colonies", async () => {
       const { colony } = await setupRandomColony(colonyNetwork);
       const colonyCount = await colonyNetwork.getColonyCount();
-      expect(colony.address).to.not.equal(ZERO_ADDRESS);
+      expect(colony.address).to.not.equal(ethers.constants.AddressZero);
       expect(colonyCount).to.eq.BN(2);
     });
 
@@ -152,7 +152,7 @@ contract("Colony Network", accounts => {
     });
 
     it("should not allow users to create a colony with empty token", async () => {
-      await checkErrorRevert(colonyNetwork.createColony(ZERO_ADDRESS), "colony-token-invalid-address");
+      await checkErrorRevert(colonyNetwork.createColony(ethers.constants.AddressZero), "colony-token-invalid-address");
     });
 
     it("when any colony is created, should have the root local skill initialised", async () => {
@@ -195,12 +195,12 @@ contract("Colony Network", accounts => {
       await colonyNetwork.createColony(token.address);
       await colonyNetwork.createColony(token.address);
       const colonyAddress = await colonyNetwork.getColony(3);
-      expect(colonyAddress).to.not.equal(ZERO_ADDRESS);
+      expect(colonyAddress).to.not.equal(ethers.constants.AddressZero);
     });
 
     it("should return an empty address if there is no colony for the index provided", async () => {
       const colonyAddress = await colonyNetwork.getColony(15);
-      expect(colonyAddress).to.equal(ZERO_ADDRESS);
+      expect(colonyAddress).to.equal(ethers.constants.AddressZero);
     });
 
     it("should be able to get the Colony version", async () => {

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -1,7 +1,7 @@
 /* globals artifacts */
 import chai from "chai";
 import bnChai from "bn-chai";
-import ethers from "ethers";
+import { ethers } from "ethers";
 
 import { getTokenArgs, web3GetNetwork, web3GetBalance, checkErrorRevert, expectEvent } from "../helpers/test-helper";
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony } from "../helpers/test-data-generator";

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -1,9 +1,10 @@
 /* global artifacts */
 import chai from "chai";
 import bnChai from "bn-chai";
-import { BN } from "bn.js";
+import BN from "bn.js";
+import ethers from "ethers";
 
-import { WAD, ZERO_ADDRESS, MAX_PAYOUT } from "../helpers/constants";
+import { WAD, MAX_PAYOUT } from "../helpers/constants";
 import { checkErrorRevert, getTokenArgs } from "../helpers/test-helper";
 import { fundColonyWithTokens, setupRandomColony } from "../helpers/test-data-generator";
 
@@ -69,7 +70,7 @@ contract("Colony Payment", accounts => {
 
     it("should not allow admins to add payment with no recipient set", async () => {
       await checkErrorRevert(
-        colony.addPayment(1, 0, ZERO_ADDRESS, token.address, WAD, 1, 0, { from: COLONY_ADMIN }),
+        colony.addPayment(1, 0, ethers.constants.AddressZero, token.address, WAD, 1, 0, { from: COLONY_ADMIN }),
         "colony-payment-invalid-recipient"
       );
     });
@@ -108,7 +109,7 @@ contract("Colony Payment", accounts => {
       await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
-      await checkErrorRevert(colony.setPaymentRecipient(1, 0, paymentId, ZERO_ADDRESS, { from: COLONY_ADMIN }), "colony-payment-invalid-recipient");
+      await checkErrorRevert(colony.setPaymentRecipient(1, 0, paymentId, ethers.constants.AddressZero, { from: COLONY_ADMIN }), "colony-payment-invalid-recipient");
     });
 
     it("should allow admins to update domain", async () => {

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -2,7 +2,7 @@
 import chai from "chai";
 import bnChai from "bn-chai";
 import BN from "bn.js";
-import ethers from "ethers";
+import { ethers } from "ethers";
 
 import { WAD, MAX_PAYOUT } from "../helpers/constants";
 import { checkErrorRevert, getTokenArgs } from "../helpers/test-helper";
@@ -109,7 +109,10 @@ contract("Colony Payment", accounts => {
       await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
-      await checkErrorRevert(colony.setPaymentRecipient(1, 0, paymentId, ethers.constants.AddressZero, { from: COLONY_ADMIN }), "colony-payment-invalid-recipient");
+      await checkErrorRevert(
+        colony.setPaymentRecipient(1, 0, paymentId, ethers.constants.AddressZero, { from: COLONY_ADMIN }),
+        "colony-payment-invalid-recipient"
+      );
     });
 
     it("should allow admins to update domain", async () => {

--- a/test/colony-recovery.js
+++ b/test/colony-recovery.js
@@ -1,6 +1,6 @@
 import chai from "chai";
 import bnChai from "bn-chai";
-import ethers from "ethers";
+import { ethers } from "ethers";
 
 import { SPECIFICATION_HASH } from "../helpers/constants";
 import { web3GetStorageAt, checkErrorRevert } from "../helpers/test-helper";

--- a/test/colony-recovery.js
+++ b/test/colony-recovery.js
@@ -1,7 +1,8 @@
 import chai from "chai";
 import bnChai from "bn-chai";
+import ethers from "ethers";
 
-import { SPECIFICATION_HASH, ZERO_ADDRESS } from "../helpers/constants";
+import { SPECIFICATION_HASH } from "../helpers/constants";
 import { web3GetStorageAt, checkErrorRevert } from "../helpers/test-helper";
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony } from "../helpers/test-data-generator";
 
@@ -92,7 +93,7 @@ contract("Colony Recovery", accounts => {
       await colony.enterRecoveryMode();
       await metaColony.enterRecoveryMode();
 
-      await checkErrorRevert(colony.initialiseColony(ZERO_ADDRESS, ZERO_ADDRESS), "colony-in-recovery-mode");
+      await checkErrorRevert(colony.initialiseColony(ethers.constants.AddressZero, ethers.constants.AddressZero), "colony-in-recovery-mode");
       await checkErrorRevert(colony.mintTokens(1000), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.addGlobalSkill(0), "colony-in-recovery-mode");
       await checkErrorRevert(colony.makeTask(1, 0, SPECIFICATION_HASH, 0, 0, 0), "colony-in-recovery-mode");

--- a/test/colony-reward-payouts.js
+++ b/test/colony-reward-payouts.js
@@ -7,7 +7,7 @@ import bnChai from "bn-chai";
 import path from "path";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
-import { INT128_MAX, WAD, MANAGER_ROLE, INITIAL_FUNDING, DEFAULT_STAKE, ZERO_ADDRESS, SECONDS_PER_DAY } from "../helpers/constants";
+import { INT128_MAX, WAD, MANAGER_ROLE, INITIAL_FUNDING, DEFAULT_STAKE, SECONDS_PER_DAY } from "../helpers/constants";
 
 import {
   getTokenArgs,
@@ -151,7 +151,7 @@ contract("Colony Reward Payouts", accounts => {
 
       const result = await colony.getDomain(1);
       const rootDomainSkill = result.skillId;
-      const globalKey = ReputationMinerTestWrapper.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
+      const globalKey = ReputationMinerTestWrapper.getKey(newColony.address, rootDomainSkill, ethers.constants.AddressZero);
       await client.insert(globalKey, new BN(10), 0);
 
       await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
@@ -322,7 +322,7 @@ contract("Colony Reward Payouts", accounts => {
       const result = await newColony.getDomain(1);
       const rootDomainSkill = result.skillId;
 
-      const globalKey = ReputationMinerTestWrapper.getKey(newColony.address, rootDomainSkill, ZERO_ADDRESS);
+      const globalKey = ReputationMinerTestWrapper.getKey(newColony.address, rootDomainSkill, ethers.constants.AddressZero);
       await client.insert(globalKey, new BN(0), 0);
 
       await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });

--- a/test/colony-reward-payouts.js
+++ b/test/colony-reward-payouts.js
@@ -1,5 +1,6 @@
 /* globals artifacts */
 import { BN } from "bn.js";
+import { ethers } from "ethers";
 import { sha3 } from "web3-utils";
 import chai from "chai";
 import bnChai from "bn-chai";

--- a/test/colony-task-work-rating.js
+++ b/test/colony-task-work-rating.js
@@ -53,7 +53,7 @@ contract("Colony Task Work Rating", accounts => {
 
       await colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR });
       const currentTime1 = await currentBlockTime();
-      const rating1 = await colony.getTaskWorkRatings(taskId);
+      const rating1 = await colony.getTaskWorkRatingSecretsInfo(taskId);
       expect(rating1.nSecrets).to.eq.BN(1);
       expect(rating1.lastSubmittedAt.toNumber()).to.be.closeTo(currentTime1, 2);
       const ratingSecret1 = await colony.getTaskWorkRatingSecret(taskId, WORKER_ROLE);
@@ -61,7 +61,7 @@ contract("Colony Task Work Rating", accounts => {
 
       await colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: WORKER });
       const currentTime2 = await currentBlockTime();
-      const rating2 = await colony.getTaskWorkRatings(taskId);
+      const rating2 = await colony.getTaskWorkRatingSecretsInfo(taskId);
       expect(rating2.nSecrets).to.eq.BN(2);
       expect(rating2.lastSubmittedAt.toNumber()).to.be.closeTo(currentTime2, 2);
       const ratingSecret2 = await colony.getTaskWorkRatingSecret(taskId, MANAGER_ROLE);
@@ -75,7 +75,7 @@ contract("Colony Task Work Rating", accounts => {
 
       await colony.submitTaskDeliverableAndRating(taskId, DELIVERABLE_HASH, RATING_1_SECRET, { from: WORKER });
       const currentTime2 = await currentBlockTime();
-      const ratings = await colony.getTaskWorkRatings(taskId);
+      const ratings = await colony.getTaskWorkRatingSecretsInfo(taskId);
       expect(ratings.nSecrets).to.eq.BN(1);
       expect(ratings.lastSubmittedAt.toNumber()).to.be.closeTo(currentTime2, 2);
       const ratingSecret = await colony.getTaskWorkRatingSecret(taskId, MANAGER_ROLE);
@@ -100,7 +100,7 @@ contract("Colony Task Work Rating", accounts => {
       dueDate += SECONDS_PER_DAY * 7;
       const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
       await checkErrorRevert(colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR }), "colony-task-not-complete");
-      const ratingSecrets = await colony.getTaskWorkRatings(taskId);
+      const ratingSecrets = await colony.getTaskWorkRatingSecretsInfo(taskId);
       expect(ratingSecrets.nSecrets).to.be.zero;
     });
 
@@ -142,7 +142,7 @@ contract("Colony Task Work Rating", accounts => {
         colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: OTHER }),
         "colony-user-cannot-rate-task-worker"
       );
-      const ratingSecrets = await colony.getTaskWorkRatings(taskId);
+      const ratingSecrets = await colony.getTaskWorkRatingSecretsInfo(taskId);
       expect(ratingSecrets[1]).to.be.zero;
     });
 
@@ -154,7 +154,7 @@ contract("Colony Task Work Rating", accounts => {
         colony.submitTaskWorkRating(taskId, MANAGER_ROLE, RATING_1_SECRET, { from: OTHER }),
         "colony-user-cannot-rate-task-manager"
       );
-      const ratingSecrets = await colony.getTaskWorkRatings(taskId);
+      const ratingSecrets = await colony.getTaskWorkRatingSecretsInfo(taskId);
       expect(ratingSecrets.nSecrets).to.be.zero;
     });
 
@@ -166,7 +166,7 @@ contract("Colony Task Work Rating", accounts => {
         colony.submitTaskWorkRating(taskId, EVALUATOR_ROLE, RATING_2_SECRET, { from: EVALUATOR }),
         "colony-unsupported-role-to-rate"
       );
-      const ratingSecrets = await colony.getTaskWorkRatings(taskId);
+      const ratingSecrets = await colony.getTaskWorkRatingSecretsInfo(taskId);
       expect(ratingSecrets.nSecrets).to.be.zero;
     });
 
@@ -180,7 +180,7 @@ contract("Colony Task Work Rating", accounts => {
         colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_1_SECRET, { from: EVALUATOR }),
         "colony-task-rating-secret-already-exists"
       );
-      const ratingSecrets = await colony.getTaskWorkRatings(taskId);
+      const ratingSecrets = await colony.getTaskWorkRatingSecretsInfo(taskId);
       expect(ratingSecrets.nSecrets).to.eq.BN(1);
       const ratingSecret = await colony.getTaskWorkRatingSecret(taskId, WORKER_ROLE);
       expect(ratingSecret).to.eq.BN(RATING_2_SECRET);
@@ -196,7 +196,7 @@ contract("Colony Task Work Rating", accounts => {
         colony.submitTaskWorkRating(taskId, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR }),
         "colony-task-rating-secret-submit-period-closed"
       );
-      const ratingSecrets = await colony.getTaskWorkRatings(taskId);
+      const ratingSecrets = await colony.getTaskWorkRatingSecretsInfo(taskId);
       expect(ratingSecrets.nSecrets).to.be.zero;
     });
 
@@ -204,7 +204,7 @@ contract("Colony Task Work Rating", accounts => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony });
 
       await checkErrorRevert(colony.submitTaskWorkRating(10, WORKER_ROLE, RATING_2_SECRET, { from: EVALUATOR }), "colony-task-not-complete");
-      const ratingSecrets = await colony.getTaskWorkRatings(taskId);
+      const ratingSecrets = await colony.getTaskWorkRatingSecretsInfo(taskId);
       expect(ratingSecrets.nSecrets).to.be.zero;
     });
 
@@ -219,7 +219,7 @@ contract("Colony Task Work Rating", accounts => {
         "colony-task-rating-secret-missing"
       );
 
-      const ratingSecrets = await colony.getTaskWorkRatings(taskId);
+      const ratingSecrets = await colony.getTaskWorkRatingSecretsInfo(taskId);
       // No rating was accepted. Ratings count is 0
       expect(ratingSecrets.nSecrets).to.be.zero;
     });

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -1616,7 +1616,10 @@ contract("ColonyTask", accounts => {
         args: [taskId, accounts[4]]
       });
 
-      await checkErrorRevert(colony.setAllTaskPayouts(taskId, ethers.constants.AddressZero, 5000, 1000, 98000), "colony-funding-evaluator-already-set");
+      await checkErrorRevert(
+        colony.setAllTaskPayouts(taskId, ethers.constants.AddressZero, 5000, 1000, 98000),
+        "colony-funding-evaluator-already-set"
+      );
     });
 
     it("should log a TaskWorkerPayoutSet event, if the task's worker's payout changed", async () => {

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -1,5 +1,6 @@
 /* global artifacts */
-import { BN } from "bn.js";
+import BN from "bn.js";
+import { ethers } from "ethers";
 import chai from "chai";
 import bnChai from "bn-chai";
 
@@ -19,7 +20,6 @@ import {
   ACTIVE_TASK_STATE,
   CANCELLED_TASK_STATE,
   FINALIZED_TASK_STATE,
-  ZERO_ADDRESS,
   MANAGER_RATING,
   WORKER_RATING,
   RATING_1_SALT,
@@ -53,8 +53,6 @@ import {
   setupRandomColony,
   assignRoles
 } from "../helpers/test-data-generator";
-
-const ethers = require("ethers");
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
@@ -139,7 +137,7 @@ contract("ColonyTask", accounts => {
       });
 
       taskEvaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
-      expect(taskEvaluator.user).to.equal(ZERO_ADDRESS);
+      expect(taskEvaluator.user).to.equal(ethers.constants.AddressZero);
 
       await executeSignedRoleAssignment({
         colony,
@@ -334,7 +332,7 @@ contract("ColonyTask", accounts => {
       );
 
       const evaluator = await colony.getTaskRole(taskId, EVALUATOR_ROLE);
-      expect(evaluator.user).to.equal(ZERO_ADDRESS);
+      expect(evaluator.user).to.equal(ethers.constants.AddressZero);
 
       await checkErrorRevert(
         executeSignedRoleAssignment({
@@ -349,7 +347,7 @@ contract("ColonyTask", accounts => {
       );
 
       const worker = await colony.getTaskRole(taskId, WORKER_ROLE);
-      expect(worker.user).to.equal(ZERO_ADDRESS);
+      expect(worker.user).to.equal(ethers.constants.AddressZero);
     });
 
     it("should not allow role to be assigned if it is already assigned to somebody", async () => {
@@ -414,7 +412,7 @@ contract("ColonyTask", accounts => {
       });
 
       workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
-      expect(workerInfo.user).to.equal(ZERO_ADDRESS);
+      expect(workerInfo.user).to.equal(ethers.constants.AddressZero);
     });
 
     it("should not allow role to be unassigned, if current assigned address does not agree", async () => {
@@ -436,7 +434,7 @@ contract("ColonyTask", accounts => {
           functionName: "setTaskWorkerRole",
           signers: [MANAGER, OTHER],
           sigTypes: [0, 0],
-          args: [taskId, ZERO_ADDRESS]
+          args: [taskId, ethers.constants.AddressZero]
         }),
         "colony-task-role-assignment-not-signed-by-new-user-for-role"
       );
@@ -464,7 +462,7 @@ contract("ColonyTask", accounts => {
       );
 
       const workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
-      expect(workerInfo.user).to.equal(ZERO_ADDRESS);
+      expect(workerInfo.user).to.equal(ethers.constants.AddressZero);
     });
 
     it("should allow manager to assign himself to a role", async () => {
@@ -499,7 +497,7 @@ contract("ColonyTask", accounts => {
       );
 
       const workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
-      expect(workerInfo.user).to.equal(ZERO_ADDRESS);
+      expect(workerInfo.user).to.equal(ethers.constants.AddressZero);
     });
 
     it("should allow different modes of signing when assigning roles", async () => {
@@ -534,7 +532,7 @@ contract("ColonyTask", accounts => {
       );
 
       const workerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
-      expect(workerInfo.user).to.equal(ZERO_ADDRESS);
+      expect(workerInfo.user).to.equal(ethers.constants.AddressZero);
     });
 
     it("should allow to change manager role if the user agrees", async () => {
@@ -569,7 +567,7 @@ contract("ColonyTask", accounts => {
       );
 
       const managerInfo = await colony.getTaskRole(taskId, WORKER_ROLE);
-      expect(managerInfo.user).to.equal(ZERO_ADDRESS);
+      expect(managerInfo.user).to.equal(ethers.constants.AddressZero);
     });
 
     it("should not allow assignment of manager role if the user does not agree", async () => {
@@ -620,7 +618,7 @@ contract("ColonyTask", accounts => {
           functionName: "setTaskManagerRole",
           signers: [MANAGER, COLONY_ADMIN],
           sigTypes: [0, 0],
-          args: [taskId, ZERO_ADDRESS, 1, 0]
+          args: [taskId, ethers.constants.AddressZero, 1, 0]
         }),
         "colony-task-role-assignment-not-signed-by-new-user-for-role"
       );
@@ -1358,8 +1356,8 @@ contract("ColonyTask", accounts => {
       // Our test-data-generator already set up some task fund with tokens,
       // but we need some Ether, too
       await colony.send(101);
-      await colony.claimColonyFunds(ZERO_ADDRESS);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, taskPotId, 100, ZERO_ADDRESS);
+      await colony.claimColonyFunds(ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, 0, 0, 1, taskPotId, 100, ethers.constants.AddressZero);
 
       // And another token
       await otherToken.mint(colony.address, 101);
@@ -1367,8 +1365,8 @@ contract("ColonyTask", accounts => {
       await colony.moveFundsBetweenPots(1, 0, 0, 1, taskPotId, 100, otherToken.address);
 
       // Keep track of original Ether balance in funding pots
-      const originalDomainEtherBalance = await colony.getFundingPotBalance(domain.fundingPotId, ZERO_ADDRESS);
-      const originalTaskEtherBalance = await colony.getFundingPotBalance(taskPotId, ZERO_ADDRESS);
+      const originalDomainEtherBalance = await colony.getFundingPotBalance(domain.fundingPotId, ethers.constants.AddressZero);
+      const originalTaskEtherBalance = await colony.getFundingPotBalance(taskPotId, ethers.constants.AddressZero);
       // And same for the token
       const originalDomainTokenBalance = await colony.getFundingPotBalance(domain.fundingPotId, token.address);
       const originalTaskTokenBalance = await colony.getFundingPotBalance(taskPotId, token.address);
@@ -1386,12 +1384,12 @@ contract("ColonyTask", accounts => {
         args: [taskId]
       });
 
-      await colony.moveFundsBetweenPots(1, 0, 0, taskPotId, domain.fundingPotId, originalTaskEtherBalance, ZERO_ADDRESS);
+      await colony.moveFundsBetweenPots(1, 0, 0, taskPotId, domain.fundingPotId, originalTaskEtherBalance, ethers.constants.AddressZero);
       await colony.moveFundsBetweenPots(1, 0, 0, taskPotId, domain.fundingPotId, originalTaskTokenBalance, token.address);
       await colony.moveFundsBetweenPots(1, 0, 0, taskPotId, domain.fundingPotId, originalTaskOtherTokenBalance, otherToken.address);
 
-      const cancelledTaskEtherBalance = await colony.getFundingPotBalance(taskPotId, ZERO_ADDRESS);
-      const cancelledDomainEtherBalance = await colony.getFundingPotBalance(domain.fundingPotId, ZERO_ADDRESS);
+      const cancelledTaskEtherBalance = await colony.getFundingPotBalance(taskPotId, ethers.constants.AddressZero);
+      const cancelledDomainEtherBalance = await colony.getFundingPotBalance(domain.fundingPotId, ethers.constants.AddressZero);
       const cancelledTaskTokenBalance = await colony.getFundingPotBalance(taskPotId, token.address);
       const cancelledDomainTokenBalance = await colony.getFundingPotBalance(domain.fundingPotId, token.address);
       const cancelledTaskOtherTokenBalance = await colony.getFundingPotBalance(taskPotId, otherToken.address);
@@ -1489,7 +1487,7 @@ contract("ColonyTask", accounts => {
         functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
-        args: [taskId, ZERO_ADDRESS, 5000]
+        args: [taskId, ethers.constants.AddressZero, 5000]
       });
 
       await executeSignedTaskChange({
@@ -1508,7 +1506,7 @@ contract("ColonyTask", accounts => {
         functionName: "setTaskEvaluatorPayout",
         signers: [MANAGER],
         sigTypes: [0],
-        args: [taskId, ZERO_ADDRESS, 1000]
+        args: [taskId, ethers.constants.AddressZero, 1000]
       });
 
       // Set the evaluator payout as 40 colony tokens
@@ -1528,7 +1526,7 @@ contract("ColonyTask", accounts => {
         functionName: "setTaskWorkerPayout",
         signers: [MANAGER, WORKER],
         sigTypes: [0, 0],
-        args: [taskId, ZERO_ADDRESS, 98000]
+        args: [taskId, ethers.constants.AddressZero, 98000]
       });
 
       await executeSignedTaskChange({
@@ -1540,17 +1538,17 @@ contract("ColonyTask", accounts => {
         args: [taskId, token.address, 200]
       });
 
-      const taskPayoutManager1 = await colony.getTaskPayout(taskId, MANAGER_ROLE, ZERO_ADDRESS);
+      const taskPayoutManager1 = await colony.getTaskPayout(taskId, MANAGER_ROLE, ethers.constants.AddressZero);
       expect(taskPayoutManager1).to.eq.BN(5000);
       const taskPayoutManager2 = await colony.getTaskPayout(taskId, MANAGER_ROLE, token.address);
       expect(taskPayoutManager2).to.eq.BN(100);
 
-      const taskPayoutEvaluator1 = await colony.getTaskPayout(taskId, EVALUATOR_ROLE, ZERO_ADDRESS);
+      const taskPayoutEvaluator1 = await colony.getTaskPayout(taskId, EVALUATOR_ROLE, ethers.constants.AddressZero);
       expect(taskPayoutEvaluator1).to.eq.BN(1000);
       const taskPayoutEvaluator2 = await colony.getTaskPayout(taskId, EVALUATOR_ROLE, token.address);
       expect(taskPayoutEvaluator2).to.eq.BN(40);
 
-      const taskPayoutWorker1 = await colony.getTaskPayout(taskId, WORKER_ROLE, ZERO_ADDRESS);
+      const taskPayoutWorker1 = await colony.getTaskPayout(taskId, WORKER_ROLE, ethers.constants.AddressZero);
       expect(taskPayoutWorker1).to.eq.BN(98000);
       const taskPayoutWorker2 = await colony.getTaskPayout(taskId, WORKER_ROLE, token.address);
       expect(taskPayoutWorker2).to.eq.BN(200);
@@ -1562,18 +1560,18 @@ contract("ColonyTask", accounts => {
 
       const taskId = await makeTask({ colony, dueDate });
       await checkErrorRevert(
-        colony.setAllTaskPayouts(taskId, ZERO_ADDRESS, 5000, 1000, 98000, { from: OTHER }),
+        colony.setAllTaskPayouts(taskId, ethers.constants.AddressZero, 5000, 1000, 98000, { from: OTHER }),
         "colony-task-role-identity-mismatch"
       );
-      await colony.setAllTaskPayouts(taskId, ZERO_ADDRESS, 5000, 1000, 98000);
+      await colony.setAllTaskPayouts(taskId, ethers.constants.AddressZero, 5000, 1000, 98000);
 
-      const taskPayoutManager = await colony.getTaskPayout(taskId, MANAGER_ROLE, ZERO_ADDRESS);
+      const taskPayoutManager = await colony.getTaskPayout(taskId, MANAGER_ROLE, ethers.constants.AddressZero);
       expect(taskPayoutManager).to.eq.BN(5000);
 
-      const taskPayoutEvaluator = await colony.getTaskPayout(taskId, EVALUATOR_ROLE, ZERO_ADDRESS);
+      const taskPayoutEvaluator = await colony.getTaskPayout(taskId, EVALUATOR_ROLE, ethers.constants.AddressZero);
       expect(taskPayoutEvaluator).to.eq.BN(1000);
 
-      const taskPayoutWorker = await colony.getTaskPayout(taskId, WORKER_ROLE, ZERO_ADDRESS);
+      const taskPayoutWorker = await colony.getTaskPayout(taskId, WORKER_ROLE, ethers.constants.AddressZero);
       expect(taskPayoutWorker).to.eq.BN(98000);
     });
 
@@ -1592,7 +1590,7 @@ contract("ColonyTask", accounts => {
         args: [taskId, WORKER]
       });
 
-      await checkErrorRevert(colony.setAllTaskPayouts(taskId, ZERO_ADDRESS, 5000, 1000, 98000), "colony-funding-worker-already-set");
+      await checkErrorRevert(colony.setAllTaskPayouts(taskId, ethers.constants.AddressZero, 5000, 1000, 98000), "colony-funding-worker-already-set");
     });
 
     it("should not be able to set all payments at once if evaluator is assigned and not manager", async () => {
@@ -1618,7 +1616,7 @@ contract("ColonyTask", accounts => {
         args: [taskId, accounts[4]]
       });
 
-      await checkErrorRevert(colony.setAllTaskPayouts(taskId, ZERO_ADDRESS, 5000, 1000, 98000), "colony-funding-evaluator-already-set");
+      await checkErrorRevert(colony.setAllTaskPayouts(taskId, ethers.constants.AddressZero, 5000, 1000, 98000), "colony-funding-evaluator-already-set");
     });
 
     it("should log a TaskWorkerPayoutSet event, if the task's worker's payout changed", async () => {
@@ -1642,7 +1640,7 @@ contract("ColonyTask", accounts => {
           functionName: "setTaskWorkerPayout",
           signers: [MANAGER, WORKER],
           sigTypes: [0, 0],
-          args: [taskId, ZERO_ADDRESS, 98000]
+          args: [taskId, ethers.constants.AddressZero, 98000]
         }),
         "TaskPayoutSet"
       );
@@ -1667,7 +1665,7 @@ contract("ColonyTask", accounts => {
         functionName: "setTaskManagerPayout",
         signers: [MANAGER],
         sigTypes: [0],
-        args: [taskId, ZERO_ADDRESS, MAX_PAYOUT]
+        args: [taskId, ethers.constants.AddressZero, MAX_PAYOUT]
       });
 
       await checkErrorRevert(
@@ -1677,7 +1675,7 @@ contract("ColonyTask", accounts => {
           functionName: "setTaskManagerPayout",
           signers: [MANAGER],
           sigTypes: [0],
-          args: [taskId, ZERO_ADDRESS, MAX_PAYOUT.addn(1)]
+          args: [taskId, ethers.constants.AddressZero, MAX_PAYOUT.addn(1)]
         }),
         "colony-task-change-execution-failed" // Should be "colony-payout-too-large"
       );
@@ -1709,14 +1707,14 @@ contract("ColonyTask", accounts => {
 
     it("should payout agreed ether for a task", async () => {
       await colony.send(400);
-      await colony.claimColonyFunds(ZERO_ADDRESS);
+      await colony.claimColonyFunds(ethers.constants.AddressZero);
 
       let dueDate = await currentBlockTime();
       dueDate -= 1;
       const taskId = await setupFinalizedTask({
         colonyNetwork,
         colony,
-        token: ZERO_ADDRESS,
+        token: ethers.constants.AddressZero,
         dueDate,
         managerPayout: 100,
         evaluatorPayout: 50,
@@ -1725,12 +1723,12 @@ contract("ColonyTask", accounts => {
 
       const task = await colony.getTask(taskId);
       const taskPotId = task.fundingPotId;
-      const potBalanceBefore = await colony.getFundingPotBalance(taskPotId, ZERO_ADDRESS);
+      const potBalanceBefore = await colony.getFundingPotBalance(taskPotId, ethers.constants.AddressZero);
 
       const workerBalanceBefore = await web3GetBalance(WORKER);
       const metaBalanceBefore = await web3GetBalance(metaColony.address);
 
-      await colony.claimTaskPayout(taskId, WORKER_ROLE, ZERO_ADDRESS, { gasPrice: 0 });
+      await colony.claimTaskPayout(taskId, WORKER_ROLE, ethers.constants.AddressZero, { gasPrice: 0 });
 
       const workerBalanceAfter = await web3GetBalance(WORKER);
       expect(new BN(workerBalanceAfter).sub(new BN(workerBalanceBefore))).to.eq.BN(new BN(197));
@@ -1738,7 +1736,7 @@ contract("ColonyTask", accounts => {
       const metaBalanceAfter = await web3GetBalance(metaColony.address);
       expect(new BN(metaBalanceAfter).sub(new BN(metaBalanceBefore))).to.eq.BN(3);
 
-      const potBalanceAfter = await colony.getFundingPotBalance(taskPotId, ZERO_ADDRESS);
+      const potBalanceAfter = await colony.getFundingPotBalance(taskPotId, ethers.constants.AddressZero);
       expect(potBalanceBefore.sub(potBalanceAfter)).to.eq.BN(new BN(200));
     });
 

--- a/test/colony-task.js
+++ b/test/colony-task.js
@@ -97,7 +97,7 @@ contract("ColonyTask", accounts => {
       const taskId = await makeTask({ colony, dueDate });
       const task = await colony.getTask(taskId);
       expect(task.specificationHash).to.equal(SPECIFICATION_HASH);
-      expect(task.deliverableHash).to.equal("0x0000000000000000000000000000000000000000000000000000000000000000");
+      expect(task.deliverableHash).to.equal(ethers.constants.HashZero);
       expect(task.status).to.eq.BN(ACTIVE_TASK_STATE);
       expect(task.dueDate).to.eq.BN(dueDate);
       expect(task.domainId).to.eq.BN(1);
@@ -1213,7 +1213,7 @@ contract("ColonyTask", accounts => {
       const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
 
       let task = await colony.getTask(taskId);
-      expect(task.deliverableHash).to.equal("0x0000000000000000000000000000000000000000000000000000000000000000");
+      expect(task.deliverableHash).to.equal(ethers.constants.HashZero);
 
       await colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH, { from: WORKER });
       const currentTime = await currentBlockTime();

--- a/test/colony.js
+++ b/test/colony.js
@@ -11,7 +11,6 @@ import {
   RATING_2_SALT,
   RATING_1_SECRET,
   RATING_2_SECRET,
-  ZERO_ADDRESS,
   WAD
 } from "../helpers/constants";
 import { getTokenArgs, web3GetBalance, checkErrorRevert, expectAllEvents } from "../helpers/test-helper";
@@ -56,7 +55,7 @@ contract("Colony", accounts => {
 
     it("should not have owner", async () => {
       const owner = await colony.owner();
-      expect(owner).to.be.equal(ZERO_ADDRESS);
+      expect(owner).to.be.equal(ethers.constants.AddressZero);
     });
 
     it("should return zero task count", async () => {
@@ -81,7 +80,7 @@ contract("Colony", accounts => {
     });
 
     it("should not allow reinitialisation", async () => {
-      await checkErrorRevert(colony.initialiseColony(ZERO_ADDRESS, ZERO_ADDRESS), "colony-already-initialised-network");
+      await checkErrorRevert(colony.initialiseColony(ethers.constants.AddressZero, ethers.constants.AddressZero), "colony-already-initialised-network");
     });
 
     it("should correctly generate a rating secret", async () => {

--- a/test/colony.js
+++ b/test/colony.js
@@ -2,6 +2,7 @@
 
 import chai from "chai";
 import bnChai from "bn-chai";
+import { ethers } from "ethers";
 
 import {
   UINT256_MAX,
@@ -80,7 +81,10 @@ contract("Colony", accounts => {
     });
 
     it("should not allow reinitialisation", async () => {
-      await checkErrorRevert(colony.initialiseColony(ethers.constants.AddressZero, ethers.constants.AddressZero), "colony-already-initialised-network");
+      await checkErrorRevert(
+        colony.initialiseColony(ethers.constants.AddressZero, ethers.constants.AddressZero),
+        "colony-already-initialised-network"
+      );
     });
 
     it("should correctly generate a rating secret", async () => {

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -2,8 +2,9 @@
 
 import chai from "chai";
 import bnChai from "bn-chai";
+import ethers from "ethers";
 
-import { WAD, INITIAL_FUNDING, ZERO_ADDRESS } from "../../helpers/constants";
+import { WAD, INITIAL_FUNDING } from "../../helpers/constants";
 import { checkErrorRevert } from "../../helpers/test-helper";
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony, fundColonyWithTokens } from "../../helpers/test-data-generator";
 
@@ -59,9 +60,9 @@ contract("One transaction payments", accounts => {
     it("should allow a single-transaction payment of ETH to occur", async () => {
       const balanceBefore = await web3.eth.getBalance(RECIPIENT);
       await colony.send(10); // NB 10 wei, not ten ether!
-      await colony.claimColonyFunds(ZERO_ADDRESS);
+      await colony.claimColonyFunds(ethers.constants.AddressZero);
       // This is the one transactions. Those ones above don't count...
-      await oneTxExtension.makePayment(1, 0, 1, 0, RECIPIENT, ZERO_ADDRESS, 10, 1, globalSkillId, { from: COLONY_ADMIN });
+      await oneTxExtension.makePayment(1, 0, 1, 0, RECIPIENT, ethers.constants.AddressZero, 10, 1, globalSkillId, { from: COLONY_ADMIN });
       // Check it completed
       const balanceAfter = await web3.eth.getBalance(RECIPIENT);
       // So only 9 here, because of the same rounding errors as applied to the token

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -2,7 +2,7 @@
 
 import chai from "chai";
 import bnChai from "bn-chai";
-import ethers from "ethers";
+import { ethers } from "ethers";
 
 import { WAD, INITIAL_FUNDING } from "../../helpers/constants";
 import { checkErrorRevert } from "../../helpers/test-helper";

--- a/test/reputation-mining/basic-functionality.js
+++ b/test/reputation-mining/basic-functionality.js
@@ -3,7 +3,7 @@
 import BN from "bn.js";
 import chai from "chai";
 import bnChai from "bn-chai";
-import ethers from "ethers";
+import { ethers } from "ethers";
 
 import { giveUserCLNYTokens, giveUserCLNYTokensAndStake } from "../../helpers/test-data-generator";
 import { MINING_CYCLE_DURATION } from "../../helpers/constants";

--- a/test/reputation-mining/basic-functionality.js
+++ b/test/reputation-mining/basic-functionality.js
@@ -3,9 +3,10 @@
 import BN from "bn.js";
 import chai from "chai";
 import bnChai from "bn-chai";
+import ethers from "ethers";
 
 import { giveUserCLNYTokens, giveUserCLNYTokensAndStake } from "../../helpers/test-data-generator";
-import { MINING_CYCLE_DURATION, ZERO_ADDRESS } from "../../helpers/constants";
+import { MINING_CYCLE_DURATION } from "../../helpers/constants";
 import { forwardTime, checkErrorRevert, getActiveRepCycle } from "../../helpers/test-helper";
 
 const { expect } = chai;
@@ -153,7 +154,7 @@ contract("Reputation mining - basic functionality", accounts => {
       const repCycle = await getActiveRepCycle(colonyNetwork);
 
       await checkErrorRevert(
-        repCycle.rewardStakersWithReputation([MINER1], [1], ZERO_ADDRESS, 10000, 3),
+        repCycle.rewardStakersWithReputation([MINER1], [1], ethers.constants.AddressZero, 10000, 3),
         "colony-reputation-mining-sender-not-network"
       );
     });

--- a/test/reputation-mining/client-calculations.js
+++ b/test/reputation-mining/client-calculations.js
@@ -33,7 +33,7 @@ let clnyToken;
 let goodClient;
 const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
 
-const setupNewNetworkInstance = async MINER1 => {
+const setupNewNetworkInstance = async (MINER1, MINER2) => {
   colonyNetwork = await setupColonyNetwork();
   ({ metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
 
@@ -57,7 +57,7 @@ process.env.SOLIDITY_COVERAGE
 
       before(async () => {
         // Setup a new network instance as we'll be modifying the global skills tree
-        await setupNewNetworkInstance(MINER1);
+        await setupNewNetworkInstance(MINER1, MINER2);
       });
 
       beforeEach(async () => {

--- a/test/reputation-mining/client-calculations.js
+++ b/test/reputation-mining/client-calculations.js
@@ -2,7 +2,7 @@ import path from "path";
 import BN from "bn.js";
 import chai from "chai";
 import bnChai from "bn-chai";
-import ethers from "ethers";
+import { ethers } from "ethers";
 
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
@@ -147,15 +147,15 @@ process.env.SOLIDITY_COVERAGE
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER2)].slice(2, 66), 16)).to.eq.BN(900);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER2)].slice(2, 66), 16)).to.eq.BN(1900);
 
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
-            100
-          );
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
-            1000
-          );
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
-            2000
-          );
+          expect(
+            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ethers.constants.AddressZero)].slice(2, 66), 16)
+          ).to.eq.BN(100);
+          expect(
+            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ethers.constants.AddressZero)].slice(2, 66), 16)
+          ).to.eq.BN(1000);
+          expect(
+            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ethers.constants.AddressZero)].slice(2, 66), 16)
+          ).to.eq.BN(2000);
         });
 
         it("should correctly calculate decrements in child reputations", async () => {
@@ -212,15 +212,15 @@ process.env.SOLIDITY_COVERAGE
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER2)].slice(2, 66), 16)).to.eq.BN(800);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER2)].slice(2, 66), 16)).to.eq.BN(800);
 
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
-            180
-          );
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
-            900
-          );
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
-            900
-          );
+          expect(
+            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ethers.constants.AddressZero)].slice(2, 66), 16)
+          ).to.eq.BN(180);
+          expect(
+            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ethers.constants.AddressZero)].slice(2, 66), 16)
+          ).to.eq.BN(900);
+          expect(
+            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ethers.constants.AddressZero)].slice(2, 66), 16)
+          ).to.eq.BN(900);
         });
 
         it("should correctly calculate decrements in child reputations if the user loses all reputation", async () => {
@@ -287,15 +287,15 @@ process.env.SOLIDITY_COVERAGE
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER2)].slice(2, 66), 16)).to.eq.BN(0);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER2)].slice(2, 66), 16)).to.eq.BN(500);
 
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
-            100
-          );
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
-            100
-          );
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
-            600
-          );
+          expect(
+            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ethers.constants.AddressZero)].slice(2, 66), 16)
+          ).to.eq.BN(100);
+          expect(
+            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ethers.constants.AddressZero)].slice(2, 66), 16)
+          ).to.eq.BN(100);
+          expect(
+            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ethers.constants.AddressZero)].slice(2, 66), 16)
+          ).to.eq.BN(600);
         });
       });
     });

--- a/test/reputation-mining/client-calculations.js
+++ b/test/reputation-mining/client-calculations.js
@@ -2,10 +2,11 @@ import path from "path";
 import BN from "bn.js";
 import chai from "chai";
 import bnChai from "bn-chai";
+import ethers from "ethers";
 
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
-import { DEFAULT_STAKE, INITIAL_FUNDING, ZERO_ADDRESS } from "../../helpers/constants";
+import { DEFAULT_STAKE, INITIAL_FUNDING } from "../../helpers/constants";
 import { advanceMiningCycleNoContest, getActiveRepCycle, finishReputationMiningCycle } from "../../helpers/test-helper";
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
 
@@ -146,13 +147,13 @@ process.env.SOLIDITY_COVERAGE
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER2)].slice(2, 66), 16)).to.eq.BN(900);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER2)].slice(2, 66), 16)).to.eq.BN(1900);
 
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
             100
           );
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
             1000
           );
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
             2000
           );
         });
@@ -211,13 +212,13 @@ process.env.SOLIDITY_COVERAGE
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER2)].slice(2, 66), 16)).to.eq.BN(800);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER2)].slice(2, 66), 16)).to.eq.BN(800);
 
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
             180
           );
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
             900
           );
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
             900
           );
         });
@@ -286,13 +287,13 @@ process.env.SOLIDITY_COVERAGE
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, MINER2)].slice(2, 66), 16)).to.eq.BN(0);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, MINER2)].slice(2, 66), 16)).to.eq.BN(500);
 
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
             100
           );
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
             100
           );
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ZERO_ADDRESS)].slice(2, 66), 16)).to.eq.BN(
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ethers.constants.AddressZero)].slice(2, 66), 16)).to.eq.BN(
             600
           );
         });

--- a/test/reputation-mining/client-calculations.js
+++ b/test/reputation-mining/client-calculations.js
@@ -6,7 +6,7 @@ import bnChai from "bn-chai";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
 import { DEFAULT_STAKE, INITIAL_FUNDING, ZERO_ADDRESS } from "../../helpers/constants";
-import { advanceMiningCycleNoContest, getActiveRepCycle, finishReputationMiningCycleAndWithdrawAllMinerStakes } from "../../helpers/test-helper";
+import { advanceMiningCycleNoContest, getActiveRepCycle, finishReputationMiningCycle } from "../../helpers/test-helper";
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
 
 import {
@@ -41,6 +41,7 @@ const setupNewNetworkInstance = async MINER1 => {
   await metaColony.addGlobalSkill(4);
 
   await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
+  await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
   await colonyNetwork.initialiseReputationMining();
   await colonyNetwork.startNextCycle();
 
@@ -72,17 +73,11 @@ process.env.SOLIDITY_COVERAGE
         const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
         expect(nInactiveLogEntries).to.eq.BN(1);
 
-        // Burn MAIN_ACCOUNTS accumulated mining rewards.
-        const userBalance = await clnyToken.balanceOf(MINER1);
-        await clnyToken.burn(userBalance, { from: MINER1 });
-
-        await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
-        await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
         await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(4));
       });
 
       afterEach(async () => {
-        const reputationMiningGotClean = await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+        const reputationMiningGotClean = await finishReputationMiningCycle(colonyNetwork, this);
         if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1);
       });
 

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -426,7 +426,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await runBinarySearch(goodClient, badClient);
 
       const [round, index] = await goodClient.getMySubmissionRoundAndIndex();
-      const submission = await repCycle.getDisputeRounds(round, index);
+      const submission = await repCycle.getDisputeRoundSubmission(round, index);
       const targetNode = submission.lowerBound;
       const targetNodeKey = ReputationMinerTestWrapper.getHexString(targetNode, 64);
       const [branchMask, siblings] = await goodClient.justificationTree.getProof(targetNodeKey);

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -16,7 +16,7 @@ import {
   getActiveRepCycle,
   advanceMiningCycleNoContest,
   accommodateChallengeAndInvalidateHash,
-  finishReputationMiningCycleAndWithdrawAllMinerStakes
+  finishReputationMiningCycle
 } from "../../helpers/test-helper";
 
 import {
@@ -60,6 +60,7 @@ const setupNewNetworkInstance = async MINER1 => {
   await metaColony.addGlobalSkill(4);
 
   await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
+  await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
   await colonyNetwork.initialiseReputationMining();
   await colonyNetwork.startNextCycle();
 
@@ -90,17 +91,11 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
     const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
     expect(nInactiveLogEntries).to.eq.BN(1);
 
-    // Burn MAIN_ACCOUNTS accumulated mining rewards.
-    const userBalance = await clnyToken.balanceOf(MINER1);
-    await clnyToken.burn(userBalance, { from: MINER1 });
-
-    await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
-    await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
     await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(4));
   });
 
   afterEach(async () => {
-    const reputationMiningGotClean = await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+    const reputationMiningGotClean = await finishReputationMiningCycle(colonyNetwork, this);
     if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1);
   });
 
@@ -116,7 +111,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 1, 0xfffffffff);
       await badClient.initialise(colonyNetwork.address);
 
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const addr = await colonyNetwork.getReputationMiningCycle(true);
@@ -244,7 +238,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       // Note that our jrhNNodes can never be a power of two, because we always have an even number of updates (because every reputation change
       // has a user-specific an a colony-specific effect, and we always have one extra state in the Justification Tree because we include the last
       // accepted hash as the first node. jrhNNodes is always odd, therefore, and can never be a power of two.
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(4));
@@ -358,7 +351,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 1, 0xfffffffff);
       await badClient.initialise(colonyNetwork.address);
 
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -396,7 +388,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 1, 0xfffffffff);
       await badClient.initialise(colonyNetwork.address);
 
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -420,7 +411,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
 
   describe("when miner misbehaving during confirmBinarySearchResult stage", async () => {
     it("incorrectly confirming a binary search result should fail", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 3, 0xffffffffffff);
@@ -456,8 +446,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
 
   describe("when miner misbehaving during respondToChallenge stage", async () => {
     it("should correctly check the proof of the previously newest reputation, if necessary", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
-
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(3));
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -493,9 +481,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
     });
 
     it("should correctly check the proof of the origin skill reputation, if necessary", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
-
       await fundColonyWithTokens(
         metaColony,
         clnyToken,
@@ -555,9 +540,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
     });
 
     it("should correctly check the proof of the child skill reputation, if necessary", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
-
       await fundColonyWithTokens(
         metaColony,
         clnyToken,
@@ -628,8 +610,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
     });
 
     it("should correctly require the proof of the reputation under dispute before and after the change in question", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
-
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(3));
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
       await setupFinalizedTask({ colonyNetwork, colony: metaColony });
@@ -670,7 +650,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
     });
 
     it("should fail to respondToChallenge if any part of the key or hashedKey is wrong", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 3, 0xffffffffffff);
@@ -762,7 +741,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 1, 0xfffffffff);
       await badClient.initialise(colonyNetwork.address);
 
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -809,7 +787,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       async args => {
         it(`should fail to respondToChallenge if supplied log entry does not correspond to the entry under disagreement and supplied log entry
           is too ${args.word}`, async () => {
-          await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
           await giveUserCLNYTokensAndStake(colonyNetwork, MINER3, DEFAULT_STAKE);
 
           await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(2));
@@ -871,7 +848,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 1, 0xfffffffff);
       await badClient.initialise(colonyNetwork.address);
 
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -888,7 +864,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
     });
 
     it("should refuse to confirmNewHash while the minimum submission window has not elapsed", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -51,7 +51,7 @@ let clnyToken;
 let goodClient;
 const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
 
-const setupNewNetworkInstance = async MINER1 => {
+const setupNewNetworkInstance = async (MINER1, MINER2) => {
   colonyNetwork = await setupColonyNetwork();
   ({ metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
 
@@ -74,7 +74,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
 
   before(async () => {
     // Setup a new network instance as we'll be modifying the global skills tree
-    await setupNewNetworkInstance(MINER1);
+    await setupNewNetworkInstance(MINER1, MINER2);
   });
 
   beforeEach(async () => {

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -357,7 +357,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
 
       // Now get all the information needed to fire off a respondToChallenge call
       const [round, index] = await goodClient.getMySubmissionRoundAndIndex();
-      const submission = await repCycle.getDisputeRounds(round.toString(), index.toString());
+      const submission = await repCycle.getDisputeRoundSubmission(round.toString(), index.toString());
       const firstDisagreeIdx = new BN(submission[8].toString());
       const lastAgreeIdx = firstDisagreeIdx.subn(1);
       const reputationKey = await goodClient.getKeyForUpdateNumber(lastAgreeIdx.toString());
@@ -498,7 +498,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
 
       // Now get all the information needed to fire off a respondToChallenge call
       const [round, index] = await goodClient.getMySubmissionRoundAndIndex();
-      const submission = await repCycle.getDisputeRounds(round.toString(), index.toString());
+      const submission = await repCycle.getDisputeRoundSubmission(round.toString(), index.toString());
       const firstDisagreeIdx = new BN(submission[8].toString());
       const lastAgreeIdx = firstDisagreeIdx.subn(1);
       const reputationKey = await goodClient.getKeyForUpdateNumber(lastAgreeIdx.toString());
@@ -1470,7 +1470,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
 
     // Now get all the information needed to fire off a respondToChallenge call
     const [round, index] = await goodClient.getMySubmissionRoundAndIndex();
-    const submission = await repCycle.getDisputeRounds(round.toString(), index.toString());
+    const submission = await repCycle.getDisputeRoundSubmission(round.toString(), index.toString());
     const firstDisagreeIdx = new BN(submission[8].toString());
     const lastAgreeIdx = firstDisagreeIdx.subn(1);
     const reputationKey = await goodClient.getKeyForUpdateNumber(lastAgreeIdx.toString());

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -15,7 +15,7 @@ import {
   getActiveRepCycle,
   advanceMiningCycleNoContest,
   accommodateChallengeAndInvalidateHash,
-  finishReputationMiningCycleAndWithdrawAllMinerStakes
+  finishReputationMiningCycle
 } from "../../helpers/test-helper";
 
 import {
@@ -102,7 +102,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
   });
 
   afterEach(async () => {
-    const reputationMiningGotClean = await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+    const reputationMiningGotClean = await finishReputationMiningCycle(colonyNetwork, this);
     if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1);
   });
 

--- a/test/reputation-mining/happy-paths.js
+++ b/test/reputation-mining/happy-paths.js
@@ -2,6 +2,7 @@
 
 import path from "path";
 import BN from "bn.js";
+import ethers from "ethers";
 import chai from "chai";
 import bnChai from "bn-chai";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
@@ -30,7 +31,6 @@ import {
   DEFAULT_STAKE,
   INITIAL_FUNDING,
   MINING_CYCLE_DURATION,
-  ZERO_ADDRESS,
   REWARD,
   INT128_MAX,
   DECAY_RATE,
@@ -325,7 +325,7 @@ contract("Reputation Mining - happy paths", accounts => {
 
       let repCycle = await getActiveRepCycle(colonyNetwork);
       const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId();
-      const globalKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, ZERO_ADDRESS);
+      const globalKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, ethers.constants.AddressZero);
       const userKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, MINER1);
 
       await goodClient.insert(globalKey, INT128_MAX.subn(1), 0);
@@ -366,7 +366,7 @@ contract("Reputation Mining - happy paths", accounts => {
       await badClient.initialise(colonyNetwork.address);
 
       const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId();
-      const globalKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, ZERO_ADDRESS);
+      const globalKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, ethers.constants.AddressZero);
       const userKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, MINER1);
 
       await goodClient.insert(globalKey, INT128_MAX.subn(1), 0);
@@ -753,7 +753,7 @@ contract("Reputation Mining - happy paths", accounts => {
       await badClient.initialise(colonyNetwork.address);
 
       const rootGlobalSkill = await colonyNetwork.getRootGlobalSkillId();
-      const globalKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, ZERO_ADDRESS);
+      const globalKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, ethers.constants.AddressZero);
       const userKey = ReputationMinerTestWrapper.getKey(metaColony.address, rootGlobalSkill, MINER1);
 
       await goodClient.insert(globalKey, new BN("1"), 0);

--- a/test/reputation-mining/happy-paths.js
+++ b/test/reputation-mining/happy-paths.js
@@ -2,7 +2,7 @@
 
 import path from "path";
 import BN from "bn.js";
-import ethers from "ethers";
+import { ethers } from "ethers";
 import chai from "chai";
 import bnChai from "bn-chai";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";

--- a/test/reputation-mining/happy-paths.js
+++ b/test/reputation-mining/happy-paths.js
@@ -13,7 +13,7 @@ import {
   getActiveRepCycle,
   advanceMiningCycleNoContest,
   accommodateChallengeAndInvalidateHash,
-  finishReputationMiningCycleAndWithdrawAllMinerStakes,
+  finishReputationMiningCycle,
   makeReputationKey,
   makeReputationValue
 } from "../../helpers/test-helper";
@@ -117,7 +117,7 @@ contract("Reputation Mining - happy paths", accounts => {
   });
 
   afterEach(async () => {
-    const reputationMiningGotClean = await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+    const reputationMiningGotClean = await finishReputationMiningCycle(colonyNetwork, this);
     if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1);
   });
 

--- a/test/reputation-mining/root-hash-submissions.js
+++ b/test/reputation-mining/root-hash-submissions.js
@@ -1,6 +1,6 @@
 /* globals artifacts */
 import BN from "bn.js";
-import ethers from "ethers";
+import { ethers } from "ethers";
 import path from "path";
 import chai from "chai";
 import bnChai from "bn-chai";

--- a/test/reputation-mining/root-hash-submissions.js
+++ b/test/reputation-mining/root-hash-submissions.js
@@ -1,4 +1,5 @@
 /* globals artifacts */
+import { ethers } from "ethers";
 import BN from "bn.js";
 import path from "path";
 import chai from "chai";
@@ -319,7 +320,7 @@ contract("Reputation mining - root hash submissions", accounts => {
       expect(newRepCycle.address).to.not.equal(repCycle.address);
 
       const rootHash = await colonyNetwork.getReputationRootHash();
-      expect(rootHash).to.equal("0x0000000000000000000000000000000000000000000000000000000000000000");
+      expect(rootHash).to.equal(ethers.constants.HashZero);
 
       const rootHashNNodes = await colonyNetwork.getReputationRootHashNNodes();
       expect(rootHashNNodes).to.be.zero;

--- a/test/reputation-mining/root-hash-submissions.js
+++ b/test/reputation-mining/root-hash-submissions.js
@@ -1,6 +1,6 @@
 /* globals artifacts */
-import { ethers } from "ethers";
 import BN from "bn.js";
+import ethers from "ethers";
 import path from "path";
 import chai from "chai";
 import bnChai from "bn-chai";
@@ -8,7 +8,7 @@ import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, giveUserCLNYTokensAndStake } from "../../helpers/test-data-generator";
 
-import { ZERO_ADDRESS, MINING_CYCLE_DURATION, DEFAULT_STAKE, REWARD, UINT256_MAX, MIN_STAKE } from "../../helpers/constants";
+import { MINING_CYCLE_DURATION, DEFAULT_STAKE, REWARD, UINT256_MAX, MIN_STAKE } from "../../helpers/constants";
 
 import {
   forwardTime,
@@ -315,8 +315,8 @@ contract("Reputation mining - root hash submissions", accounts => {
       await advanceMiningCycleNoContest({ colonyNetwork, test: this }); // Defaults to (0x00, 0)
 
       const newRepCycle = await getActiveRepCycle(colonyNetwork);
-      expect(newRepCycle.address).to.not.equal(ZERO_ADDRESS);
-      expect(repCycle.address).to.not.equal(ZERO_ADDRESS);
+      expect(newRepCycle.address).to.not.equal(ethers.constants.AddressZero);
+      expect(repCycle.address).to.not.equal(ethers.constants.AddressZero);
       expect(newRepCycle.address).to.not.equal(repCycle.address);
 
       const rootHash = await colonyNetwork.getReputationRootHash();
@@ -339,8 +339,8 @@ contract("Reputation mining - root hash submissions", accounts => {
 
       await repCycle.confirmNewHash(1);
       const newRepCycle = await getActiveRepCycle(colonyNetwork);
-      expect(newRepCycle.address).to.not.equal(ZERO_ADDRESS);
-      expect(repCycle.address).to.not.equal(ZERO_ADDRESS);
+      expect(newRepCycle.address).to.not.equal(ethers.constants.AddressZero);
+      expect(repCycle.address).to.not.equal(ethers.constants.AddressZero);
       expect(newRepCycle.address).to.not.equal(repCycle.address);
 
       const rootHash = await colonyNetwork.getReputationRootHash();
@@ -366,8 +366,8 @@ contract("Reputation mining - root hash submissions", accounts => {
       await repCycle.confirmNewHash(2);
 
       const newRepCycle = await getActiveRepCycle(colonyNetwork);
-      expect(newRepCycle.address).to.not.equal(ZERO_ADDRESS);
-      expect(repCycle.address).to.not.equal(ZERO_ADDRESS);
+      expect(newRepCycle.address).to.not.equal(ethers.constants.AddressZero);
+      expect(repCycle.address).to.not.equal(ethers.constants.AddressZero);
       expect(newRepCycle.address).to.not.equal(repCycle.address);
 
       const rootHash = await colonyNetwork.getReputationRootHash();
@@ -386,8 +386,8 @@ contract("Reputation mining - root hash submissions", accounts => {
 
       await checkErrorRevert(repCycle.confirmNewHash(0), "colony-reputation-mining-final-round-not-complete");
       const newAddr = await colonyNetwork.getReputationMiningCycle(true);
-      expect(newAddr).to.not.equal(ZERO_ADDRESS);
-      expect(repCycle.address).to.not.equal(ZERO_ADDRESS);
+      expect(newAddr).to.not.equal(ethers.constants.AddressZero);
+      expect(repCycle.address).to.not.equal(ethers.constants.AddressZero);
       expect(newAddr).to.equal(repCycle.address);
 
       // Eliminate one so that the afterAll works.

--- a/test/reputation-mining/root-hash-submissions.js
+++ b/test/reputation-mining/root-hash-submissions.js
@@ -1,5 +1,5 @@
 /* globals artifacts */
-
+import BN from "bn.js";
 import path from "path";
 import chai from "chai";
 import bnChai from "bn-chai";
@@ -17,7 +17,7 @@ import {
   submitAndForwardTimeToDispute,
   accommodateChallengeAndInvalidateHash,
   getValidEntryNumber,
-  finishReputationMiningCycleAndWithdrawAllMinerStakes
+  finishReputationMiningCycle
 } from "../../helpers/test-helper";
 
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
@@ -51,6 +51,8 @@ const setupNewNetworkInstance = async (MINER1, MINER2, MINER3) => {
   ({ metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
 
   await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
+  await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
+  await giveUserCLNYTokensAndStake(colonyNetwork, MINER3, DEFAULT_STAKE);
   await colonyNetwork.initialiseReputationMining();
   await colonyNetwork.startNextCycle();
 
@@ -65,6 +67,7 @@ contract("Reputation mining - root hash submissions", accounts => {
   const MINER1 = accounts[5];
   const MINER2 = accounts[6];
   const MINER3 = accounts[7];
+  const MINER4 = accounts[8];
 
   before(async () => {
     // Setup a new network instance as we'll be modifying the global skills tree
@@ -80,9 +83,6 @@ contract("Reputation mining - root hash submissions", accounts => {
     await badClient.initialise(colonyNetwork.address);
     await badClient2.initialise(colonyNetwork.address);
 
-    const lock = await tokenLocking.getUserLock(clnyToken.address, MINER1);
-    expect(lock.balance).to.eq.BN(DEFAULT_STAKE);
-
     // Advance two cycles to clear active and inactive state.
     await advanceMiningCycleNoContest({ colonyNetwork, test: this });
     await advanceMiningCycleNoContest({ colonyNetwork, test: this });
@@ -92,14 +92,10 @@ contract("Reputation mining - root hash submissions", accounts => {
     const repCycle = await getActiveRepCycle(colonyNetwork);
     const nInactiveLogEntries = await repCycle.getReputationUpdateLogLength();
     expect(nInactiveLogEntries).to.eq.BN(1);
-
-    // Burn MAIN_ACCOUNTS accumulated mining rewards.
-    const userBalance = await clnyToken.balanceOf(MINER1);
-    await clnyToken.burn(userBalance, { from: MINER1 });
   });
 
   afterEach(async () => {
-    const reputationMiningGotClean = await finishReputationMiningCycleAndWithdrawAllMinerStakes(colonyNetwork, this);
+    const reputationMiningGotClean = await finishReputationMiningCycle(colonyNetwork, this);
     if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1, MINER2, MINER3);
   });
 
@@ -292,16 +288,16 @@ contract("Reputation mining - root hash submissions", accounts => {
 
     it("should not allow someone to submit a new reputation hash if they stake after the cycle begins", async () => {
       await forwardTime(1, this); // The condition is `windowOpen >= stakeTimestamp` so we make sure they aren't equal.
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER4, DEFAULT_STAKE); // Just stake an extra token to reset the time to now
       await forwardTime(MINING_CYCLE_DURATION, this);
 
       let repCycle = await getActiveRepCycle(colonyNetwork);
-      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MINER2 }), "colony-reputation-mining-stake-too-recent");
+      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MINER4 }), "colony-reputation-mining-stake-too-recent");
 
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
       await forwardTime(MINING_CYCLE_DURATION, this);
       repCycle = await getActiveRepCycle(colonyNetwork);
-      await repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MINER2 });
+      await repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MINER4 });
     });
 
     it("should not allow someone to withdraw their stake if they have submitted a hash this round", async () => {
@@ -332,7 +328,6 @@ contract("Reputation mining - root hash submissions", accounts => {
 
   describe("when eliminating submissions", () => {
     it("should allow a new reputation hash to be set if all but one submitted have been eliminated", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -356,8 +351,6 @@ contract("Reputation mining - root hash submissions", accounts => {
     });
 
     it("should allow a new reputation hash to be moved to the next stage of competition even if it does not have a partner", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER3, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -385,7 +378,6 @@ contract("Reputation mining - root hash submissions", accounts => {
     });
 
     it("should not allow a new reputation hash to be set if more than one was submitted and they have not been elimintated", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -404,7 +396,6 @@ contract("Reputation mining - root hash submissions", accounts => {
     });
 
     it("should not allow the last reputation hash to be eliminated", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -420,8 +411,6 @@ contract("Reputation mining - root hash submissions", accounts => {
     });
 
     it("should fail if one tries to invalidate a hash that does not exist", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER3, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -441,7 +430,6 @@ contract("Reputation mining - root hash submissions", accounts => {
     });
 
     it("should fail if one tries to invalidate a hash that has completed more challenge rounds than its opponent", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -458,7 +446,6 @@ contract("Reputation mining - root hash submissions", accounts => {
     });
 
     it("should not allow a hash to be invalidated multiple times, which would move extra copies of its opponent to the next stage", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -471,7 +458,6 @@ contract("Reputation mining - root hash submissions", accounts => {
     });
 
     it("should not allow a hash to be invalidated and then moved on to the next stage by invalidating its now non-existent opponent", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -484,8 +470,6 @@ contract("Reputation mining - root hash submissions", accounts => {
     });
 
     it("should invalidate a hash and its partner if both have timed out", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER3, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -497,7 +481,6 @@ contract("Reputation mining - root hash submissions", accounts => {
     });
 
     it("should prevent invalidation of hashes before they have timed out on a challenge", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
@@ -509,30 +492,24 @@ contract("Reputation mining - root hash submissions", accounts => {
       await badClient.submitRootHash();
 
       await checkErrorRevert(repCycle.invalidateHash(0, 1), "colony-reputation-mining-not-timed-out");
-
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
       await checkErrorRevert(repCycle.confirmNewHash(1), "colony-reputation-mining-final-round-not-complete");
+
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-increased-reputation-value-incorrect" }
       });
+
       await repCycle.confirmNewHash(1);
     });
   });
 
   describe("when rewarding and punishing good and bad submissions", () => {
     it("should punish all stakers if they misbehave (and report a bad hash)", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER3, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
-      let userLock0 = await tokenLocking.getUserLock(clnyToken.address, MINER1);
-      expect(userLock0.balance).to.eq.BN(DEFAULT_STAKE);
-
-      let userLock1 = await tokenLocking.getUserLock(clnyToken.address, MINER2);
-      expect(userLock1.balance).to.eq.BN(DEFAULT_STAKE);
-
-      let userLock2 = await tokenLocking.getUserLock(clnyToken.address, MINER3);
-      expect(userLock2.balance).to.eq.BN(DEFAULT_STAKE);
+      const userLockMiner1Before = await tokenLocking.getUserLock(clnyToken.address, MINER1);
+      const userLockMiner2Before = await tokenLocking.getUserLock(clnyToken.address, MINER2);
+      const userLockMiner3Before = await tokenLocking.getUserLock(clnyToken.address, MINER3);
 
       // We want badClient2 to submit the same hash as badClient for this test.
       badClient2 = new MaliciousReputationMinerExtraRep({ loader, minerAddress: MINER3, realProviderPort, useJsTree }, 1, "0xfffffffff");
@@ -552,18 +529,17 @@ contract("Reputation mining - root hash submissions", accounts => {
         client2: { respondToChallenge: "colony-reputation-mining-increased-reputation-value-incorrect" }
       });
 
-      userLock0 = await tokenLocking.getUserLock(clnyToken.address, MINER1);
-      expect(userLock0.balance, "Account was not rewarded properly").to.eq.BN(DEFAULT_STAKE.add(MIN_STAKE.muln(2)));
+      const userLockMiner1 = await tokenLocking.getUserLock(clnyToken.address, MINER1);
+      expect(userLockMiner1.balance, "Account was not rewarded properly").to.eq.BN(new BN(userLockMiner1Before.balance).add(MIN_STAKE.muln(2)));
 
-      userLock1 = await tokenLocking.getUserLock(clnyToken.address, MINER2);
-      expect(userLock1.balance, "Account was not punished properly").to.eq.BN(DEFAULT_STAKE.sub(MIN_STAKE));
+      const userLockMiner2 = await tokenLocking.getUserLock(clnyToken.address, MINER2);
+      expect(userLockMiner2.balance, "Account was not punished properly").to.eq.BN(new BN(userLockMiner2Before.balance).sub(MIN_STAKE));
 
-      userLock2 = await tokenLocking.getUserLock(clnyToken.address, MINER3);
-      expect(userLock2.balance, "Account was not punished properly").to.eq.BN(DEFAULT_STAKE.sub(MIN_STAKE));
+      const userLockMiner3 = await tokenLocking.getUserLock(clnyToken.address, MINER3);
+      expect(userLockMiner3.balance, "Account was not punished properly").to.eq.BN(new BN(userLockMiner3Before.balance).sub(MIN_STAKE));
     });
 
     it("should reward all stakers if they submitted the agreed new hash", async () => {
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
       await clnyToken.burn(REWARD, { from: MINER1 });
 

--- a/test/reputation-mining/types-of-disagreement.js
+++ b/test/reputation-mining/types-of-disagreement.js
@@ -54,7 +54,7 @@ let clnyToken;
 let goodClient;
 const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
 
-const setupNewNetworkInstance = async MINER1 => {
+const setupNewNetworkInstance = async (MINER1, MINER2) => {
   colonyNetwork = await setupColonyNetwork();
   ({ metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
 
@@ -71,7 +71,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
   before(async () => {
     // Setup a new network instance as we'll be modifying the global skills tree
-    await setupNewNetworkInstance(MINER1);
+    await setupNewNetworkInstance(MINER1, MINER2);
   });
 
   beforeEach(async () => {

--- a/test/reputation-mining/types-of-disagreement.js
+++ b/test/reputation-mining/types-of-disagreement.js
@@ -130,7 +130,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const nSubmittedHashes = await repCycle.getNSubmittedHashes();
       expect(nSubmittedHashes).to.eq.BN(2);
 
-      const submission = await repCycle.getDisputeRounds(0, 0);
+      const submission = await repCycle.getDisputeRoundSubmission(0, 0);
 
       expect(submission.jrhNNodes).to.be.zero;
       await forwardTime(10, this); // This is just to ensure that the timestamps checked below will be different if JRH was submitted.
@@ -140,7 +140,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
       // Check that we can't re-submit a JRH
       await checkErrorRevertEthers(goodClient.confirmJustificationRootHash(), "colony-reputation-jrh-hash-already-verified");
 
-      const submissionAfterJRHConfirmed = await repCycle.getDisputeRounds(0, 0);
+      const submissionAfterJRHConfirmed = await repCycle.getDisputeRoundSubmission(0, 0);
       const jrh = await goodClient.justificationTree.getRootHash();
       expect(submissionAfterJRHConfirmed.jrh).to.eq.BN(jrh);
 
@@ -197,17 +197,17 @@ contract("Reputation Mining - types of disagreement", accounts => {
       expect(nSubmittedHashes).to.eq.BN(2);
 
       await goodClient.confirmJustificationRootHash();
-      const submissionAfterJRHConfirmed = await repCycle.getDisputeRounds(0, 0);
+      const submissionAfterJRHConfirmed = await repCycle.getDisputeRoundSubmission(0, 0);
       const jrh = await goodClient.justificationTree.getRootHash();
       expect(submissionAfterJRHConfirmed.jrh).to.eq.BN(jrh);
 
       await badClient.confirmJustificationRootHash();
-      const badSubmissionAfterJRHConfirmed = await repCycle.getDisputeRounds(0, 1);
+      const badSubmissionAfterJRHConfirmed = await repCycle.getDisputeRoundSubmission(0, 1);
       const badJrh = await badClient.justificationTree.getRootHash();
       expect(badSubmissionAfterJRHConfirmed.jrh).to.eq.BN(badJrh);
 
-      let goodSubmission = await repCycle.getDisputeRounds(0, 0);
-      let badSubmission = await repCycle.getDisputeRounds(0, 1);
+      let goodSubmission = await repCycle.getDisputeRoundSubmission(0, 0);
+      let badSubmission = await repCycle.getDisputeRoundSubmission(0, 1);
       expect(goodSubmission.challengeStepCompleted).to.eq.BN(1); // Challenge steps completed
       expect(goodSubmission.lowerBound).to.be.zero; // Lower bound for binary search
       expect(goodSubmission.upperBound).to.eq.BN(28); // Upper bound for binary search
@@ -216,8 +216,8 @@ contract("Reputation Mining - types of disagreement", accounts => {
       expect(badSubmission.upperBound).to.eq.BN(28);
 
       await goodClient.respondToBinarySearchForChallenge();
-      goodSubmission = await repCycle.getDisputeRounds(0, 0);
-      badSubmission = await repCycle.getDisputeRounds(0, 1);
+      goodSubmission = await repCycle.getDisputeRoundSubmission(0, 0);
+      badSubmission = await repCycle.getDisputeRoundSubmission(0, 1);
       expect(goodSubmission.challengeStepCompleted).to.eq.BN(2);
       expect(goodSubmission.lowerBound).to.be.zero;
       expect(goodSubmission.upperBound).to.eq.BN(28);
@@ -226,8 +226,8 @@ contract("Reputation Mining - types of disagreement", accounts => {
       expect(badSubmission.upperBound).to.eq.BN(28);
 
       await badClient.respondToBinarySearchForChallenge();
-      goodSubmission = await repCycle.getDisputeRounds(0, 0);
-      badSubmission = await repCycle.getDisputeRounds(0, 1);
+      goodSubmission = await repCycle.getDisputeRoundSubmission(0, 0);
+      badSubmission = await repCycle.getDisputeRoundSubmission(0, 1);
       expect(goodSubmission.lowerBound).to.be.zero;
       expect(goodSubmission.upperBound).to.eq.BN(15);
       expect(badSubmission.lowerBound).to.be.zero;
@@ -235,8 +235,8 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
-      goodSubmission = await repCycle.getDisputeRounds(0, 0);
-      badSubmission = await repCycle.getDisputeRounds(0, 1);
+      goodSubmission = await repCycle.getDisputeRoundSubmission(0, 0);
+      badSubmission = await repCycle.getDisputeRoundSubmission(0, 1);
       expect(goodSubmission.lowerBound).to.eq.BN(8);
       expect(goodSubmission.upperBound).to.eq.BN(15);
       expect(badSubmission.lowerBound).to.eq.BN(8);
@@ -244,8 +244,8 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
-      goodSubmission = await repCycle.getDisputeRounds(0, 0);
-      badSubmission = await repCycle.getDisputeRounds(0, 1);
+      goodSubmission = await repCycle.getDisputeRoundSubmission(0, 0);
+      badSubmission = await repCycle.getDisputeRoundSubmission(0, 1);
 
       expect(goodSubmission.lowerBound).to.eq.BN(12);
       expect(goodSubmission.upperBound).to.eq.BN(15);
@@ -254,8 +254,8 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
-      goodSubmission = await repCycle.getDisputeRounds(0, 0);
-      badSubmission = await repCycle.getDisputeRounds(0, 1);
+      goodSubmission = await repCycle.getDisputeRoundSubmission(0, 0);
+      badSubmission = await repCycle.getDisputeRoundSubmission(0, 1);
       expect(goodSubmission.lowerBound).to.eq.BN(12);
       expect(goodSubmission.upperBound).to.eq.BN(13);
       expect(badSubmission.lowerBound).to.eq.BN(12);
@@ -263,8 +263,8 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
-      goodSubmission = await repCycle.getDisputeRounds(0, 0);
-      badSubmission = await repCycle.getDisputeRounds(0, 1);
+      goodSubmission = await repCycle.getDisputeRoundSubmission(0, 0);
+      badSubmission = await repCycle.getDisputeRoundSubmission(0, 1);
       expect(goodSubmission.lowerBound).to.eq.BN(13);
       expect(goodSubmission.upperBound).to.eq.BN(13);
       expect(badSubmission.lowerBound).to.eq.BN(13);
@@ -278,8 +278,8 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await checkErrorRevertEthers(badClient.respondToChallenge(), "colony-reputation-mining-increased-reputation-value-incorrect");
 
       // Check
-      const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 0);
-      const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 1);
+      const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 0);
+      const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 1);
       const delta = goodSubmissionAfterResponseToChallenge.challengeStepCompleted - badSubmissionAfterResponseToChallenge.challengeStepCompleted;
       expect(delta).to.eq.BN(1);
       // checks that challengeStepCompleted is one more for the good submission than the bad one.
@@ -522,8 +522,8 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await checkErrorRevertEthers(badClient.respondToChallenge(), "colony-reputation-mining-uid-changed-for-existing-reputation");
 
       // Check
-      const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 0);
-      const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 1);
+      const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 0);
+      const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 1);
       const delta = goodSubmissionAfterResponseToChallenge.challengeStepCompleted - badSubmissionAfterResponseToChallenge.challengeStepCompleted;
       expect(delta).to.eq.BN(1);
 
@@ -575,8 +575,8 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await badClient.respondToChallenge();
 
       // Check
-      const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 0);
-      const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 1);
+      const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 0);
+      const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 1);
       const delta = goodSubmissionAfterResponseToChallenge.challengeStepCompleted - badSubmissionAfterResponseToChallenge.challengeStepCompleted;
       expect(delta).to.be.zero;
       // Both sides have completed the same amount of challenges, but one has proved that a large number already exists
@@ -679,8 +679,8 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await checkErrorRevertEthers(badClient.respondToChallenge(), "colony-reputation-mining-proved-uid-inconsistent");
 
       // Check badClient respondToChallenge failed
-      const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 0);
-      const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRounds(0, 1);
+      const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 0);
+      const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 1);
       const delta = goodSubmissionAfterResponseToChallenge.challengeStepCompleted - badSubmissionAfterResponseToChallenge.challengeStepCompleted;
       expect(delta).to.eq.BN(2);
 

--- a/test/router-resolver.js
+++ b/test/router-resolver.js
@@ -1,9 +1,9 @@
 /* globals artifacts */
 import chai from "chai";
 import bnChai from "bn-chai";
+import { ethers } from "ethers";
 
 import { checkErrorRevert } from "../helpers/test-helper";
-import { ZERO_ADDRESS } from "../helpers/constants";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
@@ -76,7 +76,7 @@ contract("EtherRouter / Resolver", accounts => {
 
     it("when checking destination for a function that doesn't exist, should return 0", async () => {
       const destination = await resolver.lookup("0xdeadbeef");
-      expect(destination).to.equal(ZERO_ADDRESS);
+      expect(destination).to.equal(ethers.constants.AddressZero);
     });
 
     it("should return correctly encoded function signature", async () => {

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -3,6 +3,7 @@ import path from "path";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 import chai from "chai";
 import bnChai from "bn-chai";
+import { ethers } from "ethers";
 
 import { getTokenArgs, checkErrorRevert, forwardTime, makeReputationKey, getBlockTime, advanceMiningCycleNoContest } from "../helpers/test-helper";
 import { giveUserCLNYTokensAndStake, setupRandomColony } from "../helpers/test-data-generator";

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -6,7 +6,7 @@ import bnChai from "bn-chai";
 
 import { getTokenArgs, checkErrorRevert, forwardTime, makeReputationKey, getBlockTime, advanceMiningCycleNoContest } from "../helpers/test-helper";
 import { giveUserCLNYTokensAndStake, setupRandomColony } from "../helpers/test-data-generator";
-import { UINT256_MAX, MIN_STAKE, DEFAULT_STAKE, ZERO_ADDRESS } from "../helpers/constants";
+import { UINT256_MAX, MIN_STAKE, DEFAULT_STAKE } from "../helpers/constants";
 
 import ReputationMinerTestWrapper from "../packages/reputation-miner/test/ReputationMinerTestWrapper";
 
@@ -75,9 +75,9 @@ contract("Token Locking", addresses => {
 
   describe("when locking tokens", async () => {
     it("should correctly set colony network address", async () => {
-      await tokenLocking.setColonyNetwork(ZERO_ADDRESS);
+      await tokenLocking.setColonyNetwork(ethers.constants.AddressZero);
       let colonyNetworkAddress = await tokenLocking.getColonyNetwork();
-      expect(colonyNetworkAddress).to.equal(ZERO_ADDRESS);
+      expect(colonyNetworkAddress).to.equal(ethers.constants.AddressZero);
 
       await tokenLocking.setColonyNetwork(colonyNetwork.address);
       colonyNetworkAddress = await tokenLocking.getColonyNetwork();
@@ -273,7 +273,7 @@ contract("Token Locking", addresses => {
 
     it('should not allow "punishStakers" to be called from an account that is not not reputationMiningCycle', async () => {
       await checkErrorRevert(
-        tokenLocking.punishStakers([addresses[0], addresses[1]], ZERO_ADDRESS, MIN_STAKE),
+        tokenLocking.punishStakers([addresses[0], addresses[1]], ethers.constants.AddressZero, MIN_STAKE),
         "colony-token-locking-sender-not-reputation-mining-cycle"
       );
     });


### PR DESCRIPTION
This is my own personal running tap of bits that bother me all bundled up nicely here as none are big enough to attribute own issue and PR.

- Remove the funding and withdrawing of CLNY to the miner accounts. There's really no need for to-ing-and fro-ing with the CLNY deposit that enable a miner to propose a hash. I've left the helper function (`withdrawAllMinerStakes`) in there just in case we ever need it again.

- Use [ethers constants](https://docs.ethers.io/ethers.js/html/api-utils.html#constants) `HashZero` and `AddressZero`

- Naming is important!
`getReputationHashSubmissions` -> `getReputationHashSubmission`
`getSubmittedHashes` -> `getSubmissionUser`
`getDisputeRounds` -> `getDisputeRoundSubmission`
`getTaskWorkRatings` -> `getTaskWorkRatingSecretsInfo`