### PR TITLE
Split dispute resolution properties away from the Submission struct

### DIFF
--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -26,8 +26,8 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @notice The getter for the disputeRounds mapping of array of dispute rounds.
   /// @param _round The dispute round to query
   /// @param _index The index in the dispute round to query
-  /// @return The elements of the Submission struct for the submission requested. See ReputationMiningCycleDataTypes for the full description
-  function getDisputeRoundSubmission(uint256 _round, uint256 _index) public view returns (Submission memory submission);
+  /// @return The elements of the DisputedEntry struct for the submission requested. See ReputationMiningCycleDataTypes for the full description
+  function getDisputeRoundSubmission(uint256 _round, uint256 _index) public view returns (DisputedEntry memory submission);
 
   /// @notice The getter for the hashSubmissions mapping, which keeps track of submissions by user.
   /// @param _user Address of the user
@@ -233,5 +233,5 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @param nNodes The number of nodes that was submitted
   /// @param jrh The JRH of that was submitted
   /// @param index The index of the submission - should be 0-11, as up to twelve submissions can be made.
-  function getSubmittedHashes(bytes32 hash, uint256 nNodes, bytes32 jrh, uint256 index) public view returns (address user);
+  function getSubmissionUser(bytes32 hash, uint256 nNodes, bytes32 jrh, uint256 index) public view returns (address user);
 }

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -591,7 +591,6 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     // of updates that log entry implies by itself, plus the number of decays (the number of nodes in current state)
 
     Submission storage submission = reputationHashSubmissions[disputeRounds[round][index].firstSubmitter];
-    bytes32 jrh = submission.jrh;
     uint256 nUpdates = reputationUpdateLog[nLogEntries-1].nUpdates +
       reputationUpdateLog[nLogEntries-1].nPreviousUpdates + reputationRootHashNNodes;
     submission.jrhNNodes = nUpdates + 1;
@@ -603,7 +602,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
       mstore(add(jhLeafValue, 0x40), submittedHashNNodes)
     }
     bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(nUpdates), jhLeafValue, branchMask2, siblings2);
-    require(jrh==impliedRoot, "colony-reputation-mining-invalid-jrh-proof-2");
+    require(submission.jrh == impliedRoot, "colony-reputation-mining-invalid-jrh-proof-2");
   }
 
   function startMemberOfPair(uint256 roundNumber, uint256 index) internal {

--- a/contracts/ReputationMiningCycleDataTypes.sol
+++ b/contracts/ReputationMiningCycleDataTypes.sol
@@ -32,17 +32,21 @@ contract ReputationMiningCycleDataTypes {
   struct Submission {
     bytes32 proposedNewRootHash;          // The hash that the submitter is proposing as the next reputation hash
     uint256 nNodes;                       // The number of nodes in the reputation tree being proposed as the next reputation hash
+    bytes32 jrh;                          // The Justification Root Hash corresponding to this submission.
+    uint256 jrhNNodes;                    // The number of nodes in the tree the JRH is the root of.
+  }
+
+  struct DisputedEntry {
+    address miner;
     uint256 lastResponseTimestamp;        // If nonzero, the last time that a valid response was received corresponding to this
                                           // submission during the challenge process - either binary searching for the challenge,
                                           // responding to the challenge itself or submitting the JRH
     uint256 challengeStepCompleted;       // How many valid responses have been received corresponding to this submission during
                                           // the challenge process.
-    bytes32 jrh;                          // The Justification Root Hash corresponding to this submission.
     bytes32 intermediateReputationHash;   // The hash this submission hash has as a leaf node in the tree the JRH is the root of where
                                           // this submission and its opponent differ for the first time.
     uint256 intermediateReputationNNodes; // The number of nodes in the reputation tree in the reputation state where this submission and
                                           // its opponent first differ.
-    uint256 jrhNNodes;                    // The number of nodes in the tree the JRH is the root of.
     uint256 lowerBound;                   // During the binary search, the lowest index in the justification tree that might still be the
                                           // first place where the two submissions differ.
     uint256 upperBound;                   // During the binary search, the highest index in the justification tree that might still be the

--- a/contracts/ReputationMiningCycleDataTypes.sol
+++ b/contracts/ReputationMiningCycleDataTypes.sol
@@ -37,7 +37,7 @@ contract ReputationMiningCycleDataTypes {
   }
 
   struct DisputedEntry {
-    address miner;
+    address firstSubmitter;               // Address of the first miner who proposed the referenced Submission
     uint256 lastResponseTimestamp;        // If nonzero, the last time that a valid response was received corresponding to this
                                           // submission during the challenge process - either binary searching for the challenge,
                                           // responding to the challenge itself or submitting the JRH

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -183,6 +183,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     bytes32[] memory disagreeStateSiblings
     ) internal view
   {
+    DisputedEntry storage disputedEntry = disputeRounds[u[U_ROUND]][u[U_IDX]];
     // Check this proof is valid for the agree state
     // We binary searched to the first disagreement, so the last agreement is the one before
     bytes memory adjacentReputationValue = abi.encodePacked(u[U_ADJACENT_REPUTATION_VALUE], u[U_ADJACENT_REPUTATION_UID]);
@@ -196,13 +197,13 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     bytes memory jhLeafValue = abi.encodePacked(uint256(reputationRootHash), u[U_AGREE_STATE_NNODES]);
     // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
     bytes32 impliedRoot = getImpliedRootNoHashKey(
-      bytes32(disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1),
+      bytes32(disputedEntry.lowerBound - 1),
       jhLeafValue,
       u[U_AGREE_STATE_BRANCH_MASK],
       agreeStateSiblings);
 
     require(
-      impliedRoot == reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].firstSubmitter].jrh,
+      impliedRoot == reputationHashSubmissions[disputedEntry.firstSubmitter].jrh,
       "colony-reputation-mining-adjacent-agree-state-disagreement");
 
     // The bit added to the branchmask is based on where the (hashes of the) two keys first differ.
@@ -227,13 +228,13 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     jhLeafValue = abi.encodePacked(uint256(reputationRootHash), u[U_DISAGREE_STATE_NNODES]);
     // Prove that state is in our JRH, in the index corresponding to the first state that the two submissions disagree on
     impliedRoot = getImpliedRootNoHashKey(
-      bytes32(disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound),
+      bytes32(disputedEntry.lowerBound),
       jhLeafValue,
       u[U_DISAGREE_STATE_BRANCH_MASK],
       disagreeStateSiblings);
 
     require(
-      impliedRoot == reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].firstSubmitter].jrh,
+      impliedRoot == reputationHashSubmissions[disputedEntry.firstSubmitter].jrh,
       "colony-reputation-mining-adjacent-disagree-state-disagreement");
   }
 

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -39,13 +39,14 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     // Check the binary search has finished, but not necessarily confirmed
     require(disputeRounds[round][idx].lowerBound == disputeRounds[round][idx].upperBound, "colony-reputation-binary-search-incomplete");
     // Check the binary search result has been confirmed
+    Submission storage submission = reputationHashSubmissions[disputeRounds[round][idx].miner];
     require(
-      2**(disputeRounds[round][idx].challengeStepCompleted-2)>disputeRounds[round][idx].jrhNNodes,
+      2**(disputeRounds[round][idx].challengeStepCompleted-2)>submission.jrhNNodes,
       "colony-reputation-mining-binary-search-result-not-confirmed"
     );
     // Check that we have not already responded to the challenge
     require(
-      2**(disputeRounds[round][idx].challengeStepCompleted-3)<=disputeRounds[round][idx].jrhNNodes,
+      2**(disputeRounds[round][idx].challengeStepCompleted-3)<=submission.jrhNNodes,
       "colony-reputation-mining-challenge-already-responded"
     );
     _;
@@ -184,8 +185,6 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   {
     // Check this proof is valid for the agree state
     // We binary searched to the first disagreement, so the last agreement is the one before
-    uint256 lastAgreeIdx = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1;
-
     bytes memory adjacentReputationValue = abi.encodePacked(u[U_ADJACENT_REPUTATION_VALUE], u[U_ADJACENT_REPUTATION_UID]);
 
     bytes32 reputationRootHash = getImpliedRootNoHashKey(
@@ -196,8 +195,15 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     );
     bytes memory jhLeafValue = abi.encodePacked(uint256(reputationRootHash), u[U_AGREE_STATE_NNODES]);
     // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
-    bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
-    require(impliedRoot == disputeRounds[u[U_ROUND]][u[U_IDX]].jrh, "colony-reputation-mining-adjacent-agree-state-disagreement");
+    bytes32 impliedRoot = getImpliedRootNoHashKey(
+      bytes32(disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1),
+      jhLeafValue,
+      u[U_AGREE_STATE_BRANCH_MASK],
+      agreeStateSiblings);
+
+    require(
+      impliedRoot == reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].miner].jrh,
+      "colony-reputation-mining-adjacent-agree-state-disagreement");
 
     // The bit added to the branchmask is based on where the (hashes of the) two keys first differ.
     uint256 firstDifferenceBit = uint256(
@@ -220,8 +226,15 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
     jhLeafValue = abi.encodePacked(uint256(reputationRootHash), u[U_DISAGREE_STATE_NNODES]);
     // Prove that state is in our JRH, in the index corresponding to the first state that the two submissions disagree on
-    impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx+1), jhLeafValue, u[U_DISAGREE_STATE_BRANCH_MASK], disagreeStateSiblings);
-    require(impliedRoot == disputeRounds[u[U_ROUND]][u[U_IDX]].jrh, "colony-reputation-mining-adjacent-disagree-state-disagreement");
+    impliedRoot = getImpliedRootNoHashKey(
+      bytes32(disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound),
+      jhLeafValue,
+      u[U_DISAGREE_STATE_BRANCH_MASK],
+      disagreeStateSiblings);
+
+    require(
+      impliedRoot == reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].miner].jrh,
+      "colony-reputation-mining-adjacent-disagree-state-disagreement");
   }
 
   function buildNewSiblingsArray(
@@ -408,8 +421,6 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       return;
     }
     // Otherwise, it's an existing hash and we've just changed its value.
-
-    bytes32 jrh = disputeRounds[u[U_ROUND]][u[U_IDX]].jrh;
     // We binary searched to the first disagreement, so the last agreement is the one before.
     uint256 lastAgreeIdx = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1;
 
@@ -426,7 +437,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on.
     bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
 
-    require(impliedRoot == jrh, "colony-reputation-mining-invalid-before-reputation-proof");
+    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].miner];
+    require(impliedRoot == submission.jrh, "colony-reputation-mining-invalid-before-reputation-proof");
     // Check that they have not changed nNodes from the agree state
     // There is a check at the very start of RespondToChallenge that this difference is either 0 or 1.
     // There is an 'if' statement above that returns if this difference is 1.
@@ -444,7 +456,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     bytes32[] memory disagreeStateSiblings
   ) internal view
   {
-    bytes32 jrh = disputeRounds[u[U_ROUND]][u[U_IDX]].jrh;
+    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].miner];
     uint256 firstDisagreeIdx = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound;
 
     bytes memory disagreeStateReputationValue = abi.encodePacked(u[U_DISAGREE_STATE_REPUTATION_VALUE], u[U_DISAGREE_STATE_REPUTATION_UID]);
@@ -464,7 +476,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       u[U_DISAGREE_STATE_BRANCH_MASK],
       disagreeStateSiblings
     );
-    require(jrh==impliedRoot, "colony-reputation-mining-invalid-after-reputation-proof");
+    require(submission.jrh==impliedRoot, "colony-reputation-mining-invalid-after-reputation-proof");
   }
 
   function performReputationCalculation(
@@ -629,7 +641,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     bytes memory jhLeafValue = abi.encodePacked(uint256(reputationRootHash), u[U_AGREE_STATE_NNODES]);
     // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
     bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
-    require(impliedRoot == disputeRounds[u[U_ROUND]][u[U_IDX]].jrh, "colony-reputation-mining-last-state-disagreement");
+    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].miner];
+    require(impliedRoot == submission.jrh, "colony-reputation-mining-last-state-disagreement");
   }
 
   function checkKeyHashesAdjacent(bytes32 hash1, bytes32 hash2, uint256 branchMask) internal pure returns (bool) {
@@ -666,8 +679,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
     bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
 
-    bytes32 jrh = disputeRounds[u[U_ROUND]][u[U_IDX]].jrh;
-    if (impliedRoot == jrh) {
+    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].miner];
+    if (impliedRoot == submission.jrh) {
       // They successfully proved the user origin value is in the lastAgreeState, so we're done here
       return;
     }
@@ -697,7 +710,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
     // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
     impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
-    require(impliedRoot == jrh, "colony-reputation-mining-origin-adjacent-proof-invalid");
+    require(impliedRoot == submission.jrh, "colony-reputation-mining-origin-adjacent-proof-invalid");
   }
 
   function checkChildReputationInState(
@@ -725,8 +738,8 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
     bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
 
-    bytes32 jrh = disputeRounds[u[U_ROUND]][u[U_IDX]].jrh;
-    if (impliedRoot == jrh) {
+    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].miner];
+    if (impliedRoot == submission.jrh) {
       // They successfully proved the user origin value is in the lastAgreeState, so we're done here
       return;
     }
@@ -754,7 +767,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
 
     // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
     impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
-    require(impliedRoot == jrh, "colony-reputation-mining-child-adjacent-proof-invalid");
+    require(impliedRoot == submission.jrh, "colony-reputation-mining-child-adjacent-proof-invalid");
   }
 
   function saveProvedReputation(uint256[29] memory u) internal {
@@ -777,5 +790,4 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     }
     return reputationKey;
   }
-
 }

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -39,7 +39,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     // Check the binary search has finished, but not necessarily confirmed
     require(disputeRounds[round][idx].lowerBound == disputeRounds[round][idx].upperBound, "colony-reputation-binary-search-incomplete");
     // Check the binary search result has been confirmed
-    Submission storage submission = reputationHashSubmissions[disputeRounds[round][idx].miner];
+    Submission storage submission = reputationHashSubmissions[disputeRounds[round][idx].firstSubmitter];
     require(
       2**(disputeRounds[round][idx].challengeStepCompleted-2)>submission.jrhNNodes,
       "colony-reputation-mining-binary-search-result-not-confirmed"
@@ -202,7 +202,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       agreeStateSiblings);
 
     require(
-      impliedRoot == reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].miner].jrh,
+      impliedRoot == reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].firstSubmitter].jrh,
       "colony-reputation-mining-adjacent-agree-state-disagreement");
 
     // The bit added to the branchmask is based on where the (hashes of the) two keys first differ.
@@ -233,7 +233,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
       disagreeStateSiblings);
 
     require(
-      impliedRoot == reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].miner].jrh,
+      impliedRoot == reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].firstSubmitter].jrh,
       "colony-reputation-mining-adjacent-disagree-state-disagreement");
   }
 
@@ -437,7 +437,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on.
     bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
 
-    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].miner];
+    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].firstSubmitter];
     require(impliedRoot == submission.jrh, "colony-reputation-mining-invalid-before-reputation-proof");
     // Check that they have not changed nNodes from the agree state
     // There is a check at the very start of RespondToChallenge that this difference is either 0 or 1.
@@ -456,7 +456,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     bytes32[] memory disagreeStateSiblings
   ) internal view
   {
-    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].miner];
+    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].firstSubmitter];
     uint256 firstDisagreeIdx = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound;
 
     bytes memory disagreeStateReputationValue = abi.encodePacked(u[U_DISAGREE_STATE_REPUTATION_VALUE], u[U_DISAGREE_STATE_REPUTATION_UID]);
@@ -641,7 +641,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     bytes memory jhLeafValue = abi.encodePacked(uint256(reputationRootHash), u[U_AGREE_STATE_NNODES]);
     // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
     bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
-    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].miner];
+    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].firstSubmitter];
     require(impliedRoot == submission.jrh, "colony-reputation-mining-last-state-disagreement");
   }
 
@@ -679,7 +679,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
     bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
 
-    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].miner];
+    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].firstSubmitter];
     if (impliedRoot == submission.jrh) {
       // They successfully proved the user origin value is in the lastAgreeState, so we're done here
       return;
@@ -738,7 +738,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     // Prove that state is in our JRH, in the index corresponding to the last state that the two submissions agree on
     bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(lastAgreeIdx), jhLeafValue, u[U_AGREE_STATE_BRANCH_MASK], agreeStateSiblings);
 
-    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].miner];
+    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].firstSubmitter];
     if (impliedRoot == submission.jrh) {
       // They successfully proved the user origin value is in the lastAgreeState, so we're done here
       return;

--- a/contracts/ReputationMiningCycleStorage.sol
+++ b/contracts/ReputationMiningCycleStorage.sol
@@ -34,8 +34,12 @@ contract ReputationMiningCycleStorage is ReputationMiningCycleDataTypes, DSAuth 
 
   ReputationLogEntry[] reputationUpdateLog; // Storage slot 6
   mapping (bytes32 => mapping(uint256 => mapping(bytes32 => address[]))) submittedHashes; // Storage slot 7
+  // Maps a submission with the first miner address who submitted it
+  // This address is used as a lookup key from DisputedEntry struct
   mapping (address => Submission) reputationHashSubmissions; // Storage slot 8
   uint256 reputationMiningWindowOpenTimestamp; // Storage slot 9
+  // Maps dispute rounds onto individual submissions indexed in an array
+  // Each DisputeEntry corresponds to a Submission in reputationHashSubmissions
   mapping (uint256 => DisputedEntry[]) disputeRounds; // Storage slot 10
 
   // Tracks the number of submissions in each round that have completed their challenge, one way or the other.

--- a/contracts/ReputationMiningCycleStorage.sol
+++ b/contracts/ReputationMiningCycleStorage.sol
@@ -33,10 +33,10 @@ contract ReputationMiningCycleStorage is ReputationMiningCycleDataTypes, DSAuth 
   address clnyTokenAddress; // Storage slot 5
 
   ReputationLogEntry[] reputationUpdateLog; // Storage slot 6
-  mapping (bytes32 => mapping( uint256 => mapping( bytes32 => address[]))) submittedHashes; // Storage slot 7
+  mapping (bytes32 => mapping(uint256 => mapping(bytes32 => address[]))) submittedHashes; // Storage slot 7
   mapping (address => Submission) reputationHashSubmissions; // Storage slot 8
   uint256 reputationMiningWindowOpenTimestamp; // Storage slot 9
-  mapping (uint256 => Submission[]) disputeRounds; // Storage slot 10
+  mapping (uint256 => DisputedEntry[]) disputeRounds; // Storage slot 10
 
   // Tracks the number of submissions in each round that have completed their challenge, one way or the other.
   // This might be that they passed the challenge, it might be that their opponent passed (and therefore by implication,

--- a/contracts/ReputationMiningCycleStorage.sol
+++ b/contracts/ReputationMiningCycleStorage.sol
@@ -34,8 +34,7 @@ contract ReputationMiningCycleStorage is ReputationMiningCycleDataTypes, DSAuth 
 
   ReputationLogEntry[] reputationUpdateLog; // Storage slot 6
   mapping (bytes32 => mapping(uint256 => mapping(bytes32 => address[]))) submittedHashes; // Storage slot 7
-  // Maps a submission with the first miner address who submitted it
-  // This address is used as a lookup key from DisputedEntry struct
+  // Maps the addresses of miners making submissions on to the submissions they made
   mapping (address => Submission) reputationHashSubmissions; // Storage slot 8
   uint256 reputationMiningWindowOpenTimestamp; // Storage slot 9
   // Maps dispute rounds onto individual submissions indexed in an array

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -531,10 +531,10 @@ export async function accommodateChallengeAndInvalidateHash(colonyNetwork, test,
     await navigateChallenge(colonyNetwork, client1, client2, errors);
 
     // Work out which submission is to be invalidated.
-    const submission1 = await repCycle.getDisputeRoundSubmission(round1, idx1);
-    const submission2 = await repCycle.getDisputeRoundSubmission(round2, idx2);
+    const disputedEntry1 = await repCycle.getDisputeRoundSubmission(round1, idx1);
+    const disputedEntry2 = await repCycle.getDisputeRoundSubmission(round2, idx2);
 
-    if (new BN(submission1.challengeStepCompleted).gt(new BN(submission2.challengeStepCompleted))) {
+    if (new BN(disputedEntry1.challengeStepCompleted).gt(new BN(disputedEntry2.challengeStepCompleted))) {
       toInvalidateIdx = idx2;
     } else {
       // Note that if they're equal, they're both going to be invalidated, so we can call
@@ -555,7 +555,7 @@ export async function accommodateChallengeAndInvalidateHash(colonyNetwork, test,
 async function navigateChallenge(colonyNetwork, client1, client2, errors) {
   const repCycle = await getActiveRepCycle(colonyNetwork);
   const [round1, idx1] = await client1.getMySubmissionRoundAndIndex();
-  const submission1before = await repCycle.getDisputeRoundSubmission(round1, idx1);
+  const submission1before = await repCycle.getReputationHashSubmission(client1.minerAddress);
 
   // Submit JRH for submission 1 if needed
   // We only do this if client2 is defined so that we test JRH submission in rounds other than round 0.
@@ -569,7 +569,7 @@ async function navigateChallenge(colonyNetwork, client1, client2, errors) {
 
   const [round2, idx2] = await client2.getMySubmissionRoundAndIndex();
   expect(round1.eq(round2), "Clients do not have submissions in the same round").to.be.true;
-  const submission2before = await repCycle.getDisputeRoundSubmission(round2, idx2);
+  const submission2before = await repCycle.getReputationHashSubmission(client2.minerAddress);
   expect(
     idx1.sub(idx2).pow(2).eq(1), // eslint-disable-line prettier/prettier
     "Clients are not facing each other in this round"

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -779,7 +779,7 @@ class ReputationMiner {
   }
 
   /**
-   * Returns the round and index that our submission is currently at in the dispute cycle.
+   * Returns the round and index that our disputedEntry is currently at in the dispute cycle.
    * @return {Promise} Resolves to [round, index] which are `BigNumber`.
    */
   async getMySubmissionRoundAndIndex() {
@@ -791,10 +791,13 @@ class ReputationMiner {
     let index = ethers.constants.NegativeOne;
     let round = ethers.constants.Zero;
     let submission = [];
-    while (submission[0] !== submittedHash || submission[1].toString() !== submittedNNodes.toString() || submission[4] !== jrh) {
+    while (submission.proposedNewRootHash !== submittedHash ||
+      submission.nNodes.toString() !== submittedNNodes.toString() ||
+      submission.jrh !== jrh) {
       try {
         index = index.add(1);
-        submission = await repCycle.getDisputeRoundSubmission(round, index);
+        const disputedEntry = await repCycle.getDisputeRoundSubmission(round, index);
+        submission = await repCycle.getReputationHashSubmission(disputedEntry.miner);
       } catch (err) {
         round = round.add(1);
         index = ethers.constants.NegativeOne;
@@ -811,9 +814,9 @@ class ReputationMiner {
   async respondToBinarySearchForChallenge() {
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const repCycle = await this.getActiveRepCycle();
-    const submission = await repCycle.getDisputeRoundSubmission(round, index);
+    const disputedEntry = await repCycle.getDisputeRoundSubmission(round, index);
 
-    const targetNode = submission.lowerBound;
+    const targetNode = disputedEntry.lowerBound;
     const targetNodeKey = ReputationMiner.getHexString(targetNode, 64);
 
     const intermediateReputationHash = this.justificationHashes[targetNodeKey].jhLeafValue;
@@ -828,7 +831,7 @@ class ReputationMiner {
       siblings
     );
 
-    while (siblings.length > 1 && submission.targetHashDuringSearch !== proofEndingHash) {
+    while (siblings.length > 1 && disputedEntry.targetHashDuringSearch !== proofEndingHash) {
       // Remove the first sibling
       siblings = siblings.slice(1);
       // Recalulate ending hash
@@ -852,8 +855,8 @@ class ReputationMiner {
   async confirmBinarySearchResult() {
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const repCycle = await this.getActiveRepCycle();
-    const submission = await repCycle.getDisputeRoundSubmission(round, index);
-    const targetNode = ethers.utils.bigNumberify(submission.lowerBound);
+    const disputedEntry = await repCycle.getDisputeRoundSubmission(round, index);
+    const targetNode = ethers.utils.bigNumberify(disputedEntry.lowerBound);
     const targetNodeKey = ReputationMiner.getHexString(targetNode, 64);
 
     const intermediateReputationHash = this.justificationHashes[targetNodeKey].jhLeafValue;
@@ -871,10 +874,10 @@ class ReputationMiner {
   async respondToChallenge() {
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const repCycle = await this.getActiveRepCycle();
-    const submission = await repCycle.getDisputeRoundSubmission(round, index);
+    const disputedEntry = await repCycle.getDisputeRoundSubmission(round, index);
 
-    // console.log(submission);
-    let firstDisagreeIdx = ethers.utils.bigNumberify(submission.lowerBound);
+    // console.log(disputedEntry);
+    let firstDisagreeIdx = ethers.utils.bigNumberify(disputedEntry.lowerBound);
     let lastAgreeIdx = firstDisagreeIdx.sub(1);
     // If this is called before the binary search has finished, these would be -1 and 0, respectively, which will throw errors
     // when we try and pass -ve hex values. Instead, set them to values that will allow us to send a tx that will fail.

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -797,7 +797,7 @@ class ReputationMiner {
       try {
         index = index.add(1);
         const disputedEntry = await repCycle.getDisputeRoundSubmission(round, index);
-        submission = await repCycle.getReputationHashSubmission(disputedEntry.miner);
+        submission = await repCycle.getReputationHashSubmission(disputedEntry.firstSubmitter);
       } catch (err) {
         round = round.add(1);
         index = ethers.constants.NegativeOne;

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -14,8 +14,8 @@ class MaliciousReputationMinerWrongProofLogEntry extends ReputationMinerTestWrap
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const addr = await this.colonyNetwork.getReputationMiningCycle(true);
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
-    const submission = await repCycle.getDisputeRoundSubmission(round, index);
-    const firstDisagreeIdx = ethers.utils.bigNumberify(submission.lowerBound);
+    const disputedEntry = await repCycle.getDisputeRoundSubmission(round, index);
+    const firstDisagreeIdx = ethers.utils.bigNumberify(disputedEntry.lowerBound);
     const lastAgreeIdx = firstDisagreeIdx.sub(1);
     const reputationKey = await this.getKeyForUpdateNumber(lastAgreeIdx);
     const lastAgreeKey = MaliciousReputationMinerWrongProofLogEntry.getHexString(lastAgreeIdx, 64);

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongResponse.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongResponse.js
@@ -14,10 +14,10 @@ class MaliciousReputationMinerWrongResponse extends ReputationMinerTestWrapper {
   async respondToChallenge() {
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const repCycle = await this.getActiveRepCycle();
-    const submission = await repCycle.getDisputeRoundSubmission(round, index);
+    const disputedEntry = await repCycle.getDisputeRoundSubmission(round, index);
 
-    // console.log(submission);
-    let firstDisagreeIdx = ethers.utils.bigNumberify(submission.lowerBound);
+    // console.log(disputedEntry);
+    let firstDisagreeIdx = ethers.utils.bigNumberify(disputedEntry.lowerBound);
     let lastAgreeIdx = firstDisagreeIdx.sub(1);
     // If this is called before the binary search has finished, these would be -1 and 0, respectively, which will throw errors
     // when we try and pass -ve hex values. Instead, set them to values that will allow us to send a tx that will fail.

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -96,7 +96,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
 
   afterEach(async () => {
     const reputationMiningGotClean = await finishReputationMiningCycle(colonyNetwork, this);
-    if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1);
+    if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1, MINER2);
   });
 
   // The dispute resolution flow is as follows:

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -426,8 +426,8 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await runBinarySearch(goodClient, badClient);
 
       const [round, index] = await goodClient.getMySubmissionRoundAndIndex();
-      const submission = await repCycle.getDisputeRoundSubmission(round, index);
-      const targetNode = submission.lowerBound;
+      const disputedEntry = await repCycle.getDisputeRoundSubmission(round, index);
+      const targetNode = disputedEntry.lowerBound;
       const targetNodeKey = ReputationMinerTestWrapper.getHexString(targetNode, 64);
       const [branchMask, siblings] = await goodClient.justificationTree.getProof(targetNodeKey);
 

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -52,7 +52,7 @@ let clnyToken;
 let goodClient;
 const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
 
-const setupNewNetworkInstance = async MINER1 => {
+const setupNewNetworkInstance = async (MINER1, MINER2) => {
   colonyNetwork = await setupColonyNetwork();
   ({ metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
 
@@ -61,6 +61,7 @@ const setupNewNetworkInstance = async MINER1 => {
   await metaColony.addGlobalSkill(4);
 
   await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
+  await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
   await colonyNetwork.initialiseReputationMining();
   await colonyNetwork.startNextCycle();
 
@@ -75,7 +76,7 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
 
   before(async () => {
     // Setup a new network instance as we'll be modifying the global skills tree
-    await setupNewNetworkInstance(MINER1);
+    await setupNewNetworkInstance(MINER1, MINER2);
   });
 
   beforeEach(async () => {
@@ -96,14 +97,12 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
     const userBalance = await clnyToken.balanceOf(MINER1);
     await clnyToken.burn(userBalance, { from: MINER1 });
 
-    await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
-    await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
     await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(4));
   });
 
   afterEach(async () => {
     const reputationMiningGotClean = await finishReputationMiningCycle(colonyNetwork, this);
-    if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1);
+    if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1, MINER2);
   });
 
   describe("should correctly resolve a dispute over origin skill", () => {

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -357,8 +357,8 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
 
       // Now get all the information needed to fire off a respondToChallenge call
       const [round, index] = await goodClient.getMySubmissionRoundAndIndex();
-      const submission = await repCycle.getDisputeRoundSubmission(round.toString(), index.toString());
-      const firstDisagreeIdx = new BN(submission[8].toString());
+      const disputedEntry = await repCycle.getDisputeRoundSubmission(round.toString(), index.toString());
+      const firstDisagreeIdx = new BN(disputedEntry.lowerBound.toString());
       const lastAgreeIdx = firstDisagreeIdx.subn(1);
       const reputationKey = await goodClient.getKeyForUpdateNumber(lastAgreeIdx.toString());
       const [agreeStateBranchMask, agreeStateSiblings] = await goodClient.justificationTree.getProof(`0x${lastAgreeIdx.toString(16, 64)}`);
@@ -498,8 +498,8 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
 
       // Now get all the information needed to fire off a respondToChallenge call
       const [round, index] = await goodClient.getMySubmissionRoundAndIndex();
-      const submission = await repCycle.getDisputeRoundSubmission(round.toString(), index.toString());
-      const firstDisagreeIdx = new BN(submission[8].toString());
+      const disputedEntry = await repCycle.getDisputeRoundSubmission(round.toString(), index.toString());
+      const firstDisagreeIdx = new BN(disputedEntry.lowerBound.toString());
       const lastAgreeIdx = firstDisagreeIdx.subn(1);
       const reputationKey = await goodClient.getKeyForUpdateNumber(lastAgreeIdx.toString());
       const [agreeStateBranchMask, agreeStateSiblings] = await goodClient.justificationTree.getProof(`0x${lastAgreeIdx.toString(16, 64)}`);
@@ -1470,8 +1470,8 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
 
     // Now get all the information needed to fire off a respondToChallenge call
     const [round, index] = await goodClient.getMySubmissionRoundAndIndex();
-    const submission = await repCycle.getDisputeRoundSubmission(round.toString(), index.toString());
-    const firstDisagreeIdx = new BN(submission[8].toString());
+    const disputedEntry = await repCycle.getDisputeRoundSubmission(round.toString(), index.toString());
+    const firstDisagreeIdx = new BN(disputedEntry.lowerBound.toString());
     const lastAgreeIdx = firstDisagreeIdx.subn(1);
     const reputationKey = await goodClient.getKeyForUpdateNumber(lastAgreeIdx.toString());
     const [agreeStateBranchMask, agreeStateSiblings] = await goodClient.justificationTree.getProof(`0x${lastAgreeIdx.toString(16, 64)}`);

--- a/test/reputation-mining/happy-paths.js
+++ b/test/reputation-mining/happy-paths.js
@@ -59,7 +59,7 @@ let clnyToken;
 let goodClient;
 const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
 
-const setupNewNetworkInstance = async MINER1 => {
+const setupNewNetworkInstance = async (MINER1, MINER2) => {
   colonyNetwork = await setupColonyNetwork();
   ({ metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
 
@@ -74,6 +74,7 @@ const setupNewNetworkInstance = async MINER1 => {
   await metaColony.addGlobalSkill(9);
 
   await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
+  await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
   await colonyNetwork.initialiseReputationMining();
   await colonyNetwork.startNextCycle();
 
@@ -90,7 +91,7 @@ contract("Reputation Mining - happy paths", accounts => {
 
   before(async () => {
     // Setup a new network instance as we'll be modifying the global skills tree
-    await setupNewNetworkInstance(MINER1);
+    await setupNewNetworkInstance(MINER1, MINER2);
   });
 
   beforeEach(async () => {
@@ -111,14 +112,12 @@ contract("Reputation Mining - happy paths", accounts => {
     const userBalance = await clnyToken.balanceOf(MINER1);
     await clnyToken.burn(userBalance, { from: MINER1 });
 
-    await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
-    await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
     await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(4));
   });
 
   afterEach(async () => {
     const reputationMiningGotClean = await finishReputationMiningCycle(colonyNetwork, this);
-    if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1);
+    if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1, MINER2);
   });
 
   describe("when executing intended behaviours", () => {

--- a/test/reputation-mining/root-hash-submissions.js
+++ b/test/reputation-mining/root-hash-submissions.js
@@ -106,7 +106,7 @@ contract("Reputation mining - root hash submissions", accounts => {
       await forwardTime(MINING_CYCLE_DURATION, this);
       await repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MINER1 });
 
-      const submitterAddress = await repCycle.getSubmittedHashes("0x12345678", 10, "0x00", 0);
+      const submitterAddress = await repCycle.getSubmissionUser("0x12345678", 10, "0x00", 0);
       expect(submitterAddress).to.equal(MINER1);
     });
 
@@ -283,7 +283,7 @@ contract("Reputation mining - root hash submissions", accounts => {
         "colony-reputation-mining-cycle-submissions-closed"
       );
 
-      const submitterAddress = await repCycle.getSubmittedHashes("0x12345678", 10, "0x00", 0);
+      const submitterAddress = await repCycle.getSubmissionUser("0x12345678", 10, "0x00", 0);
       expect(submitterAddress).to.equal(MINER1);
     });
 

--- a/test/reputation-mining/types-of-disagreement.js
+++ b/test/reputation-mining/types-of-disagreement.js
@@ -91,7 +91,7 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
   afterEach(async () => {
     const reputationMiningGotClean = await finishReputationMiningCycle(colonyNetwork, this);
-    if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1);
+    if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1, MINER2);
   });
 
   describe("when there is a dispute over reputation root hash", () => {

--- a/test/reputation-mining/types-of-disagreement.js
+++ b/test/reputation-mining/types-of-disagreement.js
@@ -130,8 +130,9 @@ contract("Reputation Mining - types of disagreement", accounts => {
       const nSubmittedHashes = await repCycle.getNSubmittedHashes();
       expect(nSubmittedHashes).to.eq.BN(2);
 
-      const submission = await repCycle.getDisputeRoundSubmission(0, 0);
-
+      const [round1, index1] = await goodClient.getMySubmissionRoundAndIndex();
+      const disputedEntry = await repCycle.getDisputeRoundSubmission(round1, index1);
+      const submission = await repCycle.getReputationHashSubmission(goodClient.minerAddress);
       expect(submission.jrhNNodes).to.be.zero;
       await forwardTime(10, this); // This is just to ensure that the timestamps checked below will be different if JRH was submitted.
 
@@ -140,12 +141,14 @@ contract("Reputation Mining - types of disagreement", accounts => {
       // Check that we can't re-submit a JRH
       await checkErrorRevertEthers(goodClient.confirmJustificationRootHash(), "colony-reputation-jrh-hash-already-verified");
 
-      const submissionAfterJRHConfirmed = await repCycle.getDisputeRoundSubmission(0, 0);
+      const submissionAfterJRHConfirmed = await repCycle.getReputationHashSubmission(goodClient.minerAddress);
       const jrh = await goodClient.justificationTree.getRootHash();
       expect(submissionAfterJRHConfirmed.jrh).to.eq.BN(jrh);
 
       // Check 'last response' was updated.
-      expect(submission.lastResponseTimestamp).to.not.eq.BN(submissionAfterJRHConfirmed.lastResponseTimestamp);
+      const [round2, index2] = await goodClient.getMySubmissionRoundAndIndex();
+      const disputedEntryAfter = await repCycle.getDisputeRoundSubmission(round2, index2);
+      expect(disputedEntry.lastResponseTimestamp).to.not.eq.BN(disputedEntryAfter.lastResponseTimestamp);
 
       // Cleanup
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
@@ -197,78 +200,78 @@ contract("Reputation Mining - types of disagreement", accounts => {
       expect(nSubmittedHashes).to.eq.BN(2);
 
       await goodClient.confirmJustificationRootHash();
-      const submissionAfterJRHConfirmed = await repCycle.getDisputeRoundSubmission(0, 0);
+      const submissionAfterJRHConfirmed = await repCycle.getReputationHashSubmission(goodClient.minerAddress);
       const jrh = await goodClient.justificationTree.getRootHash();
       expect(submissionAfterJRHConfirmed.jrh).to.eq.BN(jrh);
 
       await badClient.confirmJustificationRootHash();
-      const badSubmissionAfterJRHConfirmed = await repCycle.getDisputeRoundSubmission(0, 1);
+      const badSubmissionAfterJRHConfirmed = await repCycle.getReputationHashSubmission(badClient.minerAddress);
       const badJrh = await badClient.justificationTree.getRootHash();
       expect(badSubmissionAfterJRHConfirmed.jrh).to.eq.BN(badJrh);
 
-      let goodSubmission = await repCycle.getDisputeRoundSubmission(0, 0);
-      let badSubmission = await repCycle.getDisputeRoundSubmission(0, 1);
-      expect(goodSubmission.challengeStepCompleted).to.eq.BN(1); // Challenge steps completed
-      expect(goodSubmission.lowerBound).to.be.zero; // Lower bound for binary search
-      expect(goodSubmission.upperBound).to.eq.BN(28); // Upper bound for binary search
-      expect(badSubmission.challengeStepCompleted).to.eq.BN(1);
-      expect(badSubmission.lowerBound).to.be.zero;
-      expect(badSubmission.upperBound).to.eq.BN(28);
+      let goodDisputedEntry = await repCycle.getDisputeRoundSubmission(0, 0);
+      let badDisputedEntry = await repCycle.getDisputeRoundSubmission(0, 1);
+      expect(goodDisputedEntry.challengeStepCompleted).to.eq.BN(1); // Challenge steps completed
+      expect(goodDisputedEntry.lowerBound).to.be.zero; // Lower bound for binary search
+      expect(goodDisputedEntry.upperBound).to.eq.BN(28); // Upper bound for binary search
+      expect(badDisputedEntry.challengeStepCompleted).to.eq.BN(1);
+      expect(badDisputedEntry.lowerBound).to.be.zero;
+      expect(badDisputedEntry.upperBound).to.eq.BN(28);
 
       await goodClient.respondToBinarySearchForChallenge();
-      goodSubmission = await repCycle.getDisputeRoundSubmission(0, 0);
-      badSubmission = await repCycle.getDisputeRoundSubmission(0, 1);
-      expect(goodSubmission.challengeStepCompleted).to.eq.BN(2);
-      expect(goodSubmission.lowerBound).to.be.zero;
-      expect(goodSubmission.upperBound).to.eq.BN(28);
-      expect(badSubmission.challengeStepCompleted).to.eq.BN(1);
-      expect(badSubmission.lowerBound).to.be.zero;
-      expect(badSubmission.upperBound).to.eq.BN(28);
+      goodDisputedEntry = await repCycle.getDisputeRoundSubmission(0, 0);
+      badDisputedEntry = await repCycle.getDisputeRoundSubmission(0, 1);
+      expect(goodDisputedEntry.challengeStepCompleted).to.eq.BN(2);
+      expect(goodDisputedEntry.lowerBound).to.be.zero;
+      expect(goodDisputedEntry.upperBound).to.eq.BN(28);
+      expect(badDisputedEntry.challengeStepCompleted).to.eq.BN(1);
+      expect(badDisputedEntry.lowerBound).to.be.zero;
+      expect(badDisputedEntry.upperBound).to.eq.BN(28);
 
       await badClient.respondToBinarySearchForChallenge();
-      goodSubmission = await repCycle.getDisputeRoundSubmission(0, 0);
-      badSubmission = await repCycle.getDisputeRoundSubmission(0, 1);
-      expect(goodSubmission.lowerBound).to.be.zero;
-      expect(goodSubmission.upperBound).to.eq.BN(15);
-      expect(badSubmission.lowerBound).to.be.zero;
-      expect(badSubmission.upperBound).to.eq.BN(15);
-
-      await goodClient.respondToBinarySearchForChallenge();
-      await badClient.respondToBinarySearchForChallenge();
-      goodSubmission = await repCycle.getDisputeRoundSubmission(0, 0);
-      badSubmission = await repCycle.getDisputeRoundSubmission(0, 1);
-      expect(goodSubmission.lowerBound).to.eq.BN(8);
-      expect(goodSubmission.upperBound).to.eq.BN(15);
-      expect(badSubmission.lowerBound).to.eq.BN(8);
-      expect(badSubmission.upperBound).to.eq.BN(15);
+      goodDisputedEntry = await repCycle.getDisputeRoundSubmission(0, 0);
+      badDisputedEntry = await repCycle.getDisputeRoundSubmission(0, 1);
+      expect(goodDisputedEntry.lowerBound).to.be.zero;
+      expect(goodDisputedEntry.upperBound).to.eq.BN(15);
+      expect(badDisputedEntry.lowerBound).to.be.zero;
+      expect(badDisputedEntry.upperBound).to.eq.BN(15);
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
-      goodSubmission = await repCycle.getDisputeRoundSubmission(0, 0);
-      badSubmission = await repCycle.getDisputeRoundSubmission(0, 1);
-
-      expect(goodSubmission.lowerBound).to.eq.BN(12);
-      expect(goodSubmission.upperBound).to.eq.BN(15);
-      expect(badSubmission.lowerBound).to.eq.BN(12);
-      expect(badSubmission.upperBound).to.eq.BN(15);
-
-      await goodClient.respondToBinarySearchForChallenge();
-      await badClient.respondToBinarySearchForChallenge();
-      goodSubmission = await repCycle.getDisputeRoundSubmission(0, 0);
-      badSubmission = await repCycle.getDisputeRoundSubmission(0, 1);
-      expect(goodSubmission.lowerBound).to.eq.BN(12);
-      expect(goodSubmission.upperBound).to.eq.BN(13);
-      expect(badSubmission.lowerBound).to.eq.BN(12);
-      expect(badSubmission.upperBound).to.eq.BN(13);
+      goodDisputedEntry = await repCycle.getDisputeRoundSubmission(0, 0);
+      badDisputedEntry = await repCycle.getDisputeRoundSubmission(0, 1);
+      expect(goodDisputedEntry.lowerBound).to.eq.BN(8);
+      expect(goodDisputedEntry.upperBound).to.eq.BN(15);
+      expect(badDisputedEntry.lowerBound).to.eq.BN(8);
+      expect(badDisputedEntry.upperBound).to.eq.BN(15);
 
       await goodClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();
-      goodSubmission = await repCycle.getDisputeRoundSubmission(0, 0);
-      badSubmission = await repCycle.getDisputeRoundSubmission(0, 1);
-      expect(goodSubmission.lowerBound).to.eq.BN(13);
-      expect(goodSubmission.upperBound).to.eq.BN(13);
-      expect(badSubmission.lowerBound).to.eq.BN(13);
-      expect(badSubmission.upperBound).to.eq.BN(13);
+      goodDisputedEntry = await repCycle.getDisputeRoundSubmission(0, 0);
+      badDisputedEntry = await repCycle.getDisputeRoundSubmission(0, 1);
+
+      expect(goodDisputedEntry.lowerBound).to.eq.BN(12);
+      expect(goodDisputedEntry.upperBound).to.eq.BN(15);
+      expect(badDisputedEntry.lowerBound).to.eq.BN(12);
+      expect(badDisputedEntry.upperBound).to.eq.BN(15);
+
+      await goodClient.respondToBinarySearchForChallenge();
+      await badClient.respondToBinarySearchForChallenge();
+      goodDisputedEntry = await repCycle.getDisputeRoundSubmission(0, 0);
+      badDisputedEntry = await repCycle.getDisputeRoundSubmission(0, 1);
+      expect(goodDisputedEntry.lowerBound).to.eq.BN(12);
+      expect(goodDisputedEntry.upperBound).to.eq.BN(13);
+      expect(badDisputedEntry.lowerBound).to.eq.BN(12);
+      expect(badDisputedEntry.upperBound).to.eq.BN(13);
+
+      await goodClient.respondToBinarySearchForChallenge();
+      await badClient.respondToBinarySearchForChallenge();
+      goodDisputedEntry = await repCycle.getDisputeRoundSubmission(0, 0);
+      badDisputedEntry = await repCycle.getDisputeRoundSubmission(0, 1);
+      expect(goodDisputedEntry.lowerBound).to.eq.BN(13);
+      expect(goodDisputedEntry.upperBound).to.eq.BN(13);
+      expect(badDisputedEntry.lowerBound).to.eq.BN(13);
+      expect(badDisputedEntry.upperBound).to.eq.BN(13);
 
       await goodClient.confirmBinarySearchResult();
       await badClient.confirmBinarySearchResult();
@@ -278,9 +281,10 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await checkErrorRevertEthers(badClient.respondToChallenge(), "colony-reputation-mining-increased-reputation-value-incorrect");
 
       // Check
-      const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 0);
-      const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 1);
-      const delta = goodSubmissionAfterResponseToChallenge.challengeStepCompleted - badSubmissionAfterResponseToChallenge.challengeStepCompleted;
+      const goodDisputedEntryAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 0);
+      const badDisputedEntryAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 1);
+      const delta =
+        goodDisputedEntryAfterResponseToChallenge.challengeStepCompleted - badDisputedEntryAfterResponseToChallenge.challengeStepCompleted;
       expect(delta).to.eq.BN(1);
       // checks that challengeStepCompleted is one more for the good submission than the bad one.
 
@@ -522,9 +526,10 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await checkErrorRevertEthers(badClient.respondToChallenge(), "colony-reputation-mining-uid-changed-for-existing-reputation");
 
       // Check
-      const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 0);
-      const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 1);
-      const delta = goodSubmissionAfterResponseToChallenge.challengeStepCompleted - badSubmissionAfterResponseToChallenge.challengeStepCompleted;
+      const goodDisputedEntryAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 0);
+      const badDisputedEntryAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 1);
+      const delta =
+        goodDisputedEntryAfterResponseToChallenge.challengeStepCompleted - badDisputedEntryAfterResponseToChallenge.challengeStepCompleted;
       expect(delta).to.eq.BN(1);
 
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
@@ -575,9 +580,10 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await badClient.respondToChallenge();
 
       // Check
-      const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 0);
-      const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 1);
-      const delta = goodSubmissionAfterResponseToChallenge.challengeStepCompleted - badSubmissionAfterResponseToChallenge.challengeStepCompleted;
+      const goodDisputedEntryAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 0);
+      const badDisputedEntryAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 1);
+      const delta =
+        goodDisputedEntryAfterResponseToChallenge.challengeStepCompleted - badDisputedEntryAfterResponseToChallenge.challengeStepCompleted;
       expect(delta).to.be.zero;
       // Both sides have completed the same amount of challenges, but one has proved that a large number already exists
       // than the other, so when we call invalidate hash, only one will be eliminated.
@@ -625,7 +631,6 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await badClient.confirmBinarySearchResult();
 
       await checkErrorRevertEthers(badClient2.respondToChallenge(), "colony-reputation-mining-new-uid-incorrect");
-
       // Cleanup
       await forwardTime(MINING_CYCLE_DURATION, this);
       await goodClient.respondToChallenge();
@@ -679,9 +684,10 @@ contract("Reputation Mining - types of disagreement", accounts => {
       await checkErrorRevertEthers(badClient.respondToChallenge(), "colony-reputation-mining-proved-uid-inconsistent");
 
       // Check badClient respondToChallenge failed
-      const goodSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 0);
-      const badSubmissionAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 1);
-      const delta = goodSubmissionAfterResponseToChallenge.challengeStepCompleted - badSubmissionAfterResponseToChallenge.challengeStepCompleted;
+      const goodDisputedEntryAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 0);
+      const badDisputedEntryAfterResponseToChallenge = await repCycle.getDisputeRoundSubmission(0, 1);
+      const delta =
+        goodDisputedEntryAfterResponseToChallenge.challengeStepCompleted - badDisputedEntryAfterResponseToChallenge.challengeStepCompleted;
       expect(delta).to.eq.BN(2);
 
       await forwardTime(MINING_CYCLE_DURATION / 6, this);


### PR DESCRIPTION
Currently both `disputeRounds` and `reputationHashSubmissions` store the entire `Submission` struct. Where `reputationHashSubmissions` is only interested in the `proposedNewRootHash`, `nNodes`, `jrh`, `jrhNNodes` properties of that while `disputeRounds` manages the remainder of the properties through the dispute resolution process.

Here we introduce a `DisputedEntry` struct which is used only for dispute resolution properties while `Submission` is used for miner root hash submissions. 