### PR TITLE
Allow deprecation of global skills

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -171,12 +171,12 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     return colonyNetwork.addSkill(0);
   }
 
-  function depreciateGlobalSkill(uint256 _skillId) public
+  function deprecateGlobalSkill(uint256 _skillId) public
   stoppable
   auth
   {
     IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
-    return colonyNetwork.depreciateSkill(_skillId);
+    return colonyNetwork.deprecateSkill(_skillId);
   }
 
   function setNetworkFeeInverse(uint256 _feeInverse) public

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -171,6 +171,14 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     return colonyNetwork.addSkill(0);
   }
 
+  function depreciateGlobalSkill(uint256 _skillId) public
+  stoppable
+  auth
+  {
+    IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
+    return colonyNetwork.depreciateSkill(_skillId);
+  }
+
   function setNetworkFeeInverse(uint256 _feeInverse) public
   stoppable
   auth

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -278,16 +278,6 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     require(!protected, "colony-protected-variable");
   }
 
-  function setFunctionReviewers(bytes4 _sig, TaskRole _firstReviewer, TaskRole _secondReviewer)
-  private
-  {
-    reviewers[_sig] = [_firstReviewer, _secondReviewer];
-  }
-
-  function setRoleAssignmentFunction(bytes4 _sig) private {
-    roleAssignmentSigs[_sig] = true;
-  }
-
   function initialiseDomain(uint256 _skillId) internal skillExists(_skillId) {
     domainCount += 1;
     // Create a new funding pot
@@ -306,5 +296,15 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
     emit DomainAdded(domainCount);
     emit FundingPotAdded(fundingPotCount);
+  }
+
+  function setFunctionReviewers(bytes4 _sig, TaskRole _firstReviewer, TaskRole _secondReviewer)
+  private
+  {
+    reviewers[_sig] = [_firstReviewer, _secondReviewer];
+  }
+
+  function setRoleAssignmentFunction(bytes4 _sig) private {
+    roleAssignmentSigs[_sig] = true;
   }
 }

--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -71,6 +71,7 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ROOT_ROLE, "addNetworkColonyVersion(uint256,address)");
     addRoleCapability(ROOT_ROLE, "setNetworkFeeInverse(uint256)");
     addRoleCapability(ROOT_ROLE, "addGlobalSkill()");
+    addRoleCapability(ROOT_ROLE, "depreciateGlobalSkill(uint256)");
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {

--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -71,7 +71,7 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ROOT_ROLE, "addNetworkColonyVersion(uint256,address)");
     addRoleCapability(ROOT_ROLE, "setNetworkFeeInverse(uint256)");
     addRoleCapability(ROOT_ROLE, "addGlobalSkill()");
-    addRoleCapability(ROOT_ROLE, "depreciateGlobalSkill(uint256)");
+    addRoleCapability(ROOT_ROLE, "deprecateGlobalSkill(uint256)");
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -267,6 +267,12 @@ contract ColonyNetwork is ColonyNetworkStorage {
     return skill.children[_childSkillIndex];
   }
 
+  function depreciateSkill(uint256 _skillId) public stoppable 
+  allowedToAddSkill(true)
+  {
+    skills[_skillId].depreciated = true;
+  }
+
   function appendReputationUpdateLog(address _user, int _amount, uint _skillId) public
   stoppable
   calledByColony

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -263,10 +263,10 @@ contract ColonyNetwork is ColonyNetworkStorage {
     return skill.children[_childSkillIndex];
   }
 
-  function depreciateSkill(uint256 _skillId) public stoppable 
+  function deprecateSkill(uint256 _skillId) public stoppable 
   allowedToAddSkill(true)
   {
-    skills[_skillId].depreciated = true;
+    skills[_skillId].deprecated = true;
   }
 
   function appendReputationUpdateLog(address _user, int _amount, uint _skillId) public

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -74,10 +74,6 @@ contract ColonyNetwork is ColonyNetworkStorage {
     skill = skills[_skillId];
   }
 
-  function isGlobalSkill(uint256 _skillId) public view returns (bool) {
-    return skills[_skillId].globalSkill;
-  }
-
   function getReputationRootHash() public view returns (bytes32) {
     return reputationRootHash;
   }

--- a/contracts/ColonyNetworkDataTypes.sol
+++ b/contracts/ColonyNetworkDataTypes.sol
@@ -105,8 +105,8 @@ contract ColonyNetworkDataTypes {
     uint256[] children;
     // `true` for a global skill reused across colonies or `false` for a skill mapped to a single colony's domain
     bool globalSkill;
-    // `true` for a global skill that is depreciated  
-    bool depreciated;
+    // `true` for a global skill that is deprecated  
+    bool deprecated;
   }
 
   struct ENSRecord {

--- a/contracts/ColonyNetworkDataTypes.sol
+++ b/contracts/ColonyNetworkDataTypes.sol
@@ -55,7 +55,6 @@ contract ColonyNetworkDataTypes {
   /// @param token Address of the associated colony token
   event ColonyAdded(uint256 indexed colonyId, address indexed colonyAddress, address token);
 
-
   /// @notice Event logged when a new skill is added
   /// @dev Emitted from `IColonyNetwork.addSkill` function
   /// @param skillId The skill id
@@ -106,6 +105,8 @@ contract ColonyNetworkDataTypes {
     uint256[] children;
     // `true` for a global skill reused across colonies or `false` for a skill mapped to a single colony's domain
     bool globalSkill;
+    // `true` for a global skill that is depreciated  
+    bool depreciated;
   }
 
   struct ENSRecord {

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -111,7 +111,7 @@ contract ColonyPayment is ColonyStorage {
   authDomain(_permissionDomainId, _childSkillIndex, payments[_id].domainId)
   paymentNotFinalized(_id)
   skillExists(_skillId)
-  globalSkill(_skillId)
+  validGlobalSkill(_skillId)
   {
     payments[_id].skills[0] = _skillId;
   }

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -26,7 +26,7 @@ import "./CommonStorage.sol";
 import "./ColonyDataTypes.sol";
 
 
-contract ColonyStorage is CommonStorage, ColonyDataTypes, DSMath {
+contract ColonyStorage is CommonStorage, ColonyDataTypes, ColonyNetworkDataTypes, DSMath {
   // When adding variables, do not make them public, otherwise all contracts that inherit from
   // this one will have the getters. Make custom getters in the contract that seems most appropriate,
   // and add it to IColony.sol
@@ -116,10 +116,11 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, DSMath {
     _;
   }
 
-  modifier globalSkill(uint256 _skillId) {
+  modifier validGlobalSkill(uint256 _skillId) {
     IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
-    bool isGlobalSkill = colonyNetworkContract.isGlobalSkill(_skillId);
-    require(isGlobalSkill, "colony-not-global-skill");
+    Skill memory skill = colonyNetworkContract.getSkill(_skillId);
+    require(skill.globalSkill, "colony-not-global-skill");
+    require(!skill.depreciated, "colony-depreciated-global-skill");
     _;
   }
 

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -120,7 +120,7 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, ColonyNetworkDataTypes
     IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
     Skill memory skill = colonyNetworkContract.getSkill(_skillId);
     require(skill.globalSkill, "colony-not-global-skill");
-    require(!skill.depreciated, "colony-depreciated-global-skill");
+    require(!skill.deprecated, "colony-deprecated-global-skill");
     _;
   }
 

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -353,7 +353,7 @@ contract ColonyTask is ColonyStorage {
   taskExists(_id)
   skillExists(_skillId)
   taskNotComplete(_id)
-  globalSkill(_skillId)
+  validGlobalSkill(_skillId)
   self()
   {
     tasks[_id].skills[0] = _skillId;

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -94,6 +94,10 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @return skill The Skill struct
   function getSkill(uint256 _skillId) public view returns (Skill memory skill);
 
+  /// @notice Mark a global skill as depreciated which stops new tasks and payments from using it.
+  /// @param _skillId Id of the skill
+  function depreciateSkill(uint256 _skillId) public;
+
   /// @notice Get whether the skill with id _skillId is public or not.
   /// @param _skillId Id of the skill
   /// @return result bool

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -98,12 +98,6 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @param _skillId Id of the skill
   function depreciateSkill(uint256 _skillId) public;
 
-  /// @notice Get whether the skill with id _skillId is public or not.
-  /// @param _skillId Id of the skill
-  /// @return result bool
-  /// @dev Returns false if skill does not exist
-  function isGlobalSkill(uint256 _skillId) public view returns (bool result);
-
   /// @notice Adds a reputation update entry to log
   /// @dev Errors if it is called by anyone but a colony or if skill with id `_skillId` does not exist or
   /// @param _user The address of the user for the reputation update

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -94,9 +94,9 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @return skill The Skill struct
   function getSkill(uint256 _skillId) public view returns (Skill memory skill);
 
-  /// @notice Mark a global skill as depreciated which stops new tasks and payments from using it.
+  /// @notice Mark a global skill as deprecated which stops new tasks and payments from using it.
   /// @param _skillId Id of the skill
-  function depreciateSkill(uint256 _skillId) public;
+  function deprecateSkill(uint256 _skillId) public;
 
   /// @notice Adds a reputation update entry to log
   /// @dev Errors if it is called by anyone but a colony or if skill with id `_skillId` does not exist or

--- a/contracts/IMetaColony.sol
+++ b/contracts/IMetaColony.sol
@@ -29,10 +29,15 @@ contract IMetaColony is IColony {
   /// @param _wad Amount to mint and transfer to the colony network
   function mintTokensForColonyNetwork(uint256 _wad) public;
 
-  /// @notice Add a new global skill, under skill `_parentSkillId`
+  /// @notice Add a new global skill
   /// @dev Calls `IColonyNetwork.addSkill`
   /// @return skillId Id of the added skill
   function addGlobalSkill() public returns (uint256 skillId);
+
+  /// @notice Mark a global skill as depreciated which stops new tasks and payments from using it
+  /// @dev Calls `IColonyNetwork.depreciateSkill`
+  /// @param _skillId Id of the added skill
+  function depreciateGlobalSkill(uint256 _skillId) public;
 
   /// @notice Set the Colony Network fee inverse amount
   /// @dev Calls `IColonyNetwork.setFeeInverse`

--- a/contracts/IMetaColony.sol
+++ b/contracts/IMetaColony.sol
@@ -34,10 +34,10 @@ contract IMetaColony is IColony {
   /// @return skillId Id of the added skill
   function addGlobalSkill() public returns (uint256 skillId);
 
-  /// @notice Mark a global skill as depreciated which stops new tasks and payments from using it
-  /// @dev Calls `IColonyNetwork.depreciateSkill`
+  /// @notice Mark a global skill as deprecated which stops new tasks and payments from using it
+  /// @dev Calls `IColonyNetwork.deprecateSkill`
   /// @param _skillId Id of the added skill
-  function depreciateGlobalSkill(uint256 _skillId) public;
+  function deprecateGlobalSkill(uint256 _skillId) public;
 
   /// @notice Set the Colony Network fee inverse amount
   /// @dev Calls `IColonyNetwork.setFeeInverse`

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -318,7 +318,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   {
     // If we think we need to check the child reputation because of the update number, but the origin reputation value is
     // zero, we don't need check the child reputation because it isn't actually used in the calculation.
-    if (u[U_USER_ORIGIN_REPUTATION_VALUE] == 0) { return; }
+    if (u[U_USER_ORIGIN_REPUTATION_VALUE] == 0) {return;}
     // This function is only called if the dispute is over a child reputation update of a colony-wide reputation total
     ReputationLogEntry storage logEntry = reputationUpdateLog[u[U_LOG_ENTRY_NUMBER]];
 

--- a/contracts/testHelpers/NoLimitSubdomains.sol
+++ b/contracts/testHelpers/NoLimitSubdomains.sol
@@ -20,6 +20,7 @@ pragma experimental ABIEncoderV2;
 
 import "./../Colony.sol";
 
+
 contract NoLimitSubdomains is Colony {
   function addDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _parentDomainId) public
   stoppable

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -265,9 +265,14 @@ contract("Colony Network", accounts => {
     });
   });
 
-  describe("when adding a skill", () => {
+  describe("when working with skills", () => {
     it("should not be able to add a global skill, by an address that is not the meta colony ", async () => {
       await checkErrorRevert(colonyNetwork.addSkill(0), "colony-must-be-meta-colony");
+    });
+
+    it("should not be able to depreciate a global skill, by an address that is not the meta colony ", async () => {
+      const skillCount = await colonyNetwork.getSkillCount();
+      await checkErrorRevert(colonyNetwork.depreciateSkill(skillCount), "colony-must-be-meta-colony");
     });
 
     it("should NOT be able to add a local skill, by an address that is not a Colony", async () => {

--- a/test/colony-network.js
+++ b/test/colony-network.js
@@ -270,9 +270,9 @@ contract("Colony Network", accounts => {
       await checkErrorRevert(colonyNetwork.addSkill(0), "colony-must-be-meta-colony");
     });
 
-    it("should not be able to depreciate a global skill, by an address that is not the meta colony ", async () => {
+    it("should not be able to deprecate a global skill, by an address that is not the meta colony ", async () => {
       const skillCount = await colonyNetwork.getSkillCount();
-      await checkErrorRevert(colonyNetwork.depreciateSkill(skillCount), "colony-must-be-meta-colony");
+      await checkErrorRevert(colonyNetwork.deprecateSkill(skillCount), "colony-must-be-meta-colony");
     });
 
     it("should NOT be able to add a local skill, by an address that is not a Colony", async () => {

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -13,6 +13,7 @@ chai.use(bnChai(web3.utils.BN));
 
 const EtherRouter = artifacts.require("EtherRouter");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
+const IMetaColony = artifacts.require("IMetaColony");
 const DSToken = artifacts.require("DSToken");
 
 contract("Colony Payment", accounts => {
@@ -23,10 +24,13 @@ contract("Colony Payment", accounts => {
   let token;
   let otherToken;
   let colonyNetwork;
+  let metaColony;
 
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
+    const metaColonyAddress = await colonyNetwork.getMetaColony();
+    metaColony = await IMetaColony.at(metaColonyAddress);
 
     ({ colony, token } = await setupRandomColony(colonyNetwork));
     await colony.setRewardInverse(100);
@@ -81,6 +85,17 @@ contract("Colony Payment", accounts => {
       const fundingPotId = await colony.getFundingPotCount();
       const fundingPotBalance = await colony.getFundingPotBalance(fundingPotId, token.address);
       expect(fundingPotBalance).to.be.zero;
+    });
+
+    it("should not allow admins to add payment with depreciated global skill", async () => {
+      await metaColony.addGlobalSkill();
+      const skillId = await colonyNetwork.getSkillCount();
+      await metaColony.depreciateGlobalSkill(skillId);
+
+      await checkErrorRevert(
+        colony.addPayment(1, 0, RECIPIENT, token.address, 0, 1, skillId, { from: COLONY_ADMIN }),
+        "colony-depreciated-global-skill"
+      );
     });
 
     it("should not allow non-admins to add payment", async () => {
@@ -145,6 +160,17 @@ contract("Colony Payment", accounts => {
       await colony.setPaymentSkill(1, 0, paymentId, 3, { from: COLONY_ADMIN });
       payment = await colony.getPayment(paymentId);
       expect(payment.skills[0]).to.eq.BN(3);
+    });
+
+    it("should not allow admins to update payment with depreciated global skill", async () => {
+      await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      const paymentId = await colony.getPaymentCount();
+
+      await metaColony.addGlobalSkill();
+      const skillId = await colonyNetwork.getSkillCount();
+      await metaColony.depreciateGlobalSkill(skillId);
+
+      await checkErrorRevert(colony.setPaymentSkill(1, 0, paymentId, skillId, { from: COLONY_ADMIN }), "colony-depreciated-global-skill");
     });
 
     it("should not allow non-admins to update recipient", async () => {

--- a/test/colony-payment.js
+++ b/test/colony-payment.js
@@ -87,14 +87,14 @@ contract("Colony Payment", accounts => {
       expect(fundingPotBalance).to.be.zero;
     });
 
-    it("should not allow admins to add payment with depreciated global skill", async () => {
+    it("should not allow admins to add payment with deprecated global skill", async () => {
       await metaColony.addGlobalSkill();
       const skillId = await colonyNetwork.getSkillCount();
-      await metaColony.depreciateGlobalSkill(skillId);
+      await metaColony.deprecateGlobalSkill(skillId);
 
       await checkErrorRevert(
         colony.addPayment(1, 0, RECIPIENT, token.address, 0, 1, skillId, { from: COLONY_ADMIN }),
-        "colony-depreciated-global-skill"
+        "colony-deprecated-global-skill"
       );
     });
 
@@ -162,15 +162,15 @@ contract("Colony Payment", accounts => {
       expect(payment.skills[0]).to.eq.BN(3);
     });
 
-    it("should not allow admins to update payment with depreciated global skill", async () => {
+    it("should not allow admins to update payment with deprecated global skill", async () => {
       await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
       await metaColony.addGlobalSkill();
       const skillId = await colonyNetwork.getSkillCount();
-      await metaColony.depreciateGlobalSkill(skillId);
+      await metaColony.deprecateGlobalSkill(skillId);
 
-      await checkErrorRevert(colony.setPaymentSkill(1, 0, paymentId, skillId, { from: COLONY_ADMIN }), "colony-depreciated-global-skill");
+      await checkErrorRevert(colony.setPaymentSkill(1, 0, paymentId, skillId, { from: COLONY_ADMIN }), "colony-deprecated-global-skill");
     });
 
     it("should not allow non-admins to update recipient", async () => {

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -113,14 +113,14 @@ contract("One transaction payments", accounts => {
       );
     });
 
-    it("should not allow an admin to specify a depreciated global skill", async () => {
+    it("should not allow an admin to specify a deprecated global skill", async () => {
       await metaColony.addGlobalSkill();
       const skillId = await colonyNetwork.getSkillCount();
-      await metaColony.depreciateGlobalSkill(skillId);
+      await metaColony.deprecateGlobalSkill(skillId);
 
       await checkErrorRevert(
         oneTxExtension.makePayment(1, 0, 1, 0, RECIPIENT, token.address, 10, 1, skillId, { from: COLONY_ADMIN }),
-        "colony-depreciated-global-skill"
+        "colony-deprecated-global-skill"
       );
     });
 

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -524,13 +524,22 @@ contract("Meta Colony", accounts => {
     });
 
     it("should NOT be able to set nonexistent skill on task", async () => {
-      await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskSkill(1, 5), "colony-skill-does-not-exist");
+      const taskId = await makeTask({ colony });
+      await checkErrorRevert(colony.setTaskSkill(taskId, 5), "colony-skill-does-not-exist");
     });
 
     it("should NOT be able to set local skill on task", async () => {
-      await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskSkill(1, 1), "colony-not-global-skill");
+      const taskId = await makeTask({ colony });
+      await checkErrorRevert(colony.setTaskSkill(taskId, 1), "colony-not-global-skill");
+    });
+
+    it("should NOT be able to set a depreciated skill on task", async () => {
+      const taskId = await makeTask({ colony });
+      await metaColony.addGlobalSkill();
+      const skillId = await colonyNetwork.getSkillCount();
+      await metaColony.depreciateGlobalSkill(skillId);
+
+      await checkErrorRevert(colony.setTaskSkill(taskId, skillId), "colony-depreciated-global-skill");
     });
   });
 

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -533,13 +533,13 @@ contract("Meta Colony", accounts => {
       await checkErrorRevert(colony.setTaskSkill(taskId, 1), "colony-not-global-skill");
     });
 
-    it("should NOT be able to set a depreciated skill on task", async () => {
+    it("should NOT be able to set a deprecated skill on task", async () => {
       const taskId = await makeTask({ colony });
       await metaColony.addGlobalSkill();
       const skillId = await colonyNetwork.getSkillCount();
-      await metaColony.depreciateGlobalSkill(skillId);
+      await metaColony.deprecateGlobalSkill(skillId);
 
-      await checkErrorRevert(colony.setTaskSkill(taskId, skillId), "colony-depreciated-global-skill");
+      await checkErrorRevert(colony.setTaskSkill(taskId, skillId), "colony-deprecated-global-skill");
     });
   });
 
@@ -551,24 +551,24 @@ contract("Meta Colony", accounts => {
       expect(skill.nChildren).to.be.zero;
       expect(skill.nParents).to.be.zero;
       expect(skill.globalSkill).to.be.true;
-      expect(skill.depreciated).to.be.false;
+      expect(skill.deprecated).to.be.false;
     });
 
     it("cannot create global skills if not a root user in meta colony", async () => {
       await checkErrorRevert(metaColony.addGlobalSkill({ from: OTHER_ACCOUNT }), "ds-auth-unauthorized");
     });
 
-    it("can depreciate global skills", async () => {
+    it("can deprecate global skills", async () => {
       await metaColony.addGlobalSkill();
       const skillId = await colonyNetwork.getSkillCount();
 
       let skill = await colonyNetwork.getSkill(skillId);
-      expect(skill.depreciated).to.be.false;
+      expect(skill.deprecated).to.be.false;
 
-      await metaColony.depreciateGlobalSkill(skillId);
+      await metaColony.deprecateGlobalSkill(skillId);
 
       skill = await colonyNetwork.getSkill(skillId);
-      expect(skill.depreciated).to.be.true;
+      expect(skill.deprecated).to.be.true;
     });
   });
 

--- a/test/meta-colony.js
+++ b/test/meta-colony.js
@@ -534,6 +534,35 @@ contract("Meta Colony", accounts => {
     });
   });
 
+  describe("when managing global skills", () => {
+    it("can create global skills", async () => {
+      await metaColony.addGlobalSkill();
+      const skillId = await colonyNetwork.getSkillCount();
+      const skill = await colonyNetwork.getSkill(skillId);
+      expect(skill.nChildren).to.be.zero;
+      expect(skill.nParents).to.be.zero;
+      expect(skill.globalSkill).to.be.true;
+      expect(skill.depreciated).to.be.false;
+    });
+
+    it("cannot create global skills if not a root user in meta colony", async () => {
+      await checkErrorRevert(metaColony.addGlobalSkill({ from: OTHER_ACCOUNT }), "ds-auth-unauthorized");
+    });
+
+    it("can depreciate global skills", async () => {
+      await metaColony.addGlobalSkill();
+      const skillId = await colonyNetwork.getSkillCount();
+
+      let skill = await colonyNetwork.getSkill(skillId);
+      expect(skill.depreciated).to.be.false;
+
+      await metaColony.depreciateGlobalSkill(skillId);
+
+      skill = await colonyNetwork.getSkill(skillId);
+      expect(skill.depreciated).to.be.true;
+    });
+  });
+
   describe("when getting a skill", () => {
     it("should return a true flag if the skill is global", async () => {
       const globalSkill = await colonyNetwork.getSkill(3);


### PR DESCRIPTION
Closes #573 

Adds a `deprecateGlobalSkill` function on the Meta colony available to Root permission users. This marks a global skill as deprecated which stops it from being added to new Payments and Tasks. Reputation earned in the skill decays away while we keep the skill itself for historical purposes.