### PR TITLE
Add factories for extension contracts

### DIFF
--- a/contracts/extensions/ExtensionFactory.sol
+++ b/contracts/extensions/ExtensionFactory.sol
@@ -1,0 +1,25 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity >=0.5.3;
+pragma experimental ABIEncoderV2;
+
+
+interface ExtensionFactory {
+  function deployExtension(address _colony) external;
+  function removeExtension(address _colony) external;
+}

--- a/contracts/extensions/ExtensionFactory.sol
+++ b/contracts/extensions/ExtensionFactory.sol
@@ -22,4 +22,6 @@ pragma experimental ABIEncoderV2;
 interface ExtensionFactory {
   function deployExtension(address _colony) external;
   function removeExtension(address _colony) external;
+  event ExtensionDeployed(string _name, address _colony, address _extension);
+  event ExtensionRemoved(string _name, address _colony);
 }

--- a/contracts/extensions/OldRolesFactory.sol
+++ b/contracts/extensions/OldRolesFactory.sol
@@ -21,13 +21,14 @@ pragma experimental ABIEncoderV2;
 import "./../ColonyDataTypes.sol";
 import "./../IColony.sol";
 import "./../ColonyAuthority.sol";
+import "./ExtensionFactory.sol";
 import "./OldRoles.sol";
 
 
-contract OldRolesFactory is ColonyDataTypes {
+contract OldRolesFactory is ExtensionFactory, ColonyDataTypes {
   mapping (address => OldRoles) public deployedExtensions;	
 
-  function deployExtension(address _colony) public {
+  function deployExtension(address _colony) external {
     require(
       ColonyAuthority(IColony(_colony).authority()).hasUserRole(msg.sender, 1, uint8(ColonyRole.Root)) == true, 
       "colony-extension-user-not-root"
@@ -37,7 +38,7 @@ contract OldRolesFactory is ColonyDataTypes {
     deployedExtensions[_colony] = newExtensionAddress;
   }
 
-  function removeExtension(address _colony) public {
+  function removeExtension(address _colony) external {
     require(
       ColonyAuthority(IColony(_colony).authority()).hasUserRole(msg.sender, 1, uint8(ColonyRole.Root)) == true,
       "colony-extension-user-not-root"

--- a/contracts/extensions/OldRolesFactory.sol
+++ b/contracts/extensions/OldRolesFactory.sol
@@ -20,16 +20,29 @@ pragma experimental ABIEncoderV2;
 
 import "./../ColonyDataTypes.sol";
 import "./../IColony.sol";
+import "./../ColonyAuthority.sol";
 import "./OldRoles.sol";
 
 
-contract OldRolesFactory {
+contract OldRolesFactory is ColonyDataTypes {
   mapping (address => OldRoles) public deployedExtensions;	
 
   function deployExtension(address _colony) public {
+    require(
+      ColonyAuthority(IColony(_colony).authority()).hasUserRole(msg.sender, 1, uint8(ColonyRole.Root)) == true, 
+      "colony-extension-user-not-root"
+    );
     require(deployedExtensions[_colony] == OldRoles(0x00), "colony-extension-already-deployed");
     OldRoles newExtensionAddress = new OldRoles(_colony);
     deployedExtensions[_colony] = newExtensionAddress;
+  }
+
+  function removeExtension(address _colony) public {
+    require(
+      ColonyAuthority(IColony(_colony).authority()).hasUserRole(msg.sender, 1, uint8(ColonyRole.Root)) == true,
+      "colony-extension-user-not-root"
+    );
+    deployedExtensions[_colony] = OldRoles(0x00);
   }
 
 }

--- a/contracts/extensions/OldRolesFactory.sol
+++ b/contracts/extensions/OldRolesFactory.sol
@@ -1,0 +1,35 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity >=0.5.3;
+pragma experimental ABIEncoderV2;
+
+import "./../ColonyDataTypes.sol";
+import "./../IColony.sol";
+import "./OldRoles.sol";
+
+
+contract OldRolesFactory {
+  mapping (address => OldRoles) public deployedExtensions;	
+
+  function deployExtension(address _colony) public {
+    require(deployedExtensions[_colony] == OldRoles(0x00), "colony-extension-already-deployed");
+    OldRoles newExtensionAddress = new OldRoles(_colony);
+    deployedExtensions[_colony] = newExtensionAddress;
+  }
+
+}

--- a/contracts/extensions/OldRolesFactory.sol
+++ b/contracts/extensions/OldRolesFactory.sol
@@ -36,6 +36,7 @@ contract OldRolesFactory is ExtensionFactory, ColonyDataTypes {
     require(deployedExtensions[_colony] == OldRoles(0x00), "colony-extension-already-deployed");
     OldRoles newExtensionAddress = new OldRoles(_colony);
     deployedExtensions[_colony] = newExtensionAddress;
+    emit ExtensionDeployed("OldRoles", _colony, address(newExtensionAddress));
   }
 
   function removeExtension(address _colony) external {
@@ -44,6 +45,7 @@ contract OldRolesFactory is ExtensionFactory, ColonyDataTypes {
       "colony-extension-user-not-root"
     );
     deployedExtensions[_colony] = OldRoles(0x00);
+    emit ExtensionRemoved("OldRoles", _colony);
   }
 
 }

--- a/contracts/extensions/OneTxPaymentFactory.sol
+++ b/contracts/extensions/OneTxPaymentFactory.sol
@@ -21,13 +21,14 @@ pragma experimental ABIEncoderV2;
 import "./../ColonyDataTypes.sol";
 import "./../IColony.sol";
 import "./../ColonyAuthority.sol";
+import "./ExtensionFactory.sol";
 import "./OneTxPayment.sol";
 
 
-contract OneTxPaymentFactory is ColonyDataTypes {
+contract OneTxPaymentFactory is ExtensionFactory, ColonyDataTypes {
   mapping (address => OneTxPayment) public deployedExtensions;	
 
-  function deployExtension(address _colony) public {
+  function deployExtension(address _colony) external {
     require(
       ColonyAuthority(IColony(_colony).authority()).hasUserRole(msg.sender, 1, uint8(ColonyRole.Root)) == true, 
       "colony-extension-user-not-root"
@@ -37,7 +38,7 @@ contract OneTxPaymentFactory is ColonyDataTypes {
     deployedExtensions[_colony] = newExtensionAddress;
   }
 
-  function removeExtension(address _colony) public {
+  function removeExtension(address _colony) external {
     require(
       ColonyAuthority(IColony(_colony).authority()).hasUserRole(msg.sender, 1, uint8(ColonyRole.Root)) == true,
       "colony-extension-user-not-root"

--- a/contracts/extensions/OneTxPaymentFactory.sol
+++ b/contracts/extensions/OneTxPaymentFactory.sol
@@ -20,16 +20,29 @@ pragma experimental ABIEncoderV2;
 
 import "./../ColonyDataTypes.sol";
 import "./../IColony.sol";
+import "./../ColonyAuthority.sol";
 import "./OneTxPayment.sol";
 
 
-contract OneTxPaymentFactory {
+contract OneTxPaymentFactory is ColonyDataTypes {
   mapping (address => OneTxPayment) public deployedExtensions;	
 
   function deployExtension(address _colony) public {
+    require(
+      ColonyAuthority(IColony(_colony).authority()).hasUserRole(msg.sender, 1, uint8(ColonyRole.Root)) == true, 
+      "colony-extension-user-not-root"
+    );
     require(deployedExtensions[_colony] == OneTxPayment(0x00), "colony-extension-already-deployed");
     OneTxPayment newExtensionAddress = new OneTxPayment(_colony);
     deployedExtensions[_colony] = newExtensionAddress;
+  }
+
+  function removeExtension(address _colony) public {
+    require(
+      ColonyAuthority(IColony(_colony).authority()).hasUserRole(msg.sender, 1, uint8(ColonyRole.Root)) == true,
+      "colony-extension-user-not-root"
+    );
+    deployedExtensions[_colony] = OneTxPayment(0x00);
   }
 
 }

--- a/contracts/extensions/OneTxPaymentFactory.sol
+++ b/contracts/extensions/OneTxPaymentFactory.sol
@@ -36,6 +36,7 @@ contract OneTxPaymentFactory is ExtensionFactory, ColonyDataTypes {
     require(deployedExtensions[_colony] == OneTxPayment(0x00), "colony-extension-already-deployed");
     OneTxPayment newExtensionAddress = new OneTxPayment(_colony);
     deployedExtensions[_colony] = newExtensionAddress;
+    emit ExtensionDeployed("OneTxPayment", _colony, address(newExtensionAddress));
   }
 
   function removeExtension(address _colony) external {
@@ -44,6 +45,7 @@ contract OneTxPaymentFactory is ExtensionFactory, ColonyDataTypes {
       "colony-extension-user-not-root"
     );
     deployedExtensions[_colony] = OneTxPayment(0x00);
+    emit ExtensionRemoved("OneTxPayment", _colony);
   }
 
 }

--- a/contracts/extensions/OneTxPaymentFactory.sol
+++ b/contracts/extensions/OneTxPaymentFactory.sol
@@ -1,0 +1,35 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity >=0.5.3;
+pragma experimental ABIEncoderV2;
+
+import "./../ColonyDataTypes.sol";
+import "./../IColony.sol";
+import "./OneTxPayment.sol";
+
+
+contract OneTxPaymentFactory {
+  mapping (address => OneTxPayment) public deployedExtensions;	
+
+  function deployExtension(address _colony) public {
+    require(deployedExtensions[_colony] == OneTxPayment(0x00), "colony-extension-already-deployed");
+    OneTxPayment newExtensionAddress = new OneTxPayment(_colony);
+    deployedExtensions[_colony] = newExtensionAddress;
+  }
+
+}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -9,6 +9,9 @@ const ColonyNetworkENS = artifacts.require("./ColonyNetworkENS");
 const ReputationMiningCycle = artifacts.require("./ReputationMiningCycle");
 const ReputationMiningCycleRespond = artifacts.require("./ReputationMiningCycleRespond");
 const ENSRegistry = artifacts.require("./ENSRegistry");
+const OneTxPaymentFactory = artifacts.require("./extensions/OneTxPaymentFactory");
+const OldRolesFactory = artifacts.require("./extensions/OldRolesFactory");
+
 const EtherRouter = artifacts.require("./EtherRouter");
 const Resolver = artifacts.require("./Resolver");
 
@@ -30,4 +33,6 @@ module.exports = (deployer, network) => {
   deployer.deploy(EtherRouter);
   deployer.deploy(Resolver);
   deployer.deploy(ContractRecovery);
+  deployer.deploy(OneTxPaymentFactory);
+  deployer.deploy(OldRolesFactory);
 };

--- a/scripts/check-recovery.js
+++ b/scripts/check-recovery.js
@@ -26,8 +26,11 @@ walkSync("./contracts/").forEach(contractName => {
     [
       "contracts/ens/ENS.sol",
       "contracts/ens/ENSRegistry.sol",
+      "contracts/extensions/ExtensionFactory.sol",
       "contracts/extensions/OldRoles.sol",
+      "contracts/extensions/OldRolesFactory.sol",
       "contracts/extensions/OneTxPayment.sol",
+      "contracts/extensions/OneTxPaymentFactory.sol",
       "contracts/gnosis/MultiSigWallet.sol",
       "contracts/PatriciaTree/Bits.sol",
       "contracts/PatriciaTree/Data.sol",

--- a/scripts/check-storage.js
+++ b/scripts/check-storage.js
@@ -16,7 +16,9 @@ walkSync("./contracts/").forEach(contractName => {
   if (
     [
       "contracts/extensions/OldRoles.sol",
+      "contracts/extensions/OldRolesFactory.sol",
       "contracts/extensions/OneTxPayment.sol",
+      "contracts/extensions/OneTxPaymentFactory.sol",
       "contracts/CommonAuthority.sol",
       "contracts/ColonyAuthority.sol",
       "contracts/ColonyNetworkAuthority.sol",

--- a/test/extensions/old-roles.js
+++ b/test/extensions/old-roles.js
@@ -66,9 +66,22 @@ contract("Old Roles", accounts => {
     });
 
     it("does allow a user with root permission to remove the extension", async () => {
-      await oldRolesFactory.removeExtension(colony.address);
+      const tx = await oldRolesFactory.removeExtension(colony.address);
       const extensionAddress = await oldRolesFactory.deployedExtensions(colony.address);
       assert.equal(extensionAddress, ethers.constants.AddressZero);
+      const event = tx.logs[0];
+      assert.equal(event.args[0], "OldRoles");
+      assert.equal(event.args[1], colony.address);
+    });
+
+    it("emits the expected event when extension added", async () => {
+      ({ colony, token } = await setupRandomColony(colonyNetwork));
+      const tx = await oldRolesFactory.deployExtension(colony.address);
+      const event = tx.logs[0];
+      assert.equal(event.args[0], "OldRoles");
+      assert.equal(event.args[1], colony.address);
+      const oldRolesExtensionAddress = await oldRolesFactory.deployedExtensions(colony.address);
+      assert.equal(event.args[2], oldRolesExtensionAddress);
     });
 
     it("should be able to transfer the 'founder' role", async () => {

--- a/test/extensions/old-roles.js
+++ b/test/extensions/old-roles.js
@@ -2,6 +2,7 @@
 
 import chai from "chai";
 import bnChai from "bn-chai";
+import { ethers } from "ethers";
 
 import {
   WAD,
@@ -54,6 +55,20 @@ contract("Old Roles", accounts => {
   describe("old roles", async () => {
     it("does not allow an extension to be redeployed", async () => {
       await checkErrorRevert(oldRolesFactory.deployExtension(colony.address), "colony-extension-already-deployed");
+    });
+
+    it("does not allow a user without root permission to deploy the extension", async () => {
+      await checkErrorRevert(oldRolesFactory.deployExtension(colony.address, { from: USER1 }), "colony-extension-user-not-root");
+    });
+
+    it("does not allow a user without root permission to remove the extension", async () => {
+      await checkErrorRevert(oldRolesFactory.removeExtension(colony.address, { from: USER1 }), "colony-extension-user-not-root");
+    });
+
+    it("does allow a user with root permission to remove the extension", async () => {
+      await oldRolesFactory.removeExtension(colony.address);
+      const extensionAddress = await oldRolesFactory.deployedExtensions(colony.address);
+      assert.equal(extensionAddress, ethers.constants.AddressZero);
     });
 
     it("should be able to transfer the 'founder' role", async () => {

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -64,9 +64,22 @@ contract("One transaction payments", accounts => {
     });
 
     it("does allow a user with root permission to remove the extension", async () => {
-      await oneTxExtensionFactory.removeExtension(colony.address);
+      const tx = await oneTxExtensionFactory.removeExtension(colony.address);
       const extensionAddress = await oneTxExtensionFactory.deployedExtensions(colony.address);
       assert.equal(extensionAddress, ethers.constants.AddressZero);
+      const event = tx.logs[0];
+      assert.equal(event.args[0], "OneTxPayment");
+      assert.equal(event.args[1], colony.address);
+    });
+
+    it("emits the expected event when extension added", async () => {
+      ({ colony, token } = await setupRandomColony(colonyNetwork));
+      const tx = await oneTxExtensionFactory.deployExtension(colony.address);
+      const event = tx.logs[0];
+      assert.equal(event.args[0], "OneTxPayment");
+      assert.equal(event.args[1], colony.address);
+      const oneTxExtensionAddress = await oneTxExtensionFactory.deployedExtensions(colony.address);
+      assert.equal(event.args[2], oneTxExtensionAddress);
     });
 
     it("should allow a single-transaction payment of tokens to occur", async () => {

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -55,6 +55,20 @@ contract("One transaction payments", accounts => {
       await checkErrorRevert(oneTxExtensionFactory.deployExtension(colony.address), "colony-extension-already-deployed");
     });
 
+    it("does not allow a user without root permission to deploy the extension", async () => {
+      await checkErrorRevert(oneTxExtensionFactory.deployExtension(colony.address, { from: COLONY_ADMIN }), "colony-extension-user-not-root");
+    });
+
+    it("does not allow a user without root permission to remove the extension", async () => {
+      await checkErrorRevert(oneTxExtensionFactory.removeExtension(colony.address, { from: COLONY_ADMIN }), "colony-extension-user-not-root");
+    });
+
+    it("does allow a user with root permission to remove the extension", async () => {
+      await oneTxExtensionFactory.removeExtension(colony.address);
+      const extensionAddress = await oneTxExtensionFactory.deployedExtensions(colony.address);
+      assert.equal(extensionAddress, ethers.constants.AddressZero);
+    });
+
     it("should allow a single-transaction payment of tokens to occur", async () => {
       const balanceBefore = await token.balanceOf(RECIPIENT);
       expect(balanceBefore).to.eq.BN(0);


### PR DESCRIPTION
After talking to Chris about what would be useful to exist on-chain regarding extension contracts, we've arrived at this middle ground. In short, there needs to be a way for the dapp to work out if a supported extension is installed on a colony. We could have modified the extensions to be singletons on-chain that all colonies used, but establishing that precedent could prove dangerous if more complicated extensions were developed in the future, as the singleton would potentially have very many permissions across very many colonies, and so a bug in one could prove catastrophic.

The alternative we went for was to create a factory for each of the supported extensions. These provide a way to easily deploy an extension for a colony (just call the `deployExtension` function), as well as an easy way to look up the address of an extension for a particular colony (call the `deployedExtensions` getter).

Notes:

* I have used very generic names for the extension factory functions. This is so that in the future, when there are very many extensions (we hope) and factories, it's easier to develop against - we always know the names of these functions, rather than having to remember it's `deployOneTxExtension`, `deployOldRolesExtension` and so on.

* Adding/removing an extension from a colony is restricted to those with root permissions on the colony.

* I have deployed the factory during migrations so it's easier for people to develop against.