### PR TITLE
Provision default permissions for locked Token

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "lib/colonyToken"]
 	path = lib/colonyToken
 	url = https://github.com/JoinColony/colonyToken.git
-  branch = feature/provision-default-token-authority
+  branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "lib/colonyToken"]
 	path = lib/colonyToken
 	url = https://github.com/JoinColony/colonyToken.git
-  branch = master
+  branch = feature/provision-default-token-authority

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -411,8 +411,9 @@ export async function setupRandomColony(colonyNetwork) {
   const { logs } = await colonyNetwork.createColony(token.address);
   const { colonyAddress } = logs[0].args;
   const colony = await IColony.at(colonyAddress);
+  const tokenLockingAddress = await colonyNetwork.getTokenLocking();
 
-  const tokenAuthority = await TokenAuthority.new(token.address, colony.address, []);
+  const tokenAuthority = await TokenAuthority.new(token.address, colony.address, [tokenLockingAddress]);
   await token.setAuthority(tokenAuthority.address);
 
   return { colony, token };

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -336,15 +336,11 @@ export async function setupMetaColonyWithLockedCLNYToken(colonyNetwork) {
   const tokenLockingAddress = await colonyNetwork.getTokenLocking();
   const reputationMinerTestAccounts = accounts.slice(3, 11);
   // Second parameter is the vesting contract which is not the subject of this integration testing so passing in 0x0
-  const tokenAuthority = await TokenAuthority.new(
-    clnyToken.address,
+  const tokenAuthority = await TokenAuthority.new(clnyToken.address, metaColonyAddress, [
     colonyNetwork.address,
-    metaColonyAddress,
     tokenLockingAddress,
-    ethers.constants.AddressZero,
-    reputationMinerTestAccounts,
-    ethers.constants.AddressZero
-  );
+    ...reputationMinerTestAccounts
+  ]);
 
   await clnyToken.setAuthority(tokenAuthority.address);
   // Set the CLNY token owner to a dedicated account representing the Colony Multisig

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -26,7 +26,6 @@ const IMetaColony = artifacts.require("IMetaColony");
 const TokenLocking = artifacts.require("TokenLocking");
 const ITokenLocking = artifacts.require("ITokenLocking");
 const Token = artifacts.require("Token");
-const DSToken = artifacts.require("DSToken");
 const TokenAuthority = artifacts.require("./TokenAuthority");
 const EtherRouter = artifacts.require("EtherRouter");
 const Resolver = artifacts.require("Resolver");
@@ -403,11 +402,14 @@ export async function setupColonyNetwork() {
 
 export async function setupRandomColony(colonyNetwork) {
   const tokenArgs = getTokenArgs();
-  const token = await DSToken.new(tokenArgs[1]);
+  const token = await Token.new(...tokenArgs);
+
   const { logs } = await colonyNetwork.createColony(token.address);
   const { colonyAddress } = logs[0].args;
   const colony = await IColony.at(colonyAddress);
-  await token.setOwner(colonyAddress);
+
+  const tokenAuthority = await TokenAuthority.new(token.address, colony.address, []);
+  await token.setAuthority(tokenAuthority.address);
 
   return { colony, token };
 }

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -334,7 +334,11 @@ export async function setupMetaColonyWithLockedCLNYToken(colonyNetwork) {
 
   const tokenLockingAddress = await colonyNetwork.getTokenLocking();
   const reputationMinerTestAccounts = accounts.slice(3, 11);
-  // Second parameter is the vesting contract which is not the subject of this integration testing so passing in 0x0
+
+  // The following are the needed `transfer` function permissions on the locked CLNY that we setup via the TokenAuthority here
+  // IColonyNetworkMining: rewardStakers
+  // IColony: bootstrapColony, mintTokensForColonyNetwork, claimPayout and claimRewardPayout
+  // ITokenLocking: withdraw, deposit
   const tokenAuthority = await TokenAuthority.new(clnyToken.address, metaColonyAddress, [
     colonyNetwork.address,
     tokenLockingAddress,

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -333,17 +333,12 @@ export async function setupMetaColonyWithLockedCLNYToken(colonyNetwork) {
   await metaColony.setNetworkFeeInverse(100);
 
   const tokenLockingAddress = await colonyNetwork.getTokenLocking();
-  const reputationMinerTestAccounts = accounts.slice(3, 11);
 
   // The following are the needed `transfer` function permissions on the locked CLNY that we setup via the TokenAuthority here
   // IColonyNetworkMining: rewardStakers
   // IColony: bootstrapColony, mintTokensForColonyNetwork, claimPayout and claimRewardPayout
   // ITokenLocking: withdraw, deposit
-  const tokenAuthority = await TokenAuthority.new(clnyToken.address, metaColonyAddress, [
-    colonyNetwork.address,
-    tokenLockingAddress,
-    ...reputationMinerTestAccounts
-  ]);
+  const tokenAuthority = await TokenAuthority.new(clnyToken.address, metaColonyAddress, [colonyNetwork.address, tokenLockingAddress]);
 
   await clnyToken.setAuthority(tokenAuthority.address);
   // Set the CLNY token owner to a dedicated account representing the Colony Multisig

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -214,7 +214,7 @@ export function getRandomString(_length) {
 export function getTokenArgs() {
   const name = asciiToHex(getRandomString(5));
   const symbol = asciiToHex(getRandomString(3));
-  return [name, symbol];
+  return [name, symbol, 18];
 }
 
 export async function currentBlockTime() {

--- a/migrations/8_setup_meta_colony.js
+++ b/migrations/8_setup_meta_colony.js
@@ -11,7 +11,6 @@ const EtherRouter = artifacts.require("./EtherRouter");
 const TokenAuthority = artifacts.require("./TokenAuthority");
 
 const DEFAULT_STAKE = "2000000000000000000000000"; // 1000 * MIN_STAKE
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 // eslint-disable-next-line no-unused-vars
 module.exports = async function(deployer, network, accounts) {
@@ -30,15 +29,11 @@ module.exports = async function(deployer, network, accounts) {
   const reputationMinerTestAccounts = accounts.slice(3, 11);
 
   // Penultimate parameter is the vesting contract which is not the subject of this integration testing so passing in ZERO_ADDRESS
-  const tokenAuthority = await TokenAuthority.new(
-    clnyToken.address,
+  const tokenAuthority = await TokenAuthority.new(clnyToken.address, metaColonyAddress, [
     colonyNetwork.address,
-    metaColonyAddress,
     tokenLockingAddress,
-    ZERO_ADDRESS,
-    reputationMinerTestAccounts,
-    ZERO_ADDRESS
-  );
+    ...reputationMinerTestAccounts
+  ]);
   await clnyToken.setAuthority(tokenAuthority.address);
   await clnyToken.setOwner(accounts[11]);
 

--- a/test/colony-reward-payouts.js
+++ b/test/colony-reward-payouts.js
@@ -72,6 +72,7 @@ contract("Colony Reward Payouts", accounts => {
 
   beforeEach(async () => {
     ({ colony, token } = await setupRandomColony(colonyNetwork));
+    await token.unlock();
     await colony.setRewardInverse(100);
 
     const otherTokenArgs = getTokenArgs();

--- a/test/colony-reward-payouts.js
+++ b/test/colony-reward-payouts.js
@@ -72,7 +72,6 @@ contract("Colony Reward Payouts", accounts => {
 
   beforeEach(async () => {
     ({ colony, token } = await setupRandomColony(colonyNetwork));
-    await token.unlock();
     await colony.setRewardInverse(100);
 
     const otherTokenArgs = getTokenArgs();
@@ -342,7 +341,7 @@ contract("Colony Reward Payouts", accounts => {
     it("should not be able to claim tokens if user does not have any tokens", async () => {
       const userReputation3 = WAD.muln(10);
       await colony.bootstrapColony([userAddress3], [userReputation3]);
-      await token.transfer(colony.address, userReputation3, { from: userAddress3 });
+      await token.burn(userReputation3, { from: userAddress3 });
 
       await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });
       await advanceMiningCycleNoContest({ colonyNetwork, client, test: this });

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -45,6 +45,7 @@ contract("Token Locking", addresses => {
 
   beforeEach(async () => {
     ({ colony, token } = await setupRandomColony(colonyNetwork));
+    await token.unlock();
     await colony.mintTokens(Math.ceil(((usersTokens + otherUserTokens) * 100) / 99));
     await colony.claimColonyFunds(token.address);
     await colony.bootstrapColony([userAddress], [usersTokens]);

--- a/test/token-locking.js
+++ b/test/token-locking.js
@@ -45,7 +45,6 @@ contract("Token Locking", addresses => {
 
   beforeEach(async () => {
     ({ colony, token } = await setupRandomColony(colonyNetwork));
-    await token.unlock();
     await colony.mintTokens(Math.ceil(((usersTokens + otherUserTokens) * 100) / 99));
     await colony.claimColonyFunds(token.address);
     await colony.bootstrapColony([userAddress], [usersTokens]);


### PR DESCRIPTION
Integrate the refactored `TokenAuthority` from https://github.com/JoinColony/colonyToken/pull/16 which allows the colony `transfer` permissions on a locked Token.

Also update the `setupRandomColony` helper to generate a locked token instance. This works across our tests except for token locking and rewards functionality which is out of scope for the Colony Contribute dApp release. 

Merge order (as always with combined Token work) is to merge colonyToken#16 , change the `.gitsubmodules` branch back to `master` here and then merge this.