### PR TITLE
Real world mining client

### DIFF
--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -200,7 +200,7 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
 
   /// @notice Get the length of the ReputationUpdateLog stored on this instance of the ReputationMiningCycle contract
   /// @return nUpdates
-  function getReputationUpdateLogLength() public view returns (uint128 nUpdates);
+  function getReputationUpdateLogLength() public view returns (uint256 nUpdates);
 
   /// @notice Get the `ReputationLogEntry` at index `_id`
   /// @param _id The reputation log members array index of the entry to get

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -459,7 +459,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
       nPreviousUpdates));
   }
 
-  function getReputationUpdateLogLength() public view returns (uint) {
+  function getReputationUpdateLogLength() public view returns (uint256) {
     return reputationUpdateLog.length;
   }
 

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -297,6 +297,8 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
           msg.sender,
           MIN_STAKE
         );
+        emit HashInvalidated(opponentSubmission.proposedNewRootHash, opponentSubmission.nNodes, opponentSubmission.jrh);
+
       }
 
       // Note that two hashes have completed this challenge round (either one accepted for now and one rejected, or two rejected)
@@ -308,6 +310,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
         msg.sender,
         MIN_STAKE
       );
+      emit HashInvalidated(submission.proposedNewRootHash, submission.nNodes, submission.jrh);
     }
     //TODO: Can we do some deleting to make calling this as cheap as possible for people?
   }

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -83,7 +83,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
   /// At the beginning of the submission window, the target is set to 0 and slowly increases to 2^256 - 1.
   modifier withinTarget(bytes32 newHash, uint256 entryIndex) {
     // Check the ticket is a winning one.
-    // All entries are acceptable if the hour-long window is closed, so skip this check if that's the case
+    // All entries are acceptable if the 24 hour-long window is closed, so skip this check if that's the case
     if (!submissionWindowClosed()) {
       uint256 target = (now - reputationMiningWindowOpenTimestamp) * X;
       require(uint256(getEntryHash(msg.sender, entryIndex, newHash)) < target, "colony-reputation-mining-cycle-submission-not-within-target");

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -379,6 +379,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
       disputeRounds[round][idx].challengeStepCompleted += 1;
     }
 
+    emit BinarySearchConfirmed(submission.proposedNewRootHash, submission.nNodes, submission.jrh, disputeRounds[round][idx].lowerBound);
   }
 
   function confirmJustificationRootHash(
@@ -422,6 +423,8 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
 
     // Set bounds for first binary search if it's going to be needed
     disputeRounds[round][index].upperBound = submission.jrhNNodes - 1;
+
+    emit JustificationRootHashConfirmed(submission.proposedNewRootHash, submission.nNodes, submission.jrh);
   }
 
   function appendReputationUpdateLog(

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -197,6 +197,8 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     submittedHashes[newHash][nNodes][jrh].push(msg.sender);
     // Note that they submitted it.
     submittedEntries[msg.sender][entryIndex] = true;
+
+    emit ReputationRootHashSubmitted(msg.sender, newHash, nNodes, jrh, entryIndex);
   }
 
   function confirmNewHash(uint256 roundNumber) public

--- a/contracts/ReputationMiningCycleDataTypes.sol
+++ b/contracts/ReputationMiningCycleDataTypes.sol
@@ -66,6 +66,8 @@ contract ReputationMiningCycleDataTypes {
                                           // Justification tree.
   }
 
+  event ReputationRootHashSubmitted(address _miner, bytes32 _newHash, uint256 _nNodes, bytes32 _jrh, uint256 _entryIndex);
+
   /// @notice Event logged when a reputation UID is proven to be correct in a challenge
   event ProveUIDSuccess(uint256 previousNewReputationUID, uint256 _disagreeStateReputationUID, bool existingUID);
   

--- a/contracts/ReputationMiningCycleDataTypes.sol
+++ b/contracts/ReputationMiningCycleDataTypes.sol
@@ -67,6 +67,10 @@ contract ReputationMiningCycleDataTypes {
   }
 
   event ReputationRootHashSubmitted(address _miner, bytes32 _newHash, uint256 _nNodes, bytes32 _jrh, uint256 _entryIndex);
+  event JustificationRootHashConfirmed(bytes32 _newHash, uint256 _nNodes, bytes32 _jrh);
+  event BinarySearchConfirmed(bytes32 _newHash, uint256 _nNodes, bytes32 _jrh, uint256 _firstDisagreeIdx);
+  event ChallengeCompleted(bytes32 _newHash, uint256 _nNodes, bytes32 _jrh);
+
 
   /// @notice Event logged when a reputation UID is proven to be correct in a challenge
   event ProveUIDSuccess(uint256 previousNewReputationUID, uint256 _disagreeStateReputationUID, bool existingUID);

--- a/contracts/ReputationMiningCycleDataTypes.sol
+++ b/contracts/ReputationMiningCycleDataTypes.sol
@@ -70,6 +70,7 @@ contract ReputationMiningCycleDataTypes {
   event JustificationRootHashConfirmed(bytes32 _newHash, uint256 _nNodes, bytes32 _jrh);
   event BinarySearchConfirmed(bytes32 _newHash, uint256 _nNodes, bytes32 _jrh, uint256 _firstDisagreeIdx);
   event ChallengeCompleted(bytes32 _newHash, uint256 _nNodes, bytes32 _jrh);
+  event HashInvalidated(bytes32 _newHash, uint256 _nNodes, bytes32 _jrh);
 
 
   /// @notice Event logged when a reputation UID is proven to be correct in a challenge

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -343,6 +343,9 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     // If everthing checked out, note that we've responded to the challenge.
     disputeRounds[u[U_ROUND]][u[U_IDX]].challengeStepCompleted += 1;
     disputeRounds[u[U_ROUND]][u[U_IDX]].lastResponseTimestamp = now;
+    Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].firstSubmitter];
+
+    emit ChallengeCompleted(submission.proposedNewRootHash, submission.nNodes, submission.jrh);
   }
 
   function checkKey(uint256[29] memory u, bytes32[8] memory b32) internal view {

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -302,6 +302,29 @@ export async function forwardTime(seconds, test) {
   return p;
 }
 
+export async function mineBlock() {
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_mine",
+        params: [],
+        id: new Date().getTime()
+      },
+      err => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve();
+      }
+    );
+  });
+}
+
+export function getFunctionSignature(sig) {
+  return sha3(sig).slice(0, 10);
+}
+
 export function bnSqrt(bn, isGreater) {
   let a = bn.addn(1).divn(2);
   let b = bn;

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -190,6 +190,7 @@ export async function checkSuccessEthers(promise, errorMessage) {
   if (receipt.status === 1) {
     return;
   }
+  console.log("receipt", receipt);
   const txid = receipt.transactionHash;
   const tx = await web3GetTransaction(txid);
   const response = await web3GetRawCall({ from: tx.from, to: tx.to, data: tx.input, gas: tx.gas, value: tx.value });
@@ -269,7 +270,7 @@ export async function forwardTime(seconds, test) {
     if (client.indexOf("TestRPC") === -1) {
       resolve(test.skip());
     } else {
-      // console.log(`Forwarding time with ${seconds}s ...`);
+      console.log(`Forwarding time with ${seconds}s ...`);
       web3.currentProvider.send(
         {
           jsonrpc: "2.0",

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -190,7 +190,6 @@ export async function checkSuccessEthers(promise, errorMessage) {
   if (receipt.status === 1) {
     return;
   }
-
   const txid = receipt.transactionHash;
   const tx = await web3GetTransaction(txid);
   const response = await web3GetRawCall({ from: tx.from, to: tx.to, data: tx.input, gas: tx.gas, value: tx.value });
@@ -320,10 +319,6 @@ export async function mineBlock() {
       }
     );
   });
-}
-
-export function getFunctionSignature(sig) {
-  return sha3(sig).slice(0, 10);
 }
 
 export function bnSqrt(bn, isGreater) {
@@ -615,11 +610,10 @@ async function navigateChallenge(colonyNetwork, client1, client2, errors) {
 
 export async function finishReputationMiningCycle(colonyNetwork, test) {
   // Finish the current cycle. Can only do this at the start of a new cycle, if anyone has submitted a hash in this current cycle.
+  await forwardTime(MINING_CYCLE_DURATION, test);
   const repCycle = await getActiveRepCycle(colonyNetwork);
   const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
-
   if (nUniqueSubmittedHashes.gtn(0)) {
-    await forwardTime(MINING_CYCLE_DURATION, test);
     const nInvalidatedHashes = await repCycle.getNInvalidatedHashes();
     if (nUniqueSubmittedHashes.sub(nInvalidatedHashes).eqn(1)) {
       await repCycle.confirmNewHash(nUniqueSubmittedHashes.eqn(1) ? 0 : 1); // Not a general solution - only works for one or two submissions.

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -617,13 +617,13 @@ export async function finishReputationMiningCycle(colonyNetwork, test) {
   // Finish the current cycle. Can only do this at the start of a new cycle, if anyone has submitted a hash in this current cycle.
   const repCycle = await getActiveRepCycle(colonyNetwork);
   const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
-  console.log('nUniqueSubmittedHashes during finishReputationMiningCycle', nUniqueSubmittedHashes)
+  console.log("nUniqueSubmittedHashes during finishReputationMiningCycle", nUniqueSubmittedHashes);
   if (nUniqueSubmittedHashes.gtn(0)) {
     await forwardTime(MINING_CYCLE_DURATION, test);
     const nInvalidatedHashes = await repCycle.getNInvalidatedHashes();
     if (nUniqueSubmittedHashes.sub(nInvalidatedHashes).eqn(1)) {
       await repCycle.confirmNewHash(nUniqueSubmittedHashes.eqn(1) ? 0 : 1); // Not a general solution - only works for one or two submissions.
-      console.log('*****completed');
+      console.log("*****completed");
       // But for now, that's okay.
     } else {
       // We shouldn't get here. If this fires during a test, you haven't finished writing the test.

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -190,7 +190,7 @@ export async function checkSuccessEthers(promise, errorMessage) {
   if (receipt.status === 1) {
     return;
   }
-  console.log("receipt", receipt);
+
   const txid = receipt.transactionHash;
   const tx = await web3GetTransaction(txid);
   const response = await web3GetRawCall({ from: tx.from, to: tx.to, data: tx.input, gas: tx.gas, value: tx.value });
@@ -270,7 +270,7 @@ export async function forwardTime(seconds, test) {
     if (client.indexOf("TestRPC") === -1) {
       resolve(test.skip());
     } else {
-      console.log(`Forwarding time with ${seconds}s ...`);
+      // console.log(`Forwarding time with ${seconds}s ...`);
       web3.currentProvider.send(
         {
           jsonrpc: "2.0",
@@ -617,13 +617,12 @@ export async function finishReputationMiningCycle(colonyNetwork, test) {
   // Finish the current cycle. Can only do this at the start of a new cycle, if anyone has submitted a hash in this current cycle.
   const repCycle = await getActiveRepCycle(colonyNetwork);
   const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
-  console.log("nUniqueSubmittedHashes during finishReputationMiningCycle", nUniqueSubmittedHashes);
+
   if (nUniqueSubmittedHashes.gtn(0)) {
     await forwardTime(MINING_CYCLE_DURATION, test);
     const nInvalidatedHashes = await repCycle.getNInvalidatedHashes();
     if (nUniqueSubmittedHashes.sub(nInvalidatedHashes).eqn(1)) {
       await repCycle.confirmNewHash(nUniqueSubmittedHashes.eqn(1) ? 0 : 1); // Not a general solution - only works for one or two submissions.
-      console.log("*****completed");
       // But for now, that's okay.
     } else {
       // We shouldn't get here. If this fires during a test, you haven't finished writing the test.

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -610,10 +610,10 @@ async function navigateChallenge(colonyNetwork, client1, client2, errors) {
 
 export async function finishReputationMiningCycle(colonyNetwork, test) {
   // Finish the current cycle. Can only do this at the start of a new cycle, if anyone has submitted a hash in this current cycle.
-  await forwardTime(MINING_CYCLE_DURATION, test);
   const repCycle = await getActiveRepCycle(colonyNetwork);
   const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
   if (nUniqueSubmittedHashes.gtn(0)) {
+    await forwardTime(MINING_CYCLE_DURATION, test);
     const nInvalidatedHashes = await repCycle.getNInvalidatedHashes();
     if (nUniqueSubmittedHashes.sub(nInvalidatedHashes).eqn(1)) {
       await repCycle.confirmNewHash(nUniqueSubmittedHashes.eqn(1) ? 0 : 1); // Not a general solution - only works for one or two submissions.

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -615,13 +615,15 @@ async function navigateChallenge(colonyNetwork, client1, client2, errors) {
 
 export async function finishReputationMiningCycle(colonyNetwork, test) {
   // Finish the current cycle. Can only do this at the start of a new cycle, if anyone has submitted a hash in this current cycle.
-  await forwardTime(MINING_CYCLE_DURATION, test);
   const repCycle = await getActiveRepCycle(colonyNetwork);
   const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
+  console.log('nUniqueSubmittedHashes during finishReputationMiningCycle', nUniqueSubmittedHashes)
   if (nUniqueSubmittedHashes.gtn(0)) {
+    await forwardTime(MINING_CYCLE_DURATION, test);
     const nInvalidatedHashes = await repCycle.getNInvalidatedHashes();
     if (nUniqueSubmittedHashes.sub(nInvalidatedHashes).eqn(1)) {
       await repCycle.confirmNewHash(nUniqueSubmittedHashes.eqn(1) ? 0 : 1); // Not a general solution - only works for one or two submissions.
+      console.log('*****completed');
       // But for now, that's okay.
     } else {
       // We shouldn't get here. If this fires during a test, you haven't finished writing the test.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start:blockchain:client": "bash ./scripts/start-blockchain-client.sh",
     "stop:blockchain:client": "bash ./scripts/stop-blockchain-client.sh",
     "flatten:contracts": "mkdir -p ./build/flattened/ && steamroller contracts/IColonyNetwork.sol > build/flattened/flatIColonyNetwork.sol && steamroller contracts/IColony.sol > build/flattened/flatIColony.sol && steamroller contracts/IReputationMiningCycle.sol > build/flattened/flatIReputationMiningCycle.sol && steamroller contracts/IMetaColony.sol > build/flattened/flatIMetaColony.sol && steamroller contracts/IRecovery.sol > build/flattened/flatIRecovery.sol && steamroller contracts/IEtherRouter.sol > build/flattened/flatIEtherRouter.sol",
-    "test:reputation": "npm run start:blockchain:client & truffle migrate --reset --compile-all && nyc truffle test ./test/reputation-system/* --network development",
+    "test:reputation": "npm run start:blockchain:client & truffle migrate --reset --compile-all && nyc truffle test ./test/reputation-system/* ./test/reputation-system/reputation-mining-client/* --network development",
     "test:contracts": "npm run start:blockchain:client & truffle migrate --reset --compile-all && truffle test ./test/contracts-network/* --network development", 
     "test:contracts:upgrade:parity": "npm run start:blockchain:client parity & npm run generate:test:contracts && truffle migrate --reset --compile-all && truffle test ./test-upgrade/* --network integration",
     "test:contracts:upgrade:ganache": "npm run start:blockchain:client & npm run generate:test:contracts && truffle migrate --reset --compile-all && truffle test ./test-upgrade/* --network development",

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -83,6 +83,7 @@ class ReputationMiner {
     const metaColonyAddress = await this.colonyNetwork.getMetaColony();
     const metaColony = new ethers.Contract(metaColonyAddress, this.colonyContractDef.abi, this.realWallet);
     this.clnyAddress = await metaColony.getToken();
+
     if (this.useJsTree) {
       this.reputationTree = new PatriciaTree();
     } else {

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -818,7 +818,15 @@ class ReputationMiner {
     const [branchMask2, siblings2] = await this.justificationTree.getProof(ReputationMiner.getHexString(totalnUpdates, 64));
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const gasEstimate = await repCycle.estimate.confirmJustificationRootHash(round, index, branchMask1, siblings1, branchMask2, siblings2);
-    return repCycle.confirmJustificationRootHash(round, index, branchMask1, siblings1, branchMask2, siblings2, { gasLimit: gasEstimate, gasPrice: this.gasPrice });
+    return repCycle.confirmJustificationRootHash(
+      round, 
+      index, 
+      branchMask1, 
+      siblings1, 
+      branchMask2,
+      siblings2,
+      { gasLimit: gasEstimate, gasPrice: this.gasPrice }
+    );
   }
 
   /**
@@ -886,11 +894,25 @@ class ReputationMiner {
         siblings
       );
     }
-    const gasEstimate = await repCycle.estimate.respondToBinarySearchForChallenge(round, index, intermediateReputationHash, branchMask.toString(), siblings);
-    return repCycle.respondToBinarySearchForChallenge(round, index, intermediateReputationHash, branchMask.toString(), siblings, {
-      gasLimit: gasEstimate,
-      gasPrice: this.gasPrice
-    });
+    const gasEstimate = await repCycle.estimate.respondToBinarySearchForChallenge(
+      round, 
+      index, 
+      intermediateReputationHash, 
+      branchMask.toString(),
+      siblings
+    );
+    
+    return repCycle.respondToBinarySearchForChallenge(
+      round, 
+      index, 
+      intermediateReputationHash,
+      branchMask.toString(),
+      siblings,
+      {
+        gasLimit: gasEstimate,
+        gasPrice: this.gasPrice
+      }
+    );
   }
 
   /**

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -638,8 +638,12 @@ class ReputationMiner {
     if (!entryIndex) {
       entryIndex = await this.getEntryIndex(); // eslint-disable-line no-param-reassign
     }
-    let gasEstimate = await repCycle.estimate.submitRootHash(hash, nNodes, jrh, entryIndex);
-    if (process.env.SOLIDITY_COVERAGE) { gasEstimate = ethers.utils.bigNumberify(1000000); }
+    let gasEstimate;
+    if (process.env.SOLIDITY_COVERAGE) { 
+      gasEstimate = ethers.utils.bigNumberify(1000000); 
+    } else {
+      gasEstimate = await repCycle.estimate.submitRootHash(hash, nNodes, jrh, entryIndex);
+    }
 
     // Submit that entry
     return repCycle.submitRootHash(hash, nNodes, jrh, entryIndex, { gasLimit: gasEstimate, gasPrice: this.gasPrice });
@@ -819,8 +823,12 @@ class ReputationMiner {
       .add(this.nReputationsBeforeLatestLog);
     const [branchMask2, siblings2] = await this.justificationTree.getProof(ReputationMiner.getHexString(totalnUpdates, 64));
     const [round, index] = await this.getMySubmissionRoundAndIndex();
-    let gasEstimate = await repCycle.estimate.confirmJustificationRootHash(round, index, branchMask1, siblings1, branchMask2, siblings2);
-    if (process.env.SOLIDITY_COVERAGE) { gasEstimate = ethers.utils.bigNumberify(6000000); }
+    let gasEstimate;
+    if (process.env.SOLIDITY_COVERAGE) { 
+      gasEstimate = ethers.utils.bigNumberify(6000000); 
+    } else {
+      gasEstimate = await repCycle.estimate.confirmJustificationRootHash(round, index, branchMask1, siblings1, branchMask2, siblings2);
+    }
     return repCycle.confirmJustificationRootHash(
       round, 
       index, 
@@ -897,15 +905,19 @@ class ReputationMiner {
         siblings
       );
     }
-    let gasEstimate = await repCycle.estimate.respondToBinarySearchForChallenge(
-      round, 
-      index, 
-      intermediateReputationHash, 
-      branchMask.toString(),
-      siblings
-    );
+    let gasEstimate;
     
-    if (process.env.SOLIDITY_COVERAGE) { gasEstimate = ethers.utils.bigNumberify(1000000); }
+    if (process.env.SOLIDITY_COVERAGE) { 
+      gasEstimate = ethers.utils.bigNumberify(1000000); 
+    } else {
+      gasEstimate = await repCycle.estimate.respondToBinarySearchForChallenge(
+        round, 
+        index, 
+        intermediateReputationHash, 
+        branchMask.toString(),
+        siblings
+      );
+    }
 
     return repCycle.respondToBinarySearchForChallenge(
       round, 
@@ -935,8 +947,12 @@ class ReputationMiner {
 
     const intermediateReputationHash = this.justificationHashes[targetNodeKey].jhLeafValue;
     const [branchMask, siblings] = await this.justificationTree.getProof(targetNodeKey);
-    let gasEstimate = await repCycle.estimate.confirmBinarySearchResult(round, index, intermediateReputationHash, branchMask, siblings);
-    if (process.env.SOLIDITY_COVERAGE) { gasEstimate = ethers.utils.bigNumberify(1000000); }
+    let gasEstimate;
+    if (process.env.SOLIDITY_COVERAGE) { 
+      gasEstimate = ethers.utils.bigNumberify(1000000); 
+    } else {
+      gasEstimate = await repCycle.estimate.confirmBinarySearchResult(round, index, intermediateReputationHash, branchMask, siblings);
+    }
 
     return repCycle.confirmBinarySearchResult(round, index, intermediateReputationHash, branchMask, siblings, {
       gasLimit: gasEstimate,
@@ -1039,8 +1055,12 @@ class ReputationMiner {
       lastAgreeJustifications.childReputationProof.siblings,
       lastAgreeJustifications.adjacentReputationProof.siblings]
     
-    let gasEstimate = await repCycle.estimate.respondToChallenge(...functionArgs);
-    if (process.env.SOLIDITY_COVERAGE) { gasEstimate = ethers.utils.bigNumberify(4000000); }
+    let gasEstimate;
+    if (process.env.SOLIDITY_COVERAGE) { 
+      gasEstimate = ethers.utils.bigNumberify(4000000); 
+    } else {
+      gasEstimate = await repCycle.estimate.respondToChallenge(...functionArgs);
+    }
 
     return repCycle.respondToChallenge(...functionArgs,
       { gasLimit: gasEstimate, gasPrice: this.gasPrice }

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -85,6 +85,7 @@ class ReputationMiner {
     this.clnyAddress = await metaColony.getToken();
 
     if (this.useJsTree) {
+      console.log('new patricia tree')
       this.reputationTree = new PatriciaTree();
     } else {
       this.patriciaTreeContractDef = await this.loader.load({ contractName: "PatriciaTree" }, { abi: true, address: false, bytecode: true });
@@ -108,6 +109,7 @@ class ReputationMiner {
    * @return {Promise}
    */
   async addLogContentsToReputationTree(blockNumber = "latest") {
+    console.log('add log contents');
     if (this.useJsTree) {
       this.justificationTree = new PatriciaTreeNoHash();
     } else {
@@ -122,17 +124,18 @@ class ReputationMiner {
 
     this.justificationHashes = {};
     this.reverseReputationHashLookup = {};
-
     const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockTag: blockNumber });
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
 
     // Do updates
 
     this.nReputationsBeforeLatestLog = ethers.utils.bigNumberify(this.nReputations.toString());
+
     // This is also the number of decays we have.
 
     // How many updates from the logs do we have?
     const nLogEntries = await repCycle.getReputationUpdateLogLength({ blockTag: blockNumber });
+    console.log('nLogEntries', nLogEntries)
     if (nLogEntries.toString() === "0") {
       console.log("WARNING: No log entries found. If this is not one of the very first two cycles, something is wrong");
       return;
@@ -168,6 +171,7 @@ class ReputationMiner {
         newestReputationProof
       })
     );
+    console.log('add log contents done');
   }
 
   /**
@@ -1078,7 +1082,6 @@ class ReputationMiner {
     if (localHash === `0x${new BN(0).toString(16, 64)}`) {
       applyLogs = true;
     }
-
     for (let i = 0; i < events.length; i += 1) {
       const event = events[i];
       const hash = event.data.slice(0, 66);
@@ -1205,6 +1208,7 @@ class ReputationMiner {
     if (currentStateHash !== reputationRootHash) {
       console.log("WARNING: The supplied state failed to be recreated successfully. Are you sure it was saved?");
     }
+    console.log(this.reputations)
     await db.close();
   }
 

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -639,7 +639,6 @@ class ReputationMiner {
     if (!entryIndex) {
       entryIndex = await this.getEntryIndex(); // eslint-disable-line no-param-reassign
     }
-
     // Submit that entry
     return repCycle.submitRootHash(hash, nNodes, jrh, entryIndex, { gasLimit: 1000000 });
   }

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -126,9 +126,7 @@ class ReputationMiner {
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
 
     // Do updates
-
     this.nReputationsBeforeLatestLog = ethers.utils.bigNumberify(this.nReputations.toString());
-
     // This is also the number of decays we have.
 
     // How many updates from the logs do we have?

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -638,7 +638,9 @@ class ReputationMiner {
     if (!entryIndex) {
       entryIndex = await this.getEntryIndex(); // eslint-disable-line no-param-reassign
     }
-    const gasEstimate = await repCycle.estimate.submitRootHash(hash, nNodes, jrh, entryIndex);
+    let gasEstimate = await repCycle.estimate.submitRootHash(hash, nNodes, jrh, entryIndex);
+    if (process.env.SOLIDITY_COVERAGE) { gasEstimate = ethers.utils.bigNumberify(1000000); }
+
     // Submit that entry
     return repCycle.submitRootHash(hash, nNodes, jrh, entryIndex, { gasLimit: gasEstimate, gasPrice: this.gasPrice });
   }
@@ -817,7 +819,8 @@ class ReputationMiner {
       .add(this.nReputationsBeforeLatestLog);
     const [branchMask2, siblings2] = await this.justificationTree.getProof(ReputationMiner.getHexString(totalnUpdates, 64));
     const [round, index] = await this.getMySubmissionRoundAndIndex();
-    const gasEstimate = await repCycle.estimate.confirmJustificationRootHash(round, index, branchMask1, siblings1, branchMask2, siblings2);
+    let gasEstimate = await repCycle.estimate.confirmJustificationRootHash(round, index, branchMask1, siblings1, branchMask2, siblings2);
+    if (process.env.SOLIDITY_COVERAGE) { gasEstimate = ethers.utils.bigNumberify(6000000); }
     return repCycle.confirmJustificationRootHash(
       round, 
       index, 
@@ -894,7 +897,7 @@ class ReputationMiner {
         siblings
       );
     }
-    const gasEstimate = await repCycle.estimate.respondToBinarySearchForChallenge(
+    let gasEstimate = await repCycle.estimate.respondToBinarySearchForChallenge(
       round, 
       index, 
       intermediateReputationHash, 
@@ -902,6 +905,8 @@ class ReputationMiner {
       siblings
     );
     
+    if (process.env.SOLIDITY_COVERAGE) { gasEstimate = ethers.utils.bigNumberify(1000000); }
+
     return repCycle.respondToBinarySearchForChallenge(
       round, 
       index, 
@@ -930,7 +935,9 @@ class ReputationMiner {
 
     const intermediateReputationHash = this.justificationHashes[targetNodeKey].jhLeafValue;
     const [branchMask, siblings] = await this.justificationTree.getProof(targetNodeKey);
-    const gasEstimate = await repCycle.estimate.confirmBinarySearchResult(round, index, intermediateReputationHash, branchMask, siblings);
+    let gasEstimate = await repCycle.estimate.confirmBinarySearchResult(round, index, intermediateReputationHash, branchMask, siblings);
+    if (process.env.SOLIDITY_COVERAGE) { gasEstimate = ethers.utils.bigNumberify(1000000); }
+
     return repCycle.confirmBinarySearchResult(round, index, intermediateReputationHash, branchMask, siblings, {
       gasLimit: gasEstimate,
       gasPrice: this.gasPrice
@@ -1032,7 +1039,8 @@ class ReputationMiner {
       lastAgreeJustifications.childReputationProof.siblings,
       lastAgreeJustifications.adjacentReputationProof.siblings]
     
-    const gasEstimate = await repCycle.estimate.respondToChallenge(...functionArgs);
+    let gasEstimate = await repCycle.estimate.respondToChallenge(...functionArgs);
+    if (process.env.SOLIDITY_COVERAGE) { gasEstimate = ethers.utils.bigNumberify(4000000); }
 
     return repCycle.respondToChallenge(...functionArgs,
       { gasLimit: gasEstimate, gasPrice: this.gasPrice }

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -1063,6 +1063,9 @@ class ReputationMiner {
    * @return {Promise}               A promise that resolves once the state is up-to-date
    */
   async sync(blockNumber, saveHistoricalStates = false) {
+    if (!blockNumber) {
+      throw new Error("Block number not supplied to sync");
+    }
     // Get the events
     const filter = this.colonyNetwork.filters.ReputationMiningCycleComplete(null, null);
     filter.fromBlock = blockNumber;

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -85,7 +85,6 @@ class ReputationMiner {
     this.clnyAddress = await metaColony.getToken();
 
     if (this.useJsTree) {
-      console.log('new patricia tree')
       this.reputationTree = new PatriciaTree();
     } else {
       this.patriciaTreeContractDef = await this.loader.load({ contractName: "PatriciaTree" }, { abi: true, address: false, bytecode: true });
@@ -109,7 +108,6 @@ class ReputationMiner {
    * @return {Promise}
    */
   async addLogContentsToReputationTree(blockNumber = "latest") {
-    console.log('add log contents');
     if (this.useJsTree) {
       this.justificationTree = new PatriciaTreeNoHash();
     } else {
@@ -135,7 +133,6 @@ class ReputationMiner {
 
     // How many updates from the logs do we have?
     const nLogEntries = await repCycle.getReputationUpdateLogLength({ blockTag: blockNumber });
-    console.log('nLogEntries', nLogEntries)
     if (nLogEntries.toString() === "0") {
       console.log("WARNING: No log entries found. If this is not one of the very first two cycles, something is wrong");
       return;
@@ -171,7 +168,6 @@ class ReputationMiner {
         newestReputationProof
       })
     );
-    console.log('add log contents done');
   }
 
   /**
@@ -1208,7 +1204,6 @@ class ReputationMiner {
     if (currentStateHash !== reputationRootHash) {
       console.log("WARNING: The supplied state failed to be recreated successfully. Are you sure it was saved?");
     }
-    console.log(this.reputations)
     await db.close();
   }
 

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -110,8 +110,6 @@ class ReputationMinerClient {
   async initialise(colonyNetworkAddress, startingBlock) {
     this.resolveBlockChecksFinished = undefined;
     await this._miner.initialise(colonyNetworkAddress);
-    // TODO: Use this._miner.repCycleContractDef which is already initialised
-    this.repCycleContractDef = await this._loader.load({ contractName: "IReputationMiningCycle" }, { abi: true, address: false });
 
     // TODO: Get latest state from database, then sync to current state on-chain.
     // However, for now, we're the only miner, so we can just load the current saved state and go from there.
@@ -212,7 +210,7 @@ class ReputationMinerClient {
     const block = await this._miner.realProvider.getBlock(blockNumber, true);
     await this.updateGasEstimate(block);
     const addr = await this._miner.colonyNetwork.getReputationMiningCycle(true);
-    const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this._miner.realWallet);
+    const repCycle = new ethers.Contract(addr, this._miner.repCycleContractDef.abi, this._miner.realWallet);
 
     const hash = await this._miner.getRootHash();
     const nNodes = await this._miner.getRootHashNNodes();
@@ -376,7 +374,7 @@ class ReputationMinerClient {
 
   async getTwelveBestSubmissions() {
     const addr = await this._miner.colonyNetwork.getReputationMiningCycle(true);
-    const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this._miner.realWallet);
+    const repCycle = new ethers.Contract(addr, this._miner.repCycleContractDef.abi, this._miner.realWallet);
     const [, balance] = await this._miner.tokenLocking.getUserLock(this._miner.clnyAddress, this._miner.minerAddress);
     const reputationMiningWindowOpenTimestamp = await repCycle.getReputationMiningWindowOpenTimestamp();
     const rootHash = await this._miner.getRootHash();
@@ -419,7 +417,7 @@ class ReputationMinerClient {
 
   async confirmEntry() {
     const addr = await this._miner.colonyNetwork.getReputationMiningCycle(true);
-    const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this._miner.realWallet);
+    const repCycle = new ethers.Contract(addr, this._miner.repCycleContractDef.abi, this._miner.realWallet);
 
     console.log("⏰ Looks like it's time to confirm the new hash");
     // Confirm hash

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -1,5 +1,3 @@
-import { checkSuccessEthers } from "../../helpers/test-helper";
-
 const ethers = require("ethers");
 const express = require("express");
 const path = require('path');
@@ -409,8 +407,7 @@ class ReputationMinerClient {
     }
     console.log("⛏️ Transaction waiting to be mined", submitRootHashTx.hash);
     
-    // TODO: Think of a better way to do error handling here
-    await checkSuccessEthers(submitRootHashTx.wait());
+    await submitRootHashTx.wait();
     console.log("🆗 New reputation hash submitted successfully");
   }
 

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -170,7 +170,7 @@ class ReputationMinerClient {
     .map(tx => ethers.utils.bigNumberify(tx.gasPrice))
     .reduce((result, gasPrice) => {
       return result.add(gasPrice)
-    }, new ethers.utils.bigNumberify(0));
+    }, new ethers.utils.bigNumberify(0)); // eslint-disable-line new-cap
 
     let average = ethers.utils.bigNumberify(20000000000);
     if (block.transactions.length > 0){
@@ -182,7 +182,14 @@ class ReputationMinerClient {
       this.gasBlockAverages.shift()
     }
 
-    this._miner.gasPrice = ethers.utils.hexlify(this.gasBlockAverages.reduce((total, sum) => { return total.add(sum) }, ethers.utils.bigNumberify(0)).div(this.gasBlockAverages.length));
+    this._miner.gasPrice = ethers.utils.hexlify(
+      this.gasBlockAverages.reduce(
+        (total, sum) => { 
+          return total.add(sum)
+        }, 
+        ethers.utils.bigNumberify(0)
+      ).div(this.gasBlockAverages.length)
+    );
     // console.log("Average gas price from last 10 blocks: ", this._miner.gasPrice);
   }
 

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -427,7 +427,8 @@ class ReputationMinerClient {
     // This won't be valid anyway if we're not confirming immediately in the next transaction
     const [round] = await this._miner.getMySubmissionRoundAndIndex();
     if (round && round.gte(0)) {
-      const gasEstimate = await repCycle.estimate.confirmNewHash(round);
+      let gasEstimate = await repCycle.estimate.confirmNewHash(round);
+      if (process.env.SOLIDITY_COVERAGE) { gasEstimate = ethers.utils.bigNumberify(3500000); }
       // This estimate still goes a bit wrong in ganache, it seems, so we add an extra 10%.
       const confirmNewHashTx = await repCycle.confirmNewHash(round, { gasLimit: gasEstimate.mul(11).div(10) , gasPrice: this._miner.gasPrice });
       console.log("⛏️ Transaction waiting to be mined", confirmNewHashTx.hash);

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -186,17 +186,17 @@ class ReputationMinerClient {
     if (!lastHashStanding && !nUniqueSubmittedHashes.isZero()) {
       // Is what we believe to be the right submission being disputed?
       const [round, index] = await this._miner.getMySubmissionRoundAndIndex();
-      console.log("round", round.toString());
-      console.log("index", index.toString())
+      // console.log("round", round.toString());
+      // console.log("index", index.toString())
       const disputeRound = await repCycle.getDisputeRound(round);
       const entry = disputeRound[index];
       const submission = await repCycle.getReputationHashSubmission(entry.firstSubmitter);
 
       // Do we have an opponent?
       const oppIndex = index.mod(2).isZero() ? index.add(1) : index.sub(1);
-      console.log("oppIndex", oppIndex);
+      // console.log("oppIndex", oppIndex);
       const oppEntry = disputeRound[oppIndex];
-      console.log("oppEntry", oppEntry);
+      // console.log("oppEntry", oppEntry);
       const oppSubmission = await repCycle.getReputationHashSubmission(oppEntry.firstSubmitter);
 
       if (oppSubmission.proposedNewRootHash === ethers.constants.AddressZero){

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -192,7 +192,6 @@ class ReputationMinerClient {
         const canSubmit = await this._miner.submissionPossible(entryIndex);
         if (canSubmit) {
           console.log("⏰ Looks like it's time to submit an entry to the current cycle");
-          await this.submitEntry(entryIndex);
           submissionIndex += 1;
           await this.submitEntry(entryIndex);
         }

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -120,6 +120,10 @@ class ReputationMinerClient {
 
     this.gasBlockAverages = [];
 
+    // See if we're talking to Ganache to fix a ganache crash (which, while fun to say, is not fun to see)
+    const clientString = await this._miner.realProvider.send("web3_clientVersion");
+    this.ganacheClient = clientString.indexOf('TestRPC') !== -1
+
     console.log("🏁 Initialised");
     if (this._auto) {
       // Initial call to process the existing log from the cycle we're currently in
@@ -420,10 +424,10 @@ class ReputationMinerClient {
     const [round] = await this._miner.getMySubmissionRoundAndIndex();
     if (round && round.gte(0)) {
       let gasEstimate;
-      if (process.env.SOLIDITY_COVERAGE) { 
+      if (process.env.SOLIDITY_COVERAGE || this.ganacheClient) {
         gasEstimate = ethers.utils.bigNumberify(3500000);
       } else {
-        gasEstimate = await repCycle.estimate.confirmNewHash(round)
+        gasEstimate = await repCycle.estimate.confirmNewHash(round);
       }
       // This estimate still goes a bit wrong in ganache, it seems, so we add an extra 10%.
       const confirmNewHashTx = await repCycle.confirmNewHash(round, { gasLimit: gasEstimate.mul(11).div(10) , gasPrice: this._miner.gasPrice });

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -170,7 +170,6 @@ class ReputationMinerClient {
    * @return {Promise}
    */
   async doBlockChecks(blockNumber) {
-    console.log("doBlockChecks", blockNumber);
     if (lockedForBlockProcessing || lockedForLogProcessing) {
       return;
     }
@@ -201,7 +200,7 @@ class ReputationMinerClient {
     }
 
     const windowOpened = await repCycle.getReputationMiningWindowOpenTimestamp();
-    
+  
     const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
     const nInvalidatedHashes = await repCycle.getNInvalidatedHashes();
     const lastHashStanding = nUniqueSubmittedHashes.sub(nInvalidatedHashes).eq(1);
@@ -285,9 +284,8 @@ class ReputationMinerClient {
       {
         await this._miner.respondToChallenge();
       }
-    } 
+    }
 
-    console.log("lastHashStanding", lastHashStanding);
     if (lastHashStanding && ethers.utils.bigNumberify(block.timestamp).sub(windowOpened).gte(miningCycleDuration)) {
       // If the submission window is closed and we are the last hash, confirm it
       best12Submissions = []; // Clear the submissions

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -111,8 +111,7 @@ class ReputationMinerClient {
     this.resolveBlockChecksFinished = undefined;
     await this._miner.initialise(colonyNetworkAddress);
 
-    // TODO: Get latest state from database, then sync to current state on-chain.
-    // However, for now, we're the only miner, so we can just load the current saved state and go from there.
+    // Get latest state from database if available, otherwise sync to current state on-chain
     const latestReputationHash = await this._miner.colonyNetwork.getReputationRootHash();
     await this._miner.createDB();
     await this._miner.loadState(latestReputationHash);
@@ -421,10 +420,6 @@ class ReputationMinerClient {
 
     console.log("⏰ Looks like it's time to confirm the new hash");
     // Confirm hash
-    // We explicitly use the previous nonce +1, in case we're using Infura and we end up
-    // querying a node that hasn't had the above transaction propagate to it yet.
-    // TODO: not sure we need this still: nonce: confirmNewHashTx.nonce + 1 in the tx below
-    // This won't be valid anyway if we're not confirming immediately in the next transaction
     const [round] = await this._miner.getMySubmissionRoundAndIndex();
     if (round && round.gte(0)) {
       let gasEstimate;

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -11,7 +11,7 @@ const ethers = require("ethers");
 const ReputationMinerClient = require("../ReputationMinerClient");
 
 const supportedInfuraNetworks = ["goerli", "rinkeby", "ropsten", "kovan", "mainnet"];
-const { minerAddress, privateKey, colonyNetworkAddress, dbPath, network, localPort } = argv;
+const { minerAddress, privateKey, colonyNetworkAddress, dbPath, network, localPort, syncFrom, auto } = argv;
 
 if ((!minerAddress && !privateKey) || !colonyNetworkAddress) {
   console.log("❗️ You have to specify all of ( --minerAddress or --privateKey ) and --colonyNetworkAddress on the command line!");
@@ -33,5 +33,5 @@ if (network) {
   provider = new ethers.providers.JsonRpcProvider(`http://localhost:${localPort || "8545"}`);
 }
 
-const client = new ReputationMinerClient({ loader, minerAddress, privateKey, provider, useJsTree: true, dbPath });
-client.initialise(colonyNetworkAddress);
+const client = new ReputationMinerClient({ loader, minerAddress, privateKey, provider, useJsTree: true, dbPath, auto });
+client.initialise(colonyNetworkAddress, syncFrom);

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -13,8 +13,8 @@ const ReputationMinerClient = require("../ReputationMinerClient");
 const supportedInfuraNetworks = ["goerli", "rinkeby", "ropsten", "kovan", "mainnet"];
 const { minerAddress, privateKey, colonyNetworkAddress, dbPath, network, localPort, syncFrom, auto } = argv;
 
-if ((!minerAddress && !privateKey) || !colonyNetworkAddress) {
-  console.log("❗️ You have to specify all of ( --minerAddress or --privateKey ) and --colonyNetworkAddress on the command line!");
+if ((!minerAddress && !privateKey) || !colonyNetworkAddress || !syncFrom) {
+  console.log("❗️ You have to specify all of ( --minerAddress or --privateKey ) and --colonyNetworkAddress and --syncFrom on the command line!");
   process.exit();
 }
 

--- a/packages/reputation-miner/test/ReputationMinerTestWrapper.js
+++ b/packages/reputation-miner/test/ReputationMinerTestWrapper.js
@@ -1,8 +1,8 @@
 import ReputationMiner from "../ReputationMiner";
 
 class ReputationMinerTestWrapper extends ReputationMiner {
-  async submitRootHash(startIndex) {
-    const tx = await super.submitRootHash(startIndex);
+  async submitRootHash(entryIndex) {
+    const tx = await super.submitRootHash(entryIndex);
     return tx.wait();
   }
 

--- a/test/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-mining-client/client-auto-functionality.js
@@ -1,0 +1,138 @@
+/* globals artifacts */
+/* eslint-disable no-underscore-dangle */
+
+import path from "path";
+import chai from "chai";
+import bnChai from "bn-chai";
+
+import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
+
+import { DEFAULT_STAKE, MINING_CYCLE_DURATION } from "../../helpers/constants";
+import { advanceMiningCycleNoContest, getActiveRepCycle, forwardTime } from "../../helpers/test-helper";
+import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, giveUserCLNYTokensAndStake } from "../../helpers/test-data-generator";
+import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
+import ReputationMinerClient from "../../packages/reputation-miner/ReputationMinerClient";
+
+const { expect } = chai;
+chai.use(bnChai(web3.utils.BN));
+
+const ITokenLocking = artifacts.require("ITokenLocking");
+
+const loader = new TruffleLoader({
+  contractDir: path.resolve(__dirname, "..", "..", "build", "contracts")
+});
+
+const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
+
+process.env.SOLIDITY_COVERAGE
+  ? contract.skip
+  : contract("Reputation miner client auto enabled functionality", accounts => {
+      const MINER1 = accounts[5];
+
+      let colonyNetwork;
+      let repCycle;
+      let clnyToken;
+      let reputationMiner;
+      let reputationMinerClient;
+
+      before(async () => {
+        // Setup a new network instance as we'll be modifying the global skills tree
+        colonyNetwork = await setupColonyNetwork();
+        const tokenLockingAddress = await colonyNetwork.getTokenLocking();
+        const tokenLocking = await ITokenLocking.at(tokenLockingAddress);
+        ({ clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
+
+        await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
+        await colonyNetwork.initialiseReputationMining();
+        await colonyNetwork.startNextCycle();
+
+        const lock = await tokenLocking.getUserLock(clnyToken.address, MINER1);
+        expect(lock.balance).to.eq.BN(DEFAULT_STAKE);
+
+        reputationMiner = new ReputationMinerTestWrapper({ loader, minerAddress: MINER1, realProviderPort, useJsTree: true });
+      });
+
+      beforeEach(async function() {
+        // Advance two cycles to clear active and inactive state.
+        await advanceMiningCycleNoContest({ colonyNetwork, test: this });
+        await advanceMiningCycleNoContest({ colonyNetwork, test: this });
+
+        await reputationMiner.resetDB();
+        await reputationMiner.initialise(colonyNetwork.address);
+        await advanceMiningCycleNoContest({ colonyNetwork, client: reputationMiner, test: this });
+        await reputationMiner.saveCurrentState();
+        repCycle = await getActiveRepCycle(colonyNetwork);
+      });
+
+      afterEach(async function() {
+        reputationMinerClient.close();
+      });
+
+      describe("core functionality", function() {
+        it("should submit 12 entries as soon as it is able to", async function() {
+          this.timeout(1000000);
+          reputationMinerClient = new ReputationMinerClient({ loader, realProviderPort, minerAddress: MINER1, useJsTree: true, auto: true });
+          await reputationMinerClient.initialise(colonyNetwork.address);
+
+          const rootHash = await reputationMinerClient._miner.getRootHash();
+          const nNodes = await reputationMinerClient._miner.getRootHashNNodes();
+          const jrh = await reputationMinerClient._miner.justificationTree.getRootHash();
+          const { minerAddress } = reputationMinerClient._miner;
+
+          // Forward through most of the cycle duration and wait for the client to submit all 12 allowed entries
+          await forwardTime(MINING_CYCLE_DURATION * 0.9, this);
+
+          const receive12Submissions = new Promise(function(resolve) {
+            reputationMinerClient._miner.realProvider.on("block", async () => {
+              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
+              if (nSubmissions.toNumber() === 12) {
+                resolve();
+              }
+            });
+          });
+          await receive12Submissions;
+
+          // Check the reputation cycle submission matches our miner
+          // Validate the miner address in submission is correct
+          const lastSubmitter = await repCycle.getSubmissionUser(rootHash, nNodes, jrh, 0);
+          expect(lastSubmitter).to.equal(minerAddress);
+
+          // Validate the root hash matches what the miner submitted
+          const submission = await repCycle.getReputationHashSubmission(minerAddress);
+          expect(submission.proposedNewRootHash).to.equal(rootHash);
+
+          // Forward time to the end of the mining cycle and since we are the only miner, check the client confirmed our hash correctly
+          await forwardTime(MINING_CYCLE_DURATION * 0.1, this);
+        });
+
+        it("should confirm entry when mining window closes and all disputes are resolved", async function() {
+          const oldHash = await colonyNetwork.getReputationRootHash();
+
+          await forwardTime(MINING_CYCLE_DURATION * 0.9, this);
+          await reputationMiner.addLogContentsToReputationTree();
+          await reputationMiner.submitRootHash();
+          await reputationMiner.saveCurrentState();
+
+          const rootHash = await reputationMiner.getRootHash();
+
+          const confirmHash = new Promise(function(resolve) {
+            reputationMiner.realProvider.on("block", async () => {
+              const newRepCycle = await getActiveRepCycle(colonyNetwork);
+              if (newRepCycle.address !== repCycle.address) {
+                const newHash = await colonyNetwork.getReputationRootHash();
+                expect(newHash).to.not.equal(oldHash, "The old and new hashes are the same");
+                expect(newHash).to.equal(rootHash, "The network root hash doens't match the one submitted");
+                resolve();
+              }
+            });
+          });
+
+          reputationMinerClient = new ReputationMinerClient({ loader, realProviderPort, minerAddress: MINER1, useJsTree: true, auto: true });
+          reputationMinerClient.initialise(colonyNetwork.address);
+
+          // Forward time to the end of the mining cycle and since we are the only miner, check the client confirmed our hash correctly
+          await forwardTime(MINING_CYCLE_DURATION * 0.1, this);
+          await confirmHash;
+        });
+      });
+    });

--- a/test/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-mining-client/client-auto-functionality.js
@@ -87,7 +87,6 @@ process.env.SOLIDITY_COVERAGE
         await goodClient.initialise(colonyNetwork.address);
         await goodClient.sync(startingBlockNumber);
         await goodClient.saveCurrentState();
-
         count += 1;
         await reputationMinerClient.initialise(colonyNetwork.address, startingBlockNumber, count);
       });
@@ -100,7 +99,7 @@ process.env.SOLIDITY_COVERAGE
 
       describe("core functionality", function() {
  
-        it.only("should successfully complete a hash submission if it's the only miner", async function() {
+        it("should successfully complete a hash submission if it's the only miner", async function() {
           const rootHash = await reputationMinerClient._miner.getRootHash();
           const nNodes = await reputationMinerClient._miner.getRootHashNNodes();
           const jrh = await reputationMinerClient._miner.justificationTree.getRootHash();
@@ -160,7 +159,7 @@ process.env.SOLIDITY_COVERAGE
           await miningCycleComplete;
         });
 
-        it.only("should successfully complete a hash submission if there are 2 good miners", async function() {
+        it("should successfully complete a hash submission if there are 2 good miners", async function() {
           const oldHash = await colonyNetwork.getReputationRootHash();
           console.log("oldHash", oldHash);
           const rootHash = await reputationMinerClient._miner.getRootHash();
@@ -231,7 +230,7 @@ process.env.SOLIDITY_COVERAGE
           await miningCycleComplete;
         });
 
-        it.only("should successfully complete a dispute resolution", async function() {
+        it("should successfully complete a dispute resolution", async function() {
           const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree: true, minerAddress: MINER2 }, 1, 0);
           await badClient.initialise(colonyNetwork.address);
           // We need to load the current good state in to the bad client.

--- a/test/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-mining-client/client-auto-functionality.js
@@ -65,13 +65,14 @@ process.env.SOLIDITY_COVERAGE
         await goodClient.resetDB();
         await goodClient.initialise(colonyNetwork.address);
 
+        await reputationMinerClient._miner.resetDB();
         await reputationMinerClient.initialise(colonyNetwork.address);
       });
 
-      after(async function() {
-        // const reputationMiningGotClean = await finishReputationMiningCycle(colonyNetwork, this);
-        // if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1, MINER2);
-        reputationMinerClient.close();
+      afterEach(async function() {
+        const reputationMiningGotClean = await finishReputationMiningCycle(colonyNetwork, this);
+        if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1, MINER2);
+        await reputationMinerClient.close();
       });
 
       describe("core functionality", function() {

--- a/test/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-mining-client/client-auto-functionality.js
@@ -7,7 +7,7 @@ import bnChai from "bn-chai";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
 import { DEFAULT_STAKE, MINING_CYCLE_DURATION } from "../../helpers/constants";
-import { getActiveRepCycle, forwardTime, finishReputationMiningCycle } from "../../helpers/test-helper";
+import { getActiveRepCycle, forwardTime, finishReputationMiningCycle, advanceMiningCycleNoContest } from "../../helpers/test-helper";
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, giveUserCLNYTokensAndStake } from "../../helpers/test-data-generator";
 import ReputationMinerClient from "../../packages/reputation-miner/ReputationMinerClient";
 
@@ -29,6 +29,7 @@ process.env.SOLIDITY_COVERAGE
       let colonyNetwork;
       let repCycle;
       let reputationMinerClient;
+      let reputationMinerClient2;
 
       const setupNewNetworkInstance = async (_MINER1, _MINER2) => {
         colonyNetwork = await setupColonyNetwork();
@@ -38,6 +39,9 @@ process.env.SOLIDITY_COVERAGE
         await giveUserCLNYTokensAndStake(colonyNetwork, _MINER2, DEFAULT_STAKE);
         await colonyNetwork.initialiseReputationMining();
         await colonyNetwork.startNextCycle();
+
+        await advanceMiningCycleNoContest({ colonyNetwork, test: this });
+        await advanceMiningCycleNoContest({ colonyNetwork, test: this });
       };
 
       before(async () => {
@@ -52,10 +56,13 @@ process.env.SOLIDITY_COVERAGE
         const reputationMiningGotClean = await finishReputationMiningCycle(colonyNetwork, this);
         if (!reputationMiningGotClean) await setupNewNetworkInstance(MINER1, MINER2);
         reputationMinerClient.close();
+        if (reputationMinerClient2) {
+          reputationMinerClient2.close();
+        }
       });
 
       describe("core functionality", function() {
-        it("should submit 12 entries as soon as it is able to", async function() {
+        it("should successfully complete a hash submission if it's the only miner", async function() {
           reputationMinerClient = new ReputationMinerClient({ loader, realProviderPort, minerAddress: MINER1, useJsTree: true, auto: true });
           await reputationMinerClient.initialise(colonyNetwork.address);
           const rootHash = await reputationMinerClient._miner.getRootHash();
@@ -68,6 +75,15 @@ process.env.SOLIDITY_COVERAGE
             repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
               const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
               if (nSubmissions.toNumber() === 12) {
+                // Check the reputation cycle submission matches our miner
+                // Validate the miner address in submission is correct
+                const lastSubmitter = await repCycle.getSubmissionUser(rootHash, nNodes, jrh, 11);
+                expect(lastSubmitter).to.equal(minerAddress);
+
+                // Validate the root hash matches what the miner submitted
+                const submission = await repCycle.getReputationHashSubmission(minerAddress);
+                expect(submission.proposedNewRootHash).to.equal(rootHash);
+
                 event.removeListener();
                 resolve();
               }
@@ -83,23 +99,12 @@ process.env.SOLIDITY_COVERAGE
           await forwardTime(MINING_CYCLE_DURATION * 0.9, this);
           await receive12Submissions;
 
-          // Check the reputation cycle submission matches our miner
-          // Validate the miner address in submission is correct
-          const lastSubmitter = await repCycle.getSubmissionUser(rootHash, nNodes, jrh, 11);
-          expect(lastSubmitter).to.equal(minerAddress);
-
-          // Validate the root hash matches what the miner submitted
-          const submission = await repCycle.getReputationHashSubmission(minerAddress);
-          expect(submission.proposedNewRootHash).to.equal(rootHash);
-
           const oldHash = await colonyNetwork.getReputationRootHash();
 
           const colonyNetworkEthers = await reputationMinerClient._miner.colonyNetwork;
-
           const miningCycleComplete = new Promise(function(resolve, reject) {
             colonyNetworkEthers.on("ReputationMiningCycleComplete", async (_hash, _nNodes, event) => {
               const newHash = await colonyNetwork.getReputationRootHash();
-              console.log("newHash", newHash);
               expect(newHash).to.not.equal(oldHash, "The old and new hashes are the same");
               expect(newHash).to.equal(rootHash, "The network root hash doens't match the one submitted");
               event.removeListener();
@@ -113,7 +118,81 @@ process.env.SOLIDITY_COVERAGE
           });
 
           // Forward time to the end of the mining cycle and since we are the only miner, check the client confirmed our hash correctly
-          await forwardTime(MINING_CYCLE_DURATION * 1, this);
+          await forwardTime(MINING_CYCLE_DURATION * 0.1, this);
+          await miningCycleComplete;
+        });
+
+        it("should successfully complete a hash submission if there are 2 good miners", async function() {
+          reputationMinerClient = new ReputationMinerClient({ loader, realProviderPort, minerAddress: MINER1, useJsTree: true, auto: true });
+          await reputationMinerClient.initialise(colonyNetwork.address);
+          reputationMinerClient2 = new ReputationMinerClient({
+            loader,
+            realProviderPort,
+            minerPort: 3002,
+            minerAddress: MINER2,
+            useJsTree: true,
+            auto: true
+          });
+          await reputationMinerClient2.initialise(colonyNetwork.address);
+          const rootHash = await reputationMinerClient._miner.getRootHash();
+          const nNodes = await reputationMinerClient._miner.getRootHashNNodes();
+          const jrh = await reputationMinerClient._miner.justificationTree.getRootHash();
+          const { minerAddress } = reputationMinerClient._miner;
+          const { minerAddress2 } = reputationMinerClient2._miner;
+
+          const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
+          const receive12Submissions = new Promise(function(resolve, reject) {
+            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
+              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
+              if (nSubmissions.toNumber() === 12) {
+                // Check the reputation cycle submission matches our miners
+                for (let i = 0; i < 12; i += 1) {
+                  // Validate the miner address in submission is correct
+                  const submitter = await repCycle.getSubmissionUser(rootHash, nNodes, jrh, i);
+                  expect(submitter).to.be.oneOf.of([minerAddress, minerAddress2]);
+                }
+
+                // Validate the root hash matches what the miners submitted
+                const submission = await repCycle.getReputationHashSubmission(minerAddress);
+                expect(submission.proposedNewRootHash).to.equal(rootHash);
+                const submission2 = await repCycle.getReputationHashSubmission(minerAddress2);
+                expect(submission2.proposedNewRootHash).to.equal(rootHash);
+
+                event.removeListener();
+                resolve();
+              }
+            });
+
+            // After 30s, we throw a timeout error
+            setTimeout(() => {
+              reject(new Error("timeout while waiting for 12 hash submissions"));
+            }, 30000);
+          });
+
+          // Forward through most of the cycle duration and wait for the client to submit all 12 allowed entries
+          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
+
+          await receive12Submissions;
+          const oldHash = await colonyNetwork.getReputationRootHash();
+
+          const colonyNetworkEthers = await reputationMinerClient._miner.colonyNetwork;
+          const miningCycleComplete = new Promise(function(resolve, reject) {
+            colonyNetworkEthers.on("ReputationMiningCycleComplete", async (_hash, _nNodes, event) => {
+              const newHash = await colonyNetwork.getReputationRootHash();
+              expect(newHash).to.not.equal(oldHash, "The old and new hashes are the same");
+              expect(newHash).to.equal(rootHash, "The network root hash doens't match the one submitted");
+              event.removeListener();
+              resolve();
+            });
+
+            // After 30s, we throw a timeout error
+            setTimeout(() => {
+              reject(new Error("timeout while waiting for confirming hash"));
+            }, 30000);
+          });
+
+          // Forward time to the end of the mining cycle and since we are the only miner, check the client confirmed our hash correctly
+          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
           await miningCycleComplete;
         });
       });

--- a/test/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-mining-client/client-auto-functionality.js
@@ -42,7 +42,7 @@ process.env.SOLIDITY_COVERAGE
   : contract("Reputation miner client auto enabled functionality", accounts => {
       const MINER1 = accounts[5];
       const MINER2 = accounts[6];
-      // const MINER3 = accounts[7];
+      const MINER3 = accounts[7];
 
       let colonyNetwork;
       let repCycle;
@@ -50,7 +50,7 @@ process.env.SOLIDITY_COVERAGE
       let goodClient;
       let startingBlockNumber;
 
-      const setupNewNetworkInstance = async (_MINER1, _MINER2) => {
+      const setupNewNetworkInstance = async (_MINER1, _MINER2, _MINER3) => {
         colonyNetwork = await setupColonyNetwork();
 
         const { metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork);
@@ -58,6 +58,7 @@ process.env.SOLIDITY_COVERAGE
 
         await giveUserCLNYTokensAndStake(colonyNetwork, _MINER1, DEFAULT_STAKE);
         await giveUserCLNYTokensAndStake(colonyNetwork, _MINER2, DEFAULT_STAKE);
+        await giveUserCLNYTokensAndStake(colonyNetwork, _MINER3, DEFAULT_STAKE);
         await colonyNetwork.initialiseReputationMining();
         await colonyNetwork.startNextCycle();
 
@@ -84,7 +85,7 @@ process.env.SOLIDITY_COVERAGE
       };
 
       before(async () => {
-        await setupNewNetworkInstance(MINER1, MINER2);
+        await setupNewNetworkInstance(MINER1, MINER2, MINER3);
       });
 
       beforeEach(async function() {
@@ -232,14 +233,13 @@ process.env.SOLIDITY_COVERAGE
         });
 
         it("should successfully complete a dispute resolution", async function() {
-          const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree: true, minerAddress: MINER2 }, 1, 0);
+          const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree: true, minerAddress: MINER3 }, 1, 0);
           await badClient.initialise(colonyNetwork.address);
           // We need to load the current good state in to the bad client.
           await badClient.sync(startingBlockNumber);
           // make the bad client behave badly again
           badClient.amountToFalsify = 0xfffffffff;
 
-          await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
           await badClient.addLogContentsToReputationTree();
 
           const rootHash = await reputationMinerClient._miner.getRootHash();

--- a/test/reputation-system/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-system/reputation-mining-client/client-auto-functionality.js
@@ -6,7 +6,7 @@ import bnChai from "bn-chai";
 
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
-import { DEFAULT_STAKE, MINING_CYCLE_DURATION } from "../../helpers/constants";
+import { DEFAULT_STAKE, MINING_CYCLE_DURATION } from "../../../helpers/constants";
 import {
   getActiveRepCycle,
   forwardTime,
@@ -16,23 +16,23 @@ import {
   mineBlock,
   finishReputationMiningCycle,
   currentBlock
-} from "../../helpers/test-helper";
+} from "../../../helpers/test-helper";
 import {
   setupColonyNetwork,
   setupMetaColonyWithLockedCLNYToken,
   giveUserCLNYTokensAndStake,
   setupFinalizedTask,
   fundColonyWithTokens
-} from "../../helpers/test-data-generator";
-import ReputationMinerClient from "../../packages/reputation-miner/ReputationMinerClient";
-import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
-import MaliciousReputationMinerExtraRep from "../../packages/reputation-miner/test/MaliciousReputationMinerExtraRep";
+} from "../../../helpers/test-data-generator";
+import ReputationMinerClient from "../../../packages/reputation-miner/ReputationMinerClient";
+import ReputationMinerTestWrapper from "../../../packages/reputation-miner/test/ReputationMinerTestWrapper";
+import MaliciousReputationMinerExtraRep from "../../../packages/reputation-miner/test/MaliciousReputationMinerExtraRep";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
 
 const loader = new TruffleLoader({
-  contractDir: path.resolve(__dirname, "..", "..", "build", "contracts")
+  contractDir: path.resolve(__dirname, "..", "..", "..", "build", "contracts")
 });
 
 const realProviderPort = process.env.SOLIDITY_COVERAGE ? 8555 : 8545;
@@ -388,6 +388,58 @@ process.env.SOLIDITY_COVERAGE
           // And finally, check the root hash was accepted as expected.
           const acceptedRootHash = await colonyNetwork.getReputationRootHash();
           assert.equal(acceptedRootHash, rootHash);
+        });
+
+        it.skip("should cope if not processing anything and a new cycle starts", async function() {
+          await reputationMinerClient.close();
+          await goodClient.addLogContentsToReputationTree();
+          await goodClient.saveCurrentState();
+          await forwardTime(MINING_CYCLE_DURATION / 2, this);
+          await goodClient.submitRootHash();
+          console.log("submitted");
+          await forwardTime(MINING_CYCLE_DURATION, this);
+          console.log("forard");
+          const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
+          const receive12Submissions = new Promise(function(resolve, reject) {
+            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
+              const nSubmissions = await repCycle.getNSubmissionsForHash(_hash, _nNodes, _jrh);
+
+              if (nSubmissions.toNumber() === 12) {
+                // Check the reputation cycle submission matches our miners
+                for (let i = 0; i < 12; i += 1) {
+                  // Validate the miner address in submission is correct
+                  const submitter = await repCycle.getSubmissionUser(_hash, _nNodes, _jrh, i);
+                  expect(submitter).to.be.oneOf([MINER1, MINER2]);
+                }
+
+                // Validate the root hash matches what the miners submitted
+                const submission = await repCycle.getReputationHashSubmission(MINER1);
+                expect(submission.proposedNewRootHash).to.equal(_hash);
+                const submission2 = await repCycle.getReputationHashSubmission(MINER2);
+                expect(submission2.proposedNewRootHash).to.equal(_hash);
+
+                event.removeListener();
+                resolve();
+              } else {
+                await mineBlock();
+              }
+            });
+
+            // After 30s, we throw a timeout error
+            setTimeout(() => {
+              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
+            }, 30000);
+          });
+
+          await reputationMinerClient.initialise(colonyNetwork.address, startingBlockNumber);
+          // const x = new Promise((resolve, reject) => {})
+          console.log("confirm");
+          // await x
+          await repCycleEthers.confirmNewHash(1);
+          console.log("confirmed");
+          await forwardTime(MINING_CYCLE_DURATION / 2, this);
+
+          await receive12Submissions;
         });
       });
     });


### PR DESCRIPTION
Implements the following parts of #211 

- Submits a root hash as soon as it is able to, (rather than wait for the end of the submission period which isn't feasible when working with multiple submissions). It does so by checking at every block if there are less than 12 submissions of the current hash/nNodes/jrh and submits if there's still room

- Confirms the last hash after the mining window closes

- Implements a listener for `ReputationMiningCycleComplete` event for when a mining cycle completes so it processes the new update log