### PR TITLE
Fix reputation mining issues

### DIFF
--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -23,12 +23,9 @@ import "./ReputationMiningCycleDataTypes.sol";
 
 contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
 
-  /// @notice The getter for the disputeRounds mapping of array of dispute rounds.
+  /// @notice The getter for the disputeRounds mapping
   /// @param _round The dispute round to query
-  /// @param _index The index in the dispute round to query
-  /// @return The elements of the DisputedEntry struct for the submission requested. See ReputationMiningCycleDataTypes for the full description
-  function getDisputeRoundSubmission(uint256 _round, uint256 _index) public view returns (DisputedEntry memory submission);
-
+  /// @return An array of DisputedEntrys struct for the round. See ReputationMiningCycleDataTypes for the full description of the properties.
   function getDisputeRound(uint256 _round) public view returns (DisputedEntry[] memory submissions);
 
   /// @notice The getter for the hashSubmissions mapping, which keeps track of submissions by user.

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -41,6 +41,14 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @return entryHash The hash for the corresponding entry
   function getEntryHash(address submitter, uint256 entryIndex, bytes32 newHash) public pure returns (bytes32 entryHash);
 
+  /// @notice Returns a boolean result of whether the miner has already submitted at this entry index
+  /// @param _hash The hash that they submitted
+  /// @param _miner The address that submitted the hash
+  /// @param _jrh The JRH that they submitted
+  /// @param _index The index of the entry that they used to submit the hash
+  /// @return result Boolean whether the entryIndex was already submitted
+  function minerSubmittedEntryIndex(bytes32 _hash, address _miner, bytes32 _jrh, uint256 _index) public view returns (bool result);
+
   /// @notice Resets the timestamp that the submission window opens to `now`
   /// @dev only allowed to be called by ColonyNetwork
   function resetWindow() public;

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -222,8 +222,8 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @dev This will only be called once, by ColonyNetwork, in the same transaction that deploys this contract
   function initialise(address tokenLocking, address clnyToken) public;
 
-  /// @notice Get the number of hashes that have been submitted this mining cycle
-  function getNSubmittedHashes() public view returns (uint256 nSubmittedHashes);
+  /// @notice Get the number of unique hashes that have been submitted this mining cycle
+  function getNUniqueSubmittedHashes() public view returns (uint256 nUniqueSubmittedHashes);
 
   /// @notice Get the number of hashes that have been invalidated this mining cycle
   function getNInvalidatedHashes() public view returns (uint256 nInvalidatedHashes);

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -52,6 +52,9 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @param entryIndex The entry number for the given `newHash` and `nNodes`
   function submitRootHash(bytes32 newHash, uint256 nNodes, bytes32 jrh, uint256 entryIndex) public;
 
+  /// @notice Get whether a challenge round is complete
+  function challengeRoundComplete(uint256 round) public view returns (bool complete);
+
   /// @notice Confirm a new reputation hash. The hash in question is either the only one that was submitted this cycle,
   /// or the last one standing after all others have been proved wrong.
   /// @param roundNumber The round number that the hash being confirmed is in as the only contendender. If only one hash was submitted, then this is zero.

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -42,12 +42,10 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   function getEntryHash(address submitter, uint256 entryIndex, bytes32 newHash) public pure returns (bytes32 entryHash);
 
   /// @notice Returns a boolean result of whether the miner has already submitted at this entry index
-  /// @param _hash The hash that they submitted
   /// @param _miner The address that submitted the hash
-  /// @param _jrh The JRH that they submitted
   /// @param _index The index of the entry that they used to submit the hash
   /// @return result Boolean whether the entryIndex was already submitted
-  function minerSubmittedEntryIndex(bytes32 _hash, address _miner, bytes32 _jrh, uint256 _index) public view returns (bool result);
+  function minerSubmittedEntryIndex(address _miner, uint256 _index) public view returns (bool result);
 
   /// @notice Resets the timestamp that the submission window opens to `now`
   /// @dev only allowed to be called by ColonyNetwork

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -29,6 +29,8 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @return The elements of the DisputedEntry struct for the submission requested. See ReputationMiningCycleDataTypes for the full description
   function getDisputeRoundSubmission(uint256 _round, uint256 _index) public view returns (DisputedEntry memory submission);
 
+  function getDisputeRound(uint256 _round) public view returns (DisputedEntry[] memory submissions);
+
   /// @notice The getter for the hashSubmissions mapping, which keeps track of submissions by user.
   /// @param _user Address of the user
   /// @return submission the Submission struct for the submission requested. See ReputationMiningCycleDataTypes.sol for the full description

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -234,4 +234,11 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @param jrh The JRH of that was submitted
   /// @param index The index of the submission - should be 0-11, as up to twelve submissions can be made.
   function getSubmissionUser(bytes32 hash, uint256 nNodes, bytes32 jrh, uint256 index) public view returns (address user);
+
+  /// @notice Get the number of submissions miners made of a particular hash / nNodes / jrh combination
+  /// @param hash The hash that was submitted
+  /// @param nNodes The number of nodes that was submitted
+  /// @param jrh The JRH of that was submitted
+  /// @return count The number of submissions - should be 0-12, as up to twelve submissions can be made
+  function getNSubmissionsForHash(bytes32 hash, uint256 nNodes, bytes32 jrh) public view returns (uint256 count);
 }

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -236,6 +236,15 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @notice Get the number of hashes that have been invalidated this mining cycle
   function getNInvalidatedHashes() public view returns (uint256 nInvalidatedHashes);
 
+  /// @notice Get the minimum stake of CLNY required to mine
+  function getMinStake() public pure returns (uint256 minStake);
+
+  /// @notice Get the length of the mining window in seconds
+  function getMiningWindowDuration() public pure returns (uint256 miningWindowDuration);
+
+  /// @notice Get the reputation decay constant.
+  function getDecayConstant() public pure returns (uint256 numerator, uint256 denominator);
+
   /// @notice Get the address that made a particular submission
   /// @param hash The hash that was submitted
   /// @param nNodes The number of nodes that was submitted

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -145,7 +145,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
   }
 
   function challengeRoundComplete(uint256 round) public view returns (bool) {
-    return nHashesCompletedChallengeRound[round] == disputeRounds[round-1].length;
+    return nHashesCompletedChallengeRound[round] == disputeRounds[round].length;
   }
 
   function submitRootHash(bytes32 newHash, uint256 nNodes, bytes32 jrh, uint256 entryIndex) public
@@ -232,7 +232,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
         require(submissionWindowClosed(), "colony-reputation-mining-submission-window-still-open");
       } else {
         // Otherwise, ensure that the previous round is complete, and this entry wouldn't possibly get an opponent later on.
-        require(nHashesCompletedChallengeRound[round-1] == disputeRounds[round-1].length, "colony-reputation-mining-previous-dispute-round-not-complete");
+        require(challengeRoundComplete(round - 1), "colony-reputation-mining-previous-dispute-round-not-complete");
       }
 
 

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -62,7 +62,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     require(reputationMiningWindowOpenTimestamp >= lockTimestamp, "colony-reputation-mining-stake-too-recent");
 
     // If this user has submitted before during this round...
-    if (reputationHashSubmissions[msg.sender].proposedNewRootHash != 0x0) {
+    if (reputationHashSubmissions[msg.sender].proposedNewRootHash != bytes32(0)) {
       // ...require that they are submitting the same hash ...
       require(newHash == reputationHashSubmissions[msg.sender].proposedNewRootHash, "colony-reputation-mining-submitting-different-hash");
       // ...require that they are submitting the same number of nodes for that hash ...
@@ -136,6 +136,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
   }
 
   function getSubmissionUser(bytes32 hash, uint256 nNodes, bytes32 jrh, uint256 index) public view returns (address) {
+    require(submittedHashes[hash][nNodes][jrh].length > index, "colony-reputation-mining-submission-index-out-of-range");
     return submittedHashes[hash][nNodes][jrh][index];
   }
 

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -109,6 +109,14 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     clnyTokenAddress = _clnyTokenAddress;
   }
 
+  function getMinStake() public pure returns (uint256) {
+    return MIN_STAKE;
+  }
+
+  function getMiningWindowDuration() public pure returns (uint256) {
+    return MINING_WINDOW_SIZE;
+  }
+
   function getEntryHash(address submitter, uint256 entryIndex, bytes32 newHash) public pure returns (bytes32) {
     return keccak256(abi.encodePacked(submitter, entryIndex, newHash));
   }

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -211,8 +211,14 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
       // this is the slot after the last entry, and so our opponentIdx will be the last entry
       // We just move the opponent on, and nothing else happens.
 
-      // Ensure that the previous round is complete, and this entry wouldn't possibly get an opponent later on.
-      require(nHashesCompletedChallengeRound[round-1] == disputeRounds[round-1].length, "colony-reputation-mining-previous-dispute-round-not-complete");
+      if (round == 0) {
+        // If we're in round zero, require that no more submissions can be made
+        require(submissionWindowClosed(), "colony-reputation-mining-submission-window-still-open");
+      } else {
+        // Otherwise, ensure that the previous round is complete, and this entry wouldn't possibly get an opponent later on.
+        require(nHashesCompletedChallengeRound[round-1] == disputeRounds[round-1].length, "colony-reputation-mining-previous-dispute-round-not-complete");
+      }
+
 
       // Prevent us invalidating the final hash
       require(disputeRounds[round].length > 1, "colony-reputation-mining-cannot-invalidate-final-hash");

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -118,6 +118,10 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     return nUniqueSubmittedHashes;
   }
 
+  function getNSubmissionsForHash(bytes32 hash, uint256 nNodes, bytes32 jrh) public view returns (uint256) {
+    return submittedHashes[hash][nNodes][jrh].length;
+  }
+
   /// @notice Get the number of hashes that have been invalidated this mining cycle
   function getNInvalidatedHashes() public view returns (uint256) {
     return nInvalidatedHashes;

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -35,7 +35,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
   /// @notice A modifier that checks that the supplied `roundNumber` is the final round
   /// @param roundNumber The `roundNumber` to check if it is the final round
   modifier finalDisputeRoundCompleted(uint256 roundNumber) {
-    require(nSubmittedHashes - nInvalidatedHashes == 1, "colony-reputation-mining-final-round-not-complete");
+    require(nUniqueSubmittedHashes - nInvalidatedHashes == 1, "colony-reputation-mining-final-round-not-complete");
     require(disputeRounds[roundNumber].length == 1, "colony-reputation-mining-not-final-round"); //i.e. this is the final round
     // Note that even if we are passed the penultimate round, which had a length of two, and had one eliminated,
     // and therefore 'delete' called in `invalidateHash`, the array still has a length of '2' - it's just that one
@@ -95,7 +95,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     // A submission is possible if this has become the active cycle (i.e. window opened) and...
     require(reputationMiningWindowOpenTimestamp > 0, "colony-reputation-mining-cycle-not-open");
     // the window has not closed or no-one has submitted
-    require(!submissionWindowClosed() || nSubmittedHashes == 0, "colony-reputation-mining-cycle-submissions-closed");
+    require(!submissionWindowClosed() || nUniqueSubmittedHashes == 0, "colony-reputation-mining-cycle-submissions-closed");
     _;
   }
 
@@ -114,8 +114,8 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
   }
 
   /// @notice Get the number of hashes that have been submitted this mining cycle
-  function getNSubmittedHashes() public view returns (uint256) {
-    return nSubmittedHashes;
+  function getNUniqueSubmittedHashes() public view returns (uint256) {
+    return nUniqueSubmittedHashes;
   }
 
   /// @notice Get the number of hashes that have been invalidated this mining cycle
@@ -140,9 +140,9 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     // Limit the total number of miners allowed to submit a specific hash to 12
     require(submittedHashes[newHash][nNodes][jrh].length < 12, "colony-reputation-mining-max-number-miners-reached");
 
-    // If this is a new hash, increment nSubmittedHashes as such.
+    // If this is a new hash, increment nUniqueSubmittedHashes as such.
     if (submittedHashes[newHash][nNodes][jrh].length == 0) {
-      nSubmittedHashes += 1;
+      nUniqueSubmittedHashes += 1;
       // And add it to the first disputeRound
       // NB if no other hash is submitted, no dispute resolution will be required.
       disputeRounds[0].push(DisputedEntry({
@@ -159,11 +159,11 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
         hash2: 0x00
       }));
       // If we've got a pair of submissions to face off, may as well start now.
-      if (nSubmittedHashes % 2 == 0) {
-        disputeRounds[0][nSubmittedHashes-1].lastResponseTimestamp = now;
-        disputeRounds[0][nSubmittedHashes-2].lastResponseTimestamp = now;
-        /* disputeRounds[0][nSubmittedHashes-1].upperBound = disputeRounds[0][nSubmittedHashes-1].jrhNNodes; */
-        /* disputeRounds[0][nSubmittedHashes-2].upperBound = disputeRounds[0][nSubmittedHashes-2].jrhNNodes; */
+      if (nUniqueSubmittedHashes % 2 == 0) {
+        disputeRounds[0][nUniqueSubmittedHashes-1].lastResponseTimestamp = now;
+        disputeRounds[0][nUniqueSubmittedHashes-2].lastResponseTimestamp = now;
+        /* disputeRounds[0][nUniqueSubmittedHashes-1].upperBound = disputeRounds[0][nUniqueSubmittedHashes-1].jrhNNodes; */
+        /* disputeRounds[0][nUniqueSubmittedHashes-2].upperBound = disputeRounds[0][nUniqueSubmittedHashes-2].jrhNNodes; */
       }
     }
 

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -467,6 +467,10 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     return submittedEntries[_miner][_index];
   }
 
+  function getDisputeRound(uint256 _round) public view returns (DisputedEntry[] memory) {
+    return disputeRounds[_round];
+  }
+
   function rewardStakersWithReputation(
     address[] memory stakers,
     uint256[] memory weights,

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -167,12 +167,15 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
       }
     }
 
-    reputationHashSubmissions[msg.sender] = Submission({
-      proposedNewRootHash: newHash,
-      nNodes: nNodes,
-      jrh: jrh,
-      jrhNNodes: 0
-    });
+    if (reputationHashSubmissions[msg.sender].proposedNewRootHash == bytes32(0)) {
+      reputationHashSubmissions[msg.sender] = Submission({
+        proposedNewRootHash: newHash,
+        nNodes: nNodes,
+        jrh: jrh,
+        jrhNNodes: 0
+      });
+    }
+    
     // And add the miner to the array list of submissions here
     submittedHashes[newHash][nNodes][jrh].push(msg.sender);
     // Note that they submitted it.

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -459,10 +459,6 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     return reputationHashSubmissions[_user];
   }
 
-  function getDisputeRoundSubmission(uint256 _round, uint256 _index) public view returns (DisputedEntry memory) {
-    return disputeRounds[_round][_index];
-  }
-
   function minerSubmittedEntryIndex(address _miner, uint256 _index) public view returns (bool result) {
     return submittedEntries[_miner][_index];
   }

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -463,6 +463,10 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     return disputeRounds[_round][_index];
   }
 
+  function minerSubmittedEntryIndex(bytes32 _hash, address _miner, bytes32 _jrh, uint256 _index) public view returns (bool result) {
+    return submittedEntries[_hash][_miner][_jrh][_index];
+  }
+
   function rewardStakersWithReputation(
     address[] memory stakers,
     uint256[] memory weights,

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -70,7 +70,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
       // ...require that they are submitting the same jrh for that hash ...
       require(jrh == reputationHashSubmissions[msg.sender].jrh, "colony-reputation-mining-submitting-different-jrh");
        // ... but not this exact entry
-      require(submittedEntries[newHash][msg.sender][jrh][entryIndex] == false, "colony-reputation-mining-submitting-same-entry-index");
+      require(submittedEntries[msg.sender][entryIndex] == false, "colony-reputation-mining-submitting-same-entry-index");
     }
     _;
   }
@@ -183,11 +183,11 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
         jrhNNodes: 0
       });
     }
-    
+
     // And add the miner to the array list of submissions here
     submittedHashes[newHash][nNodes][jrh].push(msg.sender);
     // Note that they submitted it.
-    submittedEntries[newHash][msg.sender][jrh][entryIndex] = true;
+    submittedEntries[msg.sender][entryIndex] = true;
   }
 
   function confirmNewHash(uint256 roundNumber) public
@@ -463,8 +463,8 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     return disputeRounds[_round][_index];
   }
 
-  function minerSubmittedEntryIndex(bytes32 _hash, address _miner, bytes32 _jrh, uint256 _index) public view returns (bool result) {
-    return submittedEntries[_hash][_miner][_jrh][_index];
+  function minerSubmittedEntryIndex(address _miner, uint256 _index) public view returns (bool result) {
+    return submittedEntries[_miner][_index];
   }
 
   function rewardStakersWithReputation(

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -136,6 +136,10 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     reputationMiningWindowOpenTimestamp = now;
   }
 
+  function challengeRoundComplete(uint256 round) public view returns (bool) {
+    return nHashesCompletedChallengeRound[round] == disputeRounds[round-1].length;
+  }
+
   function submitRootHash(bytes32 newHash, uint256 nNodes, bytes32 jrh, uint256 entryIndex) public
   submissionPossible()
   entryQualifies(newHash, nNodes, jrh, entryIndex)

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -95,6 +95,10 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
   uint constant DECAY_NUMERATOR =    992327946262944; // 24-hr mining cycles
   uint constant DECAY_DENOMINATOR = 1000000000000000;
 
+  function getDecayConstant() public pure returns (uint256, uint256) {
+    return (DECAY_NUMERATOR, DECAY_DENOMINATOR);
+  }
+
   function respondToChallenge(
     uint256[29] memory u, //An array of 29 UINT Params, ordered as given above.
     bytes32[8] memory b32, // An array of 8 bytes32 params, ordered as given above

--- a/contracts/ReputationMiningCycleStorage.sol
+++ b/contracts/ReputationMiningCycleStorage.sol
@@ -53,9 +53,9 @@ contract ReputationMiningCycleStorage is ReputationMiningCycleDataTypes, DSAuth 
   uint256 nUniqueSubmittedHashes = 0; // Storage slot 12
   uint256 nInvalidatedHashes = 0; // Storage slot 13
 
-  // Records for which hashes, for which addresses, for which JRHs, for which entries have been accepted
+  // Records for which addresses, for which entries have been accepted
   // Otherwise, people could keep submitting the same entry.
-  mapping (bytes32 => mapping(address => mapping(bytes32 => mapping(uint256 => bool)))) submittedEntries; // Storage slot 14
+  mapping (address => mapping(uint256 => bool)) submittedEntries; // Storage slot 14
 
   int256 constant MAX_INT128 = 2**127 - 1;
   int256 constant MIN_INT128 = (2**127)*(-1);

--- a/contracts/ReputationMiningCycleStorage.sol
+++ b/contracts/ReputationMiningCycleStorage.sol
@@ -50,7 +50,7 @@ contract ReputationMiningCycleStorage is ReputationMiningCycleDataTypes, DSAuth 
   // that's okay...?
 
   // Number of unique hashes submitted
-  uint256 nSubmittedHashes = 0; // Storage slot 12
+  uint256 nUniqueSubmittedHashes = 0; // Storage slot 12
   uint256 nInvalidatedHashes = 0; // Storage slot 13
 
   // Records for which hashes, for which addresses, for which JRHs, for which entries have been accepted

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -656,11 +656,11 @@ export async function finishReputationMiningCycle(colonyNetwork, test) {
   // Finish the current cycle. Can only do this at the start of a new cycle, if anyone has submitted a hash in this current cycle.
   await forwardTime(MINING_CYCLE_DURATION, test);
   const repCycle = await getActiveRepCycle(colonyNetwork);
-  const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-  if (nSubmittedHashes.gtn(0)) {
+  const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
+  if (nUniqueSubmittedHashes.gtn(0)) {
     const nInvalidatedHashes = await repCycle.getNInvalidatedHashes();
-    if (nSubmittedHashes.sub(nInvalidatedHashes).eqn(1)) {
-      await repCycle.confirmNewHash(nSubmittedHashes.eqn(1) ? 0 : 1); // Not a general solution - only works for one or two submissions.
+    if (nUniqueSubmittedHashes.sub(nInvalidatedHashes).eqn(1)) {
+      await repCycle.confirmNewHash(nUniqueSubmittedHashes.eqn(1) ? 0 : 1); // Not a general solution - only works for one or two submissions.
       // But for now, that's okay.
     } else {
       // We shouldn't get here. If this fires during a test, you haven't finished writing the test.

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -534,8 +534,10 @@ export async function accommodateChallengeAndInvalidateHash(colonyNetwork, test,
     await navigateChallenge(colonyNetwork, client1, client2, errors);
 
     // Work out which submission is to be invalidated.
-    const disputedEntry1 = await repCycle.getDisputeRoundSubmission(round1, idx1);
-    const disputedEntry2 = await repCycle.getDisputeRoundSubmission(round2, idx2);
+    const disputeRound1 = await repCycle.getDisputeRound(round1);
+    const disputeRound2 = await repCycle.getDisputeRound(round2);
+    const disputedEntry1 = disputeRound1[idx1];
+    const disputedEntry2 = disputeRound2[idx2];
 
     if (new BN(disputedEntry1.challengeStepCompleted).gt(new BN(disputedEntry2.challengeStepCompleted))) {
       toInvalidateIdx = idx2;
@@ -591,8 +593,8 @@ async function navigateChallenge(colonyNetwork, client1, client2, errors) {
   if (errors.client1.confirmJustificationRootHash || errors.client2.confirmJustificationRootHash) {
     return;
   }
-
-  let submission1 = await repCycle.getDisputeRoundSubmission(round1, idx1);
+  let disputeRound = await repCycle.getDisputeRound(round1);
+  let submission1 = disputeRound[idx1];
   let binarySearchStep = -1;
   let binarySearchError = false;
   while (submission1.lowerBound !== submission1.upperBound && binarySearchError === false) {
@@ -615,7 +617,8 @@ async function navigateChallenge(colonyNetwork, client1, client2, errors) {
         `Client2 failed unexpectedly on respondToBinarySearchForChallenge${binarySearchStep}`
       );
     }
-    submission1 = await repCycle.getDisputeRoundSubmission(round1, idx1);
+    disputeRound = await repCycle.getDisputeRound(round1);
+    submission1 = disputeRound[idx1];
   }
 
   if (errors.client1.respondToBinarySearchForChallenge[binarySearchStep] || errors.client2.respondToBinarySearchForChallenge[binarySearchStep]) {

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -839,7 +839,8 @@ class ReputationMiner {
   async respondToBinarySearchForChallenge() {
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const repCycle = await this.getActiveRepCycle();
-    const disputedEntry = await repCycle.getDisputeRoundSubmission(round, index);
+    const disputeRound = await repCycle.getDisputeRound(round);
+    const disputedEntry = disputeRound[index];
 
     const targetNode = disputedEntry.lowerBound;
     const targetNodeKey = ReputationMiner.getHexString(targetNode, 64);
@@ -880,7 +881,8 @@ class ReputationMiner {
   async confirmBinarySearchResult() {
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const repCycle = await this.getActiveRepCycle();
-    const disputedEntry = await repCycle.getDisputeRoundSubmission(round, index);
+    const disputeRound = await repCycle.getDisputeRound(round);
+    const disputedEntry = disputeRound[index];
     const targetNode = ethers.utils.bigNumberify(disputedEntry.lowerBound);
     const targetNodeKey = ReputationMiner.getHexString(targetNode, 64);
 
@@ -899,7 +901,8 @@ class ReputationMiner {
   async respondToChallenge() {
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const repCycle = await this.getActiveRepCycle();
-    const disputedEntry = await repCycle.getDisputeRoundSubmission(round, index);
+    const disputeRound = await repCycle.getDisputeRound(round);
+    const disputedEntry = disputeRound[index];
 
     // console.log(disputedEntry);
     let firstDisagreeIdx = ethers.utils.bigNumberify(disputedEntry.lowerBound);

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -694,9 +694,10 @@ class ReputationMiner {
       if (ethers.utils.bigNumberify(entryHash).lt(target)) {
         return true;
       }
+      return false
     }
 
-    return false;
+    return true;
   }
 
   /**

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -681,8 +681,7 @@ class ReputationMiner {
     }
 
     const hash = await this.getRootHash();
-    const jrh = await this.justificationTree.getRootHash();
-    const entryIndexAlreadySubmitted = await repCycle.minerSubmittedEntryIndex(hash, this.minerAddress, jrh, entryIndex);
+    const entryIndexAlreadySubmitted = await repCycle.minerSubmittedEntryIndex(this.minerAddress, entryIndex);
     if (entryIndexAlreadySubmitted) {
       return false;
     }

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongProofLogEntry.js
@@ -14,7 +14,8 @@ class MaliciousReputationMinerWrongProofLogEntry extends ReputationMinerTestWrap
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const addr = await this.colonyNetwork.getReputationMiningCycle(true);
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
-    const disputedEntry = await repCycle.getDisputeRoundSubmission(round, index);
+    const disputeRound = await repCycle.getDisputeRound(round);
+    const disputedEntry = disputeRound[index];
     const firstDisagreeIdx = ethers.utils.bigNumberify(disputedEntry.lowerBound);
     const lastAgreeIdx = firstDisagreeIdx.sub(1);
     const reputationKey = await this.getKeyForUpdateNumber(lastAgreeIdx);

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongResponse.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongResponse.js
@@ -14,7 +14,8 @@ class MaliciousReputationMinerWrongResponse extends ReputationMinerTestWrapper {
   async respondToChallenge() {
     const [round, index] = await this.getMySubmissionRoundAndIndex();
     const repCycle = await this.getActiveRepCycle();
-    const disputedEntry = await repCycle.getDisputeRoundSubmission(round, index);
+    const disputeRound = await repCycle.getDisputeRound(round);
+    const disputedEntry = disputeRound[index];
 
     // console.log(disputedEntry);
     let firstDisagreeIdx = ethers.utils.bigNumberify(disputedEntry.lowerBound);

--- a/test/reputation-mining/basic-functionality.js
+++ b/test/reputation-mining/basic-functionality.js
@@ -6,7 +6,7 @@ import bnChai from "bn-chai";
 import { ethers } from "ethers";
 
 import { giveUserCLNYTokens, giveUserCLNYTokensAndStake } from "../../helpers/test-data-generator";
-import { MINING_CYCLE_DURATION } from "../../helpers/constants";
+import { MIN_STAKE, MINING_CYCLE_DURATION, DECAY_RATE } from "../../helpers/constants";
 import { forwardTime, checkErrorRevert, getActiveRepCycle } from "../../helpers/test-helper";
 
 const { expect } = chai;
@@ -167,6 +167,27 @@ contract("Reputation mining - basic functionality", accounts => {
       const inactiveRepCycle = await IReputationMiningCycle.at(addr);
 
       await checkErrorRevert(inactiveRepCycle.initialise(MINER1, MINER2), "colony-reputation-mining-cycle-already-initialised");
+    });
+  });
+
+  describe("when reading reputation mining constant properties", async () => {
+    it("can get the minimum stake value", async () => {
+      const repCycle = await getActiveRepCycle(colonyNetwork);
+      const minStake = await repCycle.getMinStake();
+      expect(minStake).to.eq.BN(MIN_STAKE);
+    });
+
+    it("can get the mining window duration", async () => {
+      const repCycle = await getActiveRepCycle(colonyNetwork);
+      const miningCycleDuration = await repCycle.getMiningWindowDuration();
+      expect(miningCycleDuration).to.eq.BN(MINING_CYCLE_DURATION);
+    });
+
+    it("can get the decay constant value", async () => {
+      const repCycle = await getActiveRepCycle(colonyNetwork);
+      const decay = await repCycle.getDecayConstant();
+      expect(decay.numerator).to.eq.BN(DECAY_RATE.NUMERATOR);
+      expect(decay.denominator).to.eq.BN(DECAY_RATE.DENOMINATOR);
     });
   });
 });

--- a/test/reputation-mining/basic-functionality.js
+++ b/test/reputation-mining/basic-functionality.js
@@ -115,8 +115,8 @@ contract("Reputation mining - basic functionality", accounts => {
 
       await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, "0x00", 0), "colony-reputation-mining-zero-entry-index-passed");
 
-      const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      expect(nSubmittedHashes).to.be.zero;
+      const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
+      expect(nUniqueSubmittedHashes).to.be.zero;
     });
   });
 

--- a/test/reputation-mining/dispute-resolution-misbehaviour.js
+++ b/test/reputation-mining/dispute-resolution-misbehaviour.js
@@ -477,7 +477,8 @@ contract("Reputation Mining - disputes resolution misbehaviour", accounts => {
       await runBinarySearch(goodClient, badClient);
 
       const [round, index] = await goodClient.getMySubmissionRoundAndIndex();
-      const disputedEntry = await repCycle.getDisputeRoundSubmission(round, index);
+      const disputeRound = await repCycle.getDisputeRound(round);
+      const disputedEntry = disputeRound[index];
       const targetNode = disputedEntry.lowerBound;
       const targetNodeKey = ReputationMinerTestWrapper.getHexString(targetNode, 64);
       const [branchMask, siblings] = await goodClient.justificationTree.getProof(targetNodeKey);

--- a/test/reputation-mining/disputes-over-child-reputation.js
+++ b/test/reputation-mining/disputes-over-child-reputation.js
@@ -1351,7 +1351,9 @@ contract("Reputation Mining - disputes over child reputation", accounts => {
 
     // Now get all the information needed to fire off a respondToChallenge call
     const [round, index] = await goodClient.getMySubmissionRoundAndIndex();
-    const disputedEntry = await repCycle.getDisputeRoundSubmission(round.toString(), index.toString());
+    const disputeRound = await repCycle.getDisputeRound(round);
+    const disputedEntry = disputeRound[index];
+
     const firstDisagreeIdx = new BN(disputedEntry.lowerBound.toString());
     const lastAgreeIdx = firstDisagreeIdx.subn(1);
     const reputationKey = await goodClient.getKeyForUpdateNumber(lastAgreeIdx.toString());

--- a/test/reputation-mining/happy-paths.js
+++ b/test/reputation-mining/happy-paths.js
@@ -258,11 +258,21 @@ contract("Reputation Mining - happy paths", accounts => {
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
 
       await goodClient.submitRootHash();
+
+      const hash = await goodClient.getRootHash();
+      const nNodes = await goodClient.getRootHashNNodes();
+      const jrh = await goodClient.justificationTree.getRootHash();
+      let nSubmissions = await repCycle.getNSubmissionsForHash(hash, nNodes, jrh);
+      expect(nSubmissions).to.eq.BN(1);
+
       await badClient.submitRootHash();
 
       await goodClient.confirmJustificationRootHash();
       await badClient.confirmJustificationRootHash();
       await goodClient.submitRootHash();
+      nSubmissions = await repCycle.getNSubmissionsForHash(hash, nNodes, jrh);
+      expect(nSubmissions).to.eq.BN(2);
+
       await runBinarySearch(goodClient, badClient);
 
       await goodClient.submitRootHash();
@@ -271,6 +281,9 @@ contract("Reputation Mining - happy paths", accounts => {
       await badClient.confirmBinarySearchResult();
 
       await goodClient.submitRootHash();
+      nSubmissions = await repCycle.getNSubmissionsForHash(hash, nNodes, jrh);
+      expect(nSubmissions).to.eq.BN(5);
+
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
       await goodClient.respondToChallenge();
       await repCycle.invalidateHash(0, 1);

--- a/test/reputation-mining/happy-paths.js
+++ b/test/reputation-mining/happy-paths.js
@@ -17,7 +17,8 @@ import {
   finishReputationMiningCycle,
   makeReputationKey,
   makeReputationValue,
-  removeSubdomainLimit
+  removeSubdomainLimit,
+  checkSuccessEthers
 } from "../../helpers/test-helper";
 
 import {
@@ -256,8 +257,7 @@ contract("Reputation Mining - happy paths", accounts => {
       await badClient.addLogContentsToReputationTree();
 
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
-
-      await goodClient.submitRootHash();
+      await checkSuccessEthers(goodClient.submitRootHash());
 
       const hash = await goodClient.getRootHash();
       const nNodes = await goodClient.getRootHashNNodes();
@@ -266,15 +266,14 @@ contract("Reputation Mining - happy paths", accounts => {
       expect(nSubmissions).to.eq.BN(1);
 
       await badClient.submitRootHash();
-
       await goodClient.confirmJustificationRootHash();
       await badClient.confirmJustificationRootHash();
-      await goodClient.submitRootHash();
+
+      await checkSuccessEthers(goodClient.submitRootHash());
       nSubmissions = await repCycle.getNSubmissionsForHash(hash, nNodes, jrh);
       expect(nSubmissions).to.eq.BN(2);
 
       await runBinarySearch(goodClient, badClient);
-
       await goodClient.submitRootHash();
       await goodClient.confirmBinarySearchResult();
       await goodClient.submitRootHash();

--- a/test/reputation-mining/root-hash-submissions.js
+++ b/test/reputation-mining/root-hash-submissions.js
@@ -175,8 +175,8 @@ contract("Reputation mining - root hash submissions", accounts => {
         repCycle.submitRootHash("0x12345678", 10, "0x01", entryNumber, { from: MINER1 }),
         "colony-reputation-mining-submitting-different-jrh"
       );
-      const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      expect(nSubmittedHashes).to.eq.BN(1);
+      const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
+      expect(nUniqueSubmittedHashes).to.eq.BN(1);
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
     });
 
@@ -203,8 +203,8 @@ contract("Reputation mining - root hash submissions", accounts => {
       await repCycle.submitRootHash("0x12345678", 10, "0x00", entryNumber, { from: MINER1 });
       await repCycle.submitRootHash("0x12345678", 10, "0x00", entryNumber2, { from: MINER1 });
 
-      const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      expect(nSubmittedHashes).to.eq.BN(1);
+      const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
+      expect(nUniqueSubmittedHashes).to.eq.BN(1);
 
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
       await repCycle.confirmNewHash(0);

--- a/test/reputation-mining/root-hash-submissions.js
+++ b/test/reputation-mining/root-hash-submissions.js
@@ -19,7 +19,8 @@ import {
   accommodateChallengeAndInvalidateHash,
   getValidEntryNumber,
   finishReputationMiningCycle,
-  runBinarySearch
+  runBinarySearch,
+  checkErrorRevertEthers
 } from "../../helpers/test-helper";
 
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
@@ -325,6 +326,16 @@ contract("Reputation mining - root hash submissions", accounts => {
 
       const rootHashNNodes = await colonyNetwork.getReputationRootHashNNodes();
       expect(rootHashNNodes).to.be.zero;
+    });
+
+    it("should error if a non existent root hash submission is gotten", async () => {
+      const repCycle = await getActiveRepCycle(colonyNetwork);
+      await forwardTime(MINING_CYCLE_DURATION, this);
+      await repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MINER1 });
+      await checkErrorRevertEthers(
+        repCycle.getSubmissionUser("0x12345678", 10, "0x00", 10),
+        "colony-reputation-mining-submission-index-out-of-range"
+      );
     });
   });
 

--- a/test/reputation-mining/types-of-disagreement.js
+++ b/test/reputation-mining/types-of-disagreement.js
@@ -127,8 +127,8 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
-      const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      expect(nSubmittedHashes).to.eq.BN(2);
+      const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
+      expect(nUniqueSubmittedHashes).to.eq.BN(2);
 
       const [round1, index1] = await goodClient.getMySubmissionRoundAndIndex();
       const disputedEntry = await repCycle.getDisputeRoundSubmission(round1, index1);
@@ -196,8 +196,8 @@ contract("Reputation Mining - types of disagreement", accounts => {
 
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
 
-      const nSubmittedHashes = await repCycle.getNSubmittedHashes();
-      expect(nSubmittedHashes).to.eq.BN(2);
+      const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
+      expect(nUniqueSubmittedHashes).to.eq.BN(2);
 
       await goodClient.confirmJustificationRootHash();
       const submissionAfterJRHConfirmed = await repCycle.getReputationHashSubmission(goodClient.minerAddress);


### PR DESCRIPTION
Fixes two issues I've spotted in reputation mining:

1. People backing a submission after a dispute had started would prevent further defense of the submission
2. Incorrectly allowing a bye to be awarded in the first round to a submission that does not (yet) have an opponent.

Also adds additional read-only functions we've discovered we needed during #596, and adjusts the mining client to not have inelegant try-catches in two places (which also requires additional getters).