### PR TITLE
Add Goerli to supported Infura networks

### DIFF
--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -10,7 +10,7 @@ const ethers = require("ethers");
 
 const ReputationMinerClient = require("../ReputationMinerClient");
 
-const supportedInfuraNetworks = ["rinkeby", "ropsten", "kovan", "mainnet"];
+const supportedInfuraNetworks = ["goerli", "rinkeby", "ropsten", "kovan", "mainnet"];
 const { minerAddress, privateKey, colonyNetworkAddress, dbPath, network } = argv;
 
 if ((!minerAddress && !privateKey) || !colonyNetworkAddress) {


### PR DESCRIPTION
Adds `goerli` to the list of supported Infura networks in the mining client.

