### PR TITLE
Update role change events to include domainId

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -31,7 +31,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   function setRootRole(address _user, bool _setTo) public stoppable auth {
     ColonyAuthority(address(authority)).setUserRole(_user, uint8(ColonyRole.Root), _setTo);
 
-    emit ColonyRootRoleSet(_user, _setTo);
+    emit ColonyRoleSet(_user, 1, uint8(ColonyRole.Root), _setTo);
   }
 
   function setArchitectureRole(
@@ -47,7 +47,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     colonyAuthority.setUserRole(_user, _domainId, uint8(ColonyRole.Architecture), _setTo);
     colonyAuthority.setUserRole(_user, _domainId, uint8(ColonyRole.ArchitectureSubdomain), _setTo);
 
-    emit ColonyArchitectureRoleSet(_user, _setTo);
+    emit ColonyRoleSet(_user, _domainId, uint8(ColonyRole.Architecture), _setTo);
   }
 
   function setFundingRole(
@@ -60,7 +60,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   {
     ColonyAuthority(address(authority)).setUserRole(_user, _domainId, uint8(ColonyRole.Funding), _setTo);
 
-    emit ColonyFundingRoleSet(_user, _setTo);
+    emit ColonyRoleSet(_user, _domainId, uint8(ColonyRole.Funding), _setTo);
   }
 
   function setAdministrationRole(
@@ -73,7 +73,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   {
     ColonyAuthority(address(authority)).setUserRole(_user, _domainId, uint8(ColonyRole.Administration), _setTo);
 
-    emit ColonyAdministrationRoleSet(_user, _setTo);
+    emit ColonyRoleSet(_user, _domainId, uint8(ColonyRole.Administration), _setTo);
   }
 
   function hasUserRole(address _user, uint256 _domainId, ColonyRole _role) public view returns (bool) {

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -36,21 +36,12 @@ contract ColonyDataTypes {
   /// @param newVersion The new colony version upgraded to
   event ColonyUpgraded(uint256 oldVersion, uint256 newVersion);
 
-  /// @notice Event logged when a new user is assigned the colony funding role
-  /// @param user The newly added colony funding user address
-  event ColonyFundingRoleSet(address user, bool setTo);
-
-  /// @notice Event logged when a new user is assigned the colony administration role
-  /// @param user The newly added colony administration user address
-  event ColonyAdministrationRoleSet(address user, bool setTo);
-
-  /// @notice Event logged when a new user is assigned the colony architecture role
-  /// @param user The newly added colony architecture user address
-  event ColonyArchitectureRoleSet(address user, bool setTo);
-
-  /// @notice Event logged when a new user is assigned the colony root role
-  /// @param user The newly added colony root user address
-  event ColonyRootRoleSet(address user, bool setTo);
+  /// @notice Event logged when a user/domain/role is granted or revoked
+  /// @param user The address of the user being affected
+  /// @param domainId The damainId of the role
+  /// @param role The role being granted/revoked
+  /// @param setTo A boolean representing the action -- granted (`true`) or revoked (`false`)
+  event ColonyRoleSet(address indexed user, uint256 indexed domainId, uint8 indexed role, bool setTo);
 
   /// @notice Event logged when colony funds, either tokens or ether, has been moved between funding pots
   /// @param fromPot The source funding pot

--- a/contracts/ContractRecovery.sol
+++ b/contracts/ContractRecovery.sol
@@ -28,6 +28,8 @@ import "./IRecovery.sol";
 contract ContractRecovery is CommonStorage {
   uint8 constant RECOVERY_ROLE = uint8(ColonyDataTypes.ColonyRole.Recovery);
 
+  event RecoveryRoleSet(address indexed user, bool setTo);
+
   function setStorageSlotRecovery(uint256 _slot, bytes32 _value) public recovery auth {
     require(_slot != AUTHORITY_SLOT, "colony-common-protected-variable");
     require(_slot != OWNER_SLOT, "colony-common-protected-variable");
@@ -88,6 +90,8 @@ contract ContractRecovery is CommonStorage {
     if (!CommonAuthority(address(authority)).hasUserRole(_user, RECOVERY_ROLE)) {
       CommonAuthority(address(authority)).setUserRole(_user, RECOVERY_ROLE, true);
       recoveryRolesCount++;
+
+      emit RecoveryRoleSet(_user, true);
     }
   }
 
@@ -96,6 +100,8 @@ contract ContractRecovery is CommonStorage {
     if (CommonAuthority(address(authority)).hasUserRole(_user, RECOVERY_ROLE)) {
       CommonAuthority(address(authority)).setUserRole(_user, RECOVERY_ROLE, false);
       recoveryRolesCount--;
+
+      emit RecoveryRoleSet(_user, false);
     }
   }
 


### PR DESCRIPTION
1. Adds `domainId` as argument to role-change events.
2. Make the role-change event generic and add the `uint8(ColonyRole)`.
3. Introduce `RecoveryRoleSet` event for recovery role changes.