### PR TITLE
RepCycle Visualizer Improvements

### DIFF
--- a/packages/reputation-miner/viz/repCycle.html
+++ b/packages/reputation-miner/viz/repCycle.html
@@ -41,7 +41,7 @@
           provider: {},
           cycleContractAbi: '',
           cycleAddresses: {},
-          cycleAddress: '',
+          cycleAddress: 'loading...',
           selected: '',
           miningCycle: {},
           numEntries: null,
@@ -104,20 +104,22 @@
           }
         },
         created () {
-          axios.get('http://localhost:3000/repCycleContractDef')
-            .then((res) => { this.cycleContractAbi = res.data.abi });
+          Promise.all([
+            axios.get('http://localhost:3000/repCycleContractDef')
+              .then((res) => { this.cycleContractAbi = res.data.abi }),
 
-          axios.get('http://localhost:3000/repCycleAddresses')
-            .then((res) => { this.cycleAddresses = res.data; });
+            axios.get('http://localhost:3000/repCycleAddresses')
+              .then((res) => { this.cycleAddresses = res.data; }),
 
-          axios.get('http://localhost:3000/network')
-            .then((res) => {
-              if (res.data === 'unknown') {
-                this.provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
-              } else {
-                this.provider = new ethers.providers.InfuraProvider(res.data);
-              }
-            });
+            axios.get('http://localhost:3000/network')
+              .then((res) => {
+                if (res.data === 'unknown') {
+                  this.provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
+                } else {
+                  this.provider = new ethers.providers.InfuraProvider(res.data);
+                }
+              })
+          ]).then((_) => { this.selected = 'active' });
         }
       })
 

--- a/packages/reputation-miner/viz/repCycle.html
+++ b/packages/reputation-miner/viz/repCycle.html
@@ -105,13 +105,13 @@
         },
         created () {
           Promise.all([
-            axios.get('http://localhost:3000/repCycleContractDef')
+            axios.get('repCycleContractDef')
               .then((res) => { this.cycleContractAbi = res.data.abi }),
 
-            axios.get('http://localhost:3000/repCycleAddresses')
+            axios.get('repCycleAddresses')
               .then((res) => { this.cycleAddresses = res.data; }),
 
-            axios.get('http://localhost:3000/network')
+            axios.get('network')
               .then((res) => {
                 if (res.data === 'unknown') {
                   this.provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');

--- a/packages/reputation-miner/viz/repCycle.html
+++ b/packages/reputation-miner/viz/repCycle.html
@@ -48,6 +48,7 @@
           logEntries: [],
           miningWindowDuration: null,
           reputationMiningWindowOpenTimestamp: null,
+          currentBlockTime: null,
           nUniqueSubmittedHashes: null,
           nInvalidatedHashes: null,
         },
@@ -67,6 +68,9 @@
                 this.reputationMiningWindowOpenTimestamp = reputationMiningWindowOpenTimestamp.toNumber()
               });
 
+            this.provider.getBlock()
+              .then((block) => { this.currentBlockTime = block.timestamp })
+
             this.miningCycle.getNUniqueSubmittedHashes()
               .then((nUniqueSubmittedHashes) => { this.nUniqueSubmittedHashes = nUniqueSubmittedHashes })
 
@@ -82,7 +86,7 @@
           parseLogEntry: function (logEntry) {
             return {
               user: logEntry.user,
-              amount: ethers.utils.formatEther(logEntry.amount._hex),
+              amount: parseInt(logEntry.amount._hex),
               skillId: parseInt(logEntry.skillId._hex),
               colony: logEntry.colony,
               nUpdates: parseInt(logEntry.nUpdates._hex),
@@ -95,8 +99,7 @@
         },
         computed: {
           timeRemaining: function () {
-            const now = parseInt((new Date).getTime() / 1000);
-            const timeRemaining = (this.reputationMiningWindowOpenTimestamp + this.miningWindowDuration) - now;
+            const timeRemaining = (this.reputationMiningWindowOpenTimestamp + this.miningWindowDuration) - this.currentBlockTime;
             return  Math.max(timeRemaining, 0);
           }
         },


### PR DESCRIPTION
- This morning I realized that using the block timestamp to figure out the remaining time in the mining cycle is probably more relevant than the system timestamp. Not a big change but improves the semantics slightly.
- Changed the denomination of the reputation amount in the cycle visualizers from Ether to Wei, to match the tree visualizer.
- Realized I could drop the URI host/port and make requests locally by default (so requests are port-agnostic).
- Finally, I figured out how to cleanly bring up the active cycle on load. 💪  