### PR TITLE
Polish off the mining client and make it more resillient

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,8 @@
     "no-await-in-loop": "off",
     "no-trailing-spaces": "error",
     "no-multi-spaces": ["error", {"ignoreEOLComments": true}],
-    "eslint-comments/disable-enable-pair": ["error", {"allowWholeFile": true}]
+    "eslint-comments/disable-enable-pair": ["error", {"allowWholeFile": true}],
+    "space-infix-ops": ["error"]
   },
   "parserOptions": {
     "ecmaVersion": 2017

--- a/packages/reputation-miner/Dockerfile
+++ b/packages/reputation-miner/Dockerfile
@@ -5,4 +5,4 @@ COPY ./yarn.lock ./
 COPY ./build ./build
 RUN yarn
 EXPOSE 3000
-CMD node packages/reputation-miner/bin/index.js --file $REPUTATION_JSON_PATH --colonyNetworkAddress $COLONYNETWORK_ADDRESS --privateKey $PRIVATE_KEY --network $NETWORK
+CMD node packages/reputation-miner/bin/index.js --dbPath $REPUTATION_JSON_PATH --colonyNetworkAddress $COLONYNETWORK_ADDRESS --privateKey $PRIVATE_KEY --network $NETWORK --syncFrom $SYNC_FROM_BLOCK

--- a/packages/reputation-miner/Dockerfile
+++ b/packages/reputation-miner/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:9.1.0
+COPY ./packages ./packages
+COPY ./package.json ./
+COPY ./yarn.lock ./
+COPY ./build ./build
+RUN yarn
+EXPOSE 3000
+CMD node packages/reputation-miner/bin/index.js --file $REPUTATION_JSON_PATH --colonyNetworkAddress $COLONYNETWORK_ADDRESS --privateKey $PRIVATE_KEY --rinkeby

--- a/packages/reputation-miner/Dockerfile
+++ b/packages/reputation-miner/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:9.1.0
+FROM node:10.15.3
 COPY ./packages ./packages
 COPY ./package.json ./
 COPY ./yarn.lock ./
 COPY ./build ./build
 RUN yarn
 EXPOSE 3000
-CMD node packages/reputation-miner/bin/index.js --file $REPUTATION_JSON_PATH --colonyNetworkAddress $COLONYNETWORK_ADDRESS --privateKey $PRIVATE_KEY --rinkeby
+CMD node packages/reputation-miner/bin/index.js --file $REPUTATION_JSON_PATH --colonyNetworkAddress $COLONYNETWORK_ADDRESS --privateKey $PRIVATE_KEY --network $NETWORK

--- a/packages/reputation-miner/Dockerfile
+++ b/packages/reputation-miner/Dockerfile
@@ -5,4 +5,4 @@ COPY ./yarn.lock ./
 COPY ./build ./build
 RUN yarn
 EXPOSE 3000
-CMD node packages/reputation-miner/bin/index.js --dbPath $REPUTATION_JSON_PATH --colonyNetworkAddress $COLONYNETWORK_ADDRESS --privateKey $PRIVATE_KEY --network $NETWORK --syncFrom $SYNC_FROM_BLOCK
+CMD node packages/reputation-miner/bin/index.js --dbPath $REPUTATION_JSON_PATH --colonyNetworkAddress $COLONYNETWORK_ADDRESS --privateKey $PRIVATE_KEY --syncFrom $SYNC_FROM_BLOCK $ARGS

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -381,7 +381,7 @@ class ReputationMiner {
         childAdjacentReputationProof
       })
     );
-    // ("updateNumber", updateNumber.toString());
+    // console.log("updateNumber", updateNumber.toString());
     // console.log("key", key);
     // console.log("amount", amount.toString());
     await this.insert(key, amount, updateNumber);
@@ -470,7 +470,7 @@ class ReputationMiner {
    */
   async getLogEntryNumberForLogUpdateNumber(_i, blockNumber = "latest") {
     const updateNumber = _i;
-    const repCycle = await this.getActiveRepCycle(blockNumber)
+    const repCycle = await this.getActiveRepCycle(blockNumber);
     const nLogEntries = await repCycle.getReputationUpdateLogLength({ blockTag: blockNumber });
     let lower = ethers.constants.Zero;
     let upper = nLogEntries.sub(1);
@@ -478,6 +478,7 @@ class ReputationMiner {
     while (!upper.eq(lower)) {
       const testIdx = lower.add(upper.sub(lower).div(2));
       const testLogEntry = await repCycle.getReputationUpdateLogEntry(testIdx, { blockTag: blockNumber });
+
       const nPreviousUpdates = ethers.utils.bigNumberify(testLogEntry.nPreviousUpdates);
       if (nPreviousUpdates.gt(updateNumber)) {
         upper = testIdx.sub(1);
@@ -500,10 +501,9 @@ class ReputationMiner {
     }
     // Else it's from a log entry
     const logEntryNumber = await this.getLogEntryNumberForLogUpdateNumber(updateNumber.sub(this.nReputationsBeforeLatestLog), blockNumber);
-    const repCycle = await this.getActiveRepCycle(blockNumber)
+    const repCycle = await this.getActiveRepCycle(blockNumber);
 
     const logEntry = await repCycle.getReputationUpdateLogEntry(logEntryNumber, { blockTag: blockNumber });
-
     const key = await this.getKeyForUpdateInLogEntry(updateNumber.sub(logEntry.nPreviousUpdates).sub(this.nReputationsBeforeLatestLog), logEntry);
     return key;
   }

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -381,9 +381,9 @@ class ReputationMiner {
         childAdjacentReputationProof
       })
     );
-    // console.log("updateNumber", updateNumber.toString());
-    // console.log("key", key);
-    // console.log("amount", amount.toString());
+    console.log("updateNumber", updateNumber.toString());
+    console.log("key", key);
+    console.log("amount", amount.toString());
     await this.insert(key, amount, updateNumber);
   }
 

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -1154,7 +1154,7 @@ class ReputationMiner {
       applyLogs = true;
     }
     for (let i = 0; i < events.length; i += 1) {
-      console.log(`Syncing mining cycle ${i+1} of ${events.length}...`)
+      console.log(`Syncing mining cycle ${i + 1} of ${events.length}...`)
       const event = events[i];
       const hash = event.data.slice(0, 66);
       if (applyLogs) {

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -62,7 +62,8 @@ class ReputationMiner {
       this.realWallet = new ethers.Wallet(privateKey, this.realProvider);
       this.minerAddress = this.realWallet.address;
       // TODO: Check that this wallet can stake?
-      console.log("Transactions will be signed from ", this.minerAddress);
+      this.minerAddress = this.realWallet.address;
+      console.log("Transactions will be signed from ", this.realWallet.address);
     }
   }
 

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -381,9 +381,9 @@ class ReputationMiner {
         childAdjacentReputationProof
       })
     );
-    console.log("updateNumber", updateNumber.toString());
-    console.log("key", key);
-    console.log("amount", amount.toString());
+    // ("updateNumber", updateNumber.toString());
+    // console.log("key", key);
+    // console.log("amount", amount.toString());
     await this.insert(key, amount, updateNumber);
   }
 

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -169,7 +169,7 @@ class ReputationMinerClient {
       this.lockedForBlockProcessing = false;
       this._miner.realProvider.on('block', this.doBlockChecks.bind(this));
 
-      this.blockTimeoutCheck = setTimeout(this.reportBlockTimeout.bind(this), 60000);
+      this.blockTimeoutCheck = setTimeout(this.reportBlockTimeout.bind(this), 300000);
     }
   }
 
@@ -208,7 +208,7 @@ class ReputationMinerClient {
       if (this.blockTimeoutCheck) {
         clearTimeout(this.blockTimeoutCheck);
       }
-      this.blockTimeoutCheck = setTimeout(this.reportBlockTimeout.bind(this), 60000);
+      this.blockTimeoutCheck = setTimeout(this.reportBlockTimeout.bind(this), 300000);
 
       if (this.lockedForBlockProcessing) {
         this._adapter.log(`Processing already - block: ${this.lockedForBlockProcessing}`)
@@ -481,7 +481,7 @@ class ReputationMinerClient {
   }
 
   async reportBlockTimeout() {
-    this._adapter.error("Error: No block seen for 60 seconds. Something is almost certainly wrong!");
+    this._adapter.error("Error: No block seen for five minutes. Something is almost certainly wrong!");
   }
 
   async reportConfirmTimeout() {

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -134,9 +134,8 @@ class ReputationMinerClient {
       // Have we already submitted any of these? Need to update submissionIndex if so
       const repCycle = await this._miner.getActiveRepCycle();
       const block = await this._miner.realProvider.getBlock('latest');
-      // Ensure the submission index is reset as
+      // Ensure the submission index is reset to the correct point in the best12Submissions array
       this.submissionIndex = 0;
-
       for (let i = 0; i < this.best12Submissions.length; i+=1 ){
         if (block.timestamp >= this.best12Submissions[i].timestamp) {
           const {entryIndex} = this.best12Submissions[i];

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -222,6 +222,7 @@ class ReputationMinerClient {
   async doBlockChecks(blockNumber) {
   try {
       if (this.lockedForBlockProcessing || this.lockedForLogProcessing) {
+        console.log("Processing already - block: ", this.lockedForBlockProcessing, "log: ", this.lockedForLogProcessing)
         return;
       }
       this.lockedForBlockProcessing = true;

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -134,6 +134,8 @@ class ReputationMinerClient {
       // Have we already submitted any of these? Need to update submissionIndex if so
       const repCycle = await this._miner.getActiveRepCycle();
       const block = await this._miner.realProvider.getBlock('latest');
+      // Ensure the submission index is reset as
+      this.submissionIndex = 0;
 
       for (let i = 0; i < this.best12Submissions.length; i+=1 ){
         if (block.timestamp >= this.best12Submissions[i].timestamp) {

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -170,6 +170,10 @@ class ReputationMinerClient {
       this._miner.realProvider.on('block', this.doBlockChecks.bind(this));
 
       this.blockTimeoutCheck = setTimeout(this.reportBlockTimeout.bind(this), 300000);
+
+      // Work out when the confirm timeout should be.
+      const openTimestamp = await repCycle.getReputationMiningWindowOpenTimestamp();
+      this.confirmTimeoutCheck = setTimeout(this.reportConfirmTimeout.bind(this), (24*3600 + 600 - (Date.now()/1000-openTimestamp)) * 1000);
     }
   }
 
@@ -227,7 +231,7 @@ class ReputationMinerClient {
         this.best12Submissions = await this.getTwelveBestSubmissions();
         this.miningCycleAddress = addr;
         if (this.confirmTimeoutCheck) {
-          clearTimeout(this.blockTimeoutCheck);
+          clearTimeout(this.confirmTimeoutCheck);
         }
         // If we don't see this cycle completed in the next day and ten minutes, then report it
         this.confirmTimeoutCheck = setTimeout(this.reportConfirmTimeout.bind(this), (24*3600 + 600) * 1000);
@@ -402,7 +406,7 @@ class ReputationMinerClient {
     }
 
     if (this.confirmTimeoutCheck) {
-      clearTimeout(this.blockTimeoutCheck);
+      clearTimeout(this.confirmTimeoutCheck);
     }
 
   }

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -15,11 +15,12 @@ class ReputationMinerClient {
    * @param {string} minerAddress            The address that is staking CLNY that will allow the miner to submit reputation hashes
    * @param {Number} [realProviderPort=8545] The port that the RPC node with the ability to sign transactions from `minerAddress` is responding on. The address is assumed to be `localhost`.
    */
-  constructor({ minerAddress, loader, realProviderPort, minerPort = 3000, privateKey, provider, useJsTree, dbPath, auto, oracle }) {
+  constructor({ minerAddress, loader, realProviderPort, minerPort = 3000, privateKey, provider, useJsTree, dbPath, auto, oracle, exitOnError }) {
     this._loader = loader;
     this._miner = new ReputationMiner({ minerAddress, loader, provider, privateKey, realProviderPort, useJsTree, dbPath });
     this._auto = auto;
     this._oracle = oracle;
+    this._exitOnError = exitOnError;
     this.submissionIndex = 0;
     this.best12Submissions = [];
     this.filterReputationMiningCycleComplete;
@@ -352,6 +353,9 @@ class ReputationMinerClient {
       this.endDoBlockChecks();
     } catch (err) {
       console.log("err", err);
+      if (this._exitOnError) {
+        process.exit(1);
+      }
     }
   }
 

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -451,7 +451,7 @@ class ReputationMinerClient {
     if (round && round.gte(0)) {
       let gasEstimate;
       if (process.env.SOLIDITY_COVERAGE || this.ganacheClient) {
-        gasEstimate = ethers.utils.bigNumberify(3500000);
+        gasEstimate = ethers.utils.bigNumberify(1500000);
       } else {
         gasEstimate = await repCycle.estimate.confirmNewHash(round);
       }

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -132,7 +132,6 @@ class ReputationMinerClient {
     // See if we're talking to Ganache to fix a ganache crash (which, while fun to say, is not fun to see)
     const clientString = await this._miner.realProvider.send("web3_clientVersion");
     this.ganacheClient = clientString.indexOf('TestRPC') !== -1
-
     console.log("🏁 Initialised");
     if (this._auto) {
       // Initial call to process the existing log from the cycle we're currently in
@@ -200,7 +199,6 @@ class ReputationMinerClient {
     };
     try {
       const gasEstimates = await request(options);
-      console.log(gasEstimates, type, gasEstimates[type])
 
       if (gasEstimates[type]){
         this._miner.gasPrice = ethers.utils.hexlify(gasEstimates[type]/10 * 1e9);
@@ -211,7 +209,6 @@ class ReputationMinerClient {
       console.log(err);
       this._miner.gasPrice = ethers.utils.hexlify(20000000000);
     }
-    console.log(this._miner.gasPrice);
   }
 
   /**
@@ -461,7 +458,7 @@ class ReputationMinerClient {
     if (round && round.gte(0)) {
       let gasEstimate;
       if (process.env.SOLIDITY_COVERAGE || this.ganacheClient) {
-        gasEstimate = ethers.utils.bigNumberify(1500000);
+        gasEstimate = ethers.utils.bigNumberify(2500000);
       } else {
         gasEstimate = await repCycle.estimate.confirmNewHash(round);
       }

--- a/packages/reputation-miner/adapters/console.js
+++ b/packages/reputation-miner/adapters/console.js
@@ -1,0 +1,11 @@
+ const ConsoleAdapter = {
+  async log(output) {
+    console.log(output);
+  },
+
+  async error(output){
+    console.log(output);
+  }
+}
+
+export default ConsoleAdapter;

--- a/packages/reputation-miner/adapters/slack.js
+++ b/packages/reputation-miner/adapters/slack.js
@@ -1,0 +1,22 @@
+const token = process.env.SLACK_BOT_TOKEN;
+
+if (!token || !process.env.SLACK_CHANNEL) {
+	console.log("You need to provide both SLACK_CHANNEL and SLACK_BOT_TOKEN env variables to use the slack adapter");
+	process.exit(1)
+}
+
+const Slack = require('slack');
+
+const bot = new Slack({token})
+
+const SlackAdapter = {
+  async log(output) {
+    console.log(output);
+  },
+
+  async error(output){
+  	await bot.chat.postMessage({channel: process.env.SLACK_CHANNEL, text: output})
+  }
+}
+
+export default SlackAdapter

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -11,7 +11,19 @@ const ethers = require("ethers");
 const ReputationMinerClient = require("../ReputationMinerClient");
 
 const supportedInfuraNetworks = ["goerli", "rinkeby", "ropsten", "kovan", "mainnet"];
-const { minerAddress, privateKey, colonyNetworkAddress, dbPath, network, localPort, localProviderAddress, syncFrom, auto, oracle } = argv;
+const {
+  minerAddress,
+  privateKey,
+  colonyNetworkAddress,
+  dbPath,
+  network,
+  localPort,
+  localProviderAddress,
+  syncFrom,
+  auto,
+  oracle,
+  exitOnError
+} = argv;
 
 if ((!minerAddress && !privateKey) || !colonyNetworkAddress || !syncFrom) {
   console.log("❗️ You have to specify all of ( --minerAddress or --privateKey ) and --colonyNetworkAddress and --syncFrom on the command line!");
@@ -33,5 +45,5 @@ if (network) {
   provider = new ethers.providers.JsonRpcProvider(`http://${localProviderAddress || "localhost"}:${localPort || "8545"}`);
 }
 
-const client = new ReputationMinerClient({ loader, minerAddress, privateKey, provider, useJsTree: true, dbPath, auto, oracle });
+const client = new ReputationMinerClient({ loader, minerAddress, privateKey, provider, useJsTree: true, dbPath, auto, oracle, exitOnError });
 client.initialise(colonyNetworkAddress, syncFrom);

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -22,7 +22,8 @@ const {
   syncFrom,
   auto,
   oracle,
-  exitOnError
+  exitOnError,
+  adapter
 } = argv;
 
 if ((!minerAddress && !privateKey) || !colonyNetworkAddress || !syncFrom) {
@@ -45,5 +46,15 @@ if (network) {
   provider = new ethers.providers.JsonRpcProvider(`http://${localProviderAddress || "localhost"}:${localPort || "8545"}`);
 }
 
-const client = new ReputationMinerClient({ loader, minerAddress, privateKey, provider, useJsTree: true, dbPath, auto, oracle, exitOnError });
+let adapterObject;
+
+if (adapter === 'slack') {
+  adapterObject = require('../adapters/slack').default; // eslint-disable-line global-require
+} else {
+  adapterObject = require('../adapters/console').default; // eslint-disable-line global-require
+}
+
+const client = new ReputationMinerClient(
+  { loader, minerAddress, privateKey, provider, useJsTree: true, dbPath, auto, oracle, exitOnError, adapter:adapterObject }
+);
 client.initialise(colonyNetworkAddress, syncFrom);

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -11,7 +11,7 @@ const ethers = require("ethers");
 const ReputationMinerClient = require("../ReputationMinerClient");
 
 const supportedInfuraNetworks = ["goerli", "rinkeby", "ropsten", "kovan", "mainnet"];
-const { minerAddress, privateKey, colonyNetworkAddress, dbPath, network, localPort, syncFrom, auto } = argv;
+const { minerAddress, privateKey, colonyNetworkAddress, dbPath, network, localPort, localProviderAddress, syncFrom, auto, oracle } = argv;
 
 if ((!minerAddress && !privateKey) || !colonyNetworkAddress || !syncFrom) {
   console.log("❗️ You have to specify all of ( --minerAddress or --privateKey ) and --colonyNetworkAddress and --syncFrom on the command line!");
@@ -30,8 +30,8 @@ if (network) {
   }
   provider = new ethers.providers.InfuraProvider(network);
 } else {
-  provider = new ethers.providers.JsonRpcProvider(`http://localhost:${localPort || "8545"}`);
+  provider = new ethers.providers.JsonRpcProvider(`http://${localProviderAddress || "localhost"}:${localPort || "8545"}`);
 }
 
-const client = new ReputationMinerClient({ loader, minerAddress, privateKey, provider, useJsTree: true, dbPath, auto });
+const client = new ReputationMinerClient({ loader, minerAddress, privateKey, provider, useJsTree: true, dbPath, auto, oracle });
 client.initialise(colonyNetworkAddress, syncFrom);

--- a/packages/reputation-miner/package.json
+++ b/packages/reputation-miner/package.json
@@ -21,6 +21,7 @@
     "ganache-core": "^2.8.0",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
+    "slack": "^11.0.2",
     "sqlite": "^3.0.2",
     "web3-utils": "^1.0.0",
     "yargs": "^14.0.0"

--- a/packages/reputation-miner/package.json
+++ b/packages/reputation-miner/package.json
@@ -19,6 +19,8 @@
     "ethers": "^4.0.37",
     "express": "^4.16.3",
     "ganache-core": "^2.8.0",
+    "request": "^2.88.0",
+    "request-promise": "^4.2.4",
     "sqlite": "^3.0.2",
     "web3-utils": "^1.0.0",
     "yargs": "^14.0.0"

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongJRHRightNNodes.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongJRHRightNNodes.js
@@ -28,7 +28,7 @@ class MaliciousReputationMinerWrongJRHRightNNodes extends ReputationMinerTestWra
     // Mess up the JRH
 
     const jt2 = new PatriciaTreeNoHash();
-    for (let i = 0; i < Object.keys(this.justificationHashes).length; i+= 1){
+    for (let i = 0; i < Object.keys(this.justificationHashes).length; i += 1){
       if (this.entriesToSkip.indexOf(i.toString()) === -1){
         await jt2.insert(
           ethers.utils.hexZeroPad(ethers.utils.hexlify(parseInt(i, 10)), 32),
@@ -42,7 +42,7 @@ class MaliciousReputationMinerWrongJRHRightNNodes extends ReputationMinerTestWra
 
     this.justificationTree = jt2;
 
-    for (let i =0; i< this.entriesToFalsify.length; i += 1){
+    for (let i = 0; i < this.entriesToFalsify.length; i += 1){
       await this.justificationTree.insert(
         ethers.utils.hexZeroPad(ethers.utils.hexlify(parseInt(this.entriesToFalsify[i], 10)), 32),
         `0x${"0".repeat(127)}1`

--- a/test/reputation-system/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-system/reputation-mining-client/client-auto-functionality.js
@@ -164,92 +164,6 @@ process.env.SOLIDITY_COVERAGE
           await miningCycleComplete;
         });
 
-        it("should successfully resume submitting hashes if it's restarted", async function() {
-          const rootHash = await reputationMinerClient._miner.getRootHash();
-          const nNodes = await reputationMinerClient._miner.getRootHashNNodes();
-          const jrh = await reputationMinerClient._miner.justificationTree.getRootHash();
-
-          const oldHash = await colonyNetwork.getReputationRootHash();
-
-          const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
-          const receive2Submissions = new Promise(function(resolve, reject) {
-            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
-              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
-              if (nSubmissions.toNumber() === 2) {
-                // Check the reputation cycle submission matches our miner
-                // Validate the miner address in submission is correct
-                event.removeListener();
-                resolve();
-              } else {
-                await mineBlock();
-              }
-            });
-
-            // After 30s, we throw a timeout error
-            setTimeout(() => {
-              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
-            }, 30000);
-          });
-
-          // Forward through half of the cycle duration and wait for the client to submit some entries
-          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
-          await receive2Submissions; // It might submit a couple more, but that's fine for the purposes of this test.
-          await reputationMinerClient.close();
-
-          // start up another one.
-          const reputationMinerClient2 = new ReputationMinerClient({
-            loader,
-            realProviderPort,
-            minerAddress: MINER1,
-            useJsTree: true,
-            auto: true
-          });
-          await reputationMinerClient2.initialise(colonyNetwork.address, startingBlockNumber);
-
-          const receive12Submissions = new Promise(function(resolve, reject) {
-            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
-              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
-              if (nSubmissions.toNumber() === 12) {
-                // Check the reputation cycle submission matches our miner
-                // Validate the miner address in submission is correct
-                event.removeListener();
-                resolve();
-              } else {
-                await mineBlock();
-              }
-            });
-
-            // After 30s, we throw a timeout error
-            setTimeout(() => {
-              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
-            }, 30000);
-          });
-
-          await mineBlock();
-          await receive12Submissions;
-
-          const colonyNetworkEthers = await reputationMinerClient._miner.colonyNetwork;
-          const miningCycleComplete = new Promise(function(resolve, reject) {
-            colonyNetworkEthers.on("ReputationMiningCycleComplete", async (_hash, _nNodes, event) => {
-              const newHash = await colonyNetwork.getReputationRootHash();
-              expect(newHash).to.not.equal(oldHash, "The old and new hashes are the same");
-              expect(newHash).to.equal(rootHash, "The network root hash doens't match the one submitted");
-              event.removeListener();
-              resolve();
-            });
-
-            // After 30s, we throw a timeout error
-            setTimeout(() => {
-              reject(new Error("ERROR: timeout while waiting for confirming hash"));
-            }, 30000);
-          });
-
-          // Forward time to the end of the mining cycle and since we are the only miner, check the client confirmed our hash correctly
-          await forwardTime(MINING_CYCLE_DURATION * 0.6, this);
-          await miningCycleComplete;
-          await reputationMinerClient2.close();
-        });
-
         it("should successfully complete a hash submission if there are 2 good miners", async function() {
           const oldHash = await colonyNetwork.getReputationRootHash();
           const rootHash = await reputationMinerClient._miner.getRootHash();
@@ -526,6 +440,92 @@ process.env.SOLIDITY_COVERAGE
           await forwardTime(MINING_CYCLE_DURATION / 2, this);
 
           await receive12Submissions;
+        });
+
+        it("should successfully resume submitting hashes if it's restarted", async function() {
+          const rootHash = await reputationMinerClient._miner.getRootHash();
+          const nNodes = await reputationMinerClient._miner.getRootHashNNodes();
+          const jrh = await reputationMinerClient._miner.justificationTree.getRootHash();
+
+          const oldHash = await colonyNetwork.getReputationRootHash();
+
+          const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
+          const receive2Submissions = new Promise(function(resolve, reject) {
+            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
+              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
+              if (nSubmissions.toNumber() === 2) {
+                // Check the reputation cycle submission matches our miner
+                // Validate the miner address in submission is correct
+                event.removeListener();
+                resolve();
+              } else {
+                await mineBlock();
+              }
+            });
+
+            // After 30s, we throw a timeout error
+            setTimeout(() => {
+              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
+            }, 30000);
+          });
+
+          // Forward through half of the cycle duration and wait for the client to submit some entries
+          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
+          await receive2Submissions; // It might submit a couple more, but that's fine for the purposes of this test.
+          await reputationMinerClient.close();
+
+          // start up another one.
+          const reputationMinerClient2 = new ReputationMinerClient({
+            loader,
+            realProviderPort,
+            minerAddress: MINER1,
+            useJsTree: true,
+            auto: true
+          });
+          await reputationMinerClient2.initialise(colonyNetwork.address, startingBlockNumber);
+
+          const receive12Submissions = new Promise(function(resolve, reject) {
+            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
+              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
+              if (nSubmissions.toNumber() === 12) {
+                // Check the reputation cycle submission matches our miner
+                // Validate the miner address in submission is correct
+                event.removeListener();
+                resolve();
+              } else {
+                await mineBlock();
+              }
+            });
+
+            // After 30s, we throw a timeout error
+            setTimeout(() => {
+              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
+            }, 30000);
+          });
+
+          await mineBlock();
+          await receive12Submissions;
+
+          const colonyNetworkEthers = await reputationMinerClient._miner.colonyNetwork;
+          const miningCycleComplete = new Promise(function(resolve, reject) {
+            colonyNetworkEthers.on("ReputationMiningCycleComplete", async (_hash, _nNodes, event) => {
+              const newHash = await colonyNetwork.getReputationRootHash();
+              expect(newHash).to.not.equal(oldHash, "The old and new hashes are the same");
+              expect(newHash).to.equal(rootHash, "The network root hash doens't match the one submitted");
+              event.removeListener();
+              resolve();
+            });
+
+            // After 30s, we throw a timeout error
+            setTimeout(() => {
+              reject(new Error("ERROR: timeout while waiting for confirming hash"));
+            }, 30000);
+          });
+
+          // Forward time to the end of the mining cycle and since we are the only miner, check the client confirmed our hash correctly
+          await forwardTime(MINING_CYCLE_DURATION * 0.6, this);
+          await miningCycleComplete;
+          await reputationMinerClient2.close();
         });
       });
     });

--- a/test/reputation-system/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-system/reputation-mining-client/client-auto-functionality.js
@@ -164,6 +164,92 @@ process.env.SOLIDITY_COVERAGE
           await miningCycleComplete;
         });
 
+        it("should successfully resume submitting hashes if it's restarted", async function() {
+          const rootHash = await reputationMinerClient._miner.getRootHash();
+          const nNodes = await reputationMinerClient._miner.getRootHashNNodes();
+          const jrh = await reputationMinerClient._miner.justificationTree.getRootHash();
+
+          const oldHash = await colonyNetwork.getReputationRootHash();
+
+          const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
+          const receive2Submissions = new Promise(function(resolve, reject) {
+            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
+              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
+              if (nSubmissions.toNumber() === 2) {
+                // Check the reputation cycle submission matches our miner
+                // Validate the miner address in submission is correct
+                event.removeListener();
+                resolve();
+              } else {
+                await mineBlock();
+              }
+            });
+
+            // After 30s, we throw a timeout error
+            setTimeout(() => {
+              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
+            }, 30000);
+          });
+
+          // Forward through half of the cycle duration and wait for the client to submit some entries
+          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
+          await receive2Submissions; // It might submit a couple more, but that's fine for the purposes of this test.
+          await reputationMinerClient.close();
+
+          // start up another one.
+          const reputationMinerClient2 = new ReputationMinerClient({
+            loader,
+            realProviderPort,
+            minerAddress: MINER1,
+            useJsTree: true,
+            auto: true
+          });
+          await reputationMinerClient2.initialise(colonyNetwork.address, startingBlockNumber);
+
+          const receive12Submissions = new Promise(function(resolve, reject) {
+            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
+              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
+              if (nSubmissions.toNumber() === 12) {
+                // Check the reputation cycle submission matches our miner
+                // Validate the miner address in submission is correct
+                event.removeListener();
+                resolve();
+              } else {
+                await mineBlock();
+              }
+            });
+
+            // After 30s, we throw a timeout error
+            setTimeout(() => {
+              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
+            }, 30000);
+          });
+
+          await mineBlock();
+          await receive12Submissions;
+
+          const colonyNetworkEthers = await reputationMinerClient._miner.colonyNetwork;
+          const miningCycleComplete = new Promise(function(resolve, reject) {
+            colonyNetworkEthers.on("ReputationMiningCycleComplete", async (_hash, _nNodes, event) => {
+              const newHash = await colonyNetwork.getReputationRootHash();
+              expect(newHash).to.not.equal(oldHash, "The old and new hashes are the same");
+              expect(newHash).to.equal(rootHash, "The network root hash doens't match the one submitted");
+              event.removeListener();
+              resolve();
+            });
+
+            // After 30s, we throw a timeout error
+            setTimeout(() => {
+              reject(new Error("ERROR: timeout while waiting for confirming hash"));
+            }, 30000);
+          });
+
+          // Forward time to the end of the mining cycle and since we are the only miner, check the client confirmed our hash correctly
+          await forwardTime(MINING_CYCLE_DURATION * 0.6, this);
+          await miningCycleComplete;
+          await reputationMinerClient2.close();
+        });
+
         it("should successfully complete a hash submission if there are 2 good miners", async function() {
           const oldHash = await colonyNetwork.getReputationRootHash();
           const rootHash = await reputationMinerClient._miner.getRootHash();
@@ -174,7 +260,6 @@ process.env.SOLIDITY_COVERAGE
           const receive12Submissions = new Promise(function(resolve, reject) {
             repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
               const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
-
               if (nSubmissions.toNumber() === 12) {
                 // Check the reputation cycle submission matches our miners
                 for (let i = 0; i < 12; i += 1) {
@@ -202,12 +287,11 @@ process.env.SOLIDITY_COVERAGE
             }, 30000);
           });
 
-          // Forward through most of the cycle duration and wait for the client to submit all 12 allowed entries
-          await forwardTime(MINING_CYCLE_DURATION * 0.9, this);
-
           // Make a submission from the second client and then await the remaining 11 submissions from the first client
-          await goodClient.addLogContentsToReputationTree();
-          await goodClient.saveCurrentState();
+          await goodClient.loadState(rootHash);
+
+          // Forward time and wait for the client to submit all 12 allowed entries
+          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
           await checkSuccessEthers(goodClient.submitRootHash());
           await receive12Submissions;
 
@@ -228,7 +312,7 @@ process.env.SOLIDITY_COVERAGE
           });
 
           // Forward time to the end of the mining cycle and since we are the only miner, check the client confirmed our hash correctly
-          await forwardTime(MINING_CYCLE_DURATION * 0.1, this);
+          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
           await miningCycleComplete;
         });
 
@@ -396,9 +480,9 @@ process.env.SOLIDITY_COVERAGE
           await goodClient.saveCurrentState();
           await forwardTime(MINING_CYCLE_DURATION / 2, this);
           await goodClient.submitRootHash();
-          console.log("submitted");
+
           await forwardTime(MINING_CYCLE_DURATION, this);
-          console.log("forard");
+
           const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
           const receive12Submissions = new Promise(function(resolve, reject) {
             repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
@@ -440,92 +524,6 @@ process.env.SOLIDITY_COVERAGE
           await forwardTime(MINING_CYCLE_DURATION / 2, this);
 
           await receive12Submissions;
-        });
-
-        it("should successfully resume submitting hashes if it's restarted", async function() {
-          const rootHash = await reputationMinerClient._miner.getRootHash();
-          const nNodes = await reputationMinerClient._miner.getRootHashNNodes();
-          const jrh = await reputationMinerClient._miner.justificationTree.getRootHash();
-
-          const oldHash = await colonyNetwork.getReputationRootHash();
-
-          const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
-          const receive2Submissions = new Promise(function(resolve, reject) {
-            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
-              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
-              if (nSubmissions.toNumber() === 2) {
-                // Check the reputation cycle submission matches our miner
-                // Validate the miner address in submission is correct
-                event.removeListener();
-                resolve();
-              } else {
-                await mineBlock();
-              }
-            });
-
-            // After 30s, we throw a timeout error
-            setTimeout(() => {
-              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
-            }, 30000);
-          });
-
-          // Forward through half of the cycle duration and wait for the client to submit some entries
-          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
-          await receive2Submissions; // It might submit a couple more, but that's fine for the purposes of this test.
-          await reputationMinerClient.close();
-
-          // start up another one.
-          const reputationMinerClient2 = new ReputationMinerClient({
-            loader,
-            realProviderPort,
-            minerAddress: MINER1,
-            useJsTree: true,
-            auto: true
-          });
-          await reputationMinerClient2.initialise(colonyNetwork.address, startingBlockNumber);
-
-          const receive12Submissions = new Promise(function(resolve, reject) {
-            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
-              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
-              if (nSubmissions.toNumber() === 12) {
-                // Check the reputation cycle submission matches our miner
-                // Validate the miner address in submission is correct
-                event.removeListener();
-                resolve();
-              } else {
-                await mineBlock();
-              }
-            });
-
-            // After 30s, we throw a timeout error
-            setTimeout(() => {
-              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
-            }, 30000);
-          });
-
-          await mineBlock();
-          await receive12Submissions;
-
-          const colonyNetworkEthers = await reputationMinerClient._miner.colonyNetwork;
-          const miningCycleComplete = new Promise(function(resolve, reject) {
-            colonyNetworkEthers.on("ReputationMiningCycleComplete", async (_hash, _nNodes, event) => {
-              const newHash = await colonyNetwork.getReputationRootHash();
-              expect(newHash).to.not.equal(oldHash, "The old and new hashes are the same");
-              expect(newHash).to.equal(rootHash, "The network root hash doens't match the one submitted");
-              event.removeListener();
-              resolve();
-            });
-
-            // After 30s, we throw a timeout error
-            setTimeout(() => {
-              reject(new Error("ERROR: timeout while waiting for confirming hash"));
-            }, 30000);
-          });
-
-          // Forward time to the end of the mining cycle and since we are the only miner, check the client confirmed our hash correctly
-          await forwardTime(MINING_CYCLE_DURATION * 0.6, this);
-          await miningCycleComplete;
-          await reputationMinerClient2.close();
         });
       });
     });

--- a/test/reputation-system/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-system/reputation-mining-client/client-auto-functionality.js
@@ -164,6 +164,92 @@ process.env.SOLIDITY_COVERAGE
           await miningCycleComplete;
         });
 
+        it("should successfully resume submitting hashes if it's restarted", async function() {
+          const rootHash = await reputationMinerClient._miner.getRootHash();
+          const nNodes = await reputationMinerClient._miner.getRootHashNNodes();
+          const jrh = await reputationMinerClient._miner.justificationTree.getRootHash();
+
+          const oldHash = await colonyNetwork.getReputationRootHash();
+
+          const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
+          const receive2Submissions = new Promise(function(resolve, reject) {
+            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
+              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
+              if (nSubmissions.toNumber() === 2) {
+                // Check the reputation cycle submission matches our miner
+                // Validate the miner address in submission is correct
+                event.removeListener();
+                resolve();
+              } else {
+                await mineBlock();
+              }
+            });
+
+            // After 30s, we throw a timeout error
+            setTimeout(() => {
+              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
+            }, 30000);
+          });
+
+          // Forward through half of the cycle duration and wait for the client to submit some entries
+          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
+          await receive2Submissions; // It might submit a couple more, but that's fine for the purposes of this test.
+          await reputationMinerClient.close();
+
+          // start up another one.
+          const reputationMinerClient2 = new ReputationMinerClient({
+            loader,
+            realProviderPort,
+            minerAddress: MINER1,
+            useJsTree: true,
+            auto: true
+          });
+          await reputationMinerClient2.initialise(colonyNetwork.address, startingBlockNumber);
+
+          const receive12Submissions = new Promise(function(resolve, reject) {
+            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
+              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
+              if (nSubmissions.toNumber() === 12) {
+                // Check the reputation cycle submission matches our miner
+                // Validate the miner address in submission is correct
+                event.removeListener();
+                resolve();
+              } else {
+                await mineBlock();
+              }
+            });
+
+            // After 30s, we throw a timeout error
+            setTimeout(() => {
+              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
+            }, 30000);
+          });
+
+          await mineBlock();
+          await receive12Submissions;
+
+          const colonyNetworkEthers = await reputationMinerClient._miner.colonyNetwork;
+          const miningCycleComplete = new Promise(function(resolve, reject) {
+            colonyNetworkEthers.on("ReputationMiningCycleComplete", async (_hash, _nNodes, event) => {
+              const newHash = await colonyNetwork.getReputationRootHash();
+              expect(newHash).to.not.equal(oldHash, "The old and new hashes are the same");
+              expect(newHash).to.equal(rootHash, "The network root hash doens't match the one submitted");
+              event.removeListener();
+              resolve();
+            });
+
+            // After 30s, we throw a timeout error
+            setTimeout(() => {
+              reject(new Error("ERROR: timeout while waiting for confirming hash"));
+            }, 30000);
+          });
+
+          // Forward time to the end of the mining cycle and since we are the only miner, check the client confirmed our hash correctly
+          await forwardTime(MINING_CYCLE_DURATION * 0.6, this);
+          await miningCycleComplete;
+          await reputationMinerClient2.close();
+        });
+
         it("should successfully complete a hash submission if there are 2 good miners", async function() {
           const oldHash = await colonyNetwork.getReputationRootHash();
           const rootHash = await reputationMinerClient._miner.getRootHash();

--- a/yarn.lock
+++ b/yarn.lock
@@ -9947,6 +9947,13 @@ sisteransi@^1.0.3:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.3.tgz#98168d62b79e3a5e758e27ae63c4a053d748f4eb"
   integrity sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==
 
+slack@^11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/slack/-/slack-11.0.2.tgz#30f68527c5d1712b7faa3141db7716f89ac6e911"
+  integrity sha512-rv842+S+AGyZCmMMd8xPtW5DvJ9LzWTAKfxi8Gw57oYlXgcKtFuHd4nqk6lTPpRKdUGn3tx/Drd0rjQR3dQPqw==
+  dependencies:
+    tiny-json-http "^7.0.2"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -10745,6 +10752,11 @@ tiny-async-pool@^1.0.4:
   dependencies:
     semver "^5.5.0"
     yaassertion "^1.0.0"
+
+tiny-json-http@^7.0.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/tiny-json-http/-/tiny-json-http-7.1.2.tgz#620e189849bab08992ec23fada7b48c7c61637b4"
+  integrity sha512-XB9Bu+ohdQso6ziPFNVqK+pcTt0l8BSRkW/CCBq0pUVlLxcYDsorpo7ae5yPhu2CF1xYgJuKVLF7cfOGeLCTlA==
 
 tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9411,7 +9411,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request-promise@^4.2.2:
+request-promise@^4.2.2, request-promise@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.4.tgz#1c5ed0d71441e38ad58c7ce4ea4ea5b06d54b310"
   integrity sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==


### PR DESCRIPTION
- Add try/catch-es in mining client
- On restart, recover any submissions made
- Add test resuming submissions after making some
- Save historical states after syncing the client