### PR TITLE
Arbitration Role in IColony

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -76,6 +76,19 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     emit ColonyRoleSet(_user, _domainId, uint8(ColonyRole.Administration), _setTo);
   }
 
+  function setArbitrationRole(
+    uint256 _permissionDomainId,
+    uint256 _childSkillIndex,
+    address _user,
+    uint256 _domainId,
+    bool _setTo
+  ) public stoppable authDomain(_permissionDomainId, _childSkillIndex, _domainId)
+  {
+    ColonyAuthority(address(authority)).setUserRole(_user, _domainId, uint8(ColonyRole.Arbitration), _setTo);
+
+    emit ColonyRoleSet(_user, _domainId, uint8(ColonyRole.Arbitration), _setTo);
+  }
+
   function hasUserRole(address _user, uint256 _domainId, ColonyRole _role) public view returns (bool) {
     return ColonyAuthority(address(authority)).hasUserRole(_user, _domainId, uint8(_role));
   }

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -34,6 +34,19 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     emit ColonyRoleSet(_user, 1, uint8(ColonyRole.Root), _setTo);
   }
 
+  function setArbitrationRole(
+    uint256 _permissionDomainId,
+    uint256 _childSkillIndex,
+    address _user,
+    uint256 _domainId,
+    bool _setTo
+  ) public stoppable authDomain(_permissionDomainId, _childSkillIndex, _domainId)
+  {
+    ColonyAuthority(address(authority)).setUserRole(_user, _domainId, uint8(ColonyRole.Arbitration), _setTo);
+
+    emit ColonyRoleSet(_user, _domainId, uint8(ColonyRole.Arbitration), _setTo);
+  }
+
   function setArchitectureRole(
     uint256 _permissionDomainId,
     uint256 _childSkillIndex,
@@ -74,19 +87,6 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     ColonyAuthority(address(authority)).setUserRole(_user, _domainId, uint8(ColonyRole.Administration), _setTo);
 
     emit ColonyRoleSet(_user, _domainId, uint8(ColonyRole.Administration), _setTo);
-  }
-
-  function setArbitrationRole(
-    uint256 _permissionDomainId,
-    uint256 _childSkillIndex,
-    address _user,
-    uint256 _domainId,
-    bool _setTo
-  ) public stoppable authDomain(_permissionDomainId, _childSkillIndex, _domainId)
-  {
-    ColonyAuthority(address(authority)).setUserRole(_user, _domainId, uint8(ColonyRole.Arbitration), _setTo);
-
-    emit ColonyRoleSet(_user, _domainId, uint8(ColonyRole.Arbitration), _setTo);
   }
 
   function hasUserRole(address _user, uint256 _domainId, ColonyRole _role) public view returns (bool) {

--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -57,9 +57,12 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ROOT_ROLE, "setArchitectureRole(uint256,uint256,address,uint256,bool)");
     addRoleCapability(ROOT_ROLE, "setFundingRole(uint256,uint256,address,uint256,bool)");
     addRoleCapability(ROOT_ROLE, "setAdministrationRole(uint256,uint256,address,uint256,bool)");
+    addRoleCapability(ROOT_ROLE, "setArbitrationRole(uint256,uint256,address,uint256,bool)");
+
     // Managing recovery roles
     addRoleCapability(ROOT_ROLE, "setRecoveryRole(address)");
     addRoleCapability(ROOT_ROLE, "removeRecoveryRole(address)");
+
     // Colony functions
     addRoleCapability(ROOT_ROLE, "startNextRewardPayout(address,bytes,bytes,uint256,bytes32[])");
     addRoleCapability(ROOT_ROLE, "bootstrapColony(address[],int256[])");
@@ -67,6 +70,7 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ROOT_ROLE, "setRewardInverse(uint256)");
     addRoleCapability(ROOT_ROLE, "mintTokens(uint256)");
     addRoleCapability(ROOT_ROLE, "upgrade(uint256)");
+
     //  Meta Colony functions
     addRoleCapability(ROOT_ROLE, "addNetworkColonyVersion(uint256,address)");
     addRoleCapability(ROOT_ROLE, "setNetworkFeeInverse(uint256)");

--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -54,10 +54,10 @@ contract ColonyAuthority is CommonAuthority {
 
     // Add permissions for the Root role
     addRoleCapability(ROOT_ROLE, "setRootRole(address,bool)");
+    addRoleCapability(ROOT_ROLE, "setArbitrationRole(uint256,uint256,address,uint256,bool)");
     addRoleCapability(ROOT_ROLE, "setArchitectureRole(uint256,uint256,address,uint256,bool)");
     addRoleCapability(ROOT_ROLE, "setFundingRole(uint256,uint256,address,uint256,bool)");
     addRoleCapability(ROOT_ROLE, "setAdministrationRole(uint256,uint256,address,uint256,bool)");
-    addRoleCapability(ROOT_ROLE, "setArbitrationRole(uint256,uint256,address,uint256,bool)");
 
     // Managing recovery roles
     addRoleCapability(ROOT_ROLE, "setRecoveryRole(address)");

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -156,6 +156,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
     // Assign all permissions in root domain
     colony.setRecoveryRole(msg.sender);
     colony.setRootRole(msg.sender, true);
+    colony.setArbitrationRole(1, 0, msg.sender, 1, true);
     colony.setArchitectureRole(1, 0, msg.sender, 1, true);
     colony.setFundingRole(1, 0, msg.sender, 1, true);
     colony.setAdministrationRole(1, 0, msg.sender, 1, true);
@@ -263,7 +264,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
     return skill.children[_childSkillIndex];
   }
 
-  function deprecateSkill(uint256 _skillId) public stoppable 
+  function deprecateSkill(uint256 _skillId) public stoppable
   allowedToAddSkill(true)
   {
     skills[_skillId].deprecated = true;

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -61,6 +61,15 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _setTo The state of the role permission (true assign the permission, false revokes it)
   function setRootRole(address _user, bool _setTo) public;
 
+  /// @notice Set new colony arbitration role.
+  /// Can be called only by root role.
+  /// @param _permissionDomainId Domain in which the caller has root role
+  /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`
+  /// @param _user User we want to give an arbitration role to
+  /// @param _domainId Domain in which we are giving user the role
+  /// @param _setTo The state of the role permission (true assign the permission, false revokes it)
+  function setArbitrationRole(uint256 _permissionDomainId, uint256 _childSkillIndex, address _user, uint256 _domainId, bool _setTo) public;
+
   /// @notice Set new colony architecture role.
   /// Can be called by root role or architecture role.
   /// @param _permissionDomainId Domain in which the caller has root/architecture role
@@ -87,15 +96,6 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _domainId Domain in which we are giving user the role
   /// @param _setTo The state of the role permission (true assign the permission, false revokes it)
   function setAdministrationRole(uint256 _permissionDomainId, uint256 _childSkillIndex, address _user, uint256 _domainId, bool _setTo) public;
-
-  /// @notice Set new colony arbitration role.
-  /// Can be called only by root role.
-  /// @param _permissionDomainId Domain in which the caller has root role
-  /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`
-  /// @param _user User we want to give an arbitration role to
-  /// @param _domainId Domain in which we are giving user the role
-  /// @param _setTo The state of the role permission (true assign the permission, false revokes it)
-  function setArbitrationRole(uint256 _permissionDomainId, uint256 _childSkillIndex, address _user, uint256 _domainId, bool _setTo) public;
 
   /// @notice Check whether a given user has a given role for the colony.
   /// Calls the function of the same name on the colony's authority contract.

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -88,6 +88,15 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _setTo The state of the role permission (true assign the permission, false revokes it)
   function setAdministrationRole(uint256 _permissionDomainId, uint256 _childSkillIndex, address _user, uint256 _domainId, bool _setTo) public;
 
+  /// @notice Set new colony arbitration role.
+  /// Can be called only by root role.
+  /// @param _permissionDomainId Domain in which the caller has root role
+  /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`
+  /// @param _user User we want to give an arbitration role to
+  /// @param _domainId Domain in which we are giving user the role
+  /// @param _setTo The state of the role permission (true assign the permission, false revokes it)
+  function setArbitrationRole(uint256 _permissionDomainId, uint256 _childSkillIndex, address _user, uint256 _domainId, bool _setTo) public;
+
   /// @notice Check whether a given user has a given role for the colony.
   /// Calls the function of the same name on the colony's authority contract.
   /// @param _user The user whose role we want to check
@@ -151,7 +160,7 @@ contract IColony is ColonyDataTypes, IRecovery {
   // Implemented in ColonyPayment.sol
   /// @notice Add a new payment in the colony. Secured function to authorised members.
   /// @param _permissionDomainId The domainId in which I have the permission to take this action
-  /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`, 
+  /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`,
   /// (only used if `_permissionDomainId` is different to `_domainId`)
   /// @param _recipient Address of the payment recipient
   /// @param _token Address of the token, `0x0` value indicates Ether

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -32,7 +32,7 @@ Add a new payment in the colony. Secured function to authorised members.
 |Name|Type|Description|
 |---|---|---|
 |_permissionDomainId|uint256|The domainId in which I have the permission to take this action
-|_childSkillIndex|uint256|The index that the `_domainId` is relative to `_permissionDomainId`,  (only used if `_permissionDomainId` is different to `_domainId`)
+|_childSkillIndex|uint256|The index that the `_domainId` is relative to `_permissionDomainId`, (only used if `_permissionDomainId` is different to `_domainId`)
 |_recipient|address|Address of the payment recipient
 |_token|address|Address of the token, `0x0` value indicates Ether
 |_amount|uint256|Payout amount
@@ -744,6 +744,22 @@ Set `_token` payout for all roles in task `_id` to the respective amounts.
 |_managerAmount|uint256|Payout amount for manager
 |_evaluatorAmount|uint256|Payout amount for evaluator
 |_workerAmount|uint256|Payout amount for worker
+
+
+### `setArbitrationRole`
+
+Set new colony arbitration role. Can be called only by root role.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_permissionDomainId|uint256|Domain in which the caller has root role
+|_childSkillIndex|uint256|The index that the `_domainId` is relative to `_permissionDomainId`
+|_user|address|User we want to give an arbitration role to
+|_domainId|uint256|Domain in which we are giving user the role
+|_setTo|bool|The state of the role permission (true assign the permission, false revokes it)
 
 
 ### `setArchitectureRole`

--- a/test/contracts-network/colony-permissions.js
+++ b/test/contracts-network/colony-permissions.js
@@ -5,11 +5,11 @@ import bnChai from "bn-chai";
 import {
   WAD,
   ROOT_ROLE,
+  ARBITRATION_ROLE,
   ARCHITECTURE_ROLE,
   ARCHITECTURE_SUBDOMAIN_ROLE,
   FUNDING_ROLE,
   ADMINISTRATION_ROLE,
-  ARBITRATION_ROLE,
   INITIAL_FUNDING,
   SPECIFICATION_HASH
 } from "../../helpers/constants";
@@ -57,19 +57,19 @@ contract("ColonyPermissions", accounts => {
 
   describe("when managing domain-level permissions", () => {
     it("should give colony creator all permissions in root domain", async () => {
-      const fundingRole = await colony.hasUserRole(FOUNDER, 1, FUNDING_ROLE);
-      const administrationRole = await colony.hasUserRole(FOUNDER, 1, ADMINISTRATION_ROLE);
+      const rootRole = await colony.hasUserRole(FOUNDER, 1, ROOT_ROLE);
       const arbitrationRole = await colony.hasUserRole(FOUNDER, 1, ARBITRATION_ROLE);
       const architectureRole = await colony.hasUserRole(FOUNDER, 1, ARCHITECTURE_ROLE);
       const architectureSubdomainRole = await colony.hasUserRole(FOUNDER, 1, ARCHITECTURE_SUBDOMAIN_ROLE);
-      const rootRole = await colony.hasUserRole(FOUNDER, 1, ROOT_ROLE);
+      const fundingRole = await colony.hasUserRole(FOUNDER, 1, FUNDING_ROLE);
+      const administrationRole = await colony.hasUserRole(FOUNDER, 1, ADMINISTRATION_ROLE);
 
-      expect(fundingRole).to.be.true;
-      expect(administrationRole).to.be.true;
+      expect(rootRole).to.be.true;
       expect(arbitrationRole).to.be.true;
       expect(architectureRole).to.be.true;
       expect(architectureSubdomainRole).to.be.true;
-      expect(rootRole).to.be.true;
+      expect(fundingRole).to.be.true;
+      expect(administrationRole).to.be.true;
     });
 
     it("should allow users with funding permission manipulate funds in their domains only", async () => {
@@ -224,11 +224,11 @@ contract("ColonyPermissions", accounts => {
       expect(hasRole).to.be.true;
 
       // Can create manage permissions in the root domain!
-      await colony.setFundingRole(1, 0, USER2, 1, true, { from: USER1 });
-      await colony.setArbitrationRole(1, 0, USER2, 1, true, { from: USER1 });
-      await colony.setAdministrationRole(1, 0, USER2, 1, true, { from: USER1 });
-      await colony.setArchitectureRole(1, 0, USER2, 1, true, { from: USER1 });
       await colony.setRootRole(USER2, true, { from: USER1 });
+      await colony.setArbitrationRole(1, 0, USER2, 1, true, { from: USER1 });
+      await colony.setArchitectureRole(1, 0, USER2, 1, true, { from: USER1 });
+      await colony.setFundingRole(1, 0, USER2, 1, true, { from: USER1 });
+      await colony.setAdministrationRole(1, 0, USER2, 1, true, { from: USER1 });
 
       // // And child domains!
       await colony.setAdministrationRole(1, 0, USER2, 2, true, { from: USER1 });

--- a/test/contracts-network/colony-permissions.js
+++ b/test/contracts-network/colony-permissions.js
@@ -9,6 +9,7 @@ import {
   ARCHITECTURE_SUBDOMAIN_ROLE,
   FUNDING_ROLE,
   ADMINISTRATION_ROLE,
+  ARBITRATION_ROLE,
   INITIAL_FUNDING,
   SPECIFICATION_HASH
 } from "../../helpers/constants";
@@ -58,13 +59,14 @@ contract("ColonyPermissions", accounts => {
     it("should give colony creator all permissions in root domain", async () => {
       const fundingRole = await colony.hasUserRole(FOUNDER, 1, FUNDING_ROLE);
       const administrationRole = await colony.hasUserRole(FOUNDER, 1, ADMINISTRATION_ROLE);
-      // const arbitrationRole = await colony.hasUserRole(FOUNDER, 1, ARBITRATION_ROLE); Not implemented yet.
+      const arbitrationRole = await colony.hasUserRole(FOUNDER, 1, ARBITRATION_ROLE);
       const architectureRole = await colony.hasUserRole(FOUNDER, 1, ARCHITECTURE_ROLE);
       const architectureSubdomainRole = await colony.hasUserRole(FOUNDER, 1, ARCHITECTURE_SUBDOMAIN_ROLE);
       const rootRole = await colony.hasUserRole(FOUNDER, 1, ROOT_ROLE);
 
       expect(fundingRole).to.be.true;
       expect(administrationRole).to.be.true;
+      expect(arbitrationRole).to.be.true;
       expect(architectureRole).to.be.true;
       expect(architectureSubdomainRole).to.be.true;
       expect(rootRole).to.be.true;
@@ -223,6 +225,7 @@ contract("ColonyPermissions", accounts => {
 
       // Can create manage permissions in the root domain!
       await colony.setFundingRole(1, 0, USER2, 1, true, { from: USER1 });
+      await colony.setArbitrationRole(1, 0, USER2, 1, true, { from: USER1 });
       await colony.setAdministrationRole(1, 0, USER2, 1, true, { from: USER1 });
       await colony.setArchitectureRole(1, 0, USER2, 1, true, { from: USER1 });
       await colony.setRootRole(USER2, true, { from: USER1 });


### PR DESCRIPTION
This PR would add a `setArbitrationRole` function to a colony, allowing users to assign the role even though there are no functions in the current glider release that make use of the ARBITRATION role. 

There are reasons. First, the arbitration role is described as a "placeholder" for dispute resolution. When voting or disputes are implemented, these changes will need to be put in anyways. Not exposing a flaccid function is an understandable design decision, but it leaves the arbitration role in a weird state of being in principle useful on lower levels, but inaccessible. 

More importantly (and more generally), developers working on extensions might want to utilize a colony's permissions system separately with other contracts that are related to the colony (read: as a module). Checking colony permissions before executing some hypothetical extension function should be possible with the other roles, so why not allow the Arbitration role to be utilized for extensions? 

I would argue that exposing the arbitration role for extension contracts is a good devrel-driven design decision, because then devs have some free reign to develop novel rules around a role that (for now) doesn't also have implications elsewhere in the colony imposed by payments, tasks, etc... I can imagine developers wanting to implement their own alternative voting / dispute systems as an extension, and using the arbitration role to connect them to their colony, for example. 

--

Okay, now that I've made my case, I should say that these changes made are ones that I know are necessary, but I'm not sure they're sufficient for a PR. I'm particularly in the dark about what I need to do regarding tests and anything not in the `contracts/` folder. I suppose it's also possible that I've missed something entirely that makes this not work, or don't see some other objection originating from room 3. plz halp. 

  

