### PR TITLE
Update mining docs for Goerli, better errors and logging for miner

### DIFF
--- a/docs/_Docs_ReputationMining.md
+++ b/docs/_Docs_ReputationMining.md
@@ -9,11 +9,8 @@ order: 6
 You can start the reputation mining client against the Goerli testnet using the following command:
 
 ```
-node ./packages/reputation-miner/bin/index.js --network goerli --colonyNetworkAddress 0x79073fc2117dD054FCEdaCad
-1E7018C9CbE3ec0B --privateKey { YOUR_PRIVATE_KEY }
+node ./packages/reputation-miner/bin/index.js --network goerli --colonyNetworkAddress 0x79073fc2117dD054FCEdaCad1E7018C9CbE3ec0B --syncFrom 548534 --privateKey YOUR_PRIVATE_KEY
 ```
-
-The miner will begin to sync from scratch. To sync from a specific block number, add the `--syncFrom { BLOCK_NO }` flag.
 
 ## Local Network
 
@@ -22,12 +19,14 @@ The miner will begin to sync from scratch. To sync from a specific block number,
 You can start the reputation mining client against a local chain using the following command:
 
 ```
-node packages/reputation-miner/bin/index.js --colonyNetworkAddress { COLONYNETWORK_ADDRESS } --minerAddress { MINER_ADDRESS }
+node packages/reputation-miner/bin/index.js --colonyNetworkAddress COLONY_NETWORK_ADDRESS --minerAddress MINER_ADDRESS --syncFrom BLOCK_NO
 ```
 
-The `minerAddress` in the execution above is the sixth account in `ganache-accounts.json` if running locally using the default migrations.
+The `MINER_ADDRESS` in the execution above is the sixth account in `ganache-accounts.json` if running locally using the default migrations.
 
 The `colonyNetwork` address in the execution above is not the address outputted at contract deployment, but is the address of the Colony Network `EtherRouter`. See [Upgrades to the Colony Network](/colonynetwork/docs-the-delegate-proxy-pattern/) for more information about the EtherRouter design pattern.
+
+Due to a quirk with the mining cycle events, beginning the sync with a too-early block will result in an error. If you get this exception, try increasing the `BLOCK_NO`.
 
 ### Force Reputation Updates
 
@@ -47,7 +46,7 @@ curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","metho
 
 Note that because reputation is awarded for the *previous* submission window, you will need to use the "fast-forward" command above to speed through at least 3 reputation updates before noticing a change in the miner's reputation.
 
-### Get Reputation from the Reputation Oracle
+## Get Reputation from the Reputation Oracle
 
 The reputation mining client will answer queries for reputation scores locally over HTTP.
 

--- a/docs/_Docs_ReputationMining.md
+++ b/docs/_Docs_ReputationMining.md
@@ -4,17 +4,28 @@ section: Docs
 order: 6
 ---
 
+## Goerli Testnet
+
+You can start the reputation mining client against the Goerli testnet using the following command:
+
+```
+node ./packages/reputation-miner/bin/index.js --network goerli --colonyNetworkAddress 0x79073fc2117dD054FCEdaCad
+1E7018C9CbE3ec0B --privateKey { YOUR_PRIVATE_KEY }
+```
+
+The miner will begin to sync from scratch. To sync from a specific block number, add the `--syncFrom { BLOCK_NO }` flag.
+
 ## Local Network
 
 ### Start Mining Client
 
-You can start the reputation mining client using the following command.
+You can start the reputation mining client against a local chain using the following command:
 
 ```
 node packages/reputation-miner/bin/index.js --colonyNetworkAddress { COLONYNETWORK_ADDRESS } --minerAddress { MINER_ADDRESS }
 ```
 
-The `minerAddress` in the execution above is the sixth account in `ganache-accounts.json` if running locally.
+The `minerAddress` in the execution above is the sixth account in `ganache-accounts.json` if running locally using the default migrations.
 
 The `colonyNetwork` address in the execution above is not the address outputted at contract deployment, but is the address of the Colony Network `EtherRouter`. See [Upgrades to the Colony Network](/colonynetwork/docs-the-delegate-proxy-pattern/) for more information about the EtherRouter design pattern.
 

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -126,6 +126,11 @@ class ReputationMiner {
     const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockTag: blockNumber });
     const repCycle = new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
 
+    if (addr === `0x${new BN(0).toString(16, 40)}`) {
+      console.log(`WARNING: No active mining cycle found for block number ${blockNumber}`);
+      return;
+    }
+
     // Do updates
     this.nReputationsBeforeLatestLog = ethers.utils.bigNumberify(this.nReputations.toString());
     // This is also the number of decays we have.
@@ -1142,6 +1147,7 @@ class ReputationMiner {
       applyLogs = true;
     }
     for (let i = 0; i < events.length; i += 1) {
+      console.log(`Syncing mining cycle ${i} of ${events.length}...`)
       const event = events[i];
       const hash = event.data.slice(0, 66);
       if (applyLogs) {

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -125,11 +125,6 @@ class ReputationMiner {
     this.reverseReputationHashLookup = {};
     const repCycle = await this.getActiveRepCycle(blockNumber)
 
-    if (repCycle.address === ethers.constants.AddressZero) {
-      console.log(`WARNING: No active mining cycle found for block number ${blockNumber}`);
-      return;
-    }
-
     // Do updates
     this.nReputationsBeforeLatestLog = ethers.utils.bigNumberify(this.nReputations.toString());
     // This is also the number of decays we have.
@@ -623,6 +618,11 @@ class ReputationMiner {
    */
   async getActiveRepCycle(blockNumber = "latest") {
     const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockTag: blockNumber });
+
+    if (addr === ethers.constants.AddressZero) {
+      throw new Error(`No active mining cycle found for block number ${blockNumber}`);
+    }
+
     return new ethers.Contract(addr, this.repCycleContractDef.abi, this.realWallet);
   }
 

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -13,8 +13,8 @@ const ReputationMinerClient = require("../ReputationMinerClient");
 const supportedInfuraNetworks = ["goerli", "rinkeby", "ropsten", "kovan", "mainnet"];
 const { minerAddress, privateKey, colonyNetworkAddress, dbPath, network, localPort, syncFrom, auto } = argv;
 
-if ((!minerAddress && !privateKey) || !colonyNetworkAddress || !syncFrom) {
-  console.log("❗️ You have to specify all of ( --minerAddress or --privateKey ) and --colonyNetworkAddress and --syncFrom on the command line!");
+if ((!minerAddress && !privateKey) || !colonyNetworkAddress) {
+  console.log("❗️ You have to specify all of ( --minerAddress or --privateKey ) and --colonyNetworkAddress on the command line!");
   process.exit();
 }
 
@@ -34,4 +34,4 @@ if (network) {
 }
 
 const client = new ReputationMinerClient({ loader, minerAddress, privateKey, provider, useJsTree: true, dbPath, auto });
-client.initialise(colonyNetworkAddress, syncFrom);
+client.initialise(colonyNetworkAddress, syncFrom || 1);

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -13,8 +13,8 @@ const ReputationMinerClient = require("../ReputationMinerClient");
 const supportedInfuraNetworks = ["goerli", "rinkeby", "ropsten", "kovan", "mainnet"];
 const { minerAddress, privateKey, colonyNetworkAddress, dbPath, network, localPort, syncFrom, auto } = argv;
 
-if ((!minerAddress && !privateKey) || !colonyNetworkAddress) {
-  console.log("❗️ You have to specify all of ( --minerAddress or --privateKey ) and --colonyNetworkAddress on the command line!");
+if ((!minerAddress && !privateKey) || !colonyNetworkAddress || !syncFrom) {
+  console.log("❗️ You have to specify all of ( --minerAddress or --privateKey ) and --colonyNetworkAddress and --syncFrom on the command line!");
   process.exit();
 }
 
@@ -34,4 +34,4 @@ if (network) {
 }
 
 const client = new ReputationMinerClient({ loader, minerAddress, privateKey, provider, useJsTree: true, dbPath, auto });
-client.initialise(colonyNetworkAddress, syncFrom || 1);
+client.initialise(colonyNetworkAddress, syncFrom);


### PR DESCRIPTION
<!--- Summary of changes including design decisions -->

@gichiba recently drew my attention to the fact that the current [mining docs](https://docs.colony.io/colonynetwork/docs-reputation-mining-client) don't include instructions for Goerli. After the merge of #596 I figured I'd try and spin up the minimum viable mining client. After a few stumbles I figured it out and have updated the docs with new instructions, as well as added a bit more logging.

At first I thought it would be nice to have the miner sync from block 1 by default, but unfortunately a quirk with event logging means that the first `ReputationMiningCycleComplete` event is emitted before the first mining cycle is deployed, meaning that either an exception is raised for the missing mining cycle, or we ignore something that should really raise an exception, which would be asking for trouble down the road. So this PR adds the exception, which is the Right Thing To Do.

So, since we can't sync from block 1, the next thought was wouldn't it be fun to tell the mining client about the deployment details (such as the Colony Network address, what block to sync from, etc). That seemed like a good idea at first, but after some reflection it became clear that there are lots of ways to start a mining client (with an infura node, with a local ethereum client, with a local testnet), and making the miner smart enough to "know what to do" with all of these different configurations turned into more of a production that we bargained for. Instead, let's keep the client dumb as bricks and update the docs with the information that we otherwise might have baked into the client.