### PR TITLE
Bump Colony version to 2

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -26,7 +26,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
   // This function, exactly as defined, is used in build scripts. Take care when updating.
   // Version number should be upped with every change in Colony or its dependency contracts or libraries.
-  function version() public pure returns (uint256 colonyVersion) { return 1; }
+  function version() public pure returns (uint256 colonyVersion) { return 2; }
 
   function setRootRole(address _user, bool _setTo) public stoppable auth {
     ColonyAuthority(address(authority)).setUserRole(_user, uint8(ColonyRole.Root), _setTo);

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -187,6 +187,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
   auth
   {
     require(currentColonyVersion == 0, "colony-network-already-initialised");
+    require(_version > 0, "colony-network-invalid-version");
     colonyVersionResolver[_version] = _resolver;
     currentColonyVersion = _version;
 

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -182,13 +182,13 @@ contract ColonyNetwork is ColonyNetworkStorage {
     emit ColonyVersionAdded(_version, _resolver);
   }
 
-  function initialise(address _resolver) public
+  function initialise(address _resolver, uint256 _version) public
   stoppable
   auth
   {
     require(currentColonyVersion == 0, "colony-network-already-initialised");
-    colonyVersionResolver[1] = _resolver;
-    currentColonyVersion = 1;
+    colonyVersionResolver[_version] = _resolver;
+    currentColonyVersion = _version;
 
     emit ColonyNetworkInitialised(_resolver);
   }

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -142,8 +142,9 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
 
   /// @notice Initialises the colony network by setting the first Colony version resolver to `_resolver` address.
   /// @dev Only allowed to be run once, by the Network owner before any Colony versions are added.
-  /// @param _resolver Address of the resolver for Colony contract version 1
-  function initialise(address _resolver) public;
+  /// @param _resolver Address of the resolver for Colony contract
+  /// @param _resolver Version of the Colony contract the resolver represents
+  function initialise(address _resolver, uint256 _version) public;
 
   /// @notice Get a colony address by its Id in the network.
   /// @param _id Id of the colony to get

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -143,7 +143,7 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @notice Initialises the colony network by setting the first Colony version resolver to `_resolver` address.
   /// @dev Only allowed to be run once, by the Network owner before any Colony versions are added.
   /// @param _resolver Address of the resolver for Colony contract
-  /// @param _resolver Version of the Colony contract the resolver represents
+  /// @param _version Version of the Colony contract the resolver represents
   function initialise(address _resolver, uint256 _version) public;
 
   /// @notice Get a colony address by its Id in the network.

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -428,7 +428,8 @@ Initialises the colony network by setting the first Colony version resolver to `
 
 |Name|Type|Description|
 |---|---|---|
-|_resolver|address|Address of the resolver for Colony contract version 1
+|_resolver|address|Address of the resolver for Colony contract
+|_version|uint256|Version of the Colony contract the resolver represents
 
 
 ### `initialiseReputationMining`

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -344,7 +344,8 @@ export async function setupColonyNetwork() {
 
   const colonyNetwork = await IColonyNetwork.at(etherRouter.address);
   await setupColonyVersionResolver(colonyTemplate, colonyTask, colonyPayment, colonyFunding, contractRecovery, resolver);
-  await colonyNetwork.initialise(resolver.address);
+  const version = await colonyTemplate.version();
+  await colonyNetwork.initialise(resolver.address, version);
   // Jumping through these hoops to avoid the need to rewire ReputationMiningCycleResolver.
   const deployedColonyNetwork = await IColonyNetwork.at(EtherRouter.address);
   const reputationMiningCycleResolverAddress = await deployedColonyNetwork.getMiningResolver();

--- a/migrations/4_setup_colony_version_resolver.js
+++ b/migrations/4_setup_colony_version_resolver.js
@@ -28,7 +28,7 @@ module.exports = async function(deployer) {
 
   // Register the new Colony contract version with the newly setup Resolver
   await setupColonyVersionResolver(colony, colonyTask, colonyPayment, colonyFunding, contractRecovery, resolver);
-  await colonyNetwork.initialise(resolver.address);
+  await colonyNetwork.initialise(resolver.address, version);
 
   console.log("### Colony version", version.toString(), "set to Resolver", resolver.address);
 };

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -80,7 +80,7 @@ contract("Colony Network", accounts => {
     });
 
     it("should not be able to initialise network twice", async () => {
-      await checkErrorRevert(colonyNetwork.initialise("0xDde1400C69752A6596a7B2C1f2420Fb9A71c1FDA"), "colony-network-already-initialised");
+      await checkErrorRevert(colonyNetwork.initialise("0xDde1400C69752A6596a7B2C1f2420Fb9A71c1FDA", 3), "colony-network-already-initialised");
     });
 
     it("should not be able to create a colony if the network is not initialised", async () => {

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -48,7 +48,7 @@ contract("Colony Network", accounts => {
 
     it("should have the correct current Colony version set", async () => {
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
-      expect(currentColonyVersion).to.eq.BN(1);
+      expect(currentColonyVersion).to.eq.BN(2);
     });
 
     it("should have the Resolver for current Colony version set", async () => {

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -94,6 +94,26 @@ contract("Colony Network", accounts => {
         "colony-network-not-initialised-cannot-create-colony"
       );
     });
+
+    it("should not be able to initialise the network with colony version number 0", async () => {
+      const resolverColonyNetworkDeployed = await Resolver.deployed();
+      const etherRouter = await EtherRouter.new();
+      await etherRouter.setResolver(resolverColonyNetworkDeployed.address);
+      const colonyNetworkNew = await IColonyNetwork.at(etherRouter.address);
+
+      await checkErrorRevert(colonyNetworkNew.initialise("0xDde1400C69752A6596a7B2C1f2420Fb9A71c1FDA", 0), "colony-network-invalid-version");
+    });
+
+    it("should be able to initialise the network with any colony version number greater than 0", async () => {
+      const resolverColonyNetworkDeployed = await Resolver.deployed();
+      const etherRouter = await EtherRouter.new();
+      await etherRouter.setResolver(resolverColonyNetworkDeployed.address);
+      const colonyNetworkNew = await IColonyNetwork.at(etherRouter.address);
+
+      await colonyNetworkNew.initialise("0xDde1400C69752A6596a7B2C1f2420Fb9A71c1FDA", 79);
+      const currentColonyVersion = await colonyNetworkNew.getCurrentColonyVersion();
+      expect(currentColonyVersion).to.eq.BN(79);
+    });
   });
 
   describe("when managing the mining process", () => {


### PR DESCRIPTION
Bumps the `version()` a colony will report with the latest resolver to 2. This was already done on Goerli, just not included in the codebase. This PR also allows us to initialise ColonyNetwork with any version as the latest version. This is required because we wish to align versions between Goerli and Mainnet