### PR TITLE
Add network configurations and fork setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "provision:token:contracts": "truffle compile && truffle compile --contracts_directory 'lib/dappsys/[!note][!stop][!proxy][!thing][!token]*.sol' && bash ./scripts/provision-token-contracts.sh",
     "start:blockchain:client": "bash ./scripts/start-blockchain-client.sh",
     "stop:blockchain:client": "bash ./scripts/stop-blockchain-client.sh",
+    "fork:goerli": "yarn run ganache-cli --fork https://goerli.infura.io/v3/e21146aa267845a2b7b4da025178196d --port 8605",
+    "fork:mainnet": "yarn run ganache-cli --fork https://mainnet.infura.io/v3/e21146aa267845a2b7b4da025178196d --port 8601",
     "flatten:contracts": "mkdir -p ./build/flattened/ && steamroller contracts/IColonyNetwork.sol > build/flattened/flatIColonyNetwork.sol && steamroller contracts/IColony.sol > build/flattened/flatIColony.sol && steamroller contracts/IReputationMiningCycle.sol > build/flattened/flatIReputationMiningCycle.sol && steamroller contracts/IMetaColony.sol > build/flattened/flatIMetaColony.sol && steamroller contracts/IRecovery.sol > build/flattened/flatIRecovery.sol && steamroller contracts/IEtherRouter.sol > build/flattened/flatIEtherRouter.sol",
     "test:reputation": "npm run start:blockchain:client & truffle migrate --reset --compile-all && nyc truffle test ./test/reputation-system/* ./test/reputation-system/reputation-mining-client/* --network development",
     "test:contracts": "npm run start:blockchain:client & truffle migrate --reset --compile-all && truffle test ./test/contracts-network/* ./test/extensions/* --network development",

--- a/truffle.js
+++ b/truffle.js
@@ -26,11 +26,29 @@ module.exports = {
       network_id: 1999,
       skipDryRun: true
     },
+    goerliFork: {
+      host: "localhost",
+      port: 8605,
+      gasPrice: 0,
+      network_id: "5"
+    },
+    mainnetFork: {
+      host: "localhost",
+      port: 8601,
+      gasPrice: 0,
+      network_id: "1"
+    },
     goerli: {
       provider: () => {
         return new HDWalletProvider("replace-with-private-key-when-using", "https://goerli.infura.io/v3/e21146aa267845a2b7b4da025178196d");
       },
       network_id: "5"
+    },
+    mainnet: {
+      provider: () => {
+        return new HDWalletProvider("replace-with-private-key-when-using", "https://mainnet.infura.io/v3/e21146aa267845a2b7b4da025178196d");
+      },
+      network_id: "1"
     }
   },
   mocha: {


### PR DESCRIPTION
For the purposes of easier working with the `truffle` console and `ganache-cli` forks here we add truffle network configurations for forks of `goerli` and `mainnet`. Additionally 2 commands for starting a respective fork 
`yarn run fork:goerli`
`yarn run fork:mainnet`

Network configuration for mainnet is also added to truffle.