### PR TITLE
Subdomain single tx payment funds can be from root

### DIFF
--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -76,7 +76,7 @@ contract OneTxPayment {
     colony.moveFundsBetweenPots(
       1, // Root domain always 1
       0, // Not used, this extension contract must have funding permission in the root for this function to work
-      0, // Not used, this extension contract must have funding permission in the root for this function to work
+      _childSkillIndex,
       1, // Root domain funding pot is always 1
       payment.fundingPotId,
       _amount,

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -39,11 +39,70 @@ contract OneTxPayment {
   /// @notice Completes a colony payment in a single transaction
   /// @dev Assumes that each entity holds administration and funding roles in the same domain,
   /// although contract and caller can have the permissions in different domains.
-  /// @param _permissionDomainId The domainId in which the _caller_ has permissions to add a payment and fund it
+  /// Payment is taken from root domain, and the caller must have funding permission explicitly in the root domain
+  /// @param _permissionDomainId The domainId in which the _contract_ has permissions to add a payment and fund it
   /// @param _childSkillIndex Index of the _permissionDomainId skill.children array to get
-  /// @param _callerPermissionDomainId The domainId in which the _contract_ has permissions to add a payment and fund it
+  /// @param _callerPermissionDomainId The domainId in which the _caller_ has permissions to add a payment and fund it
   /// @param _callerChildSkillIndex Index of the _callerPermissionDomainId skill.children array to get
+  /// @param _worker The address of the recipient of the payment
+  /// @param _token The address of the token the payment is being made in. 0x00 for Ether.
+  /// @param _amount The amount of the token being paid out
+  /// @param _domainId The Id of the domain the payment should be coming from
+  /// @param _skillId The Id of the skill that the payment should be marked with, possibly awarding reputation in this skill.
   function makePayment(
+    uint256 _permissionDomainId,
+    uint256 _childSkillIndex,
+    uint256 _callerPermissionDomainId,
+    uint256 _callerChildSkillIndex,
+    address payable _worker,
+    address _token,
+    uint256 _amount,
+    uint256 _domainId,
+    uint256 _skillId) public
+  {
+    // Check caller is able to call {add,finalize}Payment and moveFundsBetweenPots on the colony in the domain in question
+    validateCallerPermissions(_callerPermissionDomainId, _callerChildSkillIndex, _domainId);
+    // In addition, check the caller is able to call moveFundsBetweenPots from the root domain
+    require(
+      ColonyAuthority(colony.authority()).canCall(msg.sender, 1, address(colony), MOVE_FUNDS_SIG),
+      "colony-one-tx-payment-root-funding-not-authorized"
+    );
+
+    // Add a new payment
+    uint256 paymentId = colony.addPayment(_permissionDomainId, _childSkillIndex, _worker, _token, _amount, _domainId, _skillId);
+    ColonyDataTypes.Payment memory payment = colony.getPayment(paymentId);
+
+    // Fund the payment
+    colony.moveFundsBetweenPots(
+      1, // Root domain always 1
+      0, // Not used, this extension contract must have funding permission in the root for this function to work
+      0, // Not used, this extension contract must have funding permission in the root for this function to work
+      1, // Root domain funding pot is always 1
+      payment.fundingPotId,
+      _amount,
+      _token
+    );
+    colony.finalizePayment(_permissionDomainId, _childSkillIndex, paymentId);
+
+    // Claim payout on behalf of the recipient
+    colony.claimPayment(paymentId, _token);
+  }
+
+
+  /// @notice Completes a colony payment in a single transaction
+  /// @dev Assumes that each entity holds administration and funding roles in the same domain,
+  /// although contract and caller can have the permissions in different domains.
+  /// Payment is taken from domain funds - if the domain does not have sufficient funds, call will fail.
+  /// @param _permissionDomainId The domainId in which the _contract_ has permissions to add a payment and fund it
+  /// @param _childSkillIndex Index of the _permissionDomainId skill.children array to get
+  /// @param _callerPermissionDomainId The domainId in which the _caller_ has permissions to add a payment and fund it
+  /// @param _callerChildSkillIndex Index of the _callerPermissionDomainId skill.children array to get
+  /// @param _worker The address of the recipient of the payment
+  /// @param _token The address of the token the payment is being made in. 0x00 for Ether.
+  /// @param _amount The amount of the token being paid out
+  /// @param _domainId The Id of the domain the payment should be coming from
+  /// @param _skillId The Id of the skill that the payment should be marked with, possibly awarding reputation in this skill.
+  function makePaymentFundedFromDomain(
     uint256 _permissionDomainId,
     uint256 _childSkillIndex,
     uint256 _callerPermissionDomainId,

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -123,6 +123,14 @@ contract("One transaction payments", accounts => {
       await oneTxExtension.makePayment(1, 0, 1, 0, RECIPIENT, token.address, 10, 2, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
     });
 
+    it("should allow a single-transaction to occur in a child domain that's not the first child, paid out from the root domain", async () => {
+      await colony.addDomain(1, 0, 1);
+      await colony.addDomain(1, 0, 1);
+
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      await oneTxExtension.makePayment(1, 1, 1, 1, RECIPIENT, token.address, 10, 3, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
+    });
+
     it("should allow a single-transaction to occur in the root domain, paid out from the root domain", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await oneTxExtension.makePayment(1, 0, 1, 0, RECIPIENT, token.address, 10, 1, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -123,6 +123,11 @@ contract("One transaction payments", accounts => {
       await oneTxExtension.makePayment(1, 0, 1, 0, RECIPIENT, token.address, 10, 2, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
     });
 
+    it("should allow a single-transaction to occur in the root domain, paid out from the root domain", async () => {
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      await oneTxExtension.makePayment(1, 0, 1, 0, RECIPIENT, token.address, 10, 1, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
+    });
+
     it(`should not allow a single-transaction to occur in a child domain, paid out from the root domain
       if the user does not have permission to take funds from root domain`, async () => {
       await colony.addDomain(1, 0, 1);


### PR DESCRIPTION
In an attempt to actually get the Dapp down to one tx everywhere, this PR makes a modification to the OneTransaction contract. In the Dapp, there is no way to move funds in to a subdomain yet, and so trying to do a single transaction payout from a subdomain would fail. One proposed solution is to have colonyJs handle the funding prior to calling the method, but that takes us up to two transactions - a lot more than one, and not much less than three (the number of transactions required if you're not using the extension at all). This takes an alternative approach i.e. to supply the functionality the dApp team thought they were getting.

Not deployed on mainnet yet, so no issues there, but it is deployed on Goerli and the old version is installed on some colonies. We don't have a method in the dapp yet to do such upgrades, so the process would have to be manual - people would deploy the new extension, give it 'admin' permissions, and remove the old extension and its permissions. The dapp would have to know to use the new version for one transaction payouts / new colonies.

I've also added an alternative function with the original functionality, so that down the line it will be possible to give people the ability to do a single-transaction payout from a subdomain, without needing to give them permission to withdraw funds from the root domain. This function is called `makePaymentFundedFromDomain`. I put the existing functionality under this new name because the new functionality is the one that was desired by product, and I am keen to change the interfaces that colonyJS / the dApp have to worry about as little as possible.

Finally, *do not merge yet*. We haven't yet had our conversation about branching now that we have a release, but I'm expecting that conversation to happen tomorrow to figure out where exactly this is going!