### PR TITLE
Fix URI for reputation tree visualizer data

### DIFF
--- a/packages/reputation-miner/viz/repTree.html
+++ b/packages/reputation-miner/viz/repTree.html
@@ -53,7 +53,7 @@
     // declares a tree layout and assigns the size
     var treemap = d3.tree().size([height, width]);
 
-    d3.request(`http://localhost:3000/reputations`, function(error, res) {
+    d3.request(`reputations`, function(error, res) {
       if (error) throw error;
 
       const { rootHash, reputations } = JSON.parse(res.response);


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #652 

<!--- Summary of changes including design decisions -->

Updated the URI for requesting the reputation data from an absolute path (`localhost:3000/reputations`) to a relative path (`reputations`), which allows the visualizer to fetch data from miners running remotely.

Tested locally by checking that the relative URI fetched data from my local miner (i.e. that D3 supports relative URIs).