### PR TITLE
Add Arbitration role setup in colony upgrade

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -285,8 +285,24 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   }
 
   function finishUpgrade2To3() public always {
-    ColonyAuthority(address(authority)).setRoleCapability(
-      uint8(ColonyDataTypes.ColonyRole.Root),
+    ColonyAuthority colonyAuthority = ColonyAuthority(address(authority));
+
+    colonyAuthority.setRoleCapability(
+     uint8(ColonyDataTypes.ColonyRole.ArchitectureSubdomain),
+      address(this),
+      bytes4(keccak256("setArbitrationRole(uint256,uint256,address,uint256,bool)")),
+      true
+    );
+
+    colonyAuthority.setRoleCapability(
+     uint8(ColonyDataTypes.ColonyRole.Root),
+      address(this),
+      bytes4(keccak256("setArbitrationRole(uint256,uint256,address,uint256,bool)")),
+      true
+    );
+
+    colonyAuthority.setRoleCapability(
+     uint8(ColonyDataTypes.ColonyRole.Root),
       address(this),
       bytes4(keccak256("updateColonyOrbitDB(string)")),
       true

--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -48,14 +48,12 @@ contract ColonyAuthority is CommonAuthority {
 
     // Add permissions for the Architecture role
     addRoleCapability(ARCHITECTURE_ROLE, "addDomain(uint256,uint256,uint256)");
-    addRoleCapability(ARCHITECTURE_SUBDOMAIN_ROLE, "setArbitrationRole(uint256,uint256,address,uint256,bool)");
     addRoleCapability(ARCHITECTURE_SUBDOMAIN_ROLE, "setArchitectureRole(uint256,uint256,address,uint256,bool)");
     addRoleCapability(ARCHITECTURE_SUBDOMAIN_ROLE, "setFundingRole(uint256,uint256,address,uint256,bool)");
     addRoleCapability(ARCHITECTURE_SUBDOMAIN_ROLE, "setAdministrationRole(uint256,uint256,address,uint256,bool)");
 
     // Add permissions for the Root role
     addRoleCapability(ROOT_ROLE, "setRootRole(address,bool)");
-    addRoleCapability(ROOT_ROLE, "setArbitrationRole(uint256,uint256,address,uint256,bool)");
     addRoleCapability(ROOT_ROLE, "setArchitectureRole(uint256,uint256,address,uint256,bool)");
     addRoleCapability(ROOT_ROLE, "setFundingRole(uint256,uint256,address,uint256,bool)");
     addRoleCapability(ROOT_ROLE, "setAdministrationRole(uint256,uint256,address,uint256,bool)");
@@ -80,6 +78,8 @@ contract ColonyAuthority is CommonAuthority {
 
     // Added in colony v3
     addRoleCapability(ROOT_ROLE, "updateColonyOrbitDB(string)");
+    addRoleCapability(ROOT_ROLE, "setArbitrationRole(uint256,uint256,address,uint256,bool)");
+    addRoleCapability(ARCHITECTURE_SUBDOMAIN_ROLE, "setArbitrationRole(uint256,uint256,address,uint256,bool)");
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {

--- a/test-upgrade/2to3/2to3.js
+++ b/test-upgrade/2to3/2to3.js
@@ -87,6 +87,7 @@ contract("Colony contract upgrade", accounts => {
 
     it("should be able to assign arbitration role", async function() {
       let hasRole = await colony.hasUserRole(accounts[3], 2, ARBITRATION_ROLE);
+      expect(hasRole).to.be.false;
       await colony.setArbitrationRole(1, 0, accounts[3], 2, true, { from: TESTCOLONY_OWNER });
       hasRole = await colony.hasUserRole(accounts[3], 2, ARBITRATION_ROLE);
       expect(hasRole).to.be.true;

--- a/test-upgrade/2to3/2to3.js
+++ b/test-upgrade/2to3/2to3.js
@@ -2,6 +2,7 @@
 /* eslint-disable prefer-arrow-callback */
 import chai from "chai";
 import { checkErrorRevert } from "../../helpers/test-helper";
+import { ARBITRATION_ROLE } from "../../helpers/constants";
 
 const namehash = require("eth-ens-namehash");
 
@@ -85,9 +86,9 @@ contract("Colony contract upgrade", accounts => {
     });
 
     it("should be able to assign arbitration role", async function() {
-      let hasRole = await colony.hasUserRole(accounts[3], 2, 2);
+      let hasRole = await colony.hasUserRole(accounts[3], 2, ARBITRATION_ROLE);
       await colony.setArbitrationRole(1, 0, accounts[3], 2, true, { from: TESTCOLONY_OWNER });
-      hasRole = await colony.hasUserRole(accounts[3], 2, 2);
+      hasRole = await colony.hasUserRole(accounts[3], 2, ARBITRATION_ROLE);
       expect(hasRole).to.be.true;
     });
 


### PR DESCRIPTION
Adds two missing steps in upgrading a colony from v2 to v3 for adding the newly introduced `Arbitration` role permissions to colonies that upgrade.