### PR TITLE
Upgrade web3-utils to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "truffle": "^5.0.14",
     "truffle-hdwallet-provider": "^1.0.9",
     "truffle-security": "^1.5.2",
-    "web3-utils": "^1.0.0-beta.55"
+    "web3-utils": "^1.0.0"
   },
   "private": true,
   "workspaces": [

--- a/packages/reputation-miner/package.json
+++ b/packages/reputation-miner/package.json
@@ -20,7 +20,7 @@
     "express": "^4.16.3",
     "ganache-core": "^2.5.3",
     "sqlite": "^3.0.2",
-    "web3-utils": "^1.0.0-beta.46",
+    "web3-utils": "^1.0.0",
     "yargs": "^13.2.4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9176,6 +9176,11 @@ underscore@1.8.3:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
   integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
 
+underscore@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
+  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
@@ -9286,15 +9291,15 @@ utf8@2.1.1:
   resolved "https://registry.yarnpkg.com/utf8/-/utf8-2.1.1.tgz#2e01db02f7d8d0944f77104f1609eb0c304cf768"
   integrity sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=
 
+utf8@3.0.0, utf8@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
+  integrity sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==
+
 utf8@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/utf8/-/utf8-2.1.2.tgz#1fa0d9270e9be850d9b05027f63519bf46457d96"
   integrity sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY=
-
-utf8@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
-  integrity sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -10033,7 +10038,7 @@ web3-utils@1.0.0-beta.50:
     randomhex "0.1.5"
     utf8 "2.1.1"
 
-web3-utils@1.0.0-beta.55, web3-utils@^1.0.0-beta.46, web3-utils@^1.0.0-beta.55:
+web3-utils@1.0.0-beta.55:
   version "1.0.0-beta.55"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.0.0-beta.55.tgz#beb40926b7c04208b752d36a9bc959d27a04b308"
   integrity sha512-ASWqUi8gtWK02Tp8ZtcoAbHenMpQXNvHrakgzvqTNNZn26wgpv+Q4mdPi0KOR6ZgHFL8R/9b5BBoUTglS1WPpg==
@@ -10048,6 +10053,19 @@ web3-utils@1.0.0-beta.55, web3-utils@^1.0.0-beta.46, web3-utils@^1.0.0-beta.55:
     number-to-bn "1.7.0"
     randombytes "^2.1.0"
     utf8 "2.1.1"
+
+web3-utils@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.0.0.tgz#b45b92ad3daff03f6b991e752e0d38a98595c636"
+  integrity sha512-zm0gdLXLk54ldwxxBMNPS62EuqHI2PaJohEGijTowacNS0BS2vEXdriNA8gp1+EplP2WgoHE0uRVmQIfpAyV+Q==
+  dependencies:
+    bn.js "4.11.8"
+    eth-lib "0.2.7"
+    ethjs-unit "0.1.6"
+    number-to-bn "1.7.0"
+    randomhex "0.1.5"
+    underscore "1.9.1"
+    utf8 "3.0.0"
 
 web3@0.20.6:
   version "0.20.6"


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #675 

<!--- Summary of changes including design decisions -->

Build initially failed due to a timeout, but re-running the build passed. Figure why not upgrade out of the beta version while we're here.
