### PR TITLE
Debug codechecks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,13 +102,10 @@ jobs:
           command: yarn run test:contracts:upgrade:2to3
       - run:
           name: "Running gas cost tests"
-          command: yarn run test:contracts:gasCosts
+          command: yarn run test:contracts:gasCosts && yarn run codechecks
       - run:
           name: "Running patricia tree tests"
           command: yarn run test:contracts:patricia
-      - run:
-          name: "Generate gas cost diff report"
-          command: yarn run codechecks
       - <<: *step_save_cache
       # Save test results
       - store_test_results:


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->

<!--- Summary of changes including design decisions -->

Hilariously, the gas diff report is somehow [already broken](https://github.com/JoinColony/colonyNetwork/pull/673/checks?check_run_id=171769254). Will investigate, I suspect that [this commit](https://github.com/JoinColony/colonyNetwork/commit/1462e63fdcb44b85b266d6267a9f3866fbca4d5e) is the culprit, perhaps codechecks must be run immediately after the gas report is generated (rather than arbitrarily after).

Update: seems my guess was correct. I'm updating the invocation so that the gas tests and diff report are done in the same step.