### PR TITLE
Add test using `.transfer` from another contract

### DIFF
--- a/contracts/testHelpers/TransferTest.sol
+++ b/contracts/testHelpers/TransferTest.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.5.0;
+
+
+contract TransferTest {
+  constructor() public payable { }
+  function() external payable { }
+
+  function fireTransfer(address payable target, uint256 amount) public {
+    target.transfer(amount);
+  }
+
+}

--- a/scripts/check-recovery.js
+++ b/scripts/check-recovery.js
@@ -49,6 +49,7 @@ walkSync("./contracts/").forEach(contractName => {
       "contracts/testHelpers/NoLimitSubdomains.sol",
       "contracts/testHelpers/TaskSkillEditing.sol",
       "contracts/testHelpers/FunctionsNotAvailableOnColony.sol",
+      "contracts/testHelpers/TransferTest.sol",
       "contracts/ERC20Extended.sol",
       "contracts/EtherRouter.sol",
       "contracts/IRecovery.sol",

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -22,6 +22,7 @@ chai.use(bnChai(web3.utils.BN));
 
 const Token = artifacts.require("Token");
 const IReputationMiningCycle = artifacts.require("IReputationMiningCycle");
+const TransferTest = artifacts.require("TransferTest");
 
 contract("Colony", accounts => {
   let colony;
@@ -52,6 +53,13 @@ contract("Colony", accounts => {
       await colony.send(1);
       const colonyBalance = await web3GetBalance(colony.address);
       expect(colonyBalance).to.eq.BN(1);
+    });
+
+    it("should accept ether from a contract using .transfer", async () => {
+      const transferTest = await TransferTest.new({ value: 10 });
+      await transferTest.fireTransfer(colony.address, 10);
+      const colonyBalance = await web3GetBalance(colony.address);
+      expect(colonyBalance).to.eq.BN(10);
     });
 
     it("should not have owner", async () => {


### PR DESCRIPTION
There was some confusion over whether this was possible with the EtherRouter pattern, so added a test to demonstrate that it works and to check that we don't break it in the future.