### PR TITLE
Drop maximum payout to UINT128_MAX

### DIFF
--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -235,5 +235,5 @@ contract ColonyDataTypes {
     uint256 fundingPotId;
   }
 
-  uint256 constant MAX_PAYOUT = 2**254 - 1; // Up to 254 bits to account for sign and payout modifiers.
+  uint256 constant MAX_PAYOUT = 2**128 - 1; // 340,282,366,920,938,463,463 WADs
 }

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -3,6 +3,7 @@ import { BN } from "bn.js";
 import shortid from "shortid";
 
 const UINT256_MAX = new BN(0).notn(256);
+const UINT128_MAX = new BN(0).notn(128);
 const INT256_MAX = new BN(0).notn(255);
 const INT128_MAX = new BN(2).pow(new BN(127)).sub(new BN(1));
 const INT128_MIN = new BN(2).pow(new BN(127)).mul(new BN(-1));
@@ -35,7 +36,7 @@ const INITIAL_FUNDING = WAD.muln(360);
 const MANAGER_PAYOUT = WAD.muln(100);
 const EVALUATOR_PAYOUT = WAD.muln(50);
 const WORKER_PAYOUT = WAD.muln(200);
-const MAX_PAYOUT = new BN(0).notn(254);
+const MAX_PAYOUT = UINT128_MAX;
 
 const MANAGER_RATING = 2;
 const WORKER_RATING = 2;


### PR DESCRIPTION
Following discussion [here](https://joincolony.slack.com/archives/C0YNG3M8B/p1567677619111500), we would like to reduce the maximum possible payout from the current `UINT254_MAX` to `UINT128_MAX`, or 340,282,366,920,938,463,463 WADs.

The rationale for the previous maximum was that we needed to reserve some range to account for the sign bit when emitting a reputation update (which accepts `int256`s), and some additional range to allow for the penalty/boost calculations when completing a task. After some analysis, I concluded that saving the two most significant bits would allow enough room for these operations.

Looking more, it seems like making payouts as big as they can possibly be given our _current_ constraints seems unnecessary, especially since `UINT254_MAX` is already such a mind-bogglingly large number. Having such a high maximum means that new types of calculations which may require more range become difficult to do. Instead, we would like to drop the range significantly to `UINT128_MAX`, which is still an enormously large number, but one which leaves ample room for many types of arithmetic operations (specifically, scaling by WAD-denominated scalars). In this sense, it is more future-proof, and also allows us to dispense with `UINT254_MAX`, which is an awkward and unconventional length.

Under the hood, we will continue to store payments as `uint256`s and enforce the restriction using a `require`, although I suppose that may change in the future.

