### PR TITLE
Colony setup bundle

### DIFF
--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -142,15 +142,16 @@ contract ColonyNetwork is ColonyNetworkStorage {
   ) public stoppable returns (address)
   {
     uint256 version = (_version == 0) ? currentColonyVersion : _version;
-    address colonyAddress = deployColony(_tokenAddress version);
+    address colonyAddress = deployColony(_tokenAddress, version);
 
     if (bytes(_colonyName).length > 0) {
       IColony(colonyAddress).registerColonyLabel(_colonyName, _orbitdb);
     }
 
-    if (_useExtensionManager) {
-      IColony(colonyAddress).setRootRole(extensionManagerAddress, true);
-    }
+    // TODO: Uncomment this after merging colonyNetwork#714
+    // if (_useExtensionManager) {
+    //   IColony(colonyAddress).setRootRole(extensionManagerAddress, true);
+    // }
 
     setFounderPermissions(colonyAddress);
     return colonyAddress;

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -127,22 +127,30 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   function createMetaColony(address _tokenAddress) public;
 
   /// @notice Creates a new colony in the network with the latest version available
-  /// Note that the token ownership (if there is one) has to be transferred to the newly created colony.
+  /// Note that the token ownership (if there is one) should be transferred to the newly created colony.
   /// @param _tokenAddress Address of an ERC20 token to serve as the colony token.
   /// Additionally token can optionally support `mint` as defined in `ERC20Extended`.
   /// Support for `mint` is mandatory only for the Meta Colony Token.
   /// @return colonyAddress Address of the newly created colony
   function createColony(address _tokenAddress) public returns (address colonyAddress);
 
-  /// @notice Creates a new colony in the network at a specific version. Not recommended unless you
-  /// are confident in what you're doing.
-  /// Note that the token ownership (if there is one) has to be transferred to the newly created colony.
-  /// @param _tokenAddress Address of an ERC20 token to serve as the colony token.
-  /// @param _version The version of colony to deploy.
-  /// Additionally token can optionally support `mint` as defined in `ERC20Extended`.
-  /// Support for `mint` is mandatory only for the Meta Colony Token.
+  /// @notice Creates a new colony in the network, with an ENS label.
+  /// Note that the token ownership (if there is one) has to be transferred to the newly created colony
+  /// Additionally token can optionally support `mint` as defined in `ERC20Extended`
+  /// Support for `mint` is mandatory only for the Meta Colony Token
+  /// @param _tokenAddress Address of an ERC20 token to serve as the colony token
+  /// @param _version The version of colony to deploy (pass 0 for the current version)
+  /// @param _colonyName The label to register (if null, no label is registered)
+  /// @param _orbitdb The path of the orbitDB database associated with the user profile
+  /// @param _useExtensionManager If true, give the ExtensionManager the root role in the colony
   /// @return colonyAddress Address of the newly created colony
-  function createColony(address _tokenAddress, uint256 _version) public returns (address colonyAddress);
+  function createColonyWithOptions(
+    address _tokenAddress,
+    uint256 _version,
+    string memory _colonyName,
+    string memory _orbitdb,
+    bool _useExtensionManager
+    ) public returns (address colonyAddress);
 
   /// @notice Adds a new Colony contract version and the address of associated `_resolver` contract. Secured function to authorised members.
   /// Allowed to be called by the Meta Colony only.

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -127,15 +127,16 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   function createMetaColony(address _tokenAddress) public;
 
   /// @notice Creates a new colony in the network with the latest version available
+  /// @dev This is now deprecated and will be removed in a future version
   /// Note that the token ownership (if there is one) should be transferred to the newly created colony.
-  /// @param _tokenAddress Address of an ERC20 token to serve as the colony token.
   /// Additionally token can optionally support `mint` as defined in `ERC20Extended`.
   /// Support for `mint` is mandatory only for the Meta Colony Token.
+  /// @param _tokenAddress Address of an ERC20 token to serve as the colony token.
   /// @return colonyAddress Address of the newly created colony
   function createColony(address _tokenAddress) public returns (address colonyAddress);
 
-  /// @notice Creates a new colony in the network, with an ENS label.
-  /// Note that the token ownership (if there is one) has to be transferred to the newly created colony
+  /// @notice Overload of the simpler `createColony`. Creates a new colony in the network with a variety of options.
+  /// Note that the token ownership (if there is one) should be transferred to the newly created colony
   /// Additionally token can optionally support `mint` as defined in `ERC20Extended`
   /// Support for `mint` is mandatory only for the Meta Colony Token
   /// @param _tokenAddress Address of an ERC20 token to serve as the colony token
@@ -144,7 +145,7 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @param _orbitdb The path of the orbitDB database associated with the user profile
   /// @param _useExtensionManager If true, give the ExtensionManager the root role in the colony
   /// @return colonyAddress Address of the newly created colony
-  function createColonyWithOptions(
+  function createColony(
     address _tokenAddress,
     uint256 _version,
     string memory _colonyName,

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -145,13 +145,8 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @param _orbitdb The path of the orbitDB database associated with the user profile
   /// @param _useExtensionManager If true, give the ExtensionManager the root role in the colony
   /// @return colonyAddress Address of the newly created colony
-  function createColony(
-    address _tokenAddress,
-    uint256 _version,
-    string memory _colonyName,
-    string memory _orbitdb,
-    bool _useExtensionManager
-    ) public returns (address colonyAddress);
+  function createColony(address _tokenAddress, uint256 _version, string memory _colonyName, string memory _orbitdb, bool _useExtensionManager)
+    public returns (address colonyAddress);
 
   /// @notice Adds a new Colony contract version and the address of associated `_resolver` contract. Secured function to authorised members.
   /// Allowed to be called by the Meta Colony only.

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -128,17 +128,13 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
 
   /// @notice Creates a new colony in the network with the latest version available
   /// @dev This is now deprecated and will be removed in a future version
-  /// Note that the token ownership (if there is one) should be transferred to the newly created colony.
-  /// Additionally token can optionally support `mint` as defined in `ERC20Extended`.
-  /// Support for `mint` is mandatory only for the Meta Colony Token.
+  /// @dev For the colony to mint tokens, token ownership must be transferred to the new colony
   /// @param _tokenAddress Address of an ERC20 token to serve as the colony token.
   /// @return colonyAddress Address of the newly created colony
   function createColony(address _tokenAddress) public returns (address colonyAddress);
 
-  /// @notice Overload of the simpler `createColony`. Creates a new colony in the network with a variety of options.
-  /// Note that the token ownership (if there is one) should be transferred to the newly created colony
-  /// Additionally token can optionally support `mint` as defined in `ERC20Extended`
-  /// Support for `mint` is mandatory only for the Meta Colony Token
+  /// @notice Overload of the simpler `createColony` -- creates a new colony in the network with a variety of options
+  /// @dev For the colony to mint tokens, token ownership must be transferred to the new colony
   /// @param _tokenAddress Address of an ERC20 token to serve as the colony token
   /// @param _version The version of colony to deploy (pass 0 for the current version)
   /// @param _colonyName The label to register (if null, no label is registered)

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -123,6 +123,26 @@ Creates a new colony in the network with the latest version available Note that 
 |---|---|---|
 |colonyAddress|address|Address of the newly created colony
 
+### `createColonyWithOptions`
+
+Creates a new colony in the network, with an ENS label. Note that the token ownership (if there is one) has to be transferred to the newly created colony Additionally token can optionally support `mint` as defined in `ERC20Extended` Support for `mint` is mandatory only for the Meta Colony Token
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_tokenAddress|address|Address of an ERC20 token to serve as the colony token
+|_colonyName|string|The label to register (if null, no label is registered)
+|_orbitdb|string|The path of the orbitDB database associated with the user profile
+|_useExtensionManager|bool|If true, give the ExtensionManager the root role in the colony
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|colonyAddress|address|Address of the newly created colony
+
 ### `createMetaColony`
 
 Create the Meta Colony, same as a normal colony plus the root skill.

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -90,8 +90,9 @@ Calculate raw miner weight in WADs.
 
 ### `createColony`
 
-Overload of the simpler `createColony`. Creates a new colony in the network with a variety of options. Note that the token ownership (if there is one) should be transferred to the newly created colony Additionally token can optionally support `mint` as defined in `ERC20Extended` Support for `mint` is mandatory only for the Meta Colony Token
+Overload of the simpler `createColony` -- creates a new colony in the network with a variety of options
 
+*Note: For the colony to mint tokens, token ownership must be transferred to the new colony*
 
 **Parameters**
 
@@ -113,7 +114,7 @@ Overload of the simpler `createColony`. Creates a new colony in the network with
 
 Creates a new colony in the network with the latest version available
 
-*Note: This is now deprecated and will be removed in a future version Note that the token ownership (if there is one) should be transferred to the newly created colony. Additionally token can optionally support `mint` as defined in `ERC20Extended`. Support for `mint` is mandatory only for the Meta Colony Token.*
+*Note: This is now deprecated and will be removed in a future version*
 
 **Parameters**
 

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -90,19 +90,18 @@ Calculate raw miner weight in WADs.
 
 ### `createColony`
 
-Creates a new colony in the network with the latest version available
+Overload of the simpler `createColony`. Creates a new colony in the network with a variety of options. Note that the token ownership (if there is one) should be transferred to the newly created colony Additionally token can optionally support `mint` as defined in `ERC20Extended` Support for `mint` is mandatory only for the Meta Colony Token
 
-*Note: This is now deprecated and will be removed in a future version Note that the token ownership (if there is one) should be transferred to the newly created colony. Additionally token can optionally support `mint` as defined in `ERC20Extended`. Support for `mint` is mandatory only for the Meta Colony Token.*
 
 **Parameters**
 
 |Name|Type|Description|
 |---|---|---|
-|_tokenAddress|address|Address of an ERC20 token to serve as the colony token.
-|_version|uint256|
-|_colonyName|string|
-|_orbitdb|string|
-|_useExtensionManager|bool|
+|_tokenAddress|address|Address of an ERC20 token to serve as the colony token
+|_version|uint256|The version of colony to deploy (pass 0 for the current version)
+|_colonyName|string|The label to register (if null, no label is registered)
+|_orbitdb|string|The path of the orbitDB database associated with the user profile
+|_useExtensionManager|bool|If true, give the ExtensionManager the root role in the colony
 
 **Return Parameters**
 

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -90,15 +90,19 @@ Calculate raw miner weight in WADs.
 
 ### `createColony`
 
-Creates a new colony in the network at a specific version. Not recommended unless you are confident in what you're doing. Note that the token ownership (if there is one) has to be transferred to the newly created colony.
+Creates a new colony in the network with the latest version available
 
+*Note: This is now deprecated and will be removed in a future version Note that the token ownership (if there is one) should be transferred to the newly created colony. Additionally token can optionally support `mint` as defined in `ERC20Extended`. Support for `mint` is mandatory only for the Meta Colony Token.*
 
 **Parameters**
 
 |Name|Type|Description|
 |---|---|---|
 |_tokenAddress|address|Address of an ERC20 token to serve as the colony token.
-|_version|uint256|The version of colony to deploy. Additionally token can optionally support `mint` as defined in `ERC20Extended`. Support for `mint` is mandatory only for the Meta Colony Token.
+|_version|uint256|
+|_colonyName|string|
+|_orbitdb|string|
+|_useExtensionManager|bool|
 
 **Return Parameters**
 
@@ -108,34 +112,15 @@ Creates a new colony in the network at a specific version. Not recommended unles
 
 ### `createColony`
 
-Creates a new colony in the network with the latest version available Note that the token ownership (if there is one) has to be transferred to the newly created colony.
+Creates a new colony in the network with the latest version available
 
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_tokenAddress|address|Address of an ERC20 token to serve as the colony token. Additionally token can optionally support `mint` as defined in `ERC20Extended`. Support for `mint` is mandatory only for the Meta Colony Token.
-
-**Return Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|colonyAddress|address|Address of the newly created colony
-
-### `createColonyWithOptions`
-
-Creates a new colony in the network, with an ENS label. Note that the token ownership (if there is one) has to be transferred to the newly created colony Additionally token can optionally support `mint` as defined in `ERC20Extended` Support for `mint` is mandatory only for the Meta Colony Token
-
+*Note: This is now deprecated and will be removed in a future version Note that the token ownership (if there is one) should be transferred to the newly created colony. Additionally token can optionally support `mint` as defined in `ERC20Extended`. Support for `mint` is mandatory only for the Meta Colony Token.*
 
 **Parameters**
 
 |Name|Type|Description|
 |---|---|---|
-|_tokenAddress|address|Address of an ERC20 token to serve as the colony token
-|_colonyName|string|The label to register (if null, no label is registered)
-|_orbitdb|string|The path of the orbitDB database associated with the user profile
-|_useExtensionManager|bool|If true, give the ExtensionManager the root role in the colony
+|_tokenAddress|address|Address of an ERC20 token to serve as the colony token.
 
 **Return Parameters**
 

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -372,11 +372,11 @@ export async function setupRandomColony(colonyNetwork) {
   const token = await Token.new(...tokenArgs);
   await token.unlock();
 
-  const { logs } = await colonyNetwork.createColony(token.address);
-  const { colonyAddress } = logs[1].args;
+  const { logs } = await colonyNetwork.createColony(token.address, 0, "", "", false);
+  const { colonyAddress } = logs[0].args;
   const colony = await IColony.at(colonyAddress);
-  const tokenLockingAddress = await colonyNetwork.getTokenLocking();
 
+  const tokenLockingAddress = await colonyNetwork.getTokenLocking();
   const tokenAuthority = await TokenAuthority.new(token.address, colony.address, [tokenLockingAddress]);
   await token.setAuthority(tokenAuthority.address);
 

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -94,7 +94,7 @@ contract("All", function(accounts) {
       const tokenArgs = getTokenArgs();
       const colonyToken = await Token.new(...tokenArgs);
       await colonyToken.unlock();
-      await colonyNetwork.createColony(colonyToken.address);
+      await colonyNetwork.createColony(colonyToken.address, 0, "", "", false);
     });
 
     it("when working with the Meta Colony", async function() {
@@ -278,6 +278,7 @@ contract("All", function(accounts) {
 
       const { colony: newColony, token: newToken } = await setupRandomColony(colonyNetwork);
 
+      await newToken.setOwner(colonyAddress);
       await newColony.mintTokens(workerReputation.add(managerReputation));
       await newColony.claimColonyFunds(newToken.address);
       await newColony.bootstrapColony([WORKER, MANAGER], [workerReputation, managerReputation]);

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -278,7 +278,7 @@ contract("All", function(accounts) {
 
       const { colony: newColony, token: newToken } = await setupRandomColony(colonyNetwork);
 
-      await newToken.setOwner(colonyAddress);
+      await newToken.setOwner(colony.address);
       await newColony.mintTokens(workerReputation.add(managerReputation));
       await newColony.claimColonyFunds(newToken.address);
       await newColony.bootstrapColony([WORKER, MANAGER], [workerReputation, managerReputation]);

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -265,7 +265,9 @@ contract("Colony Network", accounts => {
       const token = await Token.new(...TOKEN_ARGS);
       // NOTE: for some reason, `checkErrorRevert`, function overloads, and extra arguments do not play well together.
       //   Specifically, when using the 5-argument `createColony`, truffle gets confused by the "sixth" argument.
-      await checkErrorRevert(colonyNetwork.createColony(token.address, { value: 1, gas: createColonyGas }));
+      await checkErrorRevert(
+        colonyNetwork.methods["createColony(address,uint256,string,string,bool)"](token.address, 0, "", "", false, { value: 1, gas: createColonyGas })
+      );
 
       const colonyNetworkBalance = await web3GetBalance(colonyNetwork.address);
       expect(colonyNetworkBalance).to.be.zero;
@@ -384,7 +386,7 @@ contract("Colony Network", accounts => {
       expect(registrarAddress).to.equal(ensRegistry.address);
     });
 
-    it.skip("should be able to create a colony with label in one tx", async () => {
+    it("should be able to create a colony with label in one tx", async () => {
       const token = await Token.new(...TOKEN_ARGS);
       const { logs } = await colonyNetwork.createColony(token.address, 0, "test", orbitDBAddress, false);
       const { colonyAddress } = logs[0].args;

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -4,7 +4,7 @@ import bnChai from "bn-chai";
 import { ethers } from "ethers";
 
 import { getTokenArgs, web3GetNetwork, web3GetBalance, checkErrorRevert, expectEvent, getColonyEditable } from "../../helpers/test-helper";
-import { CURR_VERSION, GLOBAL_SKILL_ID } from "../../helpers/constants";
+import { CURR_VERSION, GLOBAL_SKILL_ID, ROOT_ROLE } from "../../helpers/constants";
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony } from "../../helpers/test-data-generator";
 import { setupENSRegistrar } from "../../helpers/upgradable-contracts";
 
@@ -16,6 +16,7 @@ chai.use(bnChai(web3.utils.BN));
 const ENSRegistry = artifacts.require("ENSRegistry");
 const EtherRouter = artifacts.require("EtherRouter");
 const Resolver = artifacts.require("Resolver");
+const IColony = artifacts.require("IColony");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const Token = artifacts.require("Token");
 const FunctionsNotAvailableOnColony = artifacts.require("FunctionsNotAvailableOnColony");
@@ -394,6 +395,52 @@ contract("Colony Network", accounts => {
     it("should be able to get the ENSRegistrar", async () => {
       const registrarAddress = await colonyNetwork.getENSRegistrar();
       expect(registrarAddress).to.equal(ensRegistry.address);
+    });
+
+    it("should be able to create a colony with label in one tx", async () => {
+      const token = await Token.new(...TOKEN_ARGS);
+      const { logs } = await colonyNetwork.createColonyWithOptions(token.address, "test", orbitDBAddress, false);
+      const { colonyAddress } = logs[0].args;
+
+      const name = await colonyNetwork.lookupRegisteredENSDomain(colonyAddress);
+      expect(name).to.equal("test.colony.joincolony.eth");
+
+      const colony = await IColony.at(colonyAddress);
+      const extensionManagerAddress = await colonyNetwork.getExtensionManager();
+      const hasUserRole = await colony.hasUserRole(extensionManagerAddress, 1, ROOT_ROLE);
+      expect(hasUserRole).to.be.false;
+    });
+
+    it("should be able to create a colony configured with the extension manager in one tx", async () => {
+      const token = await Token.new(...TOKEN_ARGS);
+      const { logs } = await colonyNetwork.createColonyWithOptions(token.address, "", "", true);
+      const { colonyAddress } = logs[0].args;
+
+      const name = await colonyNetwork.lookupRegisteredENSDomain(colonyAddress);
+      expect(name).to.equal("");
+
+      // No conflict for setting "multiple" null names...
+      await colonyNetwork.createColonyWithOptions(token.address, "", "", true);
+      await colonyNetwork.createColonyWithOptions(token.address, "", "", true);
+
+      const colony = await IColony.at(colonyAddress);
+      const extensionManagerAddress = await colonyNetwork.getExtensionManager();
+      const hasUserRole = await colony.hasUserRole(extensionManagerAddress, 1, ROOT_ROLE);
+      expect(hasUserRole).to.be.true;
+    });
+
+    it("should be able to create a colony with label and configured with the extension manager in one tx", async () => {
+      const token = await Token.new(...TOKEN_ARGS);
+      const { logs } = await colonyNetwork.createColonyWithOptions(token.address, "test", orbitDBAddress, true);
+      const { colonyAddress } = logs[0].args;
+
+      const name = await colonyNetwork.lookupRegisteredENSDomain(colonyAddress);
+      expect(name).to.equal("test.colony.joincolony.eth");
+
+      const colony = await IColony.at(colonyAddress);
+      const extensionManagerAddress = await colonyNetwork.getExtensionManager();
+      const hasUserRole = await colony.hasUserRole(extensionManagerAddress, 1, ROOT_ROLE);
+      expect(hasUserRole).to.be.true;
     });
 
     it("should own the root domains", async () => {

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -100,9 +100,8 @@ contract("Colony Network", accounts => {
       const etherRouter = await EtherRouter.new();
       await etherRouter.setResolver(resolverColonyNetworkDeployed.address);
       colonyNetwork = await IColonyNetwork.at(etherRouter.address);
-
       await checkErrorRevert(
-        colonyNetwork.createColony("0x8972e86549bb8E350673e0562fba9a4889d01637"),
+        colonyNetwork.createColony("0x8972e86549bb8E350673e0562fba9a4889d01637", "", "", false),
         "colony-network-not-initialised-cannot-create-colony"
       );
     });
@@ -218,13 +217,13 @@ contract("Colony Network", accounts => {
     it("should maintain correct count of colonies", async () => {
       const token = await Token.new(...getTokenArgs());
       await token.unlock();
-      await colonyNetwork.createColony(token.address);
-      await colonyNetwork.createColony(token.address);
-      await colonyNetwork.createColony(token.address);
-      await colonyNetwork.createColony(token.address);
-      await colonyNetwork.createColony(token.address);
-      await colonyNetwork.createColony(token.address);
-      await colonyNetwork.createColony(token.address);
+      await colonyNetwork.createColony(token.address, "", "", false);
+      await colonyNetwork.createColony(token.address, "", "", false);
+      await colonyNetwork.createColony(token.address, "", "", false);
+      await colonyNetwork.createColony(token.address, "", "", false);
+      await colonyNetwork.createColony(token.address, "", "", false);
+      await colonyNetwork.createColony(token.address, "", "", false);
+      await colonyNetwork.createColony(token.address, "", "", false);
       const colonyCount = await colonyNetwork.getColonyCount();
       expect(colonyCount).to.eq.BN(8);
     });
@@ -253,7 +252,7 @@ contract("Colony Network", accounts => {
     });
 
     it("should not allow users to create a colony with empty token", async () => {
-      await checkErrorRevert(colonyNetwork.createColony(ethers.constants.AddressZero), "colony-token-invalid-address");
+      await checkErrorRevert(colonyNetwork.createColony(ethers.constants.AddressZero, "", "", false), "colony-token-invalid-address");
     });
 
     it("when any colony is created, should have the root local skill initialised", async () => {
@@ -285,16 +284,16 @@ contract("Colony Network", accounts => {
 
     it("should log a ColonyAdded event", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await expectEvent(colonyNetwork.createColony(token.address), "ColonyAdded");
+      await expectEvent(colonyNetwork.createColony(token.address, "", "", false), "ColonyAdded");
     });
   });
 
   describe("when getting existing colonies", () => {
     it("should allow users to get the address of a colony by its index", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await colonyNetwork.createColony(token.address);
-      await colonyNetwork.createColony(token.address);
-      await colonyNetwork.createColony(token.address);
+      await colonyNetwork.createColony(token.address, "", "", false);
+      await colonyNetwork.createColony(token.address, "", "", false);
+      await colonyNetwork.createColony(token.address, "", "", false);
       const colonyAddress = await colonyNetwork.getColony(3);
       expect(colonyAddress).to.not.equal(ethers.constants.AddressZero);
     });
@@ -384,7 +383,6 @@ contract("Colony Network", accounts => {
 
   describe("when managing ENS names", () => {
     const orbitDBAddress = "QmPFtHi3cmfZerxtH9ySLdzpg1yFhocYDZgEZywdUXHxFU/my-db-name";
-    const rootNode = namehash.hash("joincolony.eth");
     let ensRegistry;
 
     beforeEach(async () => {
@@ -404,11 +402,6 @@ contract("Colony Network", accounts => {
 
       const name = await colonyNetwork.lookupRegisteredENSDomain(colonyAddress);
       expect(name).to.equal("test.colony.joincolony.eth");
-
-      const colony = await IColony.at(colonyAddress);
-      const extensionManagerAddress = await colonyNetwork.getExtensionManager();
-      const hasUserRole = await colony.hasUserRole(extensionManagerAddress, 1, ROOT_ROLE);
-      expect(hasUserRole).to.be.false;
     });
 
     it("should be able to create a colony configured with the extension manager in one tx", async () => {
@@ -444,6 +437,8 @@ contract("Colony Network", accounts => {
     });
 
     it("should own the root domains", async () => {
+      const rootNode = namehash.hash("joincolony.eth");
+
       let owner;
       owner = await ensRegistry.owner(rootNode);
       expect(owner).to.equal(accounts[0]);

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -263,11 +263,8 @@ contract("Colony Network", accounts => {
 
     it("should fail if ETH is sent", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      // NOTE: for some reason, `checkErrorRevert`, function overloads, and extra arguments do not play well together.
-      //   Specifically, when using the 5-argument `createColony`, truffle gets confused by the "sixth" argument.
-      await checkErrorRevert(
-        colonyNetwork.methods["createColony(address,uint256,string,string,bool)"](token.address, 0, "", "", false, { value: 1, gas: createColonyGas })
-      );
+      const sig = "createColony(address,uint256,string,string,bool)";
+      await checkErrorRevert(colonyNetwork.methods[sig](token.address, 0, "", "", false, { value: 1, gas: createColonyGas }));
 
       const colonyNetworkBalance = await web3GetBalance(colonyNetwork.address);
       expect(colonyNetworkBalance).to.be.zero;

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -399,7 +399,7 @@ contract("Colony Network", accounts => {
 
     it("should be able to create a colony with label in one tx", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      const { logs } = await colonyNetwork.createColonyWithOptions(token.address, "test", orbitDBAddress, false);
+      const { logs } = await colonyNetwork.createColony(token.address, "test", orbitDBAddress, false);
       const { colonyAddress } = logs[0].args;
 
       const name = await colonyNetwork.lookupRegisteredENSDomain(colonyAddress);
@@ -413,15 +413,15 @@ contract("Colony Network", accounts => {
 
     it("should be able to create a colony configured with the extension manager in one tx", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      const { logs } = await colonyNetwork.createColonyWithOptions(token.address, "", "", true);
+      const { logs } = await colonyNetwork.createColony(token.address, "", "", true);
       const { colonyAddress } = logs[0].args;
 
       const name = await colonyNetwork.lookupRegisteredENSDomain(colonyAddress);
       expect(name).to.equal("");
 
       // No conflict for setting "multiple" null names...
-      await colonyNetwork.createColonyWithOptions(token.address, "", "", true);
-      await colonyNetwork.createColonyWithOptions(token.address, "", "", true);
+      await colonyNetwork.createColony(token.address, "", "", true);
+      await colonyNetwork.createColony(token.address, "", "", true);
 
       const colony = await IColony.at(colonyAddress);
       const extensionManagerAddress = await colonyNetwork.getExtensionManager();
@@ -431,7 +431,7 @@ contract("Colony Network", accounts => {
 
     it("should be able to create a colony with label and configured with the extension manager in one tx", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      const { logs } = await colonyNetwork.createColonyWithOptions(token.address, "test", orbitDBAddress, true);
+      const { logs } = await colonyNetwork.createColony(token.address, "test", orbitDBAddress, true);
       const { colonyAddress } = logs[0].args;
 
       const name = await colonyNetwork.lookupRegisteredENSDomain(colonyAddress);

--- a/test/contracts-network/colony-reward-payouts.js
+++ b/test/contracts-network/colony-reward-payouts.js
@@ -845,7 +845,6 @@ contract("Colony Reward Payouts", accounts => {
       it(`should calculate fairly precise reward payout for:
         user reputation/tokens: ${data.totalReputation.divn(3).toString()}
         total reputation/tokens: ${data.totalReputation.toString()}`, async () => {
-
         const { colony: newColony, token: newToken } = await setupRandomColony(colonyNetwork);
         await newToken.setOwner(colony.address);
 

--- a/test/contracts-network/colony-reward-payouts.js
+++ b/test/contracts-network/colony-reward-payouts.js
@@ -628,12 +628,12 @@ contract("Colony Reward Payouts", accounts => {
       const newToken = await Token.new(...tokenArgs);
       await newToken.unlock();
 
-      let { logs } = await colonyNetwork.createColony(newToken.address);
-      let { colonyAddress } = logs[1].args;
+      let { logs } = await colonyNetwork.createColony(newToken.address, 0, "", "", false);
+      let { colonyAddress } = logs[0].args;
       const colony1 = await IColony.at(colonyAddress);
 
-      ({ logs } = await colonyNetwork.createColony(newToken.address));
-      ({ colonyAddress } = logs[1].args);
+      ({ logs } = await colonyNetwork.createColony(newToken.address, 0, "", "", false));
+      ({ colonyAddress } = logs[0].args);
       const colony2 = await IColony.at(colonyAddress);
 
       // Giving both colonies the capability to call `mint` function
@@ -727,12 +727,12 @@ contract("Colony Reward Payouts", accounts => {
       const newToken = await Token.new(...tokenArgs);
       await newToken.unlock();
 
-      let { logs } = await colonyNetwork.createColony(newToken.address);
-      let { colonyAddress } = logs[1].args;
+      let { logs } = await colonyNetwork.createColony(newToken.address, 0, "", "", false);
+      let { colonyAddress } = logs[0].args;
       const colony1 = await IColony.at(colonyAddress);
 
-      ({ logs } = await colonyNetwork.createColony(newToken.address));
-      ({ colonyAddress } = logs[1].args);
+      ({ logs } = await colonyNetwork.createColony(newToken.address, 0, "", "", false));
+      ({ colonyAddress } = logs[0].args);
       const colony2 = await IColony.at(colonyAddress);
 
       // Giving both colonies the capability to call `mint` function
@@ -845,7 +845,10 @@ contract("Colony Reward Payouts", accounts => {
       it(`should calculate fairly precise reward payout for:
         user reputation/tokens: ${data.totalReputation.divn(3).toString()}
         total reputation/tokens: ${data.totalReputation.toString()}`, async () => {
+
         const { colony: newColony, token: newToken } = await setupRandomColony(colonyNetwork);
+        await newToken.setOwner(colony.address);
+
         const payoutTokenArgs = getTokenArgs();
         const payoutToken = await Token.new(...payoutTokenArgs);
         await payoutToken.unlock();

--- a/test/contracts-network/colony-token-integrations.js
+++ b/test/contracts-network/colony-token-integrations.js
@@ -23,8 +23,8 @@ contract("Colony Token Integration", () => {
   beforeEach(async () => {
     // Instantiate an openzeppelin ERC20Mintable token instance
     erc20Mintable = await ERC20Mintable.new();
-    const { logs } = await colonyNetwork.createColony(erc20Mintable.address);
-    const { colonyAddress } = logs[1].args;
+    const { logs } = await colonyNetwork.createColony(erc20Mintable.address, 0, "", "", false);
+    const { colonyAddress } = logs[0].args;
     colony = await IColony.at(colonyAddress);
     await colony.setRewardInverse(100);
   });

--- a/test/contracts-network/router-resolver.js
+++ b/test/contracts-network/router-resolver.js
@@ -70,7 +70,7 @@ contract("EtherRouter / Resolver", accounts => {
     it("should return correct destination for given function, including overloads", async () => {
       const deployedColonyNetwork = await ColonyNetwork.deployed();
       const signature = await resolver.stringToSig("createColony(address)");
-      const overloadedSignature = await resolver.stringToSig("createColony(address,string,string,bool)");
+      const overloadedSignature = await resolver.stringToSig("createColony(address,uint256,string,string,bool)");
       const destination = await resolver.lookup(signature);
       const overloadedDestination = await resolver.lookup(overloadedSignature);
       expect(destination).to.equal(deployedColonyNetwork.address);

--- a/test/contracts-network/router-resolver.js
+++ b/test/contracts-network/router-resolver.js
@@ -67,11 +67,14 @@ contract("EtherRouter / Resolver", accounts => {
   });
 
   describe("Resolver", () => {
-    it("should return correct destination for given function", async () => {
+    it("should return correct destination for given function, including overloads", async () => {
       const deployedColonyNetwork = await ColonyNetwork.deployed();
       const signature = await resolver.stringToSig("createColony(address)");
+      const overloadedSignature = await resolver.stringToSig("createColony(address,string,string,bool)");
       const destination = await resolver.lookup(signature);
+      const overloadedDestination = await resolver.lookup(overloadedSignature);
       expect(destination).to.equal(deployedColonyNetwork.address);
+      expect(destination).to.equal(overloadedDestination);
     });
 
     it("when checking destination for a function that doesn't exist, should return 0", async () => {


### PR DESCRIPTION
Closes #607 

NOTE: this PR complements #714 and should be coordinated with that one, although it is not strictly a dependency.

This PR introduces the following overload function, allowing users to choose their version, set an ENS name, or configure the Extension Manager when creating their colonies:

```
  function createColony(
    address _tokenAddress,
    uint256 _version,
    string memory _colonyName,
    string memory _orbitdb,
    bool _useExtensionManager
  ) public stoppable returns (address)
```

When combined with the Extension Manager, the colony creation flow can be reduced to between 3-5 tx, [depending on when](https://joincolony.slack.com/archives/C0YNG3M8B/p1569268565092900) the Token Authority is deployed:

1. deploy Token
2. create Colony with ENS name and Extension Manager
3. install OneTxPayment
4. deploy TokenAuthority (or elsewhere)
5. configure TokenAuthority (or elsewhere)

The corresponding updates in ColonyJS can be found [here](https://github.com/JoinColony/colonyJS/pull/458).