### PR TITLE
Immutable domains

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -312,8 +312,13 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     );
   }
 
+  // v3 to v4
   function finishUpgrade() public always {
-    // Nothing here for v2 to v3, but it needs to be defined.
+    ColonyAuthority colonyAuthority = ColonyAuthority(address(authority));
+
+    // Remove function
+    bytes4 sig1 = bytes4(keccak256("setPaymentDomain(uint256,uint256,uint256,uint256)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Administration), address(this), sig1, false);
   }
 
   function checkNotAdditionalProtectedVariable(uint256 _slot) public view recovery {

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -312,13 +312,17 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     );
   }
 
+  bytes4 constant SIG1 = bytes4(keccak256("setTaskDomain(uint256,uint256)"));
+  bytes4 constant SIG2 = bytes4(keccak256("setPaymentDomain(uint256,uint256,uint256,uint256)"));
+
   // v3 to v4
   function finishUpgrade() public always {
-    ColonyAuthority colonyAuthority = ColonyAuthority(address(authority));
+    // Remove from multisig
+    delete reviewers[SIG1];
 
-    // Remove function
-    bytes4 sig1 = bytes4(keccak256("setPaymentDomain(uint256,uint256,uint256,uint256)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Administration), address(this), sig1, false);
+    // Remove from authority
+    ColonyAuthority colonyAuthority = ColonyAuthority(address(authority));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Administration), address(this), SIG2, false);
   }
 
   function checkNotAdditionalProtectedVariable(uint256 _slot) public view recovery {

--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -115,7 +115,6 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     setFunctionReviewers(bytes4(keccak256("setTaskBrief(uint256,bytes32)")), TaskRole.Manager, TaskRole.Worker);
     setFunctionReviewers(bytes4(keccak256("setTaskDueDate(uint256,uint256)")), TaskRole.Manager, TaskRole.Worker);
     setFunctionReviewers(bytes4(keccak256("setTaskSkill(uint256,uint256)")), TaskRole.Manager, TaskRole.Worker);
-    setFunctionReviewers(bytes4(keccak256("setTaskDomain(uint256,uint256)")), TaskRole.Manager, TaskRole.Worker);
     // We are setting a manager to both reviewers, but it will require just one signature from manager
     setFunctionReviewers(bytes4(keccak256("setTaskManagerPayout(uint256,address,uint256)")), TaskRole.Manager, TaskRole.Manager);
     setFunctionReviewers(bytes4(keccak256("setTaskEvaluatorPayout(uint256,address,uint256)")), TaskRole.Manager, TaskRole.Evaluator);

--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -38,7 +38,6 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ADMINISTRATION_ROLE, "makeTask(uint256,uint256,bytes32,uint256,uint256,uint256)");
     addRoleCapability(ADMINISTRATION_ROLE, "addPayment(uint256,uint256,address,address,uint256,uint256,uint256)");
     addRoleCapability(ADMINISTRATION_ROLE, "setPaymentRecipient(uint256,uint256,uint256,address)");
-    addRoleCapability(ADMINISTRATION_ROLE, "setPaymentDomain(uint256,uint256,uint256,uint256)");
     addRoleCapability(ADMINISTRATION_ROLE, "setPaymentSkill(uint256,uint256,uint256,uint256)");
     addRoleCapability(ADMINISTRATION_ROLE, "setPaymentPayout(uint256,uint256,uint256,address,uint256)");
     addRoleCapability(ADMINISTRATION_ROLE, "finalizePayment(uint256,uint256,uint256)");

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -93,11 +93,6 @@ contract ColonyDataTypes {
   /// @param dueDate New due date of the task
   event TaskDueDateSet(uint256 indexed taskId, uint256 dueDate);
 
-  /// @notice Event logged when a task's domain changes
-  /// @param taskId Id of the task
-  /// @param domainId New domain id of the task
-  event TaskDomainSet(uint256 indexed taskId, uint256 indexed domainId);
-
   /// @notice Event logged when a task's skill changes
   /// @param taskId Id of the task
   /// @param skillId New skill id of the task

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -97,15 +97,6 @@ contract ColonyPayment is ColonyStorage {
     payments[_id].recipient = _recipient;
   }
 
-  function setPaymentDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, uint256 _domainId) public
-  stoppable
-  authDomain(_permissionDomainId, _childSkillIndex, payments[_id].domainId)
-  authDomain(_permissionDomainId, _childSkillIndex, _domainId)
-  paymentNotFinalized(_id)
-  {
-    payments[_id].domainId = _domainId;
-  }
-
   function setPaymentSkill(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, uint256 _skillId) public
   stoppable
   authDomain(_permissionDomainId, _childSkillIndex, payments[_id].domainId)

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -335,19 +335,6 @@ contract ColonyTask is ColonyStorage {
     setTaskRoleUser(_id, TaskRole.Worker, address(0x0));
   }
 
-  function setTaskDomain(uint256 _id, uint256 _domainId) public
-  stoppable
-  taskExists(_id)
-  taskNotComplete(_id)
-  self()
-  {
-    require(domainExists(_domainId), "colony-domain-does-not-exist");
-
-    tasks[_id].domainId = _domainId;
-
-    emit TaskDomainSet(_id, _domainId);
-  }
-
   function setTaskSkill(uint256 _id, uint256 _skillId) public
   stoppable
   taskExists(_id)

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -397,11 +397,6 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _skillId Id of the skill which has to be a global skill
   function setTaskSkill(uint256 _id, uint256 _skillId) public;
 
-  /// @notice Set the domain for task `_id`.
-  /// @param _id Id of the task
-  /// @param _domainId Id of the domain
-  function setTaskDomain(uint256 _id, uint256 _domainId) public;
-
   /// @notice Set the hash for the task brief, aka task work specification, which identifies the task brief content in ddb.
   /// Allowed before a task is finalized.
   /// @param _id Id of the task

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -212,13 +212,6 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _recipient Address of the payment recipient
   function setPaymentRecipient(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, address payable _recipient) public;
 
-  /// @notice Sets the domain on an existing payment. Secured function to authorised members
-  /// @param _permissionDomainId The domainId in which I have the permission to take this action.
-  /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`
-  /// @param _id Payment identifier
-  /// @param _domainId Id of the new domain to set
-  function setPaymentDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, uint256 _domainId) public;
-
   /// @notice Sets the skill on an existing payment. Secured function to authorised members.
   /// @param _permissionDomainId The domainId in which I have the permission to take this action
   /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -927,19 +927,6 @@ Set the hash for the task brief, aka task work specification, which identifies t
 |_specificationHash|bytes32|Unique hash of the task brief in ddb
 
 
-### `setTaskDomain`
-
-Set the domain for task `_id`.
-
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_id|uint256|Id of the task
-|_domainId|uint256|Id of the domain
-
-
 ### `setTaskDueDate`
 
 Set the due date on task `_id`. Allowed before a task is finalized.

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -828,21 +828,6 @@ Set new colony funding role. Can be called by root role or architecture role.
 |_setTo|bool|The state of the role permission (true assign the permission, false revokes it)
 
 
-### `setPaymentDomain`
-
-Sets the domain on an existing payment. Secured function to authorised members
-
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_permissionDomainId|uint256|The domainId in which I have the permission to take this action.
-|_childSkillIndex|uint256|The index that the `_domainId` is relative to `_permissionDomainId`
-|_id|uint256|Payment identifier
-|_domainId|uint256|Id of the new domain to set
-
-
 ### `setPaymentPayout`
 
 Sets the payout for a given token on an existing payment. Secured function to authorised members.

--- a/test/contracts-network/colony-payment.js
+++ b/test/contracts-network/colony-payment.js
@@ -131,27 +131,6 @@ contract("Colony Payment", accounts => {
       );
     });
 
-    it("should allow admins to update domain", async () => {
-      await colony.addDomain(1, 0, 1);
-      await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
-      const paymentId = await colony.getPaymentCount();
-
-      let payment = await colony.getPayment(paymentId);
-      expect(payment.domainId).to.eq.BN(1);
-      await colony.setPaymentDomain(1, 0, paymentId, 2, { from: COLONY_ADMIN });
-      payment = await colony.getPayment(paymentId);
-      expect(payment.domainId).to.eq.BN(2);
-    });
-
-    it("should not allow admins to update to empty domain", async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
-      const paymentId = await colony.getPaymentCount();
-
-      const { domainId } = await colony.getPayment(paymentId);
-      expect(domainId).to.eq.BN(1);
-      await checkErrorRevert(colony.setPaymentDomain(1, 0, paymentId, 10, { from: COLONY_ADMIN }), "ds-auth-child-domain-does-not-exist");
-    });
-
     it("should allow admins to update skill", async () => {
       await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
@@ -259,11 +238,6 @@ contract("Colony Payment", accounts => {
     it("should not allow admins to update recipient", async () => {
       await colony.finalizePayment(1, 0, paymentId);
       await checkErrorRevert(colony.setPaymentRecipient(1, 0, paymentId, accounts[6], { from: COLONY_ADMIN }), "colony-payment-finalized");
-    });
-
-    it("should not allow admins to update to empty domain", async () => {
-      await colony.finalizePayment(1, 0, paymentId);
-      await checkErrorRevert(colony.setPaymentDomain(1, 0, paymentId, 2, { from: COLONY_ADMIN }), "colony-payment-finalized");
     });
 
     it("should not allow admins to update skill", async () => {

--- a/test/contracts-network/colony-task.js
+++ b/test/contracts-network/colony-task.js
@@ -1031,20 +1031,8 @@ contract("ColonyTask", accounts => {
       );
     });
 
-    it("should fail to execute task changes, when trying to set domain or skill to 0", async () => {
+    it("should fail to execute task change, when trying to set skill to 0", async () => {
       const taskId = await makeTask({ colony });
-
-      await checkErrorRevert(
-        executeSignedTaskChange({
-          colony,
-          functionName: "setTaskDomain",
-          taskId,
-          signers: [MANAGER],
-          sigTypes: [0],
-          args: [taskId, 0]
-        }),
-        "colony-task-change-execution-failed"
-      );
 
       await checkErrorRevert(
         executeSignedTaskChange({
@@ -1149,22 +1137,6 @@ contract("ColonyTask", accounts => {
       );
     });
 
-    it("should log a TaskDomainSet event, if the task domain gets changed", async () => {
-      const taskId = await makeTask({ colony });
-      await colony.addDomain(1, 0, 1);
-      await expectEvent(
-        executeSignedTaskChange({
-          colony,
-          functionName: "setTaskDomain",
-          taskId,
-          signers: [MANAGER],
-          sigTypes: [0],
-          args: [taskId, 2]
-        }),
-        "TaskDomainSet"
-      );
-    });
-
     it("should log a TaskRoleUserSet event, if a task role's user gets changed", async () => {
       const taskId = await makeTask({ colony });
 
@@ -1187,7 +1159,7 @@ contract("ColonyTask", accounts => {
       const { sigV, sigR, sigS, txData } = await getSigsAndTransactionData({
         colony,
         taskId,
-        functionName: "setTaskDomain",
+        functionName: "setTaskDueDate",
         signers: [MANAGER],
         sigTypes: [0],
         args: [taskId, 1]
@@ -1202,7 +1174,7 @@ contract("ColonyTask", accounts => {
       const { sigV, sigR, sigS, txData } = await getSigsAndTransactionData({
         colony,
         taskId,
-        functionName: "setTaskDomain",
+        functionName: "setTaskDueDate",
         signers: [MANAGER, WORKER],
         sigTypes: [0, 0],
         args: [taskId, 1]


### PR DESCRIPTION
Closes #707 

Not much to say, this PR removes both `setTaskDomain` and `setPaymentDomain` functionality. As a best practice we also remove the `setPaymentDomain` function from our `authority`, freeing up some storage (and getting a sweet gas refund).