### PR TITLE
Do not use user-supplied branchmasks if possible

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,7 @@
     "no-unused-expressions": "off",
     "no-await-in-loop": "off",
     "no-trailing-spaces": "error",
+    "no-multi-spaces": ["error", {"ignoreEOLComments": true}],
     "eslint-comments/disable-enable-pair": ["error", {"allowWholeFile": true}]
   },
   "parserOptions": {

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -77,13 +77,11 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @param round The round number the hash we are responding on behalf of is in
   /// @param idx The index in the round that the hash we are responding on behalf of is in
   /// @param jhIntermediateValue The contents of the Justification Tree at the key given by `targetNode` (see function description). The value of `targetNode` is computed locally to establish what to submit to this function.
-  /// @param branchMask The branchMask of the Merkle proof that `jhIntermediateValue` is the value at key `targetNode`
   /// @param siblings The siblings of the Merkle proof that `jhIntermediateValue` is the value at key `targetNode`
   function respondToBinarySearchForChallenge(
     uint256 round,
     uint256 idx,
     bytes memory jhIntermediateValue,
-    uint branchMask,
     bytes32[] memory siblings) public;
 
   /// @notice Confirm the result of a binary search - depending on how exactly the binary search finished, the saved binary search intermediate state might be incorrect.
@@ -91,13 +89,11 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @param round The round number the hash we are responding on behalf of is in
   /// @param idx The index in the round that the hash we are responding on behalf of is in
   /// @param jhIntermediateValue The contents of the Justification Tree at the key given by `targetNode` (see function description). The value of `targetNode` is computed locally to establish what to submit to this function.
-  /// @param branchMask The branchMask of the Merkle proof that `jhIntermediateValue` is the value at key `targetNode`
   /// @param siblings The siblings of the Merkle proof that `jhIntermediateValue` is the value at key `targetNode`
   function confirmBinarySearchResult(
     uint256 round,
     uint256 idx,
     bytes memory jhIntermediateValue,
-    uint256 branchMask,
     bytes32[] memory siblings) public;
 
   /// @notice Respond to challenge, to establish which (if either) of the two submissions facing off are correct.
@@ -166,9 +162,7 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @notice Verify the Justification Root Hash (JRH) for a submitted reputation hash is plausible.
   /// @param round The round that the hash is currently in.
   /// @param index The index in the round that the hash is currently in
-  /// @param branchMask1 The branchmask for the Merkle proof that the currently accepted reputation state (given by `ColonyNetwork.getReputationRootHash()` + `ColonyNetwork.getReputationRootHashNNodes()`, where `+` is concatenation) is at key 0x000..000 in the submitted JRH
   /// @param siblings1 The siblings for the same Merkle proof
-  /// @param branchMask2 The branchmask for the Merkle proof that the proposed new reputation state is at the key corresponding to the number of transactions expected in this update in the submitted JRH. This key should be the number of decay transactions plus the number of transactions the log indicates are to happen.
   /// @param siblings2 The siblings for the same Merkle proof
   /// @dev The majority of calls to this function will have `round` equal to `0`. The exception to this is when a submitted hash is given a bye, in which case `round` will be nonzero.
   /// @dev Note that it is possible for this function to be required to be called in every round - the hash getting the bye can wait until they will also be awarded the bye in the next round, if
@@ -177,9 +171,7 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   function confirmJustificationRootHash(
     uint256 round,
     uint256 index,
-    uint branchMask1,
     bytes32[] memory siblings1,
-    uint branchMask2,
     bytes32[] memory siblings2) public;
 
   /// @notice Add a new entry to the reputation update log.

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -402,9 +402,8 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     uint256 reputationRootHashNNodes = IColonyNetwork(colonyNetworkAddress).getReputationRootHashNNodes();
     uint256 nLogEntries = reputationUpdateLog.length;
 
-    uint256 nUpdates = reputationUpdateLog[nLogEntries-1].nUpdates +
-      reputationUpdateLog[nLogEntries-1].nPreviousUpdates + reputationRootHashNNodes;
-    submission.jrhNNodes = nUpdates + 1; // This is the number of nodes we expect in the justification tree
+    submission.jrhNNodes = reputationUpdateLog[nLogEntries-1].nUpdates +
+      reputationUpdateLog[nLogEntries-1].nPreviousUpdates + reputationRootHashNNodes + 1; // This is the number of nodes we expect in the justification tree
 
     uint256 expectedLength = expectedProofLength(submission.jrhNNodes, 0);
     require(expectedLength == siblings1.length, "colony-reputation-mining-invalid-jrh-proof-1-length");

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -319,7 +319,6 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     uint256 round,
     uint256 idx,
     bytes memory jhIntermediateValue,
-    uint256 branchMask,
     bytes32[] memory siblings
   ) public
   {
@@ -336,6 +335,9 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     uint256 expectedLength = expectedProofLength(submission.jrhNNodes, disputeRounds[round][idx].lowerBound) -
       (disputeRounds[round][idx].challengeStepCompleted - 1); // We expect shorter proofs the more chanllenge rounds we've done so far
     require(expectedLength == siblings.length, "colony-reputation-mining-invalid-binary-search-proof-length");
+    // Because branchmasks are used from the end, we can just get the whole branchmask. We will run out of siblings before we run out of
+    // branchmask, if everything is working right.
+    uint256 branchMask = expectedBranchMask(submission.jrhNNodes, disputeRounds[round][idx].lowerBound);
 
     (impliedRoot, lastSiblings) = getFinalPairAndImpliedRootNoHash(
       bytes32(targetNode),
@@ -353,7 +355,6 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     uint256 round,
     uint256 idx,
     bytes memory jhIntermediateValue,
-    uint256 branchMask,
     bytes32[] memory siblings
   ) public
   {
@@ -367,7 +368,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     );
 
     uint256 targetNode = disputeRounds[round][idx].lowerBound;
-
+    uint256 branchMask = expectedBranchMask(submission.jrhNNodes, disputeRounds[round][idx].lowerBound);
     bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(targetNode), jhIntermediateValue, branchMask, siblings);
     require(impliedRoot == submission.jrh, "colony-reputation-mining-invalid-binary-search-confirmation");
     bytes32 intermediateReputationHash;
@@ -388,9 +389,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
   function confirmJustificationRootHash(
     uint256 round,
     uint256 index,
-    uint256 branchMask1,
     bytes32[] memory siblings1,
-    uint256 branchMask2,
     bytes32[] memory siblings2
   ) public
   {
@@ -399,19 +398,13 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     // Require we've not submitted already.
     require(submission.jrhNNodes == 0, "colony-reputation-jrh-hash-already-verified");
 
-    // Get reputation root hash NNodes, which we need in both of the following checkJRHProofs
+    // Calculate how many updates we're expecting in the justification tree
     uint256 reputationRootHashNNodes = IColonyNetwork(colonyNetworkAddress).getReputationRootHashNNodes();
+    uint256 nLogEntries = reputationUpdateLog.length;
 
-
-    // Check the proofs for the JRH
-    checkJRHProof1(submission.jrh, branchMask1, siblings1, reputationRootHashNNodes);
-    checkJRHProof2(
-      round,
-      index,
-      branchMask2,
-      siblings2,
-      reputationRootHashNNodes
-    );
+    uint256 nUpdates = reputationUpdateLog[nLogEntries-1].nUpdates +
+      reputationUpdateLog[nLogEntries-1].nPreviousUpdates + reputationRootHashNNodes;
+    submission.jrhNNodes = nUpdates + 1; // This is the number of nodes we expect in the justification tree
 
     uint256 expectedLength = expectedProofLength(submission.jrhNNodes, 0);
     require(expectedLength == siblings1.length, "colony-reputation-mining-invalid-jrh-proof-1-length");
@@ -419,6 +412,17 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     expectedLength = expectedProofLength(submission.jrhNNodes, submission.jrhNNodes - 1);
     require(expectedLength == siblings2.length, "colony-reputation-mining-invalid-jrh-proof-2-length");
 
+    // Get the branch mask for the two proofs we asked for a plausible justification tree would have
+    uint256 branchMask1 = expectedBranchMask(submission.jrhNNodes, 0);
+    uint256 branchMask2 = expectedBranchMask(submission.jrhNNodes, submission.jrhNNodes-1);
+    // Check the proofs for the JRH
+    checkJRHProof1(submission.jrh, branchMask1, siblings1, reputationRootHashNNodes);
+    checkJRHProof2(
+      round,
+      index,
+      branchMask2,
+      siblings2
+    );
 
     // Record that they've responded
     disputeRounds[round][index].lastResponseTimestamp = now;
@@ -621,21 +625,16 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     uint256 round,
     uint256 index,
     uint256 branchMask2,
-    bytes32[] memory siblings2,
-    uint256 reputationRootHashNNodes
+    bytes32[] memory siblings2
   ) internal
   {
     // Proof 2 needs to prove that they finished with the reputation root hash they submitted, and the
-    // key is the number of updates implied by the contents of the reputation update log (implemented)
-    // plus the number of nodes in the last accepted update, each of which will have decayed once (not implemented)
-    uint256 nLogEntries = reputationUpdateLog.length;
+    // key is the number of updates implied by the contents of the reputation update log
+    // plus the number of nodes in the last accepted update, each of which will have decayed once.
     // The total number of updates we expect is the nPreviousUpdates in the last entry of the log plus the number
     // of updates that log entry implies by itself, plus the number of decays (the number of nodes in current state)
 
     Submission storage submission = reputationHashSubmissions[disputeRounds[round][index].firstSubmitter];
-    uint256 nUpdates = reputationUpdateLog[nLogEntries-1].nUpdates +
-      reputationUpdateLog[nLogEntries-1].nPreviousUpdates + reputationRootHashNNodes;
-    submission.jrhNNodes = nUpdates + 1;
     bytes32 submittedHash = submission.proposedNewRootHash;
     uint256 submittedHashNNodes = submission.nNodes;
     bytes memory jhLeafValue = new bytes(64);
@@ -643,7 +642,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
       mstore(add(jhLeafValue, 0x20), submittedHash)
       mstore(add(jhLeafValue, 0x40), submittedHashNNodes)
     }
-    bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(nUpdates), jhLeafValue, branchMask2, siblings2);
+    bytes32 impliedRoot = getImpliedRootNoHashKey(bytes32(submission.jrhNNodes-1), jhLeafValue, branchMask2, siblings2);
     require(submission.jrh == impliedRoot, "colony-reputation-mining-invalid-jrh-proof-2");
   }
 
@@ -700,5 +699,15 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
       nextPowerOfTwo >>= 1;
     }
     return layers;
+  }
+
+  function expectedBranchMask(uint256 nNodes, uint256 node) public pure returns (uint256) {
+    // Gets the expected branchmask for a patricia tree which has nNodes, with keys from 0 to nNodes -1
+    // i.e. the tree is 'full' - there are no missing nodes
+    uint256 mask = nNodes - 1; // Every branchmask in a full tree has at least these 1s set
+    uint256 xored = mask ^ node; // Where do mask and node differ?
+    // Set every bit in the mask from the first bit where they differ to 1
+    uint256 remainderMask = nextPowerOfTwoInclusive(xored + 1) - 1;
+    return mask | remainderMask;
   }
 }

--- a/docs/_Interface_IReputationMiningCycle.md
+++ b/docs/_Interface_IReputationMiningCycle.md
@@ -53,7 +53,6 @@ This function ensures that the intermediate hashes saved are correct.
 |round|uint256|The round number the hash we are responding on behalf of is in
 |idx|uint256|The index in the round that the hash we are responding on behalf of is in
 |jhIntermediateValue|bytes|The contents of the Justification Tree at the key given by `targetNode` (see function description). The value of `targetNode` is computed locally to establish what to submit to this function.
-|branchMask|uint256|The branchMask of the Merkle proof that `jhIntermediateValue` is the value at key `targetNode`
 |siblings|bytes32[]|The siblings of the Merkle proof that `jhIntermediateValue` is the value at key `targetNode`
 
 
@@ -69,9 +68,7 @@ Verify the Justification Root Hash (JRH) for a submitted reputation hash is plau
 |---|---|---|
 |round|uint256|The round that the hash is currently in.
 |index|uint256|The index in the round that the hash is currently in
-|branchMask1|uint|The branchmask for the Merkle proof that the currently accepted reputation state (given by `ColonyNetwork.getReputationRootHash()` + `ColonyNetwork.getReputationRootHashNNodes()`, where `+` is concatenation) is at key 0x000..000 in the submitted JRH
 |siblings1|bytes32[]|The siblings for the same Merkle proof
-|branchMask2|uint|The branchmask for the Merkle proof that the proposed new reputation state is at the key corresponding to the number of transactions expected in this update in the submitted JRH. This key should be the number of decay transactions plus the number of transactions the log indicates are to happen.
 |siblings2|bytes32[]|The siblings for the same Merkle proof
 
 
@@ -346,7 +343,6 @@ Respond to a binary search step, to eventually discover where two submitted hash
 |round|uint256|The round number the hash we are responding on behalf of is in
 |idx|uint256|The index in the round that the hash we are responding on behalf of is in
 |jhIntermediateValue|bytes|The contents of the Justification Tree at the key given by `targetNode` (see function description). The value of `targetNode` is computed locally to establish what to submit to this function.
-|branchMask|uint|The branchMask of the Merkle proof that `jhIntermediateValue` is the value at key `targetNode`
 |siblings|bytes32[]|The siblings of the Merkle proof that `jhIntermediateValue` is the value at key `targetNode`
 
 

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -244,7 +244,7 @@ class ReputationMiner {
       // is very slightly less than one (0.5 ** (1/2160) for a 1-hr mining cycle, 0.5 ** (1/90) for a 24-hr cycle).
       // Disabling prettier on the next line so we can have these two values aligned so it's easy to see
       // the fraction will be slightly less than one.
-      const numerator   = ethers.utils.bigNumberify("992327946262944");
+      const numerator = ethers.utils.bigNumberify("992327946262944");
       const denominator = ethers.utils.bigNumberify("1000000000000000");
 
       const newReputation = reputation.mul(numerator).div(denominator);

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongJRHRightNNodes.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongJRHRightNNodes.js
@@ -49,7 +49,7 @@ class MaliciousReputationMinerWrongJRHRightNNodes extends ReputationMinerTestWra
     }
     // Mess up the JRH
 
-    const jt2 =  new PatriciaTreeNoHash();
+    const jt2 = new PatriciaTreeNoHash();
     for (let i = 0; i < Object.keys(this.justificationHashes).length; i+= 1){
       if (this.entriesToSkip.indexOf(i.toString()) === -1){
         await jt2.insert(

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongJRHRightNNodes.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongJRHRightNNodes.js
@@ -1,0 +1,82 @@
+import ReputationMinerTestWrapper from "./ReputationMinerTestWrapper";
+import PatriciaTreeNoHash from "../patriciaNoHashKey";
+
+const ethers = require("ethers");
+
+const miningCycleDuration = ethers.utils.bigNumberify(60).mul(60).mul(24); // 24 hours
+const minStake = ethers.utils.bigNumberify(10).pow(18).mul(2000);
+const constant = ethers.utils.bigNumberify(2).pow(256).sub(1).div(miningCycleDuration);
+
+class MaliciousReputationMinerWrongJRHRightNNodes extends ReputationMinerTestWrapper {
+  // Only difference between this and the 'real' client should be that it submits a bad JRH
+
+  constructor(opts, entriesToFalsify, entriesToSkip) {
+    super(opts);
+    this.entriesToFalsify = entriesToFalsify.map(x => x.toString());
+    this.entriesToSkip = entriesToSkip.map(x=>x.toString());
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async respondToChallenge() {
+    // This client sometimes won't be able to respond to challenge - we mess up its JRH with a hash it doesn't know about
+  }
+
+  async submitRootHash(startIndex = 1) {
+    const hash = await this.getRootHash();
+    const repCycle = await this.getActiveRepCycle();
+    // Get how much we've staked, and thefore how many entries we have
+    let entryIndex;
+    const [, balance] = await this.tokenLocking.getUserLock(this.clnyAddress, this.minerAddress);
+    const reputationMiningWindowOpenTimestamp = await repCycle.getReputationMiningWindowOpenTimestamp();
+    for (let i = ethers.utils.bigNumberify(startIndex); i.lte(balance.div(minStake)); i = i.add(1)) {
+      // Iterate over entries until we find one that passes
+      const entryHash = await repCycle.getEntryHash(this.minerAddress, i, hash);
+      const block = await this.realProvider.getBlock("latest");
+      const { timestamp } = block;
+
+      const target = ethers.utils
+        .bigNumberify(timestamp)
+        .sub(reputationMiningWindowOpenTimestamp)
+        .mul(constant);
+
+      if (ethers.utils.bigNumberify(entryHash).lt(target)) {
+        entryIndex = i;
+        break;
+      }
+    }
+    if (!entryIndex) {
+      return new Error("No valid entry for submission found");
+    }
+    // Mess up the JRH
+
+    const jt2 =  new PatriciaTreeNoHash();
+    for (let i = 0; i < Object.keys(this.justificationHashes).length; i+= 1){
+      if (this.entriesToSkip.indexOf(i.toString()) === -1){
+        await jt2.insert(
+          ethers.utils.hexZeroPad(ethers.utils.hexlify(parseInt(i, 10)), 32),
+          this.getJRHEntryValueAsBytes(
+            this.justificationHashes[ReputationMinerTestWrapper.getHexString(i,64)].interimHash,
+            this.justificationHashes[ReputationMinerTestWrapper.getHexString(i,64)].nNodes
+          )
+        )
+      }
+    }
+
+    this.justificationTree = jt2;
+
+    for (let i =0; i< this.entriesToFalsify.length; i += 1){
+      await this.justificationTree.insert(
+        ethers.utils.hexZeroPad(ethers.utils.hexlify(parseInt(this.entriesToFalsify[i], 10)), 32),
+        `0x${"0".repeat(127)}1`
+      );
+    }
+    // Get the JRH
+    const jrh = await this.justificationTree.getRootHash();
+    // Submit that entry
+    const gas = await repCycle.estimate.submitRootHash(hash, this.nReputations, jrh, entryIndex);
+    const tx = await repCycle.submitRootHash(hash, this.nReputations, jrh, entryIndex, { gasLimit: `0x${gas.toString(16)}` });
+    return tx.wait();
+  }
+}
+
+export default MaliciousReputationMinerWrongJRHRightNNodes;

--- a/packages/reputation-miner/test/MaliciousReputationMinerWrongJRHRightNNodes.js
+++ b/packages/reputation-miner/test/MaliciousReputationMinerWrongJRHRightNNodes.js
@@ -3,10 +3,6 @@ import PatriciaTreeNoHash from "../patriciaNoHashKey";
 
 const ethers = require("ethers");
 
-const miningCycleDuration = ethers.utils.bigNumberify(60).mul(60).mul(24); // 24 hours
-const minStake = ethers.utils.bigNumberify(10).pow(18).mul(2000);
-const constant = ethers.utils.bigNumberify(2).pow(256).sub(1).div(miningCycleDuration);
-
 class MaliciousReputationMinerWrongJRHRightNNodes extends ReputationMinerTestWrapper {
   // Only difference between this and the 'real' client should be that it submits a bad JRH
 
@@ -21,32 +17,14 @@ class MaliciousReputationMinerWrongJRHRightNNodes extends ReputationMinerTestWra
     // This client sometimes won't be able to respond to challenge - we mess up its JRH with a hash it doesn't know about
   }
 
-  async submitRootHash(startIndex = 1) {
+  async submitRootHash(entryIndex) {
     const hash = await this.getRootHash();
     const repCycle = await this.getActiveRepCycle();
     // Get how much we've staked, and thefore how many entries we have
-    let entryIndex;
-    const [, balance] = await this.tokenLocking.getUserLock(this.clnyAddress, this.minerAddress);
-    const reputationMiningWindowOpenTimestamp = await repCycle.getReputationMiningWindowOpenTimestamp();
-    for (let i = ethers.utils.bigNumberify(startIndex); i.lte(balance.div(minStake)); i = i.add(1)) {
-      // Iterate over entries until we find one that passes
-      const entryHash = await repCycle.getEntryHash(this.minerAddress, i, hash);
-      const block = await this.realProvider.getBlock("latest");
-      const { timestamp } = block;
-
-      const target = ethers.utils
-        .bigNumberify(timestamp)
-        .sub(reputationMiningWindowOpenTimestamp)
-        .mul(constant);
-
-      if (ethers.utils.bigNumberify(entryHash).lt(target)) {
-        entryIndex = i;
-        break;
-      }
-    }
     if (!entryIndex) {
-      return new Error("No valid entry for submission found");
+      entryIndex = await this.getEntryIndex(); // eslint-disable-line no-param-reassign
     }
+
     // Mess up the JRH
 
     const jt2 = new PatriciaTreeNoHash();

--- a/test/reputation-system/happy-paths.js
+++ b/test/reputation-system/happy-paths.js
@@ -194,7 +194,8 @@ contract("Reputation Mining - happy paths", accounts => {
       await repCycle.confirmNewHash(3);
     });
 
-    it("should be able to process a large reputation update log", async () => {
+    it("should be able to process a large reputation update log", async function largeReputationLogTest() {
+      this.timeout(100000000);
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(30));
       // TODO It would be so much better if we could do these in parallel, but until colonyNetwork#192 is fixed, we can't.
       for (let i = 0; i < 30; i += 1) {


### PR DESCRIPTION
While working through the whitepaper updates around dispute resolution, I realised it was possible to confirm a justification root hash where RH_N was not the last leaf in the tree, but the tree had N leaves still. The correct justification tree would look like:

```
       / \
      /\ /\
     A B C D
```
 And an incorrect one could look like:
```
       / \
      /\ /\
     A B D E
```

The proofs for A and D would still have the same number of siblings, which was all we were checking during the confirmation. Such a submission would ultimately be found out, because the submitter would find themselves unable to respond during the search for the first key where there was a disagreement - either when the missing key was asked for as a `targetNode` during the search, or when a proof of the missing key was asked for during `confirmBinarySearchResult`. However, we can stop it getting to that point in this case.

Instead, now we calculate the branchmask we expect to see for a given response, rather than using one provided by the user. This means we can now guarantee that RH_N is the last key in the tree (because we know what the branchmask should look like in that case) along with RH_0 being the first (though this is trivial for key 0 in a tree where the keys are not hashed). We are still not able to guarantee that all keys between 0 and N are present, but that would only be possible by proving the existence of every second key in the tree, which is not feasible on chain.

I've tried to explain in the comments of the `expectedBranchMask` function what is going on in that function, but I appreciate it could easily look like black magic like all good bit twiddles do. Note that it assumes that the tree is 'full' i.e. all keys from 0 to N are present, but otherwise, happy to talk it through some.

We are only able to do this for the justification tree, where the keys are not hashed, not for the reputation state tree.

So long as we are still the only reputation miner when this is deployed, we can afford to be 'lazy' with the deployment, as the only changes to the mining contract interfaces are to do with the dispute resolution - which if we're the only miner, cannot happen.
