### PR TITLE
Add endpoint to reputation oracle to list addresses with skill in a colony

### DIFF
--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -1267,6 +1267,24 @@ class ReputationMiner {
     await db.close();
   }
 
+  async getAddressesWithReputation(reputationRootHash, colonyAddress, skillId) {
+    const db = await sqlite.open(this.dbPath, { Promise });
+    const res = await db.all(
+      `SELECT DISTINCT users.address as user_address
+       FROM reputations
+       INNER JOIN colonies ON colonies.rowid=reputations.colony_rowid
+       INNER JOIN users ON users.rowid=reputations.user_rowid
+       INNER JOIN reputation_states ON reputation_states.rowid=reputations.reputation_rowid
+       WHERE reputation_states.root_hash="${reputationRootHash}"
+       AND colonies.address="${colonyAddress.toLowerCase()}"
+       AND reputations.skill_id="${skillId}"
+       AND users.address!="0x0000000000000000000000000000000000000000"`
+    );
+    await db.close();
+    const addresses = res.map(x => x.user_address)
+    return addresses;
+  }
+
   async createDB() {
     const db = await sqlite.open(this.dbPath, { Promise });
     await db.run("CREATE TABLE IF NOT EXISTS users ( address text NOT NULL UNIQUE )");

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -136,7 +136,11 @@ class ReputationMinerClient {
         }
 
         try {
-          const [branchMask, siblings, value] = await this._miner.getHistoricalProofAndValue(req.params.rootHash, key);
+          const historicalProof = await this._miner.getHistoricalProofAndValue(req.params.rootHash, key);
+          if (historicalProof instanceof Error) {
+            return res.status(400).send({ message: historicalProof.message.replace("Error: ") });
+          }
+          const [branchMask, siblings, value] = historicalProof;
           const proof = { branchMask: `${branchMask.toString(16)}`, siblings, key, value };
           proof.reputationAmount = ethers.utils.bigNumberify(`0x${proof.value.slice(2, 66)}`).toString();
           return res.status(200).send(proof);

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -95,6 +95,16 @@ class ReputationMinerClient {
         return res.status(200).send({ active: activeAddr, inactive: inactiveAddr });
       });
 
+      // Query users who have given reputation in colony
+      this._app.get("/:rootHash/:colonyAddress/:skillId/", async (req, res) => {
+        const addresses = await this._miner.getAddressesWithReputation(req.params.rootHash, req.params.colonyAddress, req.params.skillId);
+        try {
+          return res.status(200).send({ addresses });
+        } catch (err) {
+          return res.status(400).send({ message: "Requested reputation does not exist or invalid request" });
+        }
+      });
+
       // Query specific reputation values
       this._app.get("/:rootHash/:colonyAddress/:skillId/:userAddress", async (req, res) => {
         const key = ReputationMiner.getKey(req.params.colonyAddress, req.params.skillId, req.params.userAddress);

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -102,31 +102,13 @@ class ReputationMinerClient {
           !ethers.utils.isHexString(req.params.colonyAddress) ||
           !ethers.utils.bigNumberify(req.params.skillId)
         ) {
-          return res.status(400).send({ message: "Requested reputation does not exist or invalid request" });
+          return res.status(400).send({ message: "One of the parameters was incorrect" });
         }
         const addresses = await this._miner.getAddressesWithReputation(req.params.rootHash, req.params.colonyAddress, req.params.skillId);
         try {
           return res.status(200).send({ addresses });
         } catch (err) {
-          return res.status(400).send({ message: "Requested reputation does not exist or invalid request" });
-        }
-      });
-
-      // Query users who have given reputation in colony
-      this._app.get("/:rootHash/:colonyAddress/:skillId/", async (req, res) => {
-        if (
-          !ethers.utils.isHexString(req.params.rootHash) ||
-          !ethers.utils.isHexString(req.params.colonyAddress) ||
-          !ethers.utils.bigNumberify(req.params.skillId)
-        ) {
-          return res.status(400).send({ message: "Requested reputation does not exist or invalid request" });
-        }
-
-        const addresses = await this._miner.getAddressesWithReputation(req.params.rootHash, req.params.colonyAddress, req.params.skillId);
-        try {
-          return res.status(200).send({ addresses });
-        } catch (err) {
-          return res.status(400).send({ message: "Requested reputation does not exist or invalid request" });
+          return res.status(500).send({ message: "An error occurred querying the reputation" });
         }
       });
 
@@ -138,7 +120,7 @@ class ReputationMinerClient {
           !ethers.utils.isHexString(req.params.userAddress) ||
           !ethers.utils.bigNumberify(req.params.skillId)
         ) {
-          return res.status(400).send({ message: "Requested reputation does not exist or invalid request" });
+          return res.status(400).send({ message: "One of the parameters was incorrect" });
         }
 
         const key = ReputationMiner.getKey(req.params.colonyAddress, req.params.skillId, req.params.userAddress);
@@ -150,7 +132,7 @@ class ReputationMinerClient {
             proof.reputationAmount = ethers.utils.bigNumberify(`0x${proof.value.slice(2, 66)}`).toString();
             return res.status(200).send(proof);
           }
-          return res.status(400).send({ message: "Requested reputation does not exist or invalid request" });
+          return res.status(400).send({ message: "Requested reputation does not exist" });
         }
 
         try {
@@ -159,7 +141,7 @@ class ReputationMinerClient {
           proof.reputationAmount = ethers.utils.bigNumberify(`0x${proof.value.slice(2, 66)}`).toString();
           return res.status(200).send(proof);
         } catch (err) {
-          return res.status(400).send({ message: "Requested reputation does not exist or invalid request" });
+          return res.status(500).send({ message: "An error occurred querying the reputation" });
         }
       });
 

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -97,6 +97,31 @@ class ReputationMinerClient {
 
       // Query users who have given reputation in colony
       this._app.get("/:rootHash/:colonyAddress/:skillId/", async (req, res) => {
+        if (
+          !ethers.utils.isHexString(req.params.rootHash) ||
+          !ethers.utils.isHexString(req.params.colonyAddress) ||
+          !ethers.utils.bigNumberify(req.params.skillId)
+        ) {
+          return res.status(400).send({ message: "Requested reputation does not exist or invalid request" });
+        }
+        const addresses = await this._miner.getAddressesWithReputation(req.params.rootHash, req.params.colonyAddress, req.params.skillId);
+        try {
+          return res.status(200).send({ addresses });
+        } catch (err) {
+          return res.status(400).send({ message: "Requested reputation does not exist or invalid request" });
+        }
+      });
+
+      // Query users who have given reputation in colony
+      this._app.get("/:rootHash/:colonyAddress/:skillId/", async (req, res) => {
+        if (
+          !ethers.utils.isHexString(req.params.rootHash) ||
+          !ethers.utils.isHexString(req.params.colonyAddress) ||
+          !ethers.utils.bigNumberify(req.params.skillId)
+        ) {
+          return res.status(400).send({ message: "Requested reputation does not exist or invalid request" });
+        }
+
         const addresses = await this._miner.getAddressesWithReputation(req.params.rootHash, req.params.colonyAddress, req.params.skillId);
         try {
           return res.status(200).send({ addresses });
@@ -107,6 +132,15 @@ class ReputationMinerClient {
 
       // Query specific reputation values
       this._app.get("/:rootHash/:colonyAddress/:skillId/:userAddress", async (req, res) => {
+        if (
+          !ethers.utils.isHexString(req.params.rootHash) ||
+          !ethers.utils.isHexString(req.params.colonyAddress) ||
+          !ethers.utils.isHexString(req.params.userAddress) ||
+          !ethers.utils.bigNumberify(req.params.skillId)
+        ) {
+          return res.status(400).send({ message: "Requested reputation does not exist or invalid request" });
+        }
+
         const key = ReputationMiner.getKey(req.params.colonyAddress, req.params.skillId, req.params.userAddress);
         const currentHash = await this._miner.getRootHash();
         if (currentHash === req.params.rootHash) {

--- a/test/reputation-system/client-core-functionality.js
+++ b/test/reputation-system/client-core-functionality.js
@@ -146,5 +146,16 @@ process.env.SOLIDITY_COVERAGE
           expect(res.statusCode).to.equal(400);
           expect(JSON.parse(res.body).message).to.equal("Requested reputation does not exist or invalid request");
         });
+
+        it("should correctly respond to a request for users that have a particular reputation in a colony", async () => {
+          const rootHash = await reputationMiner.getRootHash();
+          const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/1/`;
+          const res = await request(url);
+          expect(res.statusCode).to.equal(200);
+
+          const { addresses } = JSON.parse(res.body);
+          expect(addresses.length).to.equal(1);
+          expect(addresses[0]).to.equal(MINER1.toLowerCase());
+        });
       });
     });

--- a/test/reputation-system/client-core-functionality.js
+++ b/test/reputation-system/client-core-functionality.js
@@ -127,10 +127,10 @@ process.env.SOLIDITY_COVERAGE
 
         it("should correctly respond to a request for a valid key in a reputation state that never existed", async () => {
           const rootHash = await reputationMiner.getRootHash();
-          const url = `http://127.0.0.1:3000/${rootHash.slice(4)}0000/${metaColony.address}/2/${MINER1}`;
+          const url = `http://127.0.0.1:3000/0x${rootHash.slice(8)}000000/${metaColony.address}/2/${MINER1}`;
           const res = await request(url);
           expect(res.statusCode).to.equal(400);
-          expect(JSON.parse(res.body).message).to.equal("Requested reputation does not exist or invalid request");
+          expect(JSON.parse(res.body).message).to.equal("No such reputation state");
         });
 
         it("should correctly respond to a request for a valid key that didn't exist in a valid past reputation state", async () => {
@@ -144,7 +144,7 @@ process.env.SOLIDITY_COVERAGE
           const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/${accounts[4]}`;
           const res = await request(url);
           expect(res.statusCode).to.equal(400);
-          expect(JSON.parse(res.body).message).to.equal("Requested reputation does not exist or invalid request");
+          expect(JSON.parse(res.body).message).to.equal("Requested reputation does not exist");
         });
 
         it("should correctly respond to a request for an invalid key in a valid past reputation state", async () => {
@@ -158,7 +158,7 @@ process.env.SOLIDITY_COVERAGE
           const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/notAKey`;
           const res = await request(url);
           expect(res.statusCode).to.equal(400);
-          expect(JSON.parse(res.body).message).to.equal("Requested reputation does not exist or invalid request");
+          expect(JSON.parse(res.body).message).to.equal("One of the parameters was incorrect");
         });
 
         it("should correctly respond to a request for users that have a particular reputation in a colony", async () => {


### PR DESCRIPTION
Adds an API endpoint `/:rootHash/:colonyAddress/:skillId/` that returns 
```
{ addresses: [] }
```
Where the array contains a list of addresses that have the skill `skillId` in `colonyAddress` in the reputation state represented with the root `rootHash`.

As part of this, I've also sanitised user inputs for this and the proof endpoint, rather than just passing the user-supplied parameters in to the SQL query. Nothing ever went wrong doing that, right? 😓 

Marking this as draft for now so some discussion with the dapp team can occur as to what they might like changed.