### PR TITLE
Update solidity-parser-antlr

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "rimraf": "^3.0.0",
     "shortid": "^2.2.14",
     "solidity-coverage": "^0.6.0",
-    "solidity-parser-antlr": "^0.4.5",
+    "solidity-parser-antlr": "^0.4.11",
     "solidity-steamroller": "^1.1.0",
     "truffle": "^5.0.39",
     "truffle-hdwallet-provider": "^1.0.9",

--- a/scripts/check-auth.js
+++ b/scripts/check-auth.js
@@ -34,11 +34,11 @@ function correctAuthModifier(functionDef) {
   }
 
   // Check the first two arguments of the function are _permissionDomainId, _childSkillIndex
-  if (functionDef.parameters.parameters.length > 0 && functionDef.parameters.parameters[0].name !== "_permissionDomainId") {
+  if (functionDef.parameters.length > 0 && functionDef.parameters[0].name !== "_permissionDomainId") {
     valid = false;
     errors.push("First parameter of function is not _permissionDomainId");
   }
-  if (functionDef.parameters.parameters.length > 1 && functionDef.parameters.parameters[1].name !== "_childSkillIndex") {
+  if (functionDef.parameters.length > 1 && functionDef.parameters[1].name !== "_childSkillIndex") {
     valid = false;
     errors.push("Second parameter of function is not _childSkillIndex");
   }

--- a/scripts/docgen.js
+++ b/scripts/docgen.js
@@ -148,7 +148,7 @@ const generateMarkdown = ({ contractFile, templateFile, outputFile }) => {
         while (
           contractFileArray[paramLineIndex] &&
           contractFileArray[paramLineIndex].includes("///") &&
-          natspec.params.length !== method.parameters.parameters.length
+          natspec.params.length !== method.parameters.length
         ) {
           // Check whether the current line is a valid param line
           if (contractFileArray[paramLineIndex].includes(" @param ")) {
@@ -184,7 +184,7 @@ const generateMarkdown = ({ contractFile, templateFile, outputFile }) => {
         while (
           contractFileArray[returnLineIndex] &&
           contractFileArray[returnLineIndex].includes("///") &&
-          natspec.returns.length !== method.returnParameters.parameters.length
+          natspec.returns.length !== method.returnParameters.length
         ) {
           // Check whether the current line is a valid return line
           if (contractFileArray[returnLineIndex].includes(" @return ")) {
@@ -252,17 +252,17 @@ ${
     : ""
 }
 ${
-  method.parameters && method.parameters.parameters.length
+  method.parameters && method.parameters.length
     ? `
 **Parameters**
-${printParams(method, method.parameters.parameters, method.natspec.params)}`
+${printParams(method, method.parameters, method.natspec.params)}`
     : ""
 }
 ${
-  method.returnParameters && method.returnParameters.parameters.length
+  method.returnParameters && method.returnParameters.length
     ? `
 **Return Parameters**
-${printParams(method, method.returnParameters.parameters, method.natspec.returns)}`
+${printParams(method, method.returnParameters, method.natspec.returns)}`
     : ""
 }
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -10635,7 +10635,12 @@ solidity-parser-antlr@^0.3.3:
   resolved "https://registry.yarnpkg.com/solidity-parser-antlr/-/solidity-parser-antlr-0.3.3.tgz#0352e35f914095daa7eef9f3a55cf8074e28cc5b"
   integrity sha512-RNUc18pjf7DLWs//WF+V+VnvrbetEbNFUYxm2JFbXU62G9WSu+nVyDxV5r+FG4wu8jom17vLdM/3I7bMBGfZ9g==
 
-solidity-parser-antlr@^0.4.2, solidity-parser-antlr@^0.4.5, solidity-parser-antlr@^0.4.7:
+solidity-parser-antlr@^0.4.11:
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/solidity-parser-antlr/-/solidity-parser-antlr-0.4.11.tgz#af43e1f13b3b88309a875455f5d6e565b05ee5f1"
+  integrity sha512-4jtxasNGmyC0midtjH/lTFPZYvTTUMy6agYcF+HoMnzW8+cqo3piFrINb4ZCzpPW+7tTVFCGa5ubP34zOzeuMg==
+
+solidity-parser-antlr@^0.4.2, solidity-parser-antlr@^0.4.7:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/solidity-parser-antlr/-/solidity-parser-antlr-0.4.7.tgz#8e18867c95a956958ed008371e43f9e571dee6af"
   integrity sha512-iVjNhgqkXw+o+0E+xoLcji+3KuXLe8Rm8omUuVGhsV14+ZsTwQ70nhBRXg8O3t9xwdS0iST1q9NJ5IqHnqpWkA==


### PR DESCRIPTION
Closes #704 

The issue here is that the objects returned by the parser have changed; looking at the [changelog](https://github.com/federicobond/solidity-parser-antlr/blob/master/CHANGES.md) I think this was intended for 0.5.0, but slipped out early...