### PR TITLE
Update contracts to Solidity 0.6.0

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "./ColonyStorage.sol";

--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 import "./ColonyDataTypes.sol";
 import "./CommonAuthority.sol";

--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 
 contract ColonyDataTypes {

--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental "ABIEncoderV2";
 
 import "./ColonyStorage.sol";

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental "ABIEncoderV2";
 
 import "./ColonyAuthority.sol";

--- a/contracts/ColonyNetworkAuction.sol
+++ b/contracts/ColonyNetworkAuction.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 import "./ColonyNetworkStorage.sol";
 

--- a/contracts/ColonyNetworkAuthority.sol
+++ b/contracts/ColonyNetworkAuthority.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 import "./CommonAuthority.sol";
 

--- a/contracts/ColonyNetworkDataTypes.sol
+++ b/contracts/ColonyNetworkDataTypes.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 
 contract ColonyNetworkDataTypes {

--- a/contracts/ColonyNetworkENS.sol
+++ b/contracts/ColonyNetworkENS.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 import "./ens/ENS.sol";
 import "./ColonyNetworkStorage.sol";

--- a/contracts/ColonyNetworkMining.sol
+++ b/contracts/ColonyNetworkMining.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental "ABIEncoderV2";
 
 import "./ColonyNetworkStorage.sol";

--- a/contracts/ColonyNetworkStorage.sol
+++ b/contracts/ColonyNetworkStorage.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 import "../lib/dappsys/math.sol";
 import "./ERC20Extended.sol";

--- a/contracts/ColonyPayment.sol
+++ b/contracts/ColonyPayment.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental "ABIEncoderV2";
 
 import "./ColonyStorage.sol";

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 import "../lib/dappsys/math.sol";
 import "./ERC20Extended.sol";

--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -172,7 +172,7 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, ColonyNetworkDataTypes
     _;
   }
 
-  modifier auth {
+  modifier auth override {
     require(isAuthorized(msg.sender, 1, msg.sig), "ds-auth-unauthorized");
     _;
   }

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -545,7 +545,7 @@ contract ColonyTask is ColonyStorage {
   // https://github.com/ethereum/solidity/issues/2884
   function executeCall(address to, uint256 value, bytes memory data) internal returns (bool success) {
     assembly {
-      success := call(gas, to, value, add(data, 0x20), mload(data), 0, 0)
+      success := call(gas(), to, value, add(data, 0x20), mload(data), 0, 0)
       }
   }
 

--- a/contracts/ColonyTask.sol
+++ b/contracts/ColonyTask.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental "ABIEncoderV2";
 
 import "./ColonyStorage.sol";

--- a/contracts/CommonAuthority.sol
+++ b/contracts/CommonAuthority.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 import "./ColonyDataTypes.sol";
 import "./DomainRoles.sol";

--- a/contracts/CommonStorage.sol
+++ b/contracts/CommonStorage.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 import "../lib/dappsys/auth.sol";
 

--- a/contracts/ContractRecovery.sol
+++ b/contracts/ContractRecovery.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 import "./ColonyDataTypes.sol";
 import "./CommonStorage.sol";

--- a/contracts/ContractRecoveryDataTypes.sol
+++ b/contracts/ContractRecoveryDataTypes.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 
 contract ContractRecoveryDataTypes {

--- a/contracts/DomainRoles.sol
+++ b/contracts/DomainRoles.sol
@@ -61,15 +61,15 @@ contract DomainRoles is DSRoles {
 
   // Support old function signatures for root domain
 
-  function setUserRole(address who, uint8 role, bool enabled) public auth {
+  function setUserRole(address who, uint8 role, bool enabled) public override auth {
     return setUserRole(who, 1, role, enabled);
   }
 
-  function hasUserRole(address who, uint8 role) public view returns (bool) {
+  function hasUserRole(address who, uint8 role) public override view returns (bool) {
     return hasUserRole(who, 1, role);
   }
 
-  function canCall(address caller, address code, bytes4 sig) public view returns (bool) {
+  function canCall(address caller, address code, bytes4 sig) public override view returns (bool) {
     return canCall(caller, 1, code, sig);
   }
 

--- a/contracts/DomainRoles.sol
+++ b/contracts/DomainRoles.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8; // ignore-swc-103
+pragma solidity >=0.5.8 <0.7.0; // ignore-swc-103
 
 import "../lib/dappsys/roles.sol";
 

--- a/contracts/ERC20Extended.sol
+++ b/contracts/ERC20Extended.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8; // ignore-swc-103
+pragma solidity >=0.5.8 <0.7.0; // ignore-swc-103
 
 import "../lib/dappsys/erc20.sol";
 

--- a/contracts/ERC20Extended.sol
+++ b/contracts/ERC20Extended.sol
@@ -20,7 +20,7 @@ pragma solidity >=0.5.8 <0.7.0; // ignore-swc-103
 import "../lib/dappsys/erc20.sol";
 
 
-contract ERC20Extended is ERC20 {
+abstract contract ERC20Extended is ERC20 {
   event Mint(address indexed guy, uint wad);
   event Burn(address indexed guy, uint wad);
 

--- a/contracts/EtherRouter.sol
+++ b/contracts/EtherRouter.sol
@@ -51,13 +51,13 @@ contract EtherRouter is DSAuth {
       let size := extcodesize(destination)
       if eq(size, 0) { revert(0,0) }
 
-      calldatacopy(mload(0x40), 0, calldatasize)
-      let result := delegatecall(gas, destination, mload(0x40), calldatasize, mload(0x40), 0) // ignore-swc-113
+      calldatacopy(mload(0x40), 0, calldatasize())
+      let result := delegatecall(gas(), destination, mload(0x40), calldatasize(), mload(0x40), 0) // ignore-swc-113
       // as their addresses are controlled by the Resolver which we trust
-      returndatacopy(mload(0x40), 0, returndatasize)
+      returndatacopy(mload(0x40), 0, returndatasize())
       switch result
-      case 1 { return(mload(0x40), returndatasize) }
-      default { revert(mload(0x40), returndatasize) }
+      case 1 { return(mload(0x40), returndatasize()) }
+      default { revert(mload(0x40), returndatasize()) }
     }
   }
 

--- a/contracts/EtherRouter.sol
+++ b/contracts/EtherRouter.sol
@@ -24,7 +24,7 @@ import "../lib/dappsys/auth.sol";
 contract EtherRouter is DSAuth {
   Resolver public resolver;
 
-  function() external payable {
+  fallback() external payable {
     if (msg.sig == 0) {
       return;
     }

--- a/contracts/EtherRouter.sol
+++ b/contracts/EtherRouter.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 import "./Resolver.sol";
 import "../lib/dappsys/auth.sol";

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -24,7 +24,7 @@ import "./ColonyDataTypes.sol";
 
 /// @title Colony interface
 /// @notice All publicly available functions are available here and registered to work with EtherRouter Network contract
-contract IColony is ColonyDataTypes, IRecovery {
+abstract contract IColony is ColonyDataTypes, IRecovery {
   // Implemented in DSAuth.sol
   /// @notice Get the `ColonyAuthority` for the colony.
   /// @return colonyAuthority The `ColonyAuthority` contract address

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -24,7 +24,7 @@ import "./ColonyNetworkDataTypes.sol";
 
 /// @title Colony Network interface
 /// @notice All publicly available functions are available here and registered to work with EtherRouter Network contract
-contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
+abstract contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
 
   /// @notice Query if a contract implements an interface
   /// @param interfaceID The interface identifier, as specified in ERC-165

--- a/contracts/IEtherRouter.sol
+++ b/contracts/IEtherRouter.sol
@@ -22,7 +22,7 @@ pragma experimental ABIEncoderV2;
 // address / address payable conversion issues where we want to use this.
 
 
-contract IEtherRouter {
+abstract contract IEtherRouter {
   /// @notice Sets the resolver address. This is used in the routing of all delegatecalls by the EtherRouter.
   /// @param _resolver Address of the new Resolver
   function setResolver(address _resolver) public;

--- a/contracts/IMetaColony.sol
+++ b/contracts/IMetaColony.sol
@@ -23,7 +23,7 @@ import "./IColony.sol";
 
 /// @title MetaColony interface
 /// @notice All publicly available functions are available here and registered to work with EtherRouter Network contract
-contract IMetaColony is IColony {
+abstract contract IMetaColony is IColony {
   /// @notice Mints CLNY in the Meta Colony and transfers them to the colony network.
   /// Only allowed to be called on the Meta Colony by the colony network.
   /// @param _wad Amount to mint and transfer to the colony network

--- a/contracts/IRecovery.sol
+++ b/contracts/IRecovery.sol
@@ -23,7 +23,7 @@ import "./ContractRecoveryDataTypes.sol";
 
 /// @title Recovery interface
 /// @notice All publicly available functions are available here and registered to work with EtherRouter Network contract
-contract IRecovery is ContractRecoveryDataTypes {
+abstract contract IRecovery is ContractRecoveryDataTypes {
   /// @notice Put colony network mining into recovery mode.
   /// Can only be called by user with recovery role.
   function enterRecoveryMode() public;

--- a/contracts/IReputationMiningCycle.sol
+++ b/contracts/IReputationMiningCycle.sol
@@ -21,7 +21,7 @@ pragma experimental "ABIEncoderV2";
 import "./ReputationMiningCycleDataTypes.sol";
 
 
-contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
+abstract contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @notice The getter for the disputeRounds mapping.
   /// @param _round The dispute round to query
   /// @return submissions An array of DisputedEntrys struct for the round.

--- a/contracts/ITokenLocking.sol
+++ b/contracts/ITokenLocking.sol
@@ -21,7 +21,7 @@ pragma experimental "ABIEncoderV2";
 import "./TokenLockingDataTypes.sol";
 
 
-contract ITokenLocking is TokenLockingDataTypes {
+abstract contract ITokenLocking is TokenLockingDataTypes {
 
   /// @notice Set the ColonyNetwork contract address.
   /// @dev ColonyNetwork is used for checking if sender is a colony created on colony network.

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 
 contract Migrations {

--- a/contracts/PatriciaTree/Bits.sol
+++ b/contracts/PatriciaTree/Bits.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental "ABIEncoderV2";
 
 

--- a/contracts/PatriciaTree/Data.sol
+++ b/contracts/PatriciaTree/Data.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental "ABIEncoderV2";
 
 import {Bits} from "./Bits.sol";

--- a/contracts/PatriciaTree/PatriciaTree.sol
+++ b/contracts/PatriciaTree/PatriciaTree.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental "ABIEncoderV2";
 
 import "./PatriciaTreeBase.sol";

--- a/contracts/PatriciaTree/PatriciaTreeBase.sol
+++ b/contracts/PatriciaTree/PatriciaTreeBase.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental "ABIEncoderV2";
 
 import {Data} from "./Data.sol";

--- a/contracts/PatriciaTree/PatriciaTreeNoHash.sol
+++ b/contracts/PatriciaTree/PatriciaTreeNoHash.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental "ABIEncoderV2";
 
 import "./PatriciaTreeBase.sol";

--- a/contracts/PatriciaTree/PatriciaTreeProofs.sol
+++ b/contracts/PatriciaTree/PatriciaTreeProofs.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental "ABIEncoderV2";
 
 import {Data} from "./Data.sol";

--- a/contracts/ReputationMiningCycle.sol
+++ b/contracts/ReputationMiningCycle.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental "ABIEncoderV2";
 
 import "../lib/dappsys/math.sol";

--- a/contracts/ReputationMiningCycleDataTypes.sol
+++ b/contracts/ReputationMiningCycleDataTypes.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 
 contract ReputationMiningCycleDataTypes {

--- a/contracts/ReputationMiningCycleRespond.sol
+++ b/contracts/ReputationMiningCycleRespond.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental "ABIEncoderV2";
 
 import "../lib/dappsys/math.sol";

--- a/contracts/ReputationMiningCycleStorage.sol
+++ b/contracts/ReputationMiningCycleStorage.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 import "../lib/dappsys/auth.sol";
 import "./ReputationMiningCycleDataTypes.sol";

--- a/contracts/Resolver.sol
+++ b/contracts/Resolver.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 import "../lib/dappsys/auth.sol";
 

--- a/contracts/TokenLocking.sol
+++ b/contracts/TokenLocking.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental "ABIEncoderV2";
 
 import "./ERC20Extended.sol";

--- a/contracts/TokenLockingDataTypes.sol
+++ b/contracts/TokenLockingDataTypes.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 
 contract TokenLockingDataTypes {

--- a/contracts/TokenLockingStorage.sol
+++ b/contracts/TokenLockingStorage.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental "ABIEncoderV2";
 
 import "../lib/dappsys/auth.sol";

--- a/contracts/ens/ENS.sol
+++ b/contracts/ens/ENS.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 
 /// @title The ENS interface.

--- a/contracts/ens/ENSRegistry.sol
+++ b/contracts/ens/ENSRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 import "./ENS.sol";
 

--- a/contracts/extensions/ExtensionFactory.sol
+++ b/contracts/extensions/ExtensionFactory.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental ABIEncoderV2;
 
 

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "./../ColonyAuthority.sol";

--- a/contracts/extensions/OneTxPaymentFactory.sol
+++ b/contracts/extensions/OneTxPaymentFactory.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "./../ColonyDataTypes.sol";

--- a/contracts/testHelpers/ContractEditing.sol
+++ b/contracts/testHelpers/ContractEditing.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 
 contract ContractEditing {

--- a/contracts/testHelpers/FunctionsNotAvailableOnColony.sol
+++ b/contracts/testHelpers/FunctionsNotAvailableOnColony.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "./../Colony.sol";

--- a/contracts/testHelpers/NoLimitSubdomains.sol
+++ b/contracts/testHelpers/NoLimitSubdomains.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "./../Colony.sol";

--- a/contracts/testHelpers/TaskSkillEditing.sol
+++ b/contracts/testHelpers/TaskSkillEditing.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "./../ColonyStorage.sol";

--- a/contracts/testHelpers/TransferTest.sol
+++ b/contracts/testHelpers/TransferTest.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity >=0.5.8 <0.7.0;
 
 
 contract TransferTest {


### PR DESCRIPTION
As part of Solidity's testing strategy, a few external projects are compiled and tested with nightly builds of the upcoming breaking release 0.6.0. The Colony contracts are part of this and would need some updates such that they compile.

This PR mainly updates fixed version pragmas to also allow 0.6.0 and adjusts to the defaulting strict inline assembly.

Target branch is up for discussion.