### PR TITLE
Greenkeeper/prettier 1.19.1

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
     "import/named": "off",
     "no-console": "off",
     "no-unused-expressions": "off",
+    "eslint-comments/no-unlimited-disable": "off",
     "no-await-in-loop": "off",
     "no-trailing-spaces": "error",
     "no-multi-spaces": ["error", {"ignoreEOLComments": true}],

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "nyc": "^14.1.1",
     "openzeppelin-solidity": "^2.2.0",
     "pre-commit": "^1.2.2",
-    "prettier": "^1.18.0",
+    "prettier": "^1.19.1",
     "rimraf": "^3.0.0",
     "shortid": "^2.2.14",
     "solidity-coverage": "0.7.0-beta.2",

--- a/scripts/check-auth.js
+++ b/scripts/check-auth.js
@@ -55,7 +55,7 @@ function correctAuthModifier(functionDef) {
   }
   // Check that the second is either a lookup of a domainId, or _domainId
   const arg2 = authDec.arguments[2];
-  if (arg2.name !== "_domainId" && (arg2.type === "MemberAccess" && arg2.memberName !== "domainId")) {
+  if (arg2.name !== "_domainId" && arg2.type === "MemberAccess" && arg2.memberName !== "domainId") {
     valid = false;
     errors.push("Second parameter to auth is not _domainId or a lookup thereof");
   }

--- a/scripts/check-recovery.js
+++ b/scripts/check-recovery.js
@@ -14,7 +14,7 @@ function correctRecoveryModifier(functionDef) {
   const isPrivate = ["private", "internal"].indexOf(functionDef.visibility) > -1;
   const isView = ["view", "pure"].indexOf(functionDef.stateMutability) > -1;
   const hasModifier = functionDef.modifiers.filter(mod => ["stoppable", "recovery", "always"].indexOf(mod.name) > -1).length > 0;
-  return isPrivate || (isView || hasModifier);
+  return isPrivate || isView || hasModifier;
 }
 
 walkSync("./contracts/").forEach(contractName => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8764,10 +8764,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.18.0:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-hrtime@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
Closes #735 

The new version of prettier throws some new errors, which have been fixed. Most wide-reaching is disabling the `eslint-comments/no-unlimited-disable` rule. Other changes involved removing redundant parenthesis in two booleans statements in our build scripts and changing spacing and indentation in a reputation miner test. 

Also, it seems like the issue we were having where greenkeeper corrupted `yarn.lock` has gone away? This one looks fine.