### PR TITLE
Greenkeeper/husky 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "ethlint": "^1.2.4",
     "ganache-cli": "^6.7.0",
     "find-in-files": "^0.5.0",
-    "husky": "^3.0.0",
+    "husky": "^3.1.0",
     "istanbul": "^0.4.5",
     "jsonfile": "^5.0.0",
     "mocha": "^6.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5800,10 +5800,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^3.0.0:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-3.0.9.tgz#a2c3e9829bfd6b4957509a9500d2eef5dbfc8044"
-  integrity sha512-Yolhupm7le2/MqC1VYLk/cNmYxsSsqKkTyBhzQHhPK1jFnC89mmmNVuGtLNabjDI6Aj8UNIr0KpRNuBkiC4+sg==
+husky@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-3.1.0.tgz#5faad520ab860582ed94f0c1a77f0f04c90b57c0"
+  integrity sha512-FJkPoHHB+6s4a+jwPqBudBDvYZsoQW5/HBuMSehC8qDiCe50kpcxeqFoDSlow+9I6wg47YxBoT3WxaURlrDIIQ==
   dependencies:
     chalk "^2.4.2"
     ci-info "^2.0.0"


### PR DESCRIPTION
Closes #740, which appears to have just been a flickery test on build of the dependencies - can see the green rebuilds [here](https://circleci.com/gh/JoinColony/colonyNetwork/tree/greenkeeper%2Fhusky-3.1.0) from before the rebase.