### PR TITLE
Make --no-auto function correctly

### DIFF
--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -191,7 +191,7 @@ class ReputationMinerClient {
     const openTimestamp = await repCycle.getReputationMiningWindowOpenTimestamp();
     this.confirmTimeoutCheck = setTimeout(this.reportConfirmTimeout.bind(this), (24 * 3600 + 600 - (Date.now() / 1000 - openTimestamp)) * 1000);
 
-    this.miningCycleAddress = await this._miner.colonyNetwork.getReputationMiningCycle(true);
+    this.miningCycleAddress = repCycle.address;
 
     if (this._auto) {
       this.best12Submissions = await this.getTwelveBestSubmissions();

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -256,6 +256,7 @@ class ReputationMinerClient {
 
       this.lockedForBlockProcessing = true;
       // DO NOT PUT ANY AWAITS ABOVE THIS LINE OR YOU WILL GET RACE CONDITIONS
+      // If you leave this function after this line, make sure to call this.endDoBlockChecks() to unlock
 
       if (this.blockTimeoutCheck) {
         clearTimeout(this.blockTimeoutCheck);
@@ -282,7 +283,10 @@ class ReputationMinerClient {
       }
 
       // If we're not auto-mining, then we don't need to do anything else.
-      if (!this._auto) return;
+      if (!this._auto) {
+        this.endDoBlockChecks();
+        return;
+      }
 
       const repCycle = new ethers.Contract(addr, this._miner.repCycleContractDef.abi, this._miner.realWallet);
 

--- a/test/reputation-system/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-system/reputation-mining-client/client-auto-functionality.js
@@ -232,6 +232,8 @@ process.env.SOLIDITY_COVERAGE
             }, 30000);
           });
 
+          let oracleCheckInterval;
+
           const rootHashBeforeUpdate = await oracleClient._miner.reputationTree.getRootHash();
           // Wait for the oracle to follow
           const oracleUpdated = new Promise(function(resolve, reject) {
@@ -243,10 +245,10 @@ process.env.SOLIDITY_COVERAGE
                 await forwardTime(1, this);
               }
             };
-            setInterval(checkOracle.bind(this), 5000);
+            oracleCheckInterval = setInterval(checkOracle.bind(this), 1000);
             setTimeout(() => {
               reject(new Error("ERROR: timeout while waiting for oracle to update"));
-            }, 30000);
+            }, 100000);
           });
 
           // Forward time to the end of the mining cycle and since we are the only miner, check the client confirmed our hash correctly
@@ -254,6 +256,8 @@ process.env.SOLIDITY_COVERAGE
           await miningCycleComplete;
 
           await oracleUpdated;
+
+          clearTimeout(oracleCheckInterval);
           await oracleClient.close();
         });
 
@@ -401,7 +405,7 @@ process.env.SOLIDITY_COVERAGE
             // After 30s, we throw a timeout error
             setTimeout(() => {
               reject(new Error("ERROR: timeout while waiting for confirming hash"));
-            }, 30000);
+            }, 60000);
           });
 
           // Forward time to the end of the mining cycle and since we are the only miner, check the client confirmed our hash correctly

--- a/test/reputation-system/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-system/reputation-mining-client/client-auto-functionality.js
@@ -15,7 +15,8 @@ import {
   checkErrorRevertEthers,
   mineBlock,
   finishReputationMiningCycle,
-  currentBlock
+  currentBlock,
+  getWaitForNSubmissionsPromise
 } from "../../../helpers/test-helper";
 import {
   setupColonyNetwork,
@@ -111,34 +112,9 @@ process.env.SOLIDITY_COVERAGE
           const jrh = await reputationMinerClient._miner.justificationTree.getRootHash();
 
           const oldHash = await colonyNetwork.getReputationRootHash();
-          const { minerAddress } = reputationMinerClient._miner;
 
           const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
-          const receive12Submissions = new Promise(function(resolve, reject) {
-            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
-              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
-              if (nSubmissions.toNumber() === 12) {
-                // Check the reputation cycle submission matches our miner
-                // Validate the miner address in submission is correct
-                const lastSubmitter = await repCycle.getSubmissionUser(rootHash, nNodes, jrh, 11);
-                expect(lastSubmitter).to.equal(minerAddress);
-
-                // Validate the root hash matches what the miner submitted
-                const submission = await repCycle.getReputationHashSubmission(minerAddress);
-                expect(submission.proposedNewRootHash).to.equal(rootHash);
-
-                event.removeListener();
-                resolve();
-              } else {
-                await mineBlock();
-              }
-            });
-
-            // After 30s, we throw a timeout error
-            setTimeout(() => {
-              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
-            }, 30000);
-          });
+          const receive12Submissions = getWaitForNSubmissionsPromise(repCycleEthers, rootHash, nNodes, jrh, 12);
 
           // Forward through most of the cycle duration and wait for the client to submit all 12 allowed entries
           await forwardTime(MINING_CYCLE_DURATION * 0.9, this);
@@ -183,34 +159,9 @@ process.env.SOLIDITY_COVERAGE
           const jrh = await reputationMinerClient._miner.justificationTree.getRootHash();
 
           const oldHash = await colonyNetwork.getReputationRootHash();
-          const { minerAddress } = reputationMinerClient._miner;
 
           const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
-          const receive12Submissions = new Promise(function(resolve, reject) {
-            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
-              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
-              if (nSubmissions.toNumber() === 12) {
-                // Check the reputation cycle submission matches our miner
-                // Validate the miner address in submission is correct
-                const lastSubmitter = await repCycle.getSubmissionUser(rootHash, nNodes, jrh, 11);
-                expect(lastSubmitter).to.equal(minerAddress);
-
-                // Validate the root hash matches what the miner submitted
-                const submission = await repCycle.getReputationHashSubmission(minerAddress);
-                expect(submission.proposedNewRootHash).to.equal(rootHash);
-
-                event.removeListener();
-                resolve();
-              } else {
-                await mineBlock();
-              }
-            });
-
-            // After 30s, we throw a timeout error
-            setTimeout(() => {
-              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
-            }, 30000);
-          });
+          const receive12Submissions = getWaitForNSubmissionsPromise(repCycleEthers, rootHash, nNodes, jrh, 12);
 
           // Forward through most of the cycle duration and wait for the client to submit all 12 allowed entries
           await forwardTime(MINING_CYCLE_DURATION * 0.9, this);
@@ -235,17 +186,21 @@ process.env.SOLIDITY_COVERAGE
           let oracleCheckInterval;
 
           const rootHashBeforeUpdate = await oracleClient._miner.reputationTree.getRootHash();
-          // Wait for the oracle to follow
+          // Wait for the oracle to update
+
           const oracleUpdated = new Promise(function(resolve, reject) {
+            let oracleLastSeenHash = "0x00";
             const checkOracle = async function() {
               const oracleCurrentHash = await oracleClient._miner.reputationTree.getRootHash();
-              if (oracleCurrentHash !== rootHashBeforeUpdate) {
+              if (oracleCurrentHash !== rootHashBeforeUpdate && oracleCurrentHash === oracleLastSeenHash) {
+                // This 'if' statement can be read as "If the oracle has started updating AND the oracle has finished updating"
                 resolve();
               } else {
+                oracleLastSeenHash = oracleCurrentHash;
                 await forwardTime(1, this);
               }
             };
-            oracleCheckInterval = setInterval(checkOracle.bind(this), 1000);
+            oracleCheckInterval = setInterval(checkOracle.bind(this), 5000);
             setTimeout(() => {
               reject(new Error("ERROR: timeout while waiting for oracle to update"));
             }, 100000);
@@ -258,6 +213,12 @@ process.env.SOLIDITY_COVERAGE
           await oracleUpdated;
 
           clearTimeout(oracleCheckInterval);
+
+          // Check the oracle has the same root hash as the miner after updating
+          const oracleHash = await oracleClient._miner.reputationTree.getRootHash();
+          const minerHash = await reputationMinerClient._miner.reputationTree.getRootHash();
+          assert.equal(oracleHash, minerHash, "The oracle has updated, but does not have the right hash");
+
           await oracleClient.close();
         });
 
@@ -269,24 +230,7 @@ process.env.SOLIDITY_COVERAGE
           const oldHash = await colonyNetwork.getReputationRootHash();
 
           const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
-          const receive2Submissions = new Promise(function(resolve, reject) {
-            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
-              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
-              if (nSubmissions.toNumber() === 2) {
-                // Check the reputation cycle submission matches our miner
-                // Validate the miner address in submission is correct
-                event.removeListener();
-                resolve();
-              } else {
-                await mineBlock();
-              }
-            });
-
-            // After 30s, we throw a timeout error
-            setTimeout(() => {
-              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
-            }, 30000);
-          });
+          const receive2Submissions = getWaitForNSubmissionsPromise(repCycleEthers, rootHash, nNodes, jrh, 2);
 
           // Forward through half of the cycle duration and wait for the client to submit some entries
           await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
@@ -302,25 +246,7 @@ process.env.SOLIDITY_COVERAGE
             auto: true
           });
           await reputationMinerClient2.initialise(colonyNetwork.address, startingBlockNumber);
-
-          const receive12Submissions = new Promise(function(resolve, reject) {
-            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
-              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
-              if (nSubmissions.toNumber() === 12) {
-                // Check the reputation cycle submission matches our miner
-                // Validate the miner address in submission is correct
-                event.removeListener();
-                resolve();
-              } else {
-                await mineBlock();
-              }
-            });
-
-            // After 30s, we throw a timeout error
-            setTimeout(() => {
-              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
-            }, 30000);
-          });
+          const receive12Submissions = getWaitForNSubmissionsPromise(repCycleEthers, rootHash, nNodes, jrh, 12);
 
           await mineBlock();
           await receive12Submissions;
@@ -354,35 +280,7 @@ process.env.SOLIDITY_COVERAGE
           const jrh = await reputationMinerClient._miner.justificationTree.getRootHash();
 
           const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
-          const receive12Submissions = new Promise(function(resolve, reject) {
-            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
-              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
-              if (nSubmissions.toNumber() === 12) {
-                // Check the reputation cycle submission matches our miners
-                for (let i = 0; i < 12; i += 1) {
-                  // Validate the miner address in submission is correct
-                  const submitter = await repCycle.getSubmissionUser(rootHash, nNodes, jrh, i);
-                  expect(submitter).to.be.oneOf([MINER1, MINER2]);
-                }
-
-                // Validate the root hash matches what the miners submitted
-                const submission = await repCycle.getReputationHashSubmission(MINER1);
-                expect(submission.proposedNewRootHash).to.equal(rootHash);
-                const submission2 = await repCycle.getReputationHashSubmission(MINER2);
-                expect(submission2.proposedNewRootHash).to.equal(rootHash);
-
-                event.removeListener();
-                resolve();
-              } else {
-                await mineBlock();
-              }
-            });
-
-            // After 30s, we throw a timeout error
-            setTimeout(() => {
-              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
-            }, 30000);
-          });
+          const receive12Submissions = getWaitForNSubmissionsPromise(repCycleEthers, rootHash, nNodes, jrh, 12);
 
           // Make a submission from the second client and then await the remaining 11 submissions from the first client
           await goodClient.loadState(rootHash);
@@ -433,23 +331,7 @@ process.env.SOLIDITY_COVERAGE
 
           const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
 
-          const receive12Submissions = new Promise(function(resolve, reject) {
-            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
-              const nSubmissions = await repCycle.getNSubmissionsForHash(rootHash, nNodes, jrh);
-              console.log("reputation hash submitted event");
-              if (nSubmissions.toNumber() === 12) {
-                event.removeListener();
-                resolve();
-              } else {
-                await mineBlock();
-              }
-            });
-
-            // After 30s, we throw a timeout error
-            setTimeout(() => {
-              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
-            }, 30000);
-          });
+          const receive12Submissions = getWaitForNSubmissionsPromise(repCycleEthers, rootHash, nNodes, jrh, 12);
 
           // Forward through most of the cycle duration
           await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
@@ -569,58 +451,6 @@ process.env.SOLIDITY_COVERAGE
           // And finally, check the root hash was accepted as expected.
           const acceptedRootHash = await colonyNetwork.getReputationRootHash();
           assert.equal(acceptedRootHash, rootHash);
-        });
-
-        it.skip("should cope if not processing anything and a new cycle starts", async function() {
-          await reputationMinerClient.close();
-          await goodClient.addLogContentsToReputationTree();
-          await goodClient.saveCurrentState();
-          await forwardTime(MINING_CYCLE_DURATION / 2, this);
-          await goodClient.submitRootHash();
-
-          await forwardTime(MINING_CYCLE_DURATION, this);
-
-          const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
-          const receive12Submissions = new Promise(function(resolve, reject) {
-            repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nNodes, _jrh, _entryIndex, event) => {
-              const nSubmissions = await repCycle.getNSubmissionsForHash(_hash, _nNodes, _jrh);
-
-              if (nSubmissions.toNumber() === 12) {
-                // Check the reputation cycle submission matches our miners
-                for (let i = 0; i < 12; i += 1) {
-                  // Validate the miner address in submission is correct
-                  const submitter = await repCycle.getSubmissionUser(_hash, _nNodes, _jrh, i);
-                  expect(submitter).to.be.oneOf([MINER1, MINER2]);
-                }
-
-                // Validate the root hash matches what the miners submitted
-                const submission = await repCycle.getReputationHashSubmission(MINER1);
-                expect(submission.proposedNewRootHash).to.equal(_hash);
-                const submission2 = await repCycle.getReputationHashSubmission(MINER2);
-                expect(submission2.proposedNewRootHash).to.equal(_hash);
-
-                event.removeListener();
-                resolve();
-              } else {
-                await mineBlock();
-              }
-            });
-
-            // After 30s, we throw a timeout error
-            setTimeout(() => {
-              reject(new Error("ERROR: timeout while waiting for 12 hash submissions"));
-            }, 30000);
-          });
-
-          await reputationMinerClient.initialise(colonyNetwork.address, startingBlockNumber);
-          // const x = new Promise((resolve, reject) => {})
-          console.log("confirm");
-          // await x
-          await repCycleEthers.confirmNewHash(1);
-          console.log("confirmed");
-          await forwardTime(MINING_CYCLE_DURATION / 2, this);
-
-          await receive12Submissions;
         });
       });
     });


### PR DESCRIPTION
When I split up the oracle and the mining client, I failed to do it correctly. Even if we're not mining, we still need to follow updates as they happen and update our local state. So this rearranges a few things so that `--no-auto` just disables the mining, but still follows updates as they happen.

EDIT: Marking this as `in-progress` because I'm still testing with the goerli side, but I think the changes are done and would appreciate a review anyway to see if there's something obvious I've missed, just not a merge yet.