### PR TITLE
chore(package): update eslint-plugin-import to version 2.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "eslint-import-resolver-jest": "^3.0.0",
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-flowtype": "^4.5.2",
-    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.0",
     "eth-ens-namehash": "^2.0.8",
     "eth-gas-reporter": "^0.2.14",


### PR DESCRIPTION
Closes #751. The underlying issue was https://github.com/benmosher/eslint-plugin-import/issues/1558.