### PR TITLE
Arbitration State Changes

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -361,6 +361,10 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
     sig = bytes4(keccak256("setReputationMiningCycleReward(uint256)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
+
+    // Add expenditure state change support
+    sig = bytes4(keccak256("setExpenditureState(uint256,uint256,uint256,uint256,bool[],bytes32[],bytes32)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Arbitration), address(this), sig, true);
   }
 
   function checkNotAdditionalProtectedVariable(uint256 _slot) public view recovery {

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -87,12 +87,12 @@ contract ColonyAuthority is CommonAuthority {
 
     // Added in colony v5 (cerulean-lwss)
     addRoleCapability(ROOT_ROLE, "mintTokensFor(address,uint256)");
+    addRoleCapability(ROOT_ROLE, "setAnnualMetaColonyStipend(uint256)");
+    addRoleCapability(ROOT_ROLE, "setReputationMiningCycleReward(uint256)");
     addRoleCapability(ARBITRATION_ROLE, "transferStake(uint256,uint256,address,address,uint256,uint256,address)");
     addRoleCapability(ARBITRATION_ROLE, "emitDomainReputationPenalty(uint256,uint256,uint256,address,int256)");
     addRoleCapability(ARBITRATION_ROLE, "emitSkillReputationPenalty(uint256,address,int256)");
-
-    addRoleCapability(ROOT_ROLE, "setAnnualMetaColonyStipend(uint256)");
-    addRoleCapability(ROOT_ROLE, "setReputationMiningCycleReward(uint256)");
+    addRoleCapability(ARBITRATION_ROLE, "setExpenditureState(uint256,uint256,uint256,uint256,bool[],bytes32[],bytes32)");
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -288,6 +288,25 @@ contract IColony is ColonyDataTypes, IRecovery {
     uint256 _claimDelay
     ) public;
 
+  /// @notice Set arbitrary state on an expenditure slot. Can only be called by Arbitration role.
+  /// @param _permissionDomainId The domainId in which I have the permission to take this action
+  /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`,
+  /// (only used if `_permissionDomainId` is different to `_domainId`)
+  /// @param _id Expenditure identifier
+  /// @param _slot Number of the top-level storage slot
+  /// @param _mask Array of booleans indicated whether a key is a mapping (F) or offset (T).
+  /// @param _keys Array of additional keys (mappings & offsets)
+  /// @param _value Value to set at location
+  function setExpenditureState(
+    uint256 _permissionDomainId,
+    uint256 _childSkillIndex,
+    uint256 _id,
+    uint256 _slot,
+    bool[] memory _mask,
+    bytes32[] memory _keys,
+    bytes32 _value
+    ) public;
+
   /// @notice Claim the payout for an expenditure slot. Here the network receives a fee from each payout.
   /// @param _id Expenditure identifier
   /// @param _slot Number of the slot

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -222,7 +222,7 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _newOwner New owner of expenditure
   function transferExpenditure(uint256 _id, address _newOwner) public;
 
-  /// @notice Updates the expenditure owner. Can only be called by Arbitration role.
+  /// @notice DEPRECATED Updates the expenditure owner. Can only be called by Arbitration role.
   /// @param _permissionDomainId The domainId in which I have the permission to take this action
   /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`,
   /// (only used if `_permissionDomainId` is different to `_domainId`)

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -1164,6 +1164,24 @@ Sets the skill on an expenditure slot. Can only be called by expenditure owner.
 |_skillId|uint256|Id of the new skill to set
 
 
+### `setExpenditureState`
+
+Set arbitrary state on an expenditure slot. Can only be called by Arbitration role.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_permissionDomainId|uint256|The domainId in which I have the permission to take this action
+|_childSkillIndex|uint256|The index that the `_domainId` is relative to `_permissionDomainId`, (only used if `_permissionDomainId` is different to `_domainId`)
+|_id|uint256|Expenditure identifier
+|_slot|uint256|Number of the top-level storage slot
+|_mask|bool[]|Array of booleans indicated whether a key is a mapping (F) or offset (T).
+|_keys|bytes32[]|Array of additional keys (mappings & offsets)
+|_value|bytes32|Value to set at location
+
+
 ### `setFundingRole`
 
 Set new colony funding role. Can be called by root role or architecture role.

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -1469,7 +1469,7 @@ Updates the expenditure owner. Can only be called by expenditure owner.
 
 ### `transferExpenditureViaArbitration`
 
-Updates the expenditure owner. Can only be called by Arbitration role.
+DEPRECATED Updates the expenditure owner. Can only be called by Arbitration role.
 
 
 **Parameters**

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -178,6 +178,18 @@ Mark a global skill as deprecated which stops new tasks and payments from using 
 |_skillId|uint256|Id of the skill
 
 
+### `getAnnualMetaColonyStipend`
+
+Called to get the total per-cycle reputation mining reward.
+
+
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|uint256|uint256|
+
 ### `getChildSkillId`
 
 Get the id of the child skill at index `_childSkillIndex` for skill with Id `_skillId`.
@@ -406,6 +418,18 @@ Get the address of either the active or inactive reputation mining cycle, based 
 |---|---|---|
 |repMiningCycleAddress|address|address of active or inactive ReputationMiningCycle
 
+### `getReputationMiningCycleReward`
+
+Called to get the total per-cycle reputation mining reward.
+
+
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|uint256|uint256|
+
 ### `getReputationMiningSkillId`
 
 Get the `skillId` of the reputation mining skill. Only set once the metacolony is set up.
@@ -535,6 +559,13 @@ Check if specific address is a colony created on colony network.
 |---|---|---|
 |addressIsColony|bool|true if specified address is a colony, otherwise false
 
+### `issueMetaColonyStipend`
+
+Called to issue the metaColony stipend. This public function can be called by anyone at any interval, and an appropriate amount of CLNY will be minted based on the time since the last time it was called.
+
+
+
+
 ### `lookupRegisteredENSDomain`
 
 Reverse lookup a username from an address.
@@ -606,6 +637,19 @@ Used to track that a user is eligible to claim a reward
 |_amount|uint256|The amount of CLNY to be awarded
 
 
+### `setAnnualMetaColonyStipend`
+
+Called to set the metaColony stipend. This value will be the total amount of CLNY created for the metacolony in a single year. The corresponding `issueMetaColonyStipend` function can be called at any interval.
+
+*Note: Can only be called by the MetaColony.*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_amount|uint256|The amount of CLNY to issue to the metacolony every year
+
+
 ### `setFeeInverse`
 
 Set the colony network fee to pay. e.g. if the fee is 1% (or 0.01), pass 100 as `_feeInverse`.
@@ -650,6 +694,19 @@ Set a replacement log entry if we're in recovery mode.
 |_nPreviousUpdates|uint128|The number of updates in the log before this entry
 
 
+### `setReputationMiningCycleReward`
+
+Called to set the total per-cycle reputation reward, which will be split between all miners.
+
+*Note: Can only be called by the MetaColony.*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_amount|uint256|
+
+
 ### `setReputationRootHash`
 
 Set a new Reputation root hash and starts a new mining cycle. Can only be called by the ReputationMiningCycle contract.
@@ -662,7 +719,21 @@ Set a new Reputation root hash and starts a new mining cycle. Can only be called
 |newHash|bytes32|The reputation root hash
 |newNLeaves|uint256|The updated leaves count value
 |stakers|address[]|Array of users who submitted or backed the hash, being accepted here as the new reputation root hash
-|reward|uint256|Amount of CLNY to be distributed as reward to miners
+
+
+### `setReputationRootHash`
+
+This version of setReputationRootHash is deprecated and will be removed in a future release. It transparently calls the new version if it is called (essentially, removing the `reward` parameter.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|newHash|bytes32|The reputation root hash
+|newNLeaves|uint256|The updated leaves count value
+|stakers|address[]|Array of users who submitted or backed the hash, being accepted here as the new reputation root hash
+|reward|uint256|Amount of CLNY to be distributed as reward to miners (not used)
 
 
 ### `setTokenLocking`

--- a/docs/_Interface_IMetaColony.md
+++ b/docs/_Interface_IMetaColony.md
@@ -59,6 +59,19 @@ Mints CLNY in the Meta Colony and transfers them to the colony network. Only all
 |_wad|uint256|Amount to mint and transfer to the colony network
 
 
+### `setAnnualMetaColonyStipend`
+
+Called to set the metaColony stipend. This value will be the total amount of CLNY created for the metacolony in a single year.
+
+*Note: Calls the corresponding function on the ColonyNetwork.*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_amount|uint256|The amount of CLNY to issue to the metacolony every year
+
+
 ### `setNetworkFeeInverse`
 
 Set the Colony Network fee inverse amount.
@@ -70,3 +83,16 @@ Set the Colony Network fee inverse amount.
 |Name|Type|Description|
 |---|---|---|
 |_feeInverse|uint256|Nonzero amount for the fee inverse
+
+
+### `setReputationMiningCycleReward`
+
+Called to set the total per-cycle reputation reward, which will be split between all miners.
+
+*Note: Calls the corresponding function on the ColonyNetwork.*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_amount|uint256|

--- a/docs/_Interface_ITokenLocking.md
+++ b/docs/_Interface_ITokenLocking.md
@@ -190,7 +190,7 @@ Get user token lock info (lock count and deposited amount).
 
 |Name|Type|Description|
 |---|---|---|
-|lock|Lock|Lock object containing:   `lockCount` User's token lock count,   `amount` User's deposited amount,   `timestamp` Timestamp of deposit.
+|lock|Lock|Lock object containing:   `lockCount` User's token lock count,   `balance` User's deposited amount,   `DEPRECATED_timestamp` Timestamp of deposit (deprecated)   `pendingBalance` Tokens that have been sent to them, but are inaccessible until all locks are cleared and then these                    tokens are claimed
 
 ### `incrementLockCounterTo`
 

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -655,6 +655,44 @@ contract("Colony Expenditure", (accounts) => {
       expect(expenditureSlot.skills[0]).to.eq.BN(100);
     });
 
+    it("should allow arbitration users to add or remove expenditure slot skills", async () => {
+      await colony.setExpenditureSkill(expenditureId, 0, GLOBAL_SKILL_ID, { from: ADMIN });
+
+      let expenditureSlot = await colony.getExpenditureSlot(expenditureId, 0);
+      expect(expenditureSlot.skills.length).to.eq.BN(1);
+      expect(expenditureSlot.skills[0]).to.eq.BN(GLOBAL_SKILL_ID);
+
+      // Lengthen the array
+      let mask = [MAPPING, OFFSET];
+      let keys = ["0x0", bn2bytes32(new BN(3))];
+      let value = bn2bytes32(new BN(2));
+
+      await colony.setExpenditureState(1, UINT256_MAX, expenditureId, EXPENDITURESLOTS_SLOT, mask, keys, value, { from: ARBITRATOR });
+
+      // Set the new skillId
+      mask = [MAPPING, OFFSET, OFFSET];
+      keys = ["0x0", bn2bytes32(new BN(3)), bn2bytes32(new BN(1))];
+      value = bn2bytes32(new BN(100));
+
+      await colony.setExpenditureState(1, UINT256_MAX, expenditureId, EXPENDITURESLOTS_SLOT, mask, keys, value, { from: ARBITRATOR });
+
+      expenditureSlot = await colony.getExpenditureSlot(expenditureId, 0);
+      expect(expenditureSlot.skills.length).to.eq.BN(2);
+      expect(expenditureSlot.skills[0]).to.eq.BN(GLOBAL_SKILL_ID);
+      expect(expenditureSlot.skills[1]).to.eq.BN(100);
+
+      // Shrink the array
+      mask = [MAPPING, OFFSET];
+      keys = ["0x0", bn2bytes32(new BN(3))];
+      value = bn2bytes32(new BN(1));
+
+      await colony.setExpenditureState(1, UINT256_MAX, expenditureId, EXPENDITURESLOTS_SLOT, mask, keys, value, { from: ARBITRATOR });
+
+      expenditureSlot = await colony.getExpenditureSlot(expenditureId, 0);
+      expect(expenditureSlot.skills.length).to.eq.BN(1);
+      expect(expenditureSlot.skills[0]).to.eq.BN(GLOBAL_SKILL_ID);
+    });
+
     it("should allow arbitration users to update expenditure slot payouts", async () => {
       const mask = [MAPPING, MAPPING];
       const keys = ["0x0", bn2bytes32(new BN(token.address.slice(2), 16))];


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Part of #80 and related issues

Depends on #771

<!--- Summary of changes including design decisions -->

Add support for Arbitration state changes!

Specifically, this introduces an `internal` function `executeStateChange` which takes a base storage slot and applies a series of operations (concatenating mapping keys, adding struct offsets, and performing hashes) to generate the storage slot of a variable to be modified, and then updates the value of that variable. This internal function is called by the public `setExpenditureState`, which authenticates the user and uses an `expenditureId` to determine the base storage slot. This approach necessary to ensure that users cannot make unauthorized changes (which we could not do if, for example, users could pass storage slots directly).