### PR TITLE
Prevent 'finalisation' of old reward payouts

### DIFF
--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -61,7 +61,7 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, ColonyNetworkDataTypes
   // Keeps track of all reward payout cycles
   mapping (uint256 => RewardPayoutCycle) rewardPayoutCycles; // Storage slot 16
   // Active payouts for particular token address. Assures that one token is used for only one active payout
-  mapping (address => bool) activeRewardPayouts; // Storage slot 17
+  mapping (address => uint256) activeRewardPayouts; // Storage slot 17
 
   // This keeps track of how much of the colony's funds that it owns have been moved into funding pots other than pot 0,
   // which (by definition) have also had the reward amount siphoned off and put in to pot 0.


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #763 

The fix here is arguably controversial, which hinges on changing

```  
mapping (address => bool) activeRewardPayouts;
```
to
```
mapping (address => uint256) activeRewardPayouts;
```

This is a cardinal sin of upgradable contracts, after all, so how is this justifiable? It's because no-one has started a reward payout yet, and the functionality is disabled on the deployed versions - so we know that this mapping will be empty for all colonies that have not upgraded to this version. Changing it from a `bool` to a `uint256` therefore is fine, as far as I am aware.

The token lock count is a network-wide lock count for the colony's token, which means payouts in `rewardPayoutCycles` will not necessarily share adjacent keys. That lock count is [1-indexed](https://github.com/JoinColony/colonyNetwork/blob/develop/contracts/TokenLocking.sol#L69), which means we can use a 0 in `activeRewardPayouts` to indicate that there is no active reward for a token currently.

Of course, some of this logic becomes invalid as soon as I start working on #754 again but best to start from a place that we think works as intended 😓 .