### PR TITLE
UINT256_MAX in Domain Proofs

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -101,7 +101,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   {
     return (
       hasUserRole(_user, _domainId, _role) &&
-      (_domainId == _childDomainId || validateDomainInheritance(_domainId, _childSkillIndex, _childDomainId))
+      validateDomainInheritance(_domainId, _childSkillIndex, _childDomainId)
     );
   }
 

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -334,10 +334,10 @@ contract ColonyNetwork is ColonyNetworkStorage {
     IColony colony = IColony(_colonyAddress);
     colony.setRecoveryRole(msg.sender);
     colony.setRootRole(msg.sender, true);
-    colony.setArbitrationRole(1, 0, msg.sender, 1, true);
-    colony.setArchitectureRole(1, 0, msg.sender, 1, true);
-    colony.setFundingRole(1, 0, msg.sender, 1, true);
-    colony.setAdministrationRole(1, 0, msg.sender, 1, true);
+    colony.setArbitrationRole(1, UINT256_MAX, msg.sender, 1, true);
+    colony.setArchitectureRole(1, UINT256_MAX, msg.sender, 1, true);
+    colony.setFundingRole(1, UINT256_MAX, msg.sender, 1, true);
+    colony.setAdministrationRole(1, UINT256_MAX, msg.sender, 1, true);
 
     // Colony will not have owner
     DSAuth dsauth = DSAuth(_colonyAddress);

--- a/contracts/extensions/FundingQueue.sol
+++ b/contracts/extensions/FundingQueue.sol
@@ -105,12 +105,12 @@ contract FundingQueue is DSMath, PatriciaTreeProofs {
     uint256 toSkillId = colony.getDomain(toDomain).skillId;
 
     require(
-      domainSkillId == fromSkillId ||
+      (domainSkillId == fromSkillId && _fromChildSkillIndex == UINT256_MAX) ||
       fromSkillId == colonyNetwork.getChildSkillId(domainSkillId, _fromChildSkillIndex),
       "funding-queue-bad-inheritence-from"
     );
     require(
-      domainSkillId == toSkillId ||
+      (domainSkillId == toSkillId && _toChildSkillIndex == UINT256_MAX) ||
       toSkillId == colonyNetwork.getChildSkillId(domainSkillId, _toChildSkillIndex),
       "funding-queue-bad-inheritence-to"
     );
@@ -269,8 +269,8 @@ contract FundingQueue is DSMath, PatriciaTreeProofs {
 
     colony.moveFundsBetweenPots(
       proposal.domainId,
-      proposal.toChildSkillIndex,
       proposal.fromChildSkillIndex,
+      proposal.toChildSkillIndex,
       proposal.fromPot,
       proposal.toPot,
       actualFundingToTransfer,

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -27,6 +27,8 @@ import "./../colonyNetwork/IColonyNetwork.sol";
 
 
 contract OneTxPayment {
+
+  uint256 constant UINT256_MAX = 2**256 - 1;
   bytes4 constant ADD_PAYMENT_SIG = bytes4(keccak256("addPayment(uint256,uint256,address,address,uint256,uint256,uint256)"));
   bytes4 constant MOVE_FUNDS_SIG = bytes4(keccak256("moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)"));
 
@@ -113,7 +115,7 @@ contract OneTxPayment {
       // Fund the payment
       colony.moveFundsBetweenPots(
         1, // Root domain always 1
-        0, // Not used, this extension must have funding permission in the root for this function to work
+        UINT256_MAX, // Not used, this extension must have funding permission in the root for this function to work
         _childSkillIndex,
         1, // Root domain funding pot is always 1
         paymentData[2],

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -2,6 +2,7 @@ import { soliditySha3 } from "web3-utils";
 import { BN } from "bn.js";
 import shortid from "shortid";
 
+const X = new BN(0).notn(256); // Shorthand for UINT256_MAX for domain proofs
 const UINT256_MAX = new BN(0).notn(256);
 const UINT128_MAX = new BN(0).notn(128);
 const INT256_MAX = new BN(0).notn(255);
@@ -65,6 +66,7 @@ const DECAY_RATE = {
 const GLOBAL_SKILL_ID = new BN("3"); // Not a root global skill ID or anything, just the first global skill's ID
 
 module.exports = {
+  X,
   UINT256_MAX,
   INT256_MAX,
   INT128_MAX,

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -2,7 +2,6 @@ import { soliditySha3 } from "web3-utils";
 import { BN } from "bn.js";
 import shortid from "shortid";
 
-const X = new BN(0).notn(256); // Shorthand for UINT256_MAX for domain proofs
 const UINT256_MAX = new BN(0).notn(256);
 const UINT128_MAX = new BN(0).notn(128);
 const INT256_MAX = new BN(0).notn(255);
@@ -66,7 +65,6 @@ const DECAY_RATE = {
 const GLOBAL_SKILL_ID = new BN("3"); // Not a root global skill ID or anything, just the first global skill's ID
 
 module.exports = {
-  X,
   UINT256_MAX,
   INT256_MAX,
   INT128_MAX,

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -4,7 +4,7 @@ import BN from "bn.js";
 import { ethers } from "ethers";
 
 import {
-  X,
+  UINT256_MAX,
   MANAGER_PAYOUT,
   EVALUATOR_PAYOUT,
   WORKER_PAYOUT,
@@ -153,8 +153,8 @@ export async function setupFundedTask({
   const totalPayouts = managerPayoutBN.add(workerPayoutBN).add(evaluatorPayoutBN);
 
   const childSkillIndex = await getChildSkillIndex(colonyNetwork, colony, 1, task.domainId);
-  await colony.setFundingRole(1, X, manager, 1, true);
-  await colony.moveFundsBetweenPots(1, X, childSkillIndex, 1, task.fundingPotId, totalPayouts, tokenAddress, { from: manager });
+  await colony.setFundingRole(1, UINT256_MAX, manager, 1, true);
+  await colony.moveFundsBetweenPots(1, UINT256_MAX, childSkillIndex, 1, task.fundingPotId, totalPayouts, tokenAddress, { from: manager });
   await colony.setAllTaskPayouts(taskId, tokenAddress, managerPayout, evaluatorPayout, workerPayout, { from: manager });
   await assignRoles({ colony, taskId, manager, evaluator, worker });
 

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -4,6 +4,7 @@ import BN from "bn.js";
 import { ethers } from "ethers";
 
 import {
+  X,
   MANAGER_PAYOUT,
   EVALUATOR_PAYOUT,
   WORKER_PAYOUT,
@@ -152,8 +153,8 @@ export async function setupFundedTask({
   const totalPayouts = managerPayoutBN.add(workerPayoutBN).add(evaluatorPayoutBN);
 
   const childSkillIndex = await getChildSkillIndex(colonyNetwork, colony, 1, task.domainId);
-  await colony.setFundingRole(1, 0, manager, 1, true);
-  await colony.moveFundsBetweenPots(1, 0, childSkillIndex, 1, task.fundingPotId, totalPayouts, tokenAddress, { from: manager });
+  await colony.setFundingRole(1, X, manager, 1, true);
+  await colony.moveFundsBetweenPots(1, X, childSkillIndex, 1, task.fundingPotId, totalPayouts, tokenAddress, { from: manager });
   await colony.setAllTaskPayouts(taskId, tokenAddress, managerPayout, evaluatorPayout, workerPayout, { from: manager });
   await assignRoles({ colony, taskId, manager, evaluator, worker });
 

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -704,7 +704,7 @@ export async function getChildSkillIndex(colonyNetwork, colony, _parentDomainId,
   const childDomainId = new BN(_childDomainId);
 
   if (parentDomainId.eq(childDomainId)) {
-    return 0;
+    return UINT256_MAX;
   }
 
   const parentDomain = await colony.getDomain(parentDomainId);

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -4,7 +4,7 @@ import path from "path";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
 import {
-  X,
+  UINT256_MAX,
   WAD,
   MANAGER_ROLE,
   WORKER_ROLE,
@@ -108,7 +108,7 @@ contract("All", function (accounts) {
     it("when working with a Colony", async function () {
       await colony.mintTokens(200);
       await colony.claimColonyFunds(token.address);
-      await colony.setAdministrationRole(1, X, EVALUATOR, 1, true);
+      await colony.setAdministrationRole(1, UINT256_MAX, EVALUATOR, 1, true);
     });
 
     it("when working with a Task", async function () {
@@ -148,7 +148,7 @@ contract("All", function (accounts) {
       });
 
       // moveFundsBetweenPots
-      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 190, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 2, 190, token.address);
 
       // setTaskManagerPayout
       await executeSignedTaskChange({
@@ -206,20 +206,20 @@ contract("All", function (accounts) {
 
     it("when working with a Payment", async function () {
       // 4 transactions payment
-      await colony.addPayment(1, X, WORKER, token.address, WAD, 1, 0);
+      await colony.addPayment(1, UINT256_MAX, WORKER, token.address, WAD, 1, 0);
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
-      await colony.finalizePayment(1, X, paymentId);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.finalizePayment(1, UINT256_MAX, paymentId);
       await colony.claimPayment(paymentId, token.address);
 
       // 1 transaction payment
       const oneTxExtension = await OneTxPayment.new(colony.address);
-      await colony.setAdministrationRole(1, X, oneTxExtension.address, 1, true);
-      await colony.setFundingRole(1, X, oneTxExtension.address, 1, true);
+      await colony.setAdministrationRole(1, UINT256_MAX, oneTxExtension.address, 1, true);
+      await colony.setFundingRole(1, UINT256_MAX, oneTxExtension.address, 1, true);
 
-      await oneTxExtension.makePayment(1, X, 1, X, [WORKER], [token.address], [10], 1, GLOBAL_SKILL_ID);
+      await oneTxExtension.makePayment(1, UINT256_MAX, 1, UINT256_MAX, [WORKER], [token.address], [10], 1, GLOBAL_SKILL_ID);
     });
 
     it("when working with staking", async function () {
@@ -314,7 +314,7 @@ contract("All", function (accounts) {
 
       await fundColonyWithTokens(newColony, otherToken, 300);
 
-      await newColony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       const tx = await newColony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = tx.logs[0].args.rewardPayoutId;
@@ -348,7 +348,7 @@ contract("All", function (accounts) {
       await forwardTime(5184001);
       await newColony.finalizeRewardPayout(payoutId);
 
-      await newColony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       const tx2 = await newColony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId2 = tx2.logs[0].args.rewardPayoutId;

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -4,6 +4,7 @@ import path from "path";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
 import {
+  X,
   WAD,
   MANAGER_ROLE,
   WORKER_ROLE,
@@ -107,7 +108,7 @@ contract("All", function (accounts) {
     it("when working with a Colony", async function () {
       await colony.mintTokens(200);
       await colony.claimColonyFunds(token.address);
-      await colony.setAdministrationRole(1, 0, EVALUATOR, 1, true);
+      await colony.setAdministrationRole(1, X, EVALUATOR, 1, true);
     });
 
     it("when working with a Task", async function () {
@@ -147,7 +148,7 @@ contract("All", function (accounts) {
       });
 
       // moveFundsBetweenPots
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 2, 190, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 190, token.address);
 
       // setTaskManagerPayout
       await executeSignedTaskChange({
@@ -205,20 +206,20 @@ contract("All", function (accounts) {
 
     it("when working with a Payment", async function () {
       // 4 transactions payment
-      await colony.addPayment(1, 0, WORKER, token.address, WAD, 1, 0);
+      await colony.addPayment(1, X, WORKER, token.address, WAD, 1, 0);
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
-      await colony.finalizePayment(1, 0, paymentId);
+      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.finalizePayment(1, X, paymentId);
       await colony.claimPayment(paymentId, token.address);
 
       // 1 transaction payment
       const oneTxExtension = await OneTxPayment.new(colony.address);
-      await colony.setAdministrationRole(1, 0, oneTxExtension.address, 1, true);
-      await colony.setFundingRole(1, 0, oneTxExtension.address, 1, true);
+      await colony.setAdministrationRole(1, X, oneTxExtension.address, 1, true);
+      await colony.setFundingRole(1, X, oneTxExtension.address, 1, true);
 
-      await oneTxExtension.makePayment(1, 0, 1, 0, [WORKER], [token.address], [10], 1, GLOBAL_SKILL_ID);
+      await oneTxExtension.makePayment(1, X, 1, X, [WORKER], [token.address], [10], 1, GLOBAL_SKILL_ID);
     });
 
     it("when working with staking", async function () {

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -2,7 +2,7 @@
 import chai from "chai";
 import bnChai from "bn-chai";
 
-import { UINT256_MAX, INT128_MAX, WAD, SECONDS_PER_DAY, MAX_PAYOUT, GLOBAL_SKILL_ID } from "../../helpers/constants";
+import { X, UINT256_MAX, INT128_MAX, WAD, SECONDS_PER_DAY, MAX_PAYOUT, GLOBAL_SKILL_ID } from "../../helpers/constants";
 import { checkErrorRevert, getTokenArgs, forwardTime, getBlockTime } from "../../helpers/test-helper";
 import { fundColonyWithTokens, setupRandomColony } from "../../helpers/test-data-generator";
 
@@ -46,8 +46,8 @@ contract("Colony Expenditure", (accounts) => {
 
     ({ colony, token } = await setupRandomColony(colonyNetwork));
     await colony.setRewardInverse(100);
-    await colony.setAdministrationRole(1, 0, ADMIN, 1, true);
-    await colony.setArbitrationRole(1, 0, ARBITRATOR, 1, true);
+    await colony.setAdministrationRole(1, X, ADMIN, 1, true);
+    await colony.setArbitrationRole(1, X, ARBITRATOR, 1, true);
     await fundColonyWithTokens(colony, token, UINT256_MAX);
     domain1 = await colony.getDomain(1);
 
@@ -60,7 +60,7 @@ contract("Colony Expenditure", (accounts) => {
   describe("when adding expenditures", () => {
     it("should allow admins to add expenditure", async () => {
       const expendituresCountBefore = await colony.getExpenditureCount();
-      await colony.makeExpenditure(1, 0, 1, { from: ADMIN });
+      await colony.makeExpenditure(1, X, 1, { from: ADMIN });
 
       const expendituresCountAfter = await colony.getExpenditureCount();
       expect(expendituresCountAfter.sub(expendituresCountBefore)).to.eq.BN(1);
@@ -77,11 +77,11 @@ contract("Colony Expenditure", (accounts) => {
     });
 
     it("should not allow non-admins to add expenditure", async () => {
-      await checkErrorRevert(colony.makeExpenditure(1, 0, 1, { from: USER }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.makeExpenditure(1, X, 1, { from: USER }), "ds-auth-unauthorized");
     });
 
     it("should allow owners to cancel expenditures", async () => {
-      await colony.makeExpenditure(1, 0, 1, { from: ADMIN });
+      await colony.makeExpenditure(1, X, 1, { from: ADMIN });
       const expenditureId = await colony.getExpenditureCount();
 
       let expenditure = await colony.getExpenditure(expenditureId);
@@ -96,7 +96,7 @@ contract("Colony Expenditure", (accounts) => {
     });
 
     it("should allow owners to transfer expenditures", async () => {
-      await colony.makeExpenditure(1, 0, 1, { from: ADMIN });
+      await colony.makeExpenditure(1, X, 1, { from: ADMIN });
       const expenditureId = await colony.getExpenditureCount();
 
       let expenditure = await colony.getExpenditure(expenditureId);
@@ -110,14 +110,14 @@ contract("Colony Expenditure", (accounts) => {
     });
 
     it("should allow arbitration users to transfer expenditures", async () => {
-      await colony.makeExpenditure(1, 0, 1, { from: ADMIN });
+      await colony.makeExpenditure(1, X, 1, { from: ADMIN });
       const expenditureId = await colony.getExpenditureCount();
 
       let expenditure = await colony.getExpenditure(expenditureId);
       expect(expenditure.owner).to.equal(ADMIN);
 
-      await checkErrorRevert(colony.transferExpenditureViaArbitration(1, 0, expenditureId, USER, { from: ADMIN }), "ds-auth-unauthorized");
-      await colony.transferExpenditureViaArbitration(1, 0, expenditureId, USER, { from: ARBITRATOR });
+      await checkErrorRevert(colony.transferExpenditureViaArbitration(1, X, expenditureId, USER, { from: ADMIN }), "ds-auth-unauthorized");
+      await colony.transferExpenditureViaArbitration(1, X, expenditureId, USER, { from: ARBITRATOR });
 
       expenditure = await colony.getExpenditure(expenditureId);
       expect(expenditure.owner).to.equal(USER);
@@ -128,7 +128,7 @@ contract("Colony Expenditure", (accounts) => {
     let expenditureId;
 
     beforeEach(async () => {
-      await colony.makeExpenditure(1, 0, 1, { from: ADMIN });
+      await colony.makeExpenditure(1, X, 1, { from: ADMIN });
       expenditureId = await colony.getExpenditureCount();
     });
 
@@ -213,36 +213,36 @@ contract("Colony Expenditure", (accounts) => {
     });
 
     it("should allow arbitration users to set the payoutModifier", async () => {
-      await checkErrorRevert(colony.setExpenditurePayoutModifier(1, 0, expenditureId, SLOT0, WAD.divn(2), { from: ADMIN }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.setExpenditurePayoutModifier(1, X, expenditureId, SLOT0, WAD.divn(2), { from: ADMIN }), "ds-auth-unauthorized");
 
-      await colony.setExpenditurePayoutModifier(1, 0, expenditureId, SLOT0, WAD.divn(2));
+      await colony.setExpenditurePayoutModifier(1, X, expenditureId, SLOT0, WAD.divn(2));
 
       const expenditureSlot = await colony.getExpenditureSlot(expenditureId, SLOT0);
       expect(expenditureSlot.payoutModifier).to.eq.BN(WAD.divn(2));
     });
 
     it("should not allow arbitration users to set the payoutModifier above the maximum", async () => {
-      await colony.setExpenditurePayoutModifier(1, 0, expenditureId, SLOT0, MAX_PAYOUT_MODIFIER);
+      await colony.setExpenditurePayoutModifier(1, X, expenditureId, SLOT0, MAX_PAYOUT_MODIFIER);
 
       await checkErrorRevert(
-        colony.setExpenditurePayoutModifier(1, 0, expenditureId, SLOT0, MAX_PAYOUT_MODIFIER.addn(1)),
+        colony.setExpenditurePayoutModifier(1, X, expenditureId, SLOT0, MAX_PAYOUT_MODIFIER.addn(1)),
         "colony-expenditure-payout-modifier-too-large"
       );
     });
 
     it("should not allow arbitration users to set the payoutModifier below the minimum", async () => {
-      await colony.setExpenditurePayoutModifier(1, 0, expenditureId, SLOT0, MIN_PAYOUT_MODIFIER);
+      await colony.setExpenditurePayoutModifier(1, X, expenditureId, SLOT0, MIN_PAYOUT_MODIFIER);
 
       await checkErrorRevert(
-        colony.setExpenditurePayoutModifier(1, 0, expenditureId, SLOT0, MIN_PAYOUT_MODIFIER.subn(1)),
+        colony.setExpenditurePayoutModifier(1, X, expenditureId, SLOT0, MIN_PAYOUT_MODIFIER.subn(1)),
         "colony-expenditure-payout-modifier-too-small"
       );
     });
 
     it("should allow arbitration users to set the claimDelay", async () => {
-      await checkErrorRevert(colony.setExpenditureClaimDelay(1, 0, expenditureId, SLOT0, SECONDS_PER_DAY, { from: ADMIN }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.setExpenditureClaimDelay(1, X, expenditureId, SLOT0, SECONDS_PER_DAY, { from: ADMIN }), "ds-auth-unauthorized");
 
-      await colony.setExpenditureClaimDelay(1, 0, expenditureId, SLOT0, SECONDS_PER_DAY);
+      await colony.setExpenditureClaimDelay(1, X, expenditureId, SLOT0, SECONDS_PER_DAY);
 
       const expenditureSlot = await colony.getExpenditureSlot(expenditureId, SLOT0);
       expect(expenditureSlot.claimDelay).to.eq.BN(SECONDS_PER_DAY);
@@ -253,7 +253,7 @@ contract("Colony Expenditure", (accounts) => {
     let expenditureId;
 
     beforeEach(async () => {
-      await colony.makeExpenditure(1, 0, 1, { from: ADMIN });
+      await colony.makeExpenditure(1, X, 1, { from: ADMIN });
       expenditureId = await colony.getExpenditureCount();
     });
 
@@ -276,7 +276,7 @@ contract("Colony Expenditure", (accounts) => {
       await checkErrorRevert(colony.finalizeExpenditure(expenditureId, { from: ADMIN }), "colony-expenditure-not-funded");
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
 
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
     });
@@ -296,7 +296,7 @@ contract("Colony Expenditure", (accounts) => {
     let expenditureId;
 
     beforeEach(async () => {
-      await colony.makeExpenditure(1, 0, 1, { from: ADMIN });
+      await colony.makeExpenditure(1, X, 1, { from: ADMIN });
       expenditureId = await colony.getExpenditureCount();
     });
 
@@ -305,7 +305,7 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -324,8 +324,8 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayout(expenditureId, SLOT0, otherToken.address, WAD, { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
-      await colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, expenditure.fundingPotId, WAD, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, domain1.fundingPotId, expenditure.fundingPotId, WAD, otherToken.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const tokenBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -343,7 +343,7 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
       await colony.claimExpenditurePayout(expenditureId, SLOT0, token.address);
 
@@ -354,10 +354,10 @@ contract("Colony Expenditure", (accounts) => {
     it("should automatically reclaim funds for payoutModifiers of -1", async () => {
       await colony.setExpenditureRecipient(expenditureId, SLOT0, RECIPIENT, { from: ADMIN });
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
-      await colony.setExpenditurePayoutModifier(1, 0, expenditureId, SLOT0, WAD.neg());
+      await colony.setExpenditurePayoutModifier(1, X, expenditureId, SLOT0, WAD.neg());
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const balanceBefore = await colony.getFundingPotBalance(domain1.fundingPotId, token.address);
@@ -374,10 +374,10 @@ contract("Colony Expenditure", (accounts) => {
     it("should automatically reclaim funds for payoutModifiers between -1 and 0", async () => {
       await colony.setExpenditureRecipient(expenditureId, SLOT0, RECIPIENT, { from: ADMIN });
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
-      await colony.setExpenditurePayoutModifier(1, 0, expenditureId, SLOT0, WAD.divn(3).neg()); // 2/3 payout
+      await colony.setExpenditurePayoutModifier(1, X, expenditureId, SLOT0, WAD.divn(3).neg()); // 2/3 payout
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const balanceBefore = await colony.getFundingPotBalance(domain1.fundingPotId, token.address);
@@ -397,7 +397,7 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditureSkill(expenditureId, SLOT0, GLOBAL_SKILL_ID, { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
       await colony.claimExpenditurePayout(expenditureId, SLOT0, token.address);
 
@@ -421,10 +421,10 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
 
       // Modifier of -0.5 WAD translates to scalar of 0.5 WAD
-      await colony.setExpenditurePayoutModifier(1, 0, expenditureId, SLOT0, WAD.divn(2).neg());
+      await colony.setExpenditurePayoutModifier(1, X, expenditureId, SLOT0, WAD.divn(2).neg());
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -448,10 +448,10 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
 
       // Modifier of 1 WAD translates to scalar of 2 WAD
-      await colony.setExpenditurePayoutModifier(1, 0, expenditureId, SLOT0, WAD);
+      await colony.setExpenditurePayoutModifier(1, X, expenditureId, SLOT0, WAD);
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -473,10 +473,10 @@ contract("Colony Expenditure", (accounts) => {
     it("should not overflow when using the maximum payout * modifier", async () => {
       await colony.setExpenditureRecipient(expenditureId, SLOT0, RECIPIENT, { from: ADMIN });
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, MAX_PAYOUT, { from: ADMIN });
-      await colony.setExpenditurePayoutModifier(1, 0, expenditureId, SLOT0, MAX_PAYOUT_MODIFIER);
+      await colony.setExpenditurePayoutModifier(1, X, expenditureId, SLOT0, MAX_PAYOUT_MODIFIER);
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, expenditure.fundingPotId, MAX_PAYOUT, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, domain1.fundingPotId, expenditure.fundingPotId, MAX_PAYOUT, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
       await colony.claimExpenditurePayout(expenditureId, SLOT0, token.address);
 
@@ -491,10 +491,10 @@ contract("Colony Expenditure", (accounts) => {
 
     it("should delay claims by claimDelay", async () => {
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
-      await colony.setExpenditureClaimDelay(1, 0, expenditureId, SLOT0, SECONDS_PER_DAY);
+      await colony.setExpenditureClaimDelay(1, X, expenditureId, SLOT0, SECONDS_PER_DAY);
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       await checkErrorRevert(colony.claimExpenditurePayout(expenditureId, SLOT0, token.address), "colony-expenditure-cannot-claim");
@@ -512,7 +512,7 @@ contract("Colony Expenditure", (accounts) => {
     let expenditureId;
 
     beforeEach(async () => {
-      await colony.makeExpenditure(1, 0, 1, { from: ADMIN });
+      await colony.makeExpenditure(1, X, 1, { from: ADMIN });
       expenditureId = await colony.getExpenditureCount();
     });
 
@@ -525,16 +525,16 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
 
       // Try to move funds back
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, 0, 0, expenditure.fundingPotId, domain1.fundingPotId, WAD, token.address),
+        colony.moveFundsBetweenPots(1, X, X, expenditure.fundingPotId, domain1.fundingPotId, WAD, token.address),
         "colony-funding-expenditure-bad-state"
       );
 
       await colony.cancelExpenditure(expenditureId, { from: ADMIN });
-      await colony.moveFundsBetweenPots(1, 0, 0, expenditure.fundingPotId, domain1.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, expenditure.fundingPotId, domain1.fundingPotId, WAD, token.address);
     });
   });
 });

--- a/test/contracts-network/colony-funding.js
+++ b/test/contracts-network/colony-funding.js
@@ -4,6 +4,7 @@ import bnChai from "bn-chai";
 import { ethers } from "ethers";
 
 import {
+  X,
   WAD,
   MANAGER_ROLE,
   EVALUATOR_ROLE,
@@ -79,7 +80,7 @@ contract("Colony Funding", (accounts) => {
     it("should let tokens be moved between funding pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await makeTask({ colony });
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 2, 51, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 51, otherToken.address);
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
       const pot2Balance = await colony.getFundingPotBalance(2, otherToken.address);
@@ -91,7 +92,7 @@ contract("Colony Funding", (accounts) => {
     it("should not let tokens be moved between the same pot", async () => {
       await fundColonyWithTokens(colony, otherToken, 1);
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, 0, 0, 1, 1, 1, otherToken.address),
+        colony.moveFundsBetweenPots(1, X, X, 1, 1, 1, otherToken.address),
         "colony-funding-cannot-move-funds-between-the-same-pot"
       );
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
@@ -102,7 +103,7 @@ contract("Colony Funding", (accounts) => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await makeTask({ colony });
 
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 0, 0, 2, 1, otherToken.address), "colony-funding-cannot-move-funds-from-rewards-pot");
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 0, 2, 1, otherToken.address), "colony-funding-cannot-move-funds-from-rewards-pot");
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       const colonyRewardPotBalance = await colony.getFundingPotBalance(0, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
@@ -116,7 +117,7 @@ contract("Colony Funding", (accounts) => {
     it("should not let tokens be moved by non-admins", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
       await makeTask({ colony });
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 0, 1, 2, 51, otherToken.address, { from: WORKER }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 1, 2, 51, otherToken.address, { from: WORKER }), "ds-auth-unauthorized");
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
       const pot2Balance = await colony.getFundingPotBalance(2, otherToken.address);
@@ -127,10 +128,10 @@ contract("Colony Funding", (accounts) => {
 
     it("should not allow more tokens to leave a pot than the pot has (even if the colony has that many)", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
-      await colony.addDomain(1, 0, 1);
-      await colony.addDomain(1, 0, 1);
+      await colony.addDomain(1, X, 1);
+      await colony.addDomain(1, X, 1);
 
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 2, 40, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, 0, 1, 2, 40, otherToken.address);
       await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 1, 2, 3, 50, otherToken.address), "ds-math-sub-underflow");
 
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
@@ -191,7 +192,7 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 0, Payout 0
       // FundingPot was equal to payout, transition to pot being equal by changing pot (17)
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 2, 0, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 0, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
@@ -210,13 +211,13 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot Balance: 0, Payout: 40
       // FundingPot was below payout, transition to being equal by increasing pot (1)
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 2, 40, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 40, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot Balance: 40, Payout 40
       // FundingPot was equal to payout, transition to being above by increasing pot (5)
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 2, 40, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 40, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
@@ -248,13 +249,13 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 80, Payout 40
       // FundingPot was above payout, transition to being equal by decreasing pot (11)
-      await colony.moveFundsBetweenPots(1, 0, 0, 2, 1, 40, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, 2, 1, 40, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 40, Payout 40
       // FundingPot was equal to payout, transition to pot being below payout by changing pot (7)
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 0, 2, 1, 20, otherToken.address), "colony-funding-task-bad-state");
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 2, 1, 20, otherToken.address), "colony-funding-task-bad-state");
 
       // Remove 20 from pot
       await executeSignedTaskChange({
@@ -265,7 +266,7 @@ contract("Colony Funding", (accounts) => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 20],
       });
-      await colony.moveFundsBetweenPots(1, 0, 0, 2, 1, 20, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, 2, 1, 20, otherToken.address);
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -277,13 +278,13 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 20, Payout 40
       // FundingPot was below payout, change to being above by changing pot (3)
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 2, 60, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 60, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 80, Payout 40
       // FundingPot was above payout, change to being below by changing pot (9)
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 0, 2, 1, 60, otherToken.address), "colony-funding-task-bad-state");
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 2, 1, 60, otherToken.address), "colony-funding-task-bad-state");
 
       // Remove 60 from pot
       await executeSignedTaskChange({
@@ -294,7 +295,7 @@ contract("Colony Funding", (accounts) => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 20],
       });
-      await colony.moveFundsBetweenPots(1, 0, 0, 2, 1, 60, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, 2, 1, 60, otherToken.address);
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -332,7 +333,7 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 20, Payout 5
       // FundingPot was above, change to being above by changing pot (15)
-      await colony.moveFundsBetweenPots(1, 0, 0, 2, 1, 10, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, 2, 1, 10, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
@@ -364,7 +365,7 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 10, Payout 30
       // FundingPot was below payout, change to being below by changing pot (13)
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 0, 2, 1, 5, otherToken.address), "colony-funding-task-bad-state");
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 2, 1, 5, otherToken.address), "colony-funding-task-bad-state");
 
       // Remove 5 from pot
       await executeSignedTaskChange({
@@ -375,7 +376,7 @@ contract("Colony Funding", (accounts) => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 5],
       });
-      await colony.moveFundsBetweenPots(1, 0, 0, 2, 1, 5, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, 2, 1, 5, otherToken.address);
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -420,7 +421,7 @@ contract("Colony Funding", (accounts) => {
       // Note that the reward pot with id 0 is NOT included in the Colony Funding funding pots count
       expect(potCountBefore).to.eq.BN(1);
 
-      await colony.addDomain(1, 0, 1);
+      await colony.addDomain(1, X, 1);
       const potCountAfterAddingDomain = await colony.getFundingPotCount();
       expect(potCountAfterAddingDomain).to.eq.BN(2);
 
@@ -436,14 +437,14 @@ contract("Colony Funding", (accounts) => {
 
     it("should not allow contributions to nonexistent funding pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 0, 1, 5, 40, otherToken.address), "colony-funding-nonexistent-pot");
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 1, 5, 40, otherToken.address), "colony-funding-nonexistent-pot");
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       expect(colonyPotBalance).to.eq.BN(99);
     });
 
     it("should not allow attempts to move funds from nonexistent funding pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 0, 5, 1, 40, otherToken.address), "colony-funding-nonexistent-pot");
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 5, 1, 40, otherToken.address), "colony-funding-nonexistent-pot");
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       expect(colonyPotBalance).to.eq.BN(99);
     });
@@ -451,7 +452,7 @@ contract("Colony Funding", (accounts) => {
     it("should not allow funds to be removed from a task with payouts to go", async () => {
       await fundColonyWithTokens(colony, otherToken, INITIAL_FUNDING);
       await setupFinalizedTask({ colonyNetwork, colony, token: otherToken });
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 0, 2, 1, 40, otherToken.address), "colony-funding-task-bad-state");
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 2, 1, 40, otherToken.address), "colony-funding-task-bad-state");
       const colonyPotBalance = await colony.getFundingPotBalance(2, otherToken.address);
       expect(colonyPotBalance).to.eq.BN(MANAGER_PAYOUT.add(EVALUATOR_PAYOUT).add(WORKER_PAYOUT));
     });
@@ -460,11 +461,11 @@ contract("Colony Funding", (accounts) => {
       await fundColonyWithTokens(colony, otherToken, WAD.muln(363));
       const taskId = await setupFinalizedTask({ colonyNetwork, colony, token: otherToken });
 
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 2, 10, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 10, otherToken.address);
       await colony.claimTaskPayout(taskId, MANAGER_ROLE, otherToken.address);
       await colony.claimTaskPayout(taskId, WORKER_ROLE, otherToken.address);
       await colony.claimTaskPayout(taskId, EVALUATOR_ROLE, otherToken.address);
-      await colony.moveFundsBetweenPots(1, 0, 0, 2, 1, 10, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, 2, 1, 10, otherToken.address);
 
       const colonyPotBalance = await colony.getFundingPotBalance(2, otherToken.address);
       expect(colonyPotBalance).to.be.zero;
@@ -487,7 +488,7 @@ contract("Colony Funding", (accounts) => {
       const remainingPotBalance = await colony.getFundingPotBalance(task.fundingPotId, token.address);
       expect(remainingPotBalance).to.eq.BN(WORKER_PAYOUT);
 
-      await colony.moveFundsBetweenPots(1, 0, 0, task.fundingPotId, 1, remainingPotBalance, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, task.fundingPotId, 1, remainingPotBalance, token.address);
 
       const potBalance = await colony.getFundingPotBalance(task.fundingPotId, token.address);
       expect(potBalance).to.be.zero;
@@ -516,7 +517,7 @@ contract("Colony Funding", (accounts) => {
       await colony.send(100);
       await colony.claimColonyFunds(ethers.constants.AddressZero);
       await makeTask({ colony });
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 2, 51, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 51, ethers.constants.AddressZero);
       const colonyPotBalance = await colony.getFundingPotBalance(1, ethers.constants.AddressZero);
       const colonyEtherBalance = await web3GetBalance(colony.address);
       const pot2Balance = await colony.getFundingPotBalance(2, ethers.constants.AddressZero);
@@ -528,10 +529,10 @@ contract("Colony Funding", (accounts) => {
     it("should not allow more ether to leave a pot than the pot has (even if the colony has that many)", async () => {
       await colony.send(100);
       await colony.claimColonyFunds(ethers.constants.AddressZero);
-      await colony.addDomain(1, 0, 1);
-      await colony.addDomain(1, 0, 1);
+      await colony.addDomain(1, X, 1);
+      await colony.addDomain(1, X, 1);
 
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 2, 40, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, X, 0, 1, 2, 40, ethers.constants.AddressZero);
       await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 1, 2, 3, 50, ethers.constants.AddressZero), "ds-math-sub-underflow");
 
       const colonyEtherBalance = await web3GetBalance(colony.address);
@@ -572,12 +573,12 @@ contract("Colony Funding", (accounts) => {
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
       // Fund the pot equal to manager payout 40 = 40
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 2, 40, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 40, ethers.constants.AddressZero);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // Cannot bring pot balance below current payout
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 0, 2, 1, 30, ethers.constants.AddressZero), "colony-funding-task-bad-state");
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 2, 1, 30, ethers.constants.AddressZero), "colony-funding-task-bad-state");
 
       // Set manager payout above pot value 50 > 40
       await executeSignedTaskChange({
@@ -592,15 +593,15 @@ contract("Colony Funding", (accounts) => {
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
       // Fund the pot equal to manager payout, plus 10, 50 < 60
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 2, 20, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 20, ethers.constants.AddressZero);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // Cannot bring pot balance below current payout
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 0, 2, 1, 30, ethers.constants.AddressZero), "colony-funding-task-bad-state");
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 2, 1, 30, ethers.constants.AddressZero), "colony-funding-task-bad-state");
 
       // Can remove surplus 50 = 50
-      await colony.moveFundsBetweenPots(1, 0, 0, 2, 1, 10, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, X, X, 2, 1, 10, ethers.constants.AddressZero);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
     });

--- a/test/contracts-network/colony-funding.js
+++ b/test/contracts-network/colony-funding.js
@@ -4,7 +4,7 @@ import bnChai from "bn-chai";
 import { ethers } from "ethers";
 
 import {
-  X,
+  UINT256_MAX,
   WAD,
   MANAGER_ROLE,
   EVALUATOR_ROLE,
@@ -79,8 +79,9 @@ contract("Colony Funding", (accounts) => {
 
     it("should let tokens be moved between funding pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
-      await makeTask({ colony });
-      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 51, otherToken.address);
+      const taskId = await makeTask({ colony });
+      const task = await colony.getTask(taskId);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 51, otherToken.address);
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
       const pot2Balance = await colony.getFundingPotBalance(2, otherToken.address);
@@ -92,7 +93,7 @@ contract("Colony Funding", (accounts) => {
     it("should not let tokens be moved between the same pot", async () => {
       await fundColonyWithTokens(colony, otherToken, 1);
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, X, X, 1, 1, 1, otherToken.address),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 1, 1, otherToken.address),
         "colony-funding-cannot-move-funds-between-the-same-pot"
       );
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
@@ -101,9 +102,13 @@ contract("Colony Funding", (accounts) => {
 
     it("should not let tokens be moved from the pot for payouts to token holders", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
-      await makeTask({ colony });
+      const taskId = await makeTask({ colony });
+      const task = await colony.getTask(taskId);
 
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 0, 2, 1, otherToken.address), "colony-funding-cannot-move-funds-from-rewards-pot");
+      await checkErrorRevert(
+        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 0, task.fundingPotId, 1, otherToken.address),
+        "colony-funding-cannot-move-funds-from-rewards-pot"
+      );
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       const colonyRewardPotBalance = await colony.getFundingPotBalance(0, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
@@ -116,8 +121,14 @@ contract("Colony Funding", (accounts) => {
 
     it("should not let tokens be moved by non-admins", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
-      await makeTask({ colony });
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 1, 2, 51, otherToken.address, { from: WORKER }), "ds-auth-unauthorized");
+      const taskId = await makeTask({ colony });
+      const task = await colony.getTask(taskId);
+
+      await checkErrorRevert(
+        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 51, otherToken.address, { from: WORKER }),
+        "ds-auth-unauthorized"
+      );
+
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
       const pot2Balance = await colony.getFundingPotBalance(2, otherToken.address);
@@ -128,10 +139,10 @@ contract("Colony Funding", (accounts) => {
 
     it("should not allow more tokens to leave a pot than the pot has (even if the colony has that many)", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
-      await colony.addDomain(1, X, 1);
-      await colony.addDomain(1, X, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
 
-      await colony.moveFundsBetweenPots(1, X, 0, 1, 2, 40, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, 1, 2, 40, otherToken.address);
       await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 1, 2, 3, 50, otherToken.address), "ds-math-sub-underflow");
 
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
@@ -192,7 +203,7 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 0, Payout 0
       // FundingPot was equal to payout, transition to pot being equal by changing pot (17)
-      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 0, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 0, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
@@ -211,13 +222,13 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot Balance: 0, Payout: 40
       // FundingPot was below payout, transition to being equal by increasing pot (1)
-      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 40, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 40, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot Balance: 40, Payout 40
       // FundingPot was equal to payout, transition to being above by increasing pot (5)
-      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 40, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 40, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
@@ -249,13 +260,16 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 80, Payout 40
       // FundingPot was above payout, transition to being equal by decreasing pot (11)
-      await colony.moveFundsBetweenPots(1, X, X, 2, 1, 40, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 40, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 40, Payout 40
       // FundingPot was equal to payout, transition to pot being below payout by changing pot (7)
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 2, 1, 20, otherToken.address), "colony-funding-task-bad-state");
+      await checkErrorRevert(
+        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 20, otherToken.address),
+        "colony-funding-task-bad-state"
+      );
 
       // Remove 20 from pot
       await executeSignedTaskChange({
@@ -266,7 +280,7 @@ contract("Colony Funding", (accounts) => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 20],
       });
-      await colony.moveFundsBetweenPots(1, X, X, 2, 1, 20, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 20, otherToken.address);
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -278,13 +292,16 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 20, Payout 40
       // FundingPot was below payout, change to being above by changing pot (3)
-      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 60, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 60, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 80, Payout 40
       // FundingPot was above payout, change to being below by changing pot (9)
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 2, 1, 60, otherToken.address), "colony-funding-task-bad-state");
+      await checkErrorRevert(
+        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 60, otherToken.address),
+        "colony-funding-task-bad-state"
+      );
 
       // Remove 60 from pot
       await executeSignedTaskChange({
@@ -295,7 +312,7 @@ contract("Colony Funding", (accounts) => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 20],
       });
-      await colony.moveFundsBetweenPots(1, X, X, 2, 1, 60, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 60, otherToken.address);
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -333,7 +350,7 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 20, Payout 5
       // FundingPot was above, change to being above by changing pot (15)
-      await colony.moveFundsBetweenPots(1, X, X, 2, 1, 10, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 10, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
@@ -365,7 +382,10 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 10, Payout 30
       // FundingPot was below payout, change to being below by changing pot (13)
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 2, 1, 5, otherToken.address), "colony-funding-task-bad-state");
+      await checkErrorRevert(
+        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 5, otherToken.address),
+        "colony-funding-task-bad-state"
+      );
 
       // Remove 5 from pot
       await executeSignedTaskChange({
@@ -376,7 +396,7 @@ contract("Colony Funding", (accounts) => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 5],
       });
-      await colony.moveFundsBetweenPots(1, X, X, 2, 1, 5, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 5, otherToken.address);
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -421,7 +441,7 @@ contract("Colony Funding", (accounts) => {
       // Note that the reward pot with id 0 is NOT included in the Colony Funding funding pots count
       expect(potCountBefore).to.eq.BN(1);
 
-      await colony.addDomain(1, X, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
       const potCountAfterAddingDomain = await colony.getFundingPotCount();
       expect(potCountAfterAddingDomain).to.eq.BN(2);
 
@@ -437,22 +457,28 @@ contract("Colony Funding", (accounts) => {
 
     it("should not allow contributions to nonexistent funding pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 1, 5, 40, otherToken.address), "colony-funding-nonexistent-pot");
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, UINT256_MAX, 3, 1, 5, 40, otherToken.address), "colony-funding-nonexistent-pot");
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       expect(colonyPotBalance).to.eq.BN(99);
     });
 
     it("should not allow attempts to move funds from nonexistent funding pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 5, 1, 40, otherToken.address), "colony-funding-nonexistent-pot");
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, 3, UINT256_MAX, 5, 1, 40, otherToken.address), "colony-funding-nonexistent-pot");
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       expect(colonyPotBalance).to.eq.BN(99);
     });
 
     it("should not allow funds to be removed from a task with payouts to go", async () => {
       await fundColonyWithTokens(colony, otherToken, INITIAL_FUNDING);
-      await setupFinalizedTask({ colonyNetwork, colony, token: otherToken });
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 2, 1, 40, otherToken.address), "colony-funding-task-bad-state");
+      const taskId = await setupFinalizedTask({ colonyNetwork, colony, token: otherToken });
+      const task = await colony.getTask(taskId);
+
+      await checkErrorRevert(
+        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 40, otherToken.address),
+        "colony-funding-task-bad-state"
+      );
+
       const colonyPotBalance = await colony.getFundingPotBalance(2, otherToken.address);
       expect(colonyPotBalance).to.eq.BN(MANAGER_PAYOUT.add(EVALUATOR_PAYOUT).add(WORKER_PAYOUT));
     });
@@ -461,11 +487,12 @@ contract("Colony Funding", (accounts) => {
       await fundColonyWithTokens(colony, otherToken, WAD.muln(363));
       const taskId = await setupFinalizedTask({ colonyNetwork, colony, token: otherToken });
 
-      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 10, otherToken.address);
+      const task = await colony.getTask(taskId);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 10, otherToken.address);
       await colony.claimTaskPayout(taskId, MANAGER_ROLE, otherToken.address);
       await colony.claimTaskPayout(taskId, WORKER_ROLE, otherToken.address);
       await colony.claimTaskPayout(taskId, EVALUATOR_ROLE, otherToken.address);
-      await colony.moveFundsBetweenPots(1, X, X, 2, 1, 10, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 10, otherToken.address);
 
       const colonyPotBalance = await colony.getFundingPotBalance(2, otherToken.address);
       expect(colonyPotBalance).to.be.zero;
@@ -488,7 +515,7 @@ contract("Colony Funding", (accounts) => {
       const remainingPotBalance = await colony.getFundingPotBalance(task.fundingPotId, token.address);
       expect(remainingPotBalance).to.eq.BN(WORKER_PAYOUT);
 
-      await colony.moveFundsBetweenPots(1, X, X, task.fundingPotId, 1, remainingPotBalance, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, remainingPotBalance, token.address);
 
       const potBalance = await colony.getFundingPotBalance(task.fundingPotId, token.address);
       expect(potBalance).to.be.zero;
@@ -516,8 +543,9 @@ contract("Colony Funding", (accounts) => {
     it("should let ether be moved between funding pots", async () => {
       await colony.send(100);
       await colony.claimColonyFunds(ethers.constants.AddressZero);
-      await makeTask({ colony });
-      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 51, ethers.constants.AddressZero);
+      const taskId = await makeTask({ colony });
+      const task = await colony.getTask(taskId);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 51, ethers.constants.AddressZero);
       const colonyPotBalance = await colony.getFundingPotBalance(1, ethers.constants.AddressZero);
       const colonyEtherBalance = await web3GetBalance(colony.address);
       const pot2Balance = await colony.getFundingPotBalance(2, ethers.constants.AddressZero);
@@ -529,10 +557,10 @@ contract("Colony Funding", (accounts) => {
     it("should not allow more ether to leave a pot than the pot has (even if the colony has that many)", async () => {
       await colony.send(100);
       await colony.claimColonyFunds(ethers.constants.AddressZero);
-      await colony.addDomain(1, X, 1);
-      await colony.addDomain(1, X, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
 
-      await colony.moveFundsBetweenPots(1, X, 0, 1, 2, 40, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, 1, 2, 40, ethers.constants.AddressZero);
       await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 1, 2, 3, 50, ethers.constants.AddressZero), "ds-math-sub-underflow");
 
       const colonyEtherBalance = await web3GetBalance(colony.address);
@@ -549,6 +577,8 @@ contract("Colony Funding", (accounts) => {
       await colony.send(100);
       await colony.claimColonyFunds(ethers.constants.AddressZero);
       const taskId = await makeTask({ colony });
+      const task = await colony.getTask(taskId);
+
       await executeSignedRoleAssignment({
         colony,
         taskId,
@@ -568,17 +598,19 @@ contract("Colony Funding", (accounts) => {
         args: [taskId, ethers.constants.AddressZero, 40],
       });
 
-      const task = await colony.getTask(taskId);
       let fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
       // Fund the pot equal to manager payout 40 = 40
-      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 40, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 40, ethers.constants.AddressZero);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // Cannot bring pot balance below current payout
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 2, 1, 30, ethers.constants.AddressZero), "colony-funding-task-bad-state");
+      await checkErrorRevert(
+        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 30, ethers.constants.AddressZero),
+        "colony-funding-task-bad-state"
+      );
 
       // Set manager payout above pot value 50 > 40
       await executeSignedTaskChange({
@@ -593,15 +625,18 @@ contract("Colony Funding", (accounts) => {
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
       // Fund the pot equal to manager payout, plus 10, 50 < 60
-      await colony.moveFundsBetweenPots(1, X, X, 1, 2, 20, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 20, ethers.constants.AddressZero);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // Cannot bring pot balance below current payout
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, X, X, 2, 1, 30, ethers.constants.AddressZero), "colony-funding-task-bad-state");
+      await checkErrorRevert(
+        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 30, ethers.constants.AddressZero),
+        "colony-funding-task-bad-state"
+      );
 
       // Can remove surplus 50 = 50
-      await colony.moveFundsBetweenPots(1, X, X, 2, 1, 10, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 10, ethers.constants.AddressZero);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
     });

--- a/test/contracts-network/colony-payment.js
+++ b/test/contracts-network/colony-payment.js
@@ -4,7 +4,7 @@ import bnChai from "bn-chai";
 import BN from "bn.js";
 import { ethers } from "ethers";
 
-import { WAD, MAX_PAYOUT } from "../../helpers/constants";
+import { X, WAD, MAX_PAYOUT } from "../../helpers/constants";
 import { checkErrorRevert, getTokenArgs } from "../../helpers/test-helper";
 import { fundColonyWithTokens, setupRandomColony } from "../../helpers/test-data-generator";
 
@@ -34,7 +34,7 @@ contract("Colony Payment", (accounts) => {
 
     ({ colony, token } = await setupRandomColony(colonyNetwork));
     await colony.setRewardInverse(100);
-    await colony.setAdministrationRole(1, 0, COLONY_ADMIN, 1, true);
+    await colony.setAdministrationRole(1, X, COLONY_ADMIN, 1, true);
     await fundColonyWithTokens(colony, token, WAD.muln(20));
 
     const tokenArgs = getTokenArgs();
@@ -45,7 +45,7 @@ contract("Colony Payment", (accounts) => {
   describe("when adding payments", () => {
     it("should allow admins to add payment", async () => {
       const paymentsCountBefore = await colony.getPaymentCount();
-      await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
 
       const paymentsCountAfter = await colony.getPaymentCount();
       expect(paymentsCountAfter.sub(paymentsCountBefore)).to.eq.BN(1);
@@ -68,20 +68,20 @@ contract("Colony Payment", (accounts) => {
 
     it("should not allow admins to add payment with no domain set", async () => {
       await checkErrorRevert(
-        colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 0, 0, { from: COLONY_ADMIN }),
+        colony.addPayment(1, X, RECIPIENT, token.address, WAD, 0, 0, { from: COLONY_ADMIN }),
         "ds-auth-child-domain-does-not-exist"
       );
     });
 
     it("should not allow admins to add payment with no recipient set", async () => {
       await checkErrorRevert(
-        colony.addPayment(1, 0, ethers.constants.AddressZero, token.address, WAD, 1, 0, { from: COLONY_ADMIN }),
+        colony.addPayment(1, X, ethers.constants.AddressZero, token.address, WAD, 1, 0, { from: COLONY_ADMIN }),
         "colony-payment-invalid-recipient"
       );
     });
 
     it("should allow admins to add payment with zero token amount", async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, 0, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, X, RECIPIENT, token.address, 0, 1, 0, { from: COLONY_ADMIN });
 
       const fundingPotId = await colony.getFundingPotCount();
       const fundingPotBalance = await colony.getFundingPotBalance(fundingPotId, token.address);
@@ -94,18 +94,18 @@ contract("Colony Payment", (accounts) => {
       await metaColony.deprecateGlobalSkill(skillId);
 
       await checkErrorRevert(
-        colony.addPayment(1, 0, RECIPIENT, token.address, 0, 1, skillId, { from: COLONY_ADMIN }),
+        colony.addPayment(1, X, RECIPIENT, token.address, 0, 1, skillId, { from: COLONY_ADMIN }),
         "colony-deprecated-global-skill"
       );
     });
 
     it("should not allow non-admins to add payment", async () => {
-      await checkErrorRevert(colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: accounts[10] }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: accounts[10] }), "ds-auth-unauthorized");
     });
 
     it("should not be able to set a payout above the limit", async () => {
       await checkErrorRevert(
-        colony.addPayment(1, 0, RECIPIENT, token.address, MAX_PAYOUT.addn(1), 1, 0, { from: COLONY_ADMIN }),
+        colony.addPayment(1, X, RECIPIENT, token.address, MAX_PAYOUT.addn(1), 1, 0, { from: COLONY_ADMIN }),
         "colony-payout-too-large"
       );
     });
@@ -113,58 +113,58 @@ contract("Colony Payment", (accounts) => {
 
   describe("when updating payments", () => {
     it("should allow admins to update recipient", async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
-      await colony.setPaymentRecipient(1, 0, paymentId, accounts[10], { from: COLONY_ADMIN });
+      await colony.setPaymentRecipient(1, X, paymentId, accounts[10], { from: COLONY_ADMIN });
       const payment = await colony.getPayment(paymentId);
       expect(payment.recipient).to.equal(accounts[10]);
     });
 
     it("should not allow admins to update to empty recipient", async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
       await checkErrorRevert(
-        colony.setPaymentRecipient(1, 0, paymentId, ethers.constants.AddressZero, { from: COLONY_ADMIN }),
+        colony.setPaymentRecipient(1, X, paymentId, ethers.constants.AddressZero, { from: COLONY_ADMIN }),
         "colony-payment-invalid-recipient"
       );
     });
 
     it("should allow admins to update skill", async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
       let payment = await colony.getPayment(paymentId);
       expect(payment.skills[0]).to.eq.BN(0);
-      await colony.setPaymentSkill(1, 0, paymentId, 3, { from: COLONY_ADMIN });
+      await colony.setPaymentSkill(1, X, paymentId, 3, { from: COLONY_ADMIN });
       payment = await colony.getPayment(paymentId);
       expect(payment.skills[0]).to.eq.BN(3);
     });
 
     it("should not allow admins to update payment with deprecated global skill", async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
       await metaColony.addGlobalSkill();
       const skillId = await colonyNetwork.getSkillCount();
       await metaColony.deprecateGlobalSkill(skillId);
 
-      await checkErrorRevert(colony.setPaymentSkill(1, 0, paymentId, skillId, { from: COLONY_ADMIN }), "colony-deprecated-global-skill");
+      await checkErrorRevert(colony.setPaymentSkill(1, X, paymentId, skillId, { from: COLONY_ADMIN }), "colony-deprecated-global-skill");
     });
 
     it("should not allow non-admins to update recipient", async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
-      await checkErrorRevert(colony.setPaymentRecipient(1, 0, paymentId, accounts[7], { from: accounts[10] }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.setPaymentRecipient(1, X, paymentId, accounts[7], { from: accounts[10] }), "ds-auth-unauthorized");
     });
 
     it("should be able to add multiple payouts", async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
-      await colony.setPaymentPayout(1, 0, paymentId, otherToken.address, 100);
+      await colony.setPaymentPayout(1, X, paymentId, otherToken.address, 100);
       const payment = await colony.getPayment(paymentId);
       const fundingPotPayoutForToken = await colony.getFundingPotPayout(payment.fundingPotId, token.address);
       const fundingPotPayoutForOtherToken = await colony.getFundingPotPayout(payment.fundingPotId, otherToken.address);
@@ -173,27 +173,27 @@ contract("Colony Payment", (accounts) => {
     });
 
     it("should allow admins to fund a payment", async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0);
+      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0);
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
       const fundingPotPayoutForToken = await colony.getFundingPotPayout(payment.fundingPotId, token.address);
       expect(fundingPotPayoutForToken).to.eq.BN(WAD);
 
       await fundColonyWithTokens(colony, token, 40);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, payment.fundingPotId, 40, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, 40, token.address);
       const fundingPotBalanceForToken = await colony.getFundingPotBalance(payment.fundingPotId, token.address);
       expect(fundingPotBalanceForToken).to.eq.BN(40);
     });
 
     it("should allow admins to set token payment to zero", async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
       const fundingPotId = await colony.getFundingPotCount();
       let fundingPotPayout = await colony.getFundingPotPayout(paymentId, token.address);
       expect(fundingPotPayout).to.eq.BN(WAD);
 
-      await colony.setPaymentPayout(1, 0, paymentId, token.address, 0);
+      await colony.setPaymentPayout(1, X, paymentId, token.address, 0);
       fundingPotPayout = await colony.getFundingPotPayout(fundingPotId, token.address);
       expect(fundingPotPayout).to.be.zero;
     });
@@ -203,18 +203,18 @@ contract("Colony Payment", (accounts) => {
     let paymentId;
 
     beforeEach(async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, 40, 1, 0);
+      await colony.addPayment(1, X, RECIPIENT, token.address, 40, 1, 0);
       paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
       await fundColonyWithTokens(colony, token, 40);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, payment.fundingPotId, 40, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, 40, token.address);
     });
 
     it("can finalize payment when it is fully funded", async () => {
       let payment = await colony.getPayment(paymentId);
       expect(payment.finalized).to.be.false;
 
-      await colony.finalizePayment(1, 0, paymentId);
+      await colony.finalizePayment(1, X, paymentId);
 
       payment = await colony.getPayment(paymentId);
       expect(payment.finalized).to.be.true;
@@ -222,38 +222,38 @@ contract("Colony Payment", (accounts) => {
 
     it("cannnot finalize payment if it is NOT fully funded", async () => {
       const payment = await colony.getPayment(paymentId);
-      await colony.moveFundsBetweenPots(1, 0, 0, payment.fundingPotId, 1, 1, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, payment.fundingPotId, 1, 1, token.address);
       expect(payment.finalized).to.be.false;
 
-      await checkErrorRevert(colony.finalizePayment(1, 0, paymentId), "colony-payment-not-funded");
+      await checkErrorRevert(colony.finalizePayment(1, X, paymentId), "colony-payment-not-funded");
     });
 
     it("cannot finalize payment not authorised", async () => {
       const payment = await colony.getPayment(paymentId);
       expect(payment.finalized).to.be.false;
 
-      await checkErrorRevert(colony.finalizePayment(1, 0, paymentId, { from: accounts[10] }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.finalizePayment(1, X, paymentId, { from: accounts[10] }), "ds-auth-unauthorized");
     });
 
     it("should not allow admins to update recipient", async () => {
-      await colony.finalizePayment(1, 0, paymentId);
-      await checkErrorRevert(colony.setPaymentRecipient(1, 0, paymentId, accounts[6], { from: COLONY_ADMIN }), "colony-payment-finalized");
+      await colony.finalizePayment(1, X, paymentId);
+      await checkErrorRevert(colony.setPaymentRecipient(1, X, paymentId, accounts[6], { from: COLONY_ADMIN }), "colony-payment-finalized");
     });
 
     it("should not allow admins to update skill", async () => {
-      await colony.finalizePayment(1, 0, paymentId);
-      await checkErrorRevert(colony.setPaymentSkill(1, 0, paymentId, 1, { from: COLONY_ADMIN }), "colony-payment-finalized");
+      await colony.finalizePayment(1, X, paymentId);
+      await checkErrorRevert(colony.setPaymentSkill(1, X, paymentId, 1, { from: COLONY_ADMIN }), "colony-payment-finalized");
     });
 
     it("should not allow admins to update payment", async () => {
-      await colony.finalizePayment(1, 0, paymentId);
-      await checkErrorRevert(colony.setPaymentPayout(1, 0, paymentId, token.address, 1, { from: COLONY_ADMIN }), "colony-payment-finalized");
+      await colony.finalizePayment(1, X, paymentId);
+      await checkErrorRevert(colony.setPaymentPayout(1, X, paymentId, token.address, 1, { from: COLONY_ADMIN }), "colony-payment-finalized");
     });
 
     it("should not be able to set a payout above the limit", async () => {
-      await colony.finalizePayment(1, 0, paymentId);
+      await colony.finalizePayment(1, X, paymentId);
       await checkErrorRevert(
-        colony.setPaymentPayout(1, 0, paymentId, token.address, MAX_PAYOUT.addn(1), { from: COLONY_ADMIN }),
+        colony.setPaymentPayout(1, X, paymentId, token.address, MAX_PAYOUT.addn(1), { from: COLONY_ADMIN }),
         "colony-payout-too-large"
       );
     });
@@ -261,12 +261,12 @@ contract("Colony Payment", (accounts) => {
 
   describe("when claiming payments", () => {
     it("should allow recipient to claim their payment and network fee is deducated", async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0);
+      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0);
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
-      await colony.finalizePayment(1, 0, paymentId);
+      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.finalizePayment(1, X, paymentId);
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
       const networkBalanceBefore = await token.balanceOf(colonyNetwork.address);
@@ -279,12 +279,12 @@ contract("Colony Payment", (accounts) => {
     });
 
     it("should allow anyone to claim on behalf of the recipient", async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0);
+      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0);
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
-      await colony.finalizePayment(1, 0, paymentId);
+      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.finalizePayment(1, X, paymentId);
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
       const networkBalanceBefore = await token.balanceOf(colonyNetwork.address);
@@ -297,12 +297,12 @@ contract("Colony Payment", (accounts) => {
     });
 
     it("after payment is claimed it should set the payout to 0", async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, WAD, 1, 0);
+      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0);
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
-      await colony.finalizePayment(1, 0, paymentId);
+      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.finalizePayment(1, X, paymentId);
       await colony.claimPayment(paymentId, token.address);
 
       const tokenPayout = await colony.getFundingPotPayout(payment.fundingPotId, token.address);
@@ -310,37 +310,37 @@ contract("Colony Payment", (accounts) => {
     });
 
     it("should error when payment is not funded and finalized", async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, 10000, 1, 0);
+      await colony.addPayment(1, X, RECIPIENT, token.address, 10000, 1, 0);
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, payment.fundingPotId, 9999, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, 9999, token.address);
       await checkErrorRevert(colony.claimPayment(paymentId, token.address), "colony-payment-not-finalized");
     });
 
     it("should allow multiple payouts to be claimed", async () => {
-      await colony.addPayment(1, 0, RECIPIENT, token.address, 200, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, X, RECIPIENT, token.address, 200, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
       let payment = await colony.getPayment(paymentId);
 
-      await colony.setPaymentPayout(1, 0, paymentId, otherToken.address, 100);
+      await colony.setPaymentPayout(1, X, paymentId, otherToken.address, 100);
       await fundColonyWithTokens(colony, otherToken, 101);
       let fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(2);
 
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, payment.fundingPotId, 199, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, 199, token.address);
       fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(2);
 
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, payment.fundingPotId, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, 100, otherToken.address);
       fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
-      await colony.setPaymentPayout(1, 0, paymentId, token.address, 199);
+      await colony.setPaymentPayout(1, X, paymentId, token.address, 199);
       fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
-      await colony.finalizePayment(1, 0, paymentId);
+      await colony.finalizePayment(1, X, paymentId);
       payment = await colony.getPayment(paymentId);
       expect(payment.finalized).to.be.true;
 

--- a/test/contracts-network/colony-payment.js
+++ b/test/contracts-network/colony-payment.js
@@ -4,7 +4,7 @@ import bnChai from "bn-chai";
 import BN from "bn.js";
 import { ethers } from "ethers";
 
-import { X, WAD, MAX_PAYOUT } from "../../helpers/constants";
+import { UINT256_MAX, WAD, MAX_PAYOUT } from "../../helpers/constants";
 import { checkErrorRevert, getTokenArgs } from "../../helpers/test-helper";
 import { fundColonyWithTokens, setupRandomColony } from "../../helpers/test-data-generator";
 
@@ -34,7 +34,7 @@ contract("Colony Payment", (accounts) => {
 
     ({ colony, token } = await setupRandomColony(colonyNetwork));
     await colony.setRewardInverse(100);
-    await colony.setAdministrationRole(1, X, COLONY_ADMIN, 1, true);
+    await colony.setAdministrationRole(1, UINT256_MAX, COLONY_ADMIN, 1, true);
     await fundColonyWithTokens(colony, token, WAD.muln(20));
 
     const tokenArgs = getTokenArgs();
@@ -45,7 +45,7 @@ contract("Colony Payment", (accounts) => {
   describe("when adding payments", () => {
     it("should allow admins to add payment", async () => {
       const paymentsCountBefore = await colony.getPaymentCount();
-      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
 
       const paymentsCountAfter = await colony.getPaymentCount();
       expect(paymentsCountAfter.sub(paymentsCountBefore)).to.eq.BN(1);
@@ -68,20 +68,20 @@ contract("Colony Payment", (accounts) => {
 
     it("should not allow admins to add payment with no domain set", async () => {
       await checkErrorRevert(
-        colony.addPayment(1, X, RECIPIENT, token.address, WAD, 0, 0, { from: COLONY_ADMIN }),
+        colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, WAD, 0, 0, { from: COLONY_ADMIN }),
         "ds-auth-child-domain-does-not-exist"
       );
     });
 
     it("should not allow admins to add payment with no recipient set", async () => {
       await checkErrorRevert(
-        colony.addPayment(1, X, ethers.constants.AddressZero, token.address, WAD, 1, 0, { from: COLONY_ADMIN }),
+        colony.addPayment(1, UINT256_MAX, ethers.constants.AddressZero, token.address, WAD, 1, 0, { from: COLONY_ADMIN }),
         "colony-payment-invalid-recipient"
       );
     });
 
     it("should allow admins to add payment with zero token amount", async () => {
-      await colony.addPayment(1, X, RECIPIENT, token.address, 0, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, 0, 1, 0, { from: COLONY_ADMIN });
 
       const fundingPotId = await colony.getFundingPotCount();
       const fundingPotBalance = await colony.getFundingPotBalance(fundingPotId, token.address);
@@ -94,18 +94,18 @@ contract("Colony Payment", (accounts) => {
       await metaColony.deprecateGlobalSkill(skillId);
 
       await checkErrorRevert(
-        colony.addPayment(1, X, RECIPIENT, token.address, 0, 1, skillId, { from: COLONY_ADMIN }),
+        colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, 0, 1, skillId, { from: COLONY_ADMIN }),
         "colony-deprecated-global-skill"
       );
     });
 
     it("should not allow non-admins to add payment", async () => {
-      await checkErrorRevert(colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: accounts[10] }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, WAD, 1, 0, { from: accounts[10] }), "ds-auth-unauthorized");
     });
 
     it("should not be able to set a payout above the limit", async () => {
       await checkErrorRevert(
-        colony.addPayment(1, X, RECIPIENT, token.address, MAX_PAYOUT.addn(1), 1, 0, { from: COLONY_ADMIN }),
+        colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, MAX_PAYOUT.addn(1), 1, 0, { from: COLONY_ADMIN }),
         "colony-payout-too-large"
       );
     });
@@ -113,58 +113,58 @@ contract("Colony Payment", (accounts) => {
 
   describe("when updating payments", () => {
     it("should allow admins to update recipient", async () => {
-      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
-      await colony.setPaymentRecipient(1, X, paymentId, accounts[10], { from: COLONY_ADMIN });
+      await colony.setPaymentRecipient(1, UINT256_MAX, paymentId, accounts[10], { from: COLONY_ADMIN });
       const payment = await colony.getPayment(paymentId);
       expect(payment.recipient).to.equal(accounts[10]);
     });
 
     it("should not allow admins to update to empty recipient", async () => {
-      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
       await checkErrorRevert(
-        colony.setPaymentRecipient(1, X, paymentId, ethers.constants.AddressZero, { from: COLONY_ADMIN }),
+        colony.setPaymentRecipient(1, UINT256_MAX, paymentId, ethers.constants.AddressZero, { from: COLONY_ADMIN }),
         "colony-payment-invalid-recipient"
       );
     });
 
     it("should allow admins to update skill", async () => {
-      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
       let payment = await colony.getPayment(paymentId);
       expect(payment.skills[0]).to.eq.BN(0);
-      await colony.setPaymentSkill(1, X, paymentId, 3, { from: COLONY_ADMIN });
+      await colony.setPaymentSkill(1, UINT256_MAX, paymentId, 3, { from: COLONY_ADMIN });
       payment = await colony.getPayment(paymentId);
       expect(payment.skills[0]).to.eq.BN(3);
     });
 
     it("should not allow admins to update payment with deprecated global skill", async () => {
-      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
       await metaColony.addGlobalSkill();
       const skillId = await colonyNetwork.getSkillCount();
       await metaColony.deprecateGlobalSkill(skillId);
 
-      await checkErrorRevert(colony.setPaymentSkill(1, X, paymentId, skillId, { from: COLONY_ADMIN }), "colony-deprecated-global-skill");
+      await checkErrorRevert(colony.setPaymentSkill(1, UINT256_MAX, paymentId, skillId, { from: COLONY_ADMIN }), "colony-deprecated-global-skill");
     });
 
     it("should not allow non-admins to update recipient", async () => {
-      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
-      await checkErrorRevert(colony.setPaymentRecipient(1, X, paymentId, accounts[7], { from: accounts[10] }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.setPaymentRecipient(1, UINT256_MAX, paymentId, accounts[7], { from: accounts[10] }), "ds-auth-unauthorized");
     });
 
     it("should be able to add multiple payouts", async () => {
-      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
-      await colony.setPaymentPayout(1, X, paymentId, otherToken.address, 100);
+      await colony.setPaymentPayout(1, UINT256_MAX, paymentId, otherToken.address, 100);
       const payment = await colony.getPayment(paymentId);
       const fundingPotPayoutForToken = await colony.getFundingPotPayout(payment.fundingPotId, token.address);
       const fundingPotPayoutForOtherToken = await colony.getFundingPotPayout(payment.fundingPotId, otherToken.address);
@@ -173,27 +173,27 @@ contract("Colony Payment", (accounts) => {
     });
 
     it("should allow admins to fund a payment", async () => {
-      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0);
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, WAD, 1, 0);
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
       const fundingPotPayoutForToken = await colony.getFundingPotPayout(payment.fundingPotId, token.address);
       expect(fundingPotPayoutForToken).to.eq.BN(WAD);
 
       await fundColonyWithTokens(colony, token, 40);
-      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, 40, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 40, token.address);
       const fundingPotBalanceForToken = await colony.getFundingPotBalance(payment.fundingPotId, token.address);
       expect(fundingPotBalanceForToken).to.eq.BN(40);
     });
 
     it("should allow admins to set token payment to zero", async () => {
-      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
 
       const fundingPotId = await colony.getFundingPotCount();
       let fundingPotPayout = await colony.getFundingPotPayout(paymentId, token.address);
       expect(fundingPotPayout).to.eq.BN(WAD);
 
-      await colony.setPaymentPayout(1, X, paymentId, token.address, 0);
+      await colony.setPaymentPayout(1, UINT256_MAX, paymentId, token.address, 0);
       fundingPotPayout = await colony.getFundingPotPayout(fundingPotId, token.address);
       expect(fundingPotPayout).to.be.zero;
     });
@@ -203,18 +203,18 @@ contract("Colony Payment", (accounts) => {
     let paymentId;
 
     beforeEach(async () => {
-      await colony.addPayment(1, X, RECIPIENT, token.address, 40, 1, 0);
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, 40, 1, 0);
       paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
       await fundColonyWithTokens(colony, token, 40);
-      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, 40, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 40, token.address);
     });
 
     it("can finalize payment when it is fully funded", async () => {
       let payment = await colony.getPayment(paymentId);
       expect(payment.finalized).to.be.false;
 
-      await colony.finalizePayment(1, X, paymentId);
+      await colony.finalizePayment(1, UINT256_MAX, paymentId);
 
       payment = await colony.getPayment(paymentId);
       expect(payment.finalized).to.be.true;
@@ -222,38 +222,41 @@ contract("Colony Payment", (accounts) => {
 
     it("cannnot finalize payment if it is NOT fully funded", async () => {
       const payment = await colony.getPayment(paymentId);
-      await colony.moveFundsBetweenPots(1, X, X, payment.fundingPotId, 1, 1, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, payment.fundingPotId, 1, 1, token.address);
       expect(payment.finalized).to.be.false;
 
-      await checkErrorRevert(colony.finalizePayment(1, X, paymentId), "colony-payment-not-funded");
+      await checkErrorRevert(colony.finalizePayment(1, UINT256_MAX, paymentId), "colony-payment-not-funded");
     });
 
     it("cannot finalize payment not authorised", async () => {
       const payment = await colony.getPayment(paymentId);
       expect(payment.finalized).to.be.false;
 
-      await checkErrorRevert(colony.finalizePayment(1, X, paymentId, { from: accounts[10] }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.finalizePayment(1, UINT256_MAX, paymentId, { from: accounts[10] }), "ds-auth-unauthorized");
     });
 
     it("should not allow admins to update recipient", async () => {
-      await colony.finalizePayment(1, X, paymentId);
-      await checkErrorRevert(colony.setPaymentRecipient(1, X, paymentId, accounts[6], { from: COLONY_ADMIN }), "colony-payment-finalized");
+      await colony.finalizePayment(1, UINT256_MAX, paymentId);
+      await checkErrorRevert(colony.setPaymentRecipient(1, UINT256_MAX, paymentId, accounts[6], { from: COLONY_ADMIN }), "colony-payment-finalized");
     });
 
     it("should not allow admins to update skill", async () => {
-      await colony.finalizePayment(1, X, paymentId);
-      await checkErrorRevert(colony.setPaymentSkill(1, X, paymentId, 1, { from: COLONY_ADMIN }), "colony-payment-finalized");
+      await colony.finalizePayment(1, UINT256_MAX, paymentId);
+      await checkErrorRevert(colony.setPaymentSkill(1, UINT256_MAX, paymentId, 1, { from: COLONY_ADMIN }), "colony-payment-finalized");
     });
 
     it("should not allow admins to update payment", async () => {
-      await colony.finalizePayment(1, X, paymentId);
-      await checkErrorRevert(colony.setPaymentPayout(1, X, paymentId, token.address, 1, { from: COLONY_ADMIN }), "colony-payment-finalized");
+      await colony.finalizePayment(1, UINT256_MAX, paymentId);
+      await checkErrorRevert(
+        colony.setPaymentPayout(1, UINT256_MAX, paymentId, token.address, 1, { from: COLONY_ADMIN }),
+        "colony-payment-finalized"
+      );
     });
 
     it("should not be able to set a payout above the limit", async () => {
-      await colony.finalizePayment(1, X, paymentId);
+      await colony.finalizePayment(1, UINT256_MAX, paymentId);
       await checkErrorRevert(
-        colony.setPaymentPayout(1, X, paymentId, token.address, MAX_PAYOUT.addn(1), { from: COLONY_ADMIN }),
+        colony.setPaymentPayout(1, UINT256_MAX, paymentId, token.address, MAX_PAYOUT.addn(1), { from: COLONY_ADMIN }),
         "colony-payout-too-large"
       );
     });
@@ -261,12 +264,12 @@ contract("Colony Payment", (accounts) => {
 
   describe("when claiming payments", () => {
     it("should allow recipient to claim their payment and network fee is deducated", async () => {
-      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0);
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, WAD, 1, 0);
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
-      await colony.finalizePayment(1, X, paymentId);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.finalizePayment(1, UINT256_MAX, paymentId);
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
       const networkBalanceBefore = await token.balanceOf(colonyNetwork.address);
@@ -279,12 +282,12 @@ contract("Colony Payment", (accounts) => {
     });
 
     it("should allow anyone to claim on behalf of the recipient", async () => {
-      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0);
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, WAD, 1, 0);
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
-      await colony.finalizePayment(1, X, paymentId);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.finalizePayment(1, UINT256_MAX, paymentId);
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
       const networkBalanceBefore = await token.balanceOf(colonyNetwork.address);
@@ -297,12 +300,12 @@ contract("Colony Payment", (accounts) => {
     });
 
     it("after payment is claimed it should set the payout to 0", async () => {
-      await colony.addPayment(1, X, RECIPIENT, token.address, WAD, 1, 0);
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, WAD, 1, 0);
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
-      await colony.finalizePayment(1, X, paymentId);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.finalizePayment(1, UINT256_MAX, paymentId);
       await colony.claimPayment(paymentId, token.address);
 
       const tokenPayout = await colony.getFundingPotPayout(payment.fundingPotId, token.address);
@@ -310,37 +313,37 @@ contract("Colony Payment", (accounts) => {
     });
 
     it("should error when payment is not funded and finalized", async () => {
-      await colony.addPayment(1, X, RECIPIENT, token.address, 10000, 1, 0);
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, 10000, 1, 0);
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, 9999, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 9999, token.address);
       await checkErrorRevert(colony.claimPayment(paymentId, token.address), "colony-payment-not-finalized");
     });
 
     it("should allow multiple payouts to be claimed", async () => {
-      await colony.addPayment(1, X, RECIPIENT, token.address, 200, 1, 0, { from: COLONY_ADMIN });
+      await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, 200, 1, 0, { from: COLONY_ADMIN });
       const paymentId = await colony.getPaymentCount();
       let payment = await colony.getPayment(paymentId);
 
-      await colony.setPaymentPayout(1, X, paymentId, otherToken.address, 100);
+      await colony.setPaymentPayout(1, UINT256_MAX, paymentId, otherToken.address, 100);
       await fundColonyWithTokens(colony, otherToken, 101);
       let fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(2);
 
-      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, 199, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 199, token.address);
       fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(2);
 
-      await colony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 100, otherToken.address);
       fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
-      await colony.setPaymentPayout(1, X, paymentId, token.address, 199);
+      await colony.setPaymentPayout(1, UINT256_MAX, paymentId, token.address, 199);
       fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
-      await colony.finalizePayment(1, X, paymentId);
+      await colony.finalizePayment(1, UINT256_MAX, paymentId);
       payment = await colony.getPayment(paymentId);
       expect(payment.finalized).to.be.true;
 

--- a/test/contracts-network/colony-permissions.js
+++ b/test/contracts-network/colony-permissions.js
@@ -3,6 +3,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 
 import {
+  X,
   WAD,
   ROOT_ROLE,
   ARBITRATION_ROLE,
@@ -49,9 +50,10 @@ contract("ColonyPermissions", (accounts) => {
     await colony.setRewardInverse(100);
 
     // Add subdomains 2 and 3
-    await colony.addDomain(1, 0, 1);
-    await colony.addDomain(1, 0, 1);
+    await colony.addDomain(1, X, 1);
+    await colony.addDomain(1, X, 1);
     domain1 = await colony.getDomain(1);
+
     domain2 = await colony.getDomain(2);
     domain3 = await colony.getDomain(3);
   });
@@ -74,7 +76,7 @@ contract("ColonyPermissions", (accounts) => {
     it("should let users query for roles in domain and subdomains", async () => {
       let administrationRole = await colony.hasUserRole(FOUNDER, 1, ADMINISTRATION_ROLE);
       expect(administrationRole).to.be.true;
-      administrationRole = await colony.hasInheritedUserRole(FOUNDER, 1, ADMINISTRATION_ROLE, 0, 1);
+      administrationRole = await colony.hasInheritedUserRole(FOUNDER, 1, ADMINISTRATION_ROLE, X, 1);
       expect(administrationRole).to.be.true;
       administrationRole = await colony.hasInheritedUserRole(FOUNDER, 1, ADMINISTRATION_ROLE, 0, 2);
       expect(administrationRole).to.be.true;
@@ -83,7 +85,7 @@ contract("ColonyPermissions", (accounts) => {
 
       administrationRole = await colony.hasUserRole(USER1, 1, ADMINISTRATION_ROLE);
       expect(administrationRole).to.be.false;
-      administrationRole = await colony.hasInheritedUserRole(USER1, 1, ADMINISTRATION_ROLE, 0, 1);
+      administrationRole = await colony.hasInheritedUserRole(USER1, 1, ADMINISTRATION_ROLE, X, 1);
       expect(administrationRole).to.be.false;
       administrationRole = await colony.hasInheritedUserRole(USER1, 1, ADMINISTRATION_ROLE, 0, 2);
       expect(administrationRole).to.be.false;
@@ -95,7 +97,7 @@ contract("ColonyPermissions", (accounts) => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
 
       // Founder can move funds from domain 1 to domain 2.
-      await colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, X, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address);
 
       // User1 can only move funds from domain 2 into domain 2 task.
       await colony.setFundingRole(1, 0, USER1, 2, true);
@@ -103,18 +105,18 @@ contract("ColonyPermissions", (accounts) => {
       expect(hasRole).to.be.true;
 
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address, { from: USER1 }),
+        colony.moveFundsBetweenPots(1, X, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address, { from: USER1 }),
         "ds-auth-unauthorized"
       );
 
       const taskId = await makeTask({ colonyNetwork, colony, domainId: 2 });
       const task = await colony.getTask(taskId);
-      await colony.moveFundsBetweenPots(2, 0, 0, domain2.fundingPotId, task.fundingPotId, WAD, token.address, { from: USER1 });
+      await colony.moveFundsBetweenPots(2, X, X, domain2.fundingPotId, task.fundingPotId, WAD, token.address, { from: USER1 });
     });
 
     it("should allow users with administration permission manipulate expenditures in their domains only", async () => {
       // Founder can create expenditures in domain 1, 2, 3.
-      await colony.makeExpenditure(1, 0, 1, { from: FOUNDER });
+      await colony.makeExpenditure(1, X, 1, { from: FOUNDER });
       await colony.makeExpenditure(1, 0, 2, { from: FOUNDER });
       await colony.makeExpenditure(1, 1, 3, { from: FOUNDER });
 
@@ -123,13 +125,13 @@ contract("ColonyPermissions", (accounts) => {
       hasRole = await colony.hasUserRole(USER1, 2, ADMINISTRATION_ROLE);
       expect(hasRole).to.be.true;
 
-      await checkErrorRevert(colony.makeExpenditure(1, 0, 1, { from: USER1 }), "ds-auth-unauthorized");
-      await colony.makeExpenditure(2, 0, 2, { from: USER1 });
+      await checkErrorRevert(colony.makeExpenditure(1, X, 1, { from: USER1 }), "ds-auth-unauthorized");
+      await colony.makeExpenditure(2, X, 2, { from: USER1 });
     });
 
     it("should allow users with administration permission manipulate tasks/payments in their domains only", async () => {
       // Founder can create tasks in domain 1, 2, 3.
-      await colony.makeTask(1, 0, SPECIFICATION_HASH, 1, 0, 0, { from: FOUNDER });
+      await colony.makeTask(1, X, SPECIFICATION_HASH, 1, 0, 0, { from: FOUNDER });
       await colony.makeTask(1, 0, SPECIFICATION_HASH, 2, 0, 0, { from: FOUNDER });
       await colony.makeTask(1, 1, SPECIFICATION_HASH, 3, 0, 0, { from: FOUNDER });
 
@@ -138,9 +140,9 @@ contract("ColonyPermissions", (accounts) => {
       hasRole = await colony.hasUserRole(USER1, 2, ADMINISTRATION_ROLE);
       expect(hasRole).to.be.true;
 
-      await checkErrorRevert(colony.makeTask(1, 0, SPECIFICATION_HASH, 1, 0, 0, { from: USER1 }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.makeTask(1, X, SPECIFICATION_HASH, 1, 0, 0, { from: USER1 }), "ds-auth-unauthorized");
 
-      const { logs } = await colony.makeTask(2, 0, SPECIFICATION_HASH, 2, 0, 0, { from: USER1 });
+      const { logs } = await colony.makeTask(2, X, SPECIFICATION_HASH, 2, 0, 0, { from: USER1 });
       const { taskId } = logs.filter((log) => log.event === "TaskAdded")[0].args;
 
       // User1 can transfer manager role to User2 only if User2 also has administration privileges.
@@ -154,7 +156,7 @@ contract("ColonyPermissions", (accounts) => {
           functionName: "setTaskManagerRole",
           signers: [USER1, USER2],
           sigTypes: [0, 0],
-          args: [taskId, USER2, 2, 0],
+          args: [taskId, USER2, 2, X],
         }),
         "colony-task-role-assignment-execution-failed"
       );
@@ -166,7 +168,7 @@ contract("ColonyPermissions", (accounts) => {
         functionName: "setTaskManagerRole",
         signers: [USER1, USER2],
         sigTypes: [0, 0],
-        args: [taskId, USER2, 2, 0],
+        args: [taskId, USER2, 2, X],
       });
 
       // And then User2 can transfer over to Founder (permission in parent domain)
@@ -199,18 +201,18 @@ contract("ColonyPermissions", (accounts) => {
       hasRole = await colony.hasUserRole(USER1, 2, ARCHITECTURE_ROLE);
       expect(hasRole).to.be.true;
 
-      await checkErrorRevert(colony.addDomain(1, 0, 1, { from: USER1 }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.addDomain(1, X, 1, { from: USER1 }), "ds-auth-unauthorized");
 
       // Note: cannot add subdomains currently, this is just checking that the auth passed.
-      await checkErrorRevert(colony.addDomain(2, 0, 2, { from: USER1 }), "colony-parent-domain-not-root");
+      await checkErrorRevert(colony.addDomain(2, X, 2, { from: USER1 }), "colony-parent-domain-not-root");
 
       // Now User1 can manipulate domain 1 subdomains
-      await colony.setArchitectureRole(1, 0, USER1, 1, true);
+      await colony.setArchitectureRole(1, X, USER1, 1, true);
       hasRole = await colony.hasUserRole(USER1, 1, ARCHITECTURE_ROLE);
       expect(hasRole).to.be.true;
 
       // Create subdomain...
-      await colony.addDomain(1, 0, 1, { from: USER1 });
+      await colony.addDomain(1, X, 1, { from: USER1 });
 
       // Manipulate permission in subdomain...
       await colony.setArbitrationRole(1, 0, USER2, 2, true, { from: USER1 });
@@ -246,14 +248,14 @@ contract("ColonyPermissions", (accounts) => {
       expect(hasRole).to.be.false;
 
       // But not permissions in the domain itself!
-      await checkErrorRevert(colony.setAdministrationRole(1, 0, USER2, 1, true, { from: USER1 }), "ds-auth-only-authorized-in-child-domain");
+      await checkErrorRevert(colony.setAdministrationRole(1, X, USER2, 1, true, { from: USER1 }), "ds-auth-only-authorized-in-child-domain");
 
       // Not without root!
       await colony.setRootRole(USER1, true);
       hasRole = await colony.hasUserRole(USER1, 1, ROOT_ROLE);
       expect(hasRole).to.be.true;
 
-      await colony.setAdministrationRole(1, 0, USER2, 1, true, { from: USER1 });
+      await colony.setAdministrationRole(1, X, USER2, 1, true, { from: USER1 });
     });
 
     it("should allow users with root permission manipulate root domain permissions and colony-wide parameters", async () => {
@@ -263,10 +265,10 @@ contract("ColonyPermissions", (accounts) => {
 
       // Can create manage permissions in the root domain!
       await colony.setRootRole(USER2, true, { from: USER1 });
-      await colony.setArbitrationRole(1, 0, USER2, 1, true, { from: USER1 });
-      await colony.setArchitectureRole(1, 0, USER2, 1, true, { from: USER1 });
-      await colony.setFundingRole(1, 0, USER2, 1, true, { from: USER1 });
-      await colony.setAdministrationRole(1, 0, USER2, 1, true, { from: USER1 });
+      await colony.setArbitrationRole(1, X, USER2, 1, true, { from: USER1 });
+      await colony.setArchitectureRole(1, X, USER2, 1, true, { from: USER1 });
+      await colony.setFundingRole(1, X, USER2, 1, true, { from: USER1 });
+      await colony.setAdministrationRole(1, X, USER2, 1, true, { from: USER1 });
 
       // And child domains!
       await colony.setAdministrationRole(1, 0, USER2, 2, true, { from: USER1 });
@@ -275,11 +277,11 @@ contract("ColonyPermissions", (accounts) => {
 
     it("should allow permissions to propagate to subdomains", async () => {
       // Give User 2 funding permissions in domain 1
-      await colony.setFundingRole(1, 0, USER2, 1, true);
+      await colony.setFundingRole(1, X, USER2, 1, true);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       // Test we can move funds between domain 1 and 2, and also 2 and 3
-      await colony.moveFundsBetweenPots(1, 0, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address, { from: USER2 });
+      await colony.moveFundsBetweenPots(1, X, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address, { from: USER2 });
       await colony.moveFundsBetweenPots(1, 0, 1, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 });
 
       // But only with valid proofs
@@ -295,7 +297,7 @@ contract("ColonyPermissions", (accounts) => {
 
     it("should not allow operations on nonexistent domains", async () => {
       // Can make a task in an existing domain
-      await colony.makeTask(1, 0, SPECIFICATION_HASH, 1, 0, 0);
+      await colony.makeTask(1, X, SPECIFICATION_HASH, 1, 0, 0);
 
       // But can't give a bad permission domain
       await checkErrorRevert(colony.makeTask(10, 0, SPECIFICATION_HASH, 1, 0, 0), "ds-auth-permission-domain-does-not-exist");

--- a/test/contracts-network/colony-permissions.js
+++ b/test/contracts-network/colony-permissions.js
@@ -3,7 +3,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 
 import {
-  X,
+  UINT256_MAX,
   WAD,
   ROOT_ROLE,
   ARBITRATION_ROLE,
@@ -50,8 +50,8 @@ contract("ColonyPermissions", (accounts) => {
     await colony.setRewardInverse(100);
 
     // Add subdomains 2 and 3
-    await colony.addDomain(1, X, 1);
-    await colony.addDomain(1, X, 1);
+    await colony.addDomain(1, UINT256_MAX, 1);
+    await colony.addDomain(1, UINT256_MAX, 1);
     domain1 = await colony.getDomain(1);
 
     domain2 = await colony.getDomain(2);
@@ -76,7 +76,7 @@ contract("ColonyPermissions", (accounts) => {
     it("should let users query for roles in domain and subdomains", async () => {
       let administrationRole = await colony.hasUserRole(FOUNDER, 1, ADMINISTRATION_ROLE);
       expect(administrationRole).to.be.true;
-      administrationRole = await colony.hasInheritedUserRole(FOUNDER, 1, ADMINISTRATION_ROLE, X, 1);
+      administrationRole = await colony.hasInheritedUserRole(FOUNDER, 1, ADMINISTRATION_ROLE, UINT256_MAX, 1);
       expect(administrationRole).to.be.true;
       administrationRole = await colony.hasInheritedUserRole(FOUNDER, 1, ADMINISTRATION_ROLE, 0, 2);
       expect(administrationRole).to.be.true;
@@ -85,7 +85,7 @@ contract("ColonyPermissions", (accounts) => {
 
       administrationRole = await colony.hasUserRole(USER1, 1, ADMINISTRATION_ROLE);
       expect(administrationRole).to.be.false;
-      administrationRole = await colony.hasInheritedUserRole(USER1, 1, ADMINISTRATION_ROLE, X, 1);
+      administrationRole = await colony.hasInheritedUserRole(USER1, 1, ADMINISTRATION_ROLE, UINT256_MAX, 1);
       expect(administrationRole).to.be.false;
       administrationRole = await colony.hasInheritedUserRole(USER1, 1, ADMINISTRATION_ROLE, 0, 2);
       expect(administrationRole).to.be.false;
@@ -97,7 +97,7 @@ contract("ColonyPermissions", (accounts) => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
 
       // Founder can move funds from domain 1 to domain 2.
-      await colony.moveFundsBetweenPots(1, X, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address);
 
       // User1 can only move funds from domain 2 into domain 2 task.
       await colony.setFundingRole(1, 0, USER1, 2, true);
@@ -105,18 +105,18 @@ contract("ColonyPermissions", (accounts) => {
       expect(hasRole).to.be.true;
 
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, X, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address, { from: USER1 }),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address, { from: USER1 }),
         "ds-auth-unauthorized"
       );
 
       const taskId = await makeTask({ colonyNetwork, colony, domainId: 2 });
       const task = await colony.getTask(taskId);
-      await colony.moveFundsBetweenPots(2, X, X, domain2.fundingPotId, task.fundingPotId, WAD, token.address, { from: USER1 });
+      await colony.moveFundsBetweenPots(2, UINT256_MAX, UINT256_MAX, domain2.fundingPotId, task.fundingPotId, WAD, token.address, { from: USER1 });
     });
 
     it("should allow users with administration permission manipulate expenditures in their domains only", async () => {
       // Founder can create expenditures in domain 1, 2, 3.
-      await colony.makeExpenditure(1, X, 1, { from: FOUNDER });
+      await colony.makeExpenditure(1, UINT256_MAX, 1, { from: FOUNDER });
       await colony.makeExpenditure(1, 0, 2, { from: FOUNDER });
       await colony.makeExpenditure(1, 1, 3, { from: FOUNDER });
 
@@ -125,13 +125,13 @@ contract("ColonyPermissions", (accounts) => {
       hasRole = await colony.hasUserRole(USER1, 2, ADMINISTRATION_ROLE);
       expect(hasRole).to.be.true;
 
-      await checkErrorRevert(colony.makeExpenditure(1, X, 1, { from: USER1 }), "ds-auth-unauthorized");
-      await colony.makeExpenditure(2, X, 2, { from: USER1 });
+      await checkErrorRevert(colony.makeExpenditure(1, UINT256_MAX, 1, { from: USER1 }), "ds-auth-unauthorized");
+      await colony.makeExpenditure(2, UINT256_MAX, 2, { from: USER1 });
     });
 
     it("should allow users with administration permission manipulate tasks/payments in their domains only", async () => {
       // Founder can create tasks in domain 1, 2, 3.
-      await colony.makeTask(1, X, SPECIFICATION_HASH, 1, 0, 0, { from: FOUNDER });
+      await colony.makeTask(1, UINT256_MAX, SPECIFICATION_HASH, 1, 0, 0, { from: FOUNDER });
       await colony.makeTask(1, 0, SPECIFICATION_HASH, 2, 0, 0, { from: FOUNDER });
       await colony.makeTask(1, 1, SPECIFICATION_HASH, 3, 0, 0, { from: FOUNDER });
 
@@ -140,9 +140,9 @@ contract("ColonyPermissions", (accounts) => {
       hasRole = await colony.hasUserRole(USER1, 2, ADMINISTRATION_ROLE);
       expect(hasRole).to.be.true;
 
-      await checkErrorRevert(colony.makeTask(1, X, SPECIFICATION_HASH, 1, 0, 0, { from: USER1 }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.makeTask(1, UINT256_MAX, SPECIFICATION_HASH, 1, 0, 0, { from: USER1 }), "ds-auth-unauthorized");
 
-      const { logs } = await colony.makeTask(2, X, SPECIFICATION_HASH, 2, 0, 0, { from: USER1 });
+      const { logs } = await colony.makeTask(2, UINT256_MAX, SPECIFICATION_HASH, 2, 0, 0, { from: USER1 });
       const { taskId } = logs.filter((log) => log.event === "TaskAdded")[0].args;
 
       // User1 can transfer manager role to User2 only if User2 also has administration privileges.
@@ -156,7 +156,7 @@ contract("ColonyPermissions", (accounts) => {
           functionName: "setTaskManagerRole",
           signers: [USER1, USER2],
           sigTypes: [0, 0],
-          args: [taskId, USER2, 2, X],
+          args: [taskId, USER2, 2, UINT256_MAX],
         }),
         "colony-task-role-assignment-execution-failed"
       );
@@ -168,7 +168,7 @@ contract("ColonyPermissions", (accounts) => {
         functionName: "setTaskManagerRole",
         signers: [USER1, USER2],
         sigTypes: [0, 0],
-        args: [taskId, USER2, 2, X],
+        args: [taskId, USER2, 2, UINT256_MAX],
       });
 
       // And then User2 can transfer over to Founder (permission in parent domain)
@@ -201,18 +201,18 @@ contract("ColonyPermissions", (accounts) => {
       hasRole = await colony.hasUserRole(USER1, 2, ARCHITECTURE_ROLE);
       expect(hasRole).to.be.true;
 
-      await checkErrorRevert(colony.addDomain(1, X, 1, { from: USER1 }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.addDomain(1, UINT256_MAX, 1, { from: USER1 }), "ds-auth-unauthorized");
 
       // Note: cannot add subdomains currently, this is just checking that the auth passed.
-      await checkErrorRevert(colony.addDomain(2, X, 2, { from: USER1 }), "colony-parent-domain-not-root");
+      await checkErrorRevert(colony.addDomain(2, UINT256_MAX, 2, { from: USER1 }), "colony-parent-domain-not-root");
 
       // Now User1 can manipulate domain 1 subdomains
-      await colony.setArchitectureRole(1, X, USER1, 1, true);
+      await colony.setArchitectureRole(1, UINT256_MAX, USER1, 1, true);
       hasRole = await colony.hasUserRole(USER1, 1, ARCHITECTURE_ROLE);
       expect(hasRole).to.be.true;
 
       // Create subdomain...
-      await colony.addDomain(1, X, 1, { from: USER1 });
+      await colony.addDomain(1, UINT256_MAX, 1, { from: USER1 });
 
       // Manipulate permission in subdomain...
       await colony.setArbitrationRole(1, 0, USER2, 2, true, { from: USER1 });
@@ -248,14 +248,17 @@ contract("ColonyPermissions", (accounts) => {
       expect(hasRole).to.be.false;
 
       // But not permissions in the domain itself!
-      await checkErrorRevert(colony.setAdministrationRole(1, X, USER2, 1, true, { from: USER1 }), "ds-auth-only-authorized-in-child-domain");
+      await checkErrorRevert(
+        colony.setAdministrationRole(1, UINT256_MAX, USER2, 1, true, { from: USER1 }),
+        "ds-auth-only-authorized-in-child-domain"
+      );
 
       // Not without root!
       await colony.setRootRole(USER1, true);
       hasRole = await colony.hasUserRole(USER1, 1, ROOT_ROLE);
       expect(hasRole).to.be.true;
 
-      await colony.setAdministrationRole(1, X, USER2, 1, true, { from: USER1 });
+      await colony.setAdministrationRole(1, UINT256_MAX, USER2, 1, true, { from: USER1 });
     });
 
     it("should allow users with root permission manipulate root domain permissions and colony-wide parameters", async () => {
@@ -265,10 +268,10 @@ contract("ColonyPermissions", (accounts) => {
 
       // Can create manage permissions in the root domain!
       await colony.setRootRole(USER2, true, { from: USER1 });
-      await colony.setArbitrationRole(1, X, USER2, 1, true, { from: USER1 });
-      await colony.setArchitectureRole(1, X, USER2, 1, true, { from: USER1 });
-      await colony.setFundingRole(1, X, USER2, 1, true, { from: USER1 });
-      await colony.setAdministrationRole(1, X, USER2, 1, true, { from: USER1 });
+      await colony.setArbitrationRole(1, UINT256_MAX, USER2, 1, true, { from: USER1 });
+      await colony.setArchitectureRole(1, UINT256_MAX, USER2, 1, true, { from: USER1 });
+      await colony.setFundingRole(1, UINT256_MAX, USER2, 1, true, { from: USER1 });
+      await colony.setAdministrationRole(1, UINT256_MAX, USER2, 1, true, { from: USER1 });
 
       // And child domains!
       await colony.setAdministrationRole(1, 0, USER2, 2, true, { from: USER1 });
@@ -277,11 +280,11 @@ contract("ColonyPermissions", (accounts) => {
 
     it("should allow permissions to propagate to subdomains", async () => {
       // Give User 2 funding permissions in domain 1
-      await colony.setFundingRole(1, X, USER2, 1, true);
+      await colony.setFundingRole(1, UINT256_MAX, USER2, 1, true);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       // Test we can move funds between domain 1 and 2, and also 2 and 3
-      await colony.moveFundsBetweenPots(1, X, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address, { from: USER2 });
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address, { from: USER2 });
       await colony.moveFundsBetweenPots(1, 0, 1, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 });
 
       // But only with valid proofs
@@ -297,7 +300,7 @@ contract("ColonyPermissions", (accounts) => {
 
     it("should not allow operations on nonexistent domains", async () => {
       // Can make a task in an existing domain
-      await colony.makeTask(1, X, SPECIFICATION_HASH, 1, 0, 0);
+      await colony.makeTask(1, UINT256_MAX, SPECIFICATION_HASH, 1, 0, 0);
 
       // But can't give a bad permission domain
       await checkErrorRevert(colony.makeTask(10, 0, SPECIFICATION_HASH, 1, 0, 0), "ds-auth-permission-domain-does-not-exist");

--- a/test/contracts-network/colony-recovery.js
+++ b/test/contracts-network/colony-recovery.js
@@ -2,7 +2,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 import { ethers } from "ethers";
 
-import { X, SPECIFICATION_HASH } from "../../helpers/constants";
+import { UINT256_MAX, SPECIFICATION_HASH } from "../../helpers/constants";
 import { web3GetStorageAt, checkErrorRevert, expectEvent } from "../../helpers/test-helper";
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony } from "../../helpers/test-data-generator";
 
@@ -99,8 +99,8 @@ contract("Colony Recovery", (accounts) => {
 
     it("should not be able to add and remove roles when in recovery", async () => {
       await colony.enterRecoveryMode();
-      await checkErrorRevert(colony.setAdministrationRole(1, X, accounts[1], 1, true), "colony-in-recovery-mode");
-      await checkErrorRevert(colony.setAdministrationRole(1, X, accounts[1], 1, false), "colony-in-recovery-mode");
+      await checkErrorRevert(colony.setAdministrationRole(1, UINT256_MAX, accounts[1], 1, true), "colony-in-recovery-mode");
+      await checkErrorRevert(colony.setAdministrationRole(1, UINT256_MAX, accounts[1], 1, false), "colony-in-recovery-mode");
       await checkErrorRevert(colony.setRecoveryRole(accounts[1]), "colony-in-recovery-mode");
       await checkErrorRevert(colony.removeRecoveryRole(accounts[1]), "colony-in-recovery-mode");
       await checkErrorRevert(colony.setRootRole(accounts[1], true), "colony-in-recovery-mode");

--- a/test/contracts-network/colony-recovery.js
+++ b/test/contracts-network/colony-recovery.js
@@ -2,7 +2,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 import { ethers } from "ethers";
 
-import { SPECIFICATION_HASH } from "../../helpers/constants";
+import { X, SPECIFICATION_HASH } from "../../helpers/constants";
 import { web3GetStorageAt, checkErrorRevert, expectEvent } from "../../helpers/test-helper";
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony } from "../../helpers/test-data-generator";
 
@@ -99,8 +99,8 @@ contract("Colony Recovery", (accounts) => {
 
     it("should not be able to add and remove roles when in recovery", async () => {
       await colony.enterRecoveryMode();
-      await checkErrorRevert(colony.setAdministrationRole(1, 0, accounts[1], 1, true), "colony-in-recovery-mode");
-      await checkErrorRevert(colony.setAdministrationRole(1, 0, accounts[1], 1, false), "colony-in-recovery-mode");
+      await checkErrorRevert(colony.setAdministrationRole(1, X, accounts[1], 1, true), "colony-in-recovery-mode");
+      await checkErrorRevert(colony.setAdministrationRole(1, X, accounts[1], 1, false), "colony-in-recovery-mode");
       await checkErrorRevert(colony.setRecoveryRole(accounts[1]), "colony-in-recovery-mode");
       await checkErrorRevert(colony.removeRecoveryRole(accounts[1]), "colony-in-recovery-mode");
       await checkErrorRevert(colony.setRootRole(accounts[1], true), "colony-in-recovery-mode");

--- a/test/contracts-network/colony-reward-payouts.js
+++ b/test/contracts-network/colony-reward-payouts.js
@@ -193,7 +193,7 @@ contract("Colony Reward Payouts", (accounts) => {
       await colony.claimColonyFunds(token.address);
       // Move all of them in to the reward pot
       const amount = await colony.getFundingPotBalance(1, token.address);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, amount, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, amount, token.address);
 
       const tx1 = await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
       const payoutId1 = tx1.logs[0].args.rewardPayoutId;
@@ -259,7 +259,7 @@ contract("Colony Reward Payouts", (accounts) => {
       let { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
 
-      await newColony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, newToken.address);
+      await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, newToken.address);
 
       const { logs } = await newColony.startNextRewardPayout(newToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
@@ -294,7 +294,7 @@ contract("Colony Reward Payouts", (accounts) => {
       const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill);
       const { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
-      await newColony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, newToken.address);
+      await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, newToken.address);
 
       await checkErrorRevert(
         newColony.startNextRewardPayout(newToken.address, ...colonyWideReputationProof),
@@ -308,10 +308,10 @@ contract("Colony Reward Payouts", (accounts) => {
     });
 
     it("should be able to create parallel payouts of the same token", async () => {
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
     });
@@ -320,7 +320,7 @@ contract("Colony Reward Payouts", (accounts) => {
       const tx1 = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId1 = tx1.logs[0].args.rewardPayoutId;
 
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       const tx2 = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId2 = tx2.logs[0].args.rewardPayoutId;
@@ -335,7 +335,7 @@ contract("Colony Reward Payouts", (accounts) => {
       const payoutId1 = tx1.logs[0].args.rewardPayoutId;
       await forwardTime(SECONDS_PER_DAY * 60 + 1, this);
 
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.finalizeRewardPayout(payoutId1);
 
       const tx2 = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
@@ -369,7 +369,7 @@ contract("Colony Reward Payouts", (accounts) => {
 
       await forwardTime(SECONDS_PER_DAY * 60 + 1, this);
 
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.finalizeRewardPayout(payoutId1);
 
       const tx2 = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
@@ -414,7 +414,7 @@ contract("Colony Reward Payouts", (accounts) => {
       const { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
 
-      await newColony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, newToken.address);
+      await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, newToken.address);
 
       await checkErrorRevert(
         newColony.startNextRewardPayout(newToken.address, ...colonyWideReputationProof),
@@ -791,8 +791,8 @@ contract("Colony Reward Payouts", (accounts) => {
       await newToken.approve(tokenLocking.address, userReputation, { from: userAddress1 });
       await tokenLocking.deposit(newToken.address, userReputation, { from: userAddress1 });
 
-      await colony1.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
-      await colony2.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony1.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony2.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       ({ logs } = await colony1.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof1));
       const payoutId1 = logs[0].args.rewardPayoutId;
@@ -896,7 +896,7 @@ contract("Colony Reward Payouts", (accounts) => {
         await tokenLocking.deposit(newToken.address, tokensPerUser, { from: userAddress3 });
         await forwardTime(1, this);
 
-        await newColony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, payoutToken.address);
+        await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, payoutToken.address);
 
         const { logs } = await newColony.startNextRewardPayout(payoutToken.address, ...colonyWideReputationProof);
         const payoutId = logs[0].args.rewardPayoutId;

--- a/test/contracts-network/colony-reward-payouts.js
+++ b/test/contracts-network/colony-reward-payouts.js
@@ -8,7 +8,7 @@ import bnChai from "bn-chai";
 import path from "path";
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
-import { INT128_MAX, WAD, MANAGER_ROLE, INITIAL_FUNDING, DEFAULT_STAKE, SECONDS_PER_DAY } from "../../helpers/constants";
+import { UINT256_MAX, INT128_MAX, WAD, MANAGER_ROLE, INITIAL_FUNDING, DEFAULT_STAKE, SECONDS_PER_DAY } from "../../helpers/constants";
 
 import {
   getTokenArgs,
@@ -236,7 +236,7 @@ contract("Colony Reward Payouts", (accounts) => {
       const { colony: newColony, token: newToken } = await setupRandomColony(colonyNetwork);
       await fundColonyWithTokens(newColony, newToken, INITIAL_FUNDING);
 
-      await newColony.addDomain(1, 0, 1);
+      await newColony.addDomain(1, UINT256_MAX, 1);
       const domainCount = await newColony.getDomainCount();
       let domain = await newColony.getDomain(domainCount);
       const domainSkill = domain.skillId;

--- a/test/contracts-network/colony-staking.js
+++ b/test/contracts-network/colony-staking.js
@@ -3,7 +3,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 import { ethers } from "ethers";
 
-import { WAD, INITIAL_FUNDING } from "../../helpers/constants";
+import { UINT256_MAX, WAD, INITIAL_FUNDING } from "../../helpers/constants";
 import { fundColonyWithTokens, setupRandomColony, setupColony } from "../../helpers/test-data-generator";
 import { checkErrorRevert } from "../../helpers/test-helper";
 
@@ -33,15 +33,15 @@ contract("Colony Staking", (accounts) => {
 
   beforeEach(async () => {
     ({ colony, token } = await setupRandomColony(colonyNetwork));
-    await colony.addDomain(1, 0, 1);
-    await colony.setArbitrationRole(1, 0, USER2, 1, true);
+    await colony.addDomain(1, UINT256_MAX, 1);
+    await colony.setArbitrationRole(1, UINT256_MAX, USER2, 1, true);
 
-    await colony.makeExpenditure(1, 0, 1);
+    await colony.makeExpenditure(1, UINT256_MAX, 1);
     await colony.setExpenditureRecipient(1, 0, USER0);
     await colony.setExpenditureRecipient(1, 1, USER1);
 
     await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-    await colony.moveFundsBetweenPots(1, 0, 0, 1, 3, WAD.muln(200), token.address);
+    await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 3, WAD.muln(200), token.address);
     await colony.setExpenditurePayout(1, 0, token.address, WAD.muln(100));
     await colony.setExpenditurePayout(1, 1, token.address, WAD.muln(100));
 
@@ -102,7 +102,7 @@ contract("Colony Staking", (accounts) => {
       expect(approval).to.be.zero;
       expect(obligation).to.eq.BN(WAD);
 
-      await colony.transferStake(1, 0, USER0, USER1, 1, WAD, ethers.constants.AddressZero, { from: USER2 });
+      await colony.transferStake(1, UINT256_MAX, USER0, USER1, 1, WAD, ethers.constants.AddressZero, { from: USER2 });
 
       obligation = await colony.getObligation(USER1, USER0, 1);
       expect(obligation).to.be.zero;
@@ -146,7 +146,7 @@ contract("Colony Staking", (accounts) => {
       await colony.obligateStake(USER1, 1, WAD, { from: USER0 });
 
       await checkErrorRevert(
-        colony.transferStake(1, 0, USER0, USER1, 1, WAD.addn(1), ethers.constants.AddressZero, { from: USER2 }),
+        colony.transferStake(1, UINT256_MAX, USER0, USER1, 1, WAD.addn(1), ethers.constants.AddressZero, { from: USER2 }),
         "ds-math-sub-underflow"
       );
     });
@@ -194,8 +194,8 @@ contract("Colony Staking", (accounts) => {
     it("should correctly accumulate multiple slashes", async () => {
       await colony.approveStake(USER0, 1, WAD.muln(2), { from: USER1 });
       await colony.obligateStake(USER1, 1, WAD.muln(2), { from: USER0 });
-      await colony.transferStake(1, 0, USER0, USER1, 1, WAD, ethers.constants.AddressZero, { from: USER2 });
-      await colony.transferStake(1, 0, USER0, USER1, 1, WAD, ethers.constants.AddressZero, { from: USER2 });
+      await colony.transferStake(1, UINT256_MAX, USER0, USER1, 1, WAD, ethers.constants.AddressZero, { from: USER2 });
+      await colony.transferStake(1, UINT256_MAX, USER0, USER1, 1, WAD, ethers.constants.AddressZero, { from: USER2 });
 
       const deposit = await tokenLocking.getUserLock(token.address, USER1);
       expect(deposit.balance).to.eq.BN(WAD.muln(48));
@@ -217,7 +217,7 @@ contract("Colony Staking", (accounts) => {
     it("should allow for a slashed stake to be sent to a beneficiary", async () => {
       await colony.approveStake(USER0, 1, WAD, { from: USER1 });
       await colony.obligateStake(USER1, 1, WAD, { from: USER0 });
-      await colony.transferStake(1, 0, USER0, USER1, 1, WAD, USER2, { from: USER2 });
+      await colony.transferStake(1, UINT256_MAX, USER0, USER1, 1, WAD, USER2, { from: USER2 });
 
       const deposit = await tokenLocking.getUserLock(token.address, USER2);
       expect(deposit.balance).to.eq.BN(WAD);

--- a/test/contracts-network/colony-task.js
+++ b/test/contracts-network/colony-task.js
@@ -5,6 +5,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 
 import {
+  X,
   WAD,
   MANAGER_ROLE,
   EVALUATOR_ROLE,
@@ -84,7 +85,7 @@ contract("ColonyTask", (accounts) => {
 
     ({ colony, token } = await setupRandomColony(colonyNetwork));
     await colony.setRewardInverse(100);
-    await colony.setAdministrationRole(1, 0, COLONY_ADMIN, 1, true);
+    await colony.setAdministrationRole(1, X, COLONY_ADMIN, 1, true);
 
     const otherTokenArgs = getTokenArgs();
     otherToken = await Token.new(...otherTokenArgs);
@@ -105,7 +106,7 @@ contract("ColonyTask", (accounts) => {
 
     it("should fail if a non-admin user tries to make a task", async () => {
       const taskCountBefore = await colony.getTaskCount();
-      await checkErrorRevert(colony.makeTask(1, 0, SPECIFICATION_HASH, 1, 1, 0, { from: OTHER }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.makeTask(1, X, SPECIFICATION_HASH, 1, 1, 0, { from: OTHER }), "ds-auth-unauthorized");
       const taskCountAfter = await colony.getTaskCount();
       expect(taskCountBefore).to.be.eq.BN(taskCountAfter);
     });
@@ -166,14 +167,14 @@ contract("ColonyTask", (accounts) => {
     });
 
     it("should set the task domain correctly", async () => {
-      await colony.addDomain(1, 0, 1);
+      await colony.addDomain(1, X, 1);
       const taskId = await makeTask({ colonyNetwork, colony, domainId: 2 });
       const task = await colony.getTask(taskId);
       expect(task.domainId).to.eq.BN(2);
     });
 
     it("should log TaskAdded and FundingPotAdded events", async () => {
-      await expectAllEvents(colony.makeTask(1, 0, SPECIFICATION_HASH, 1, 3, 0), ["TaskAdded", "FundingPotAdded"]);
+      await expectAllEvents(colony.makeTask(1, X, SPECIFICATION_HASH, 1, 3, 0), ["TaskAdded", "FundingPotAdded"]);
     });
 
     it("should optionally set the skill and due date", async () => {
@@ -1351,12 +1352,12 @@ contract("ColonyTask", (accounts) => {
       // but we need some Ether, too
       await colony.send(101);
       await colony.claimColonyFunds(ethers.constants.AddressZero);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, taskPotId, 100, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, X, X, 1, taskPotId, 100, ethers.constants.AddressZero);
 
       // And another token
       await otherToken.mint(colony.address, 101);
       await colony.claimColonyFunds(otherToken.address);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, taskPotId, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, 1, taskPotId, 100, otherToken.address);
 
       // Keep track of original Ether balance in funding pots
       const originalDomainEtherBalance = await colony.getFundingPotBalance(domain.fundingPotId, ethers.constants.AddressZero);
@@ -1378,9 +1379,9 @@ contract("ColonyTask", (accounts) => {
         args: [taskId],
       });
 
-      await colony.moveFundsBetweenPots(1, 0, 0, taskPotId, domain.fundingPotId, originalTaskEtherBalance, ethers.constants.AddressZero);
-      await colony.moveFundsBetweenPots(1, 0, 0, taskPotId, domain.fundingPotId, originalTaskTokenBalance, token.address);
-      await colony.moveFundsBetweenPots(1, 0, 0, taskPotId, domain.fundingPotId, originalTaskOtherTokenBalance, otherToken.address);
+      await colony.moveFundsBetweenPots(1, X, X, taskPotId, domain.fundingPotId, originalTaskEtherBalance, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, X, X, taskPotId, domain.fundingPotId, originalTaskTokenBalance, token.address);
+      await colony.moveFundsBetweenPots(1, X, X, taskPotId, domain.fundingPotId, originalTaskOtherTokenBalance, otherToken.address);
 
       const cancelledTaskEtherBalance = await colony.getFundingPotBalance(taskPotId, ethers.constants.AddressZero);
       const cancelledDomainEtherBalance = await colony.getFundingPotBalance(domain.fundingPotId, ethers.constants.AddressZero);

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -5,6 +5,7 @@ import bnChai from "bn-chai";
 import { ethers } from "ethers";
 
 import {
+  X,
   UINT256_MAX,
   MANAGER_RATING,
   WORKER_RATING,
@@ -143,7 +144,7 @@ contract("Colony", (accounts) => {
 
   describe("when adding domains", () => {
     it("should log DomainAdded and FundingPotAdded events", async () => {
-      await expectAllEvents(colony.addDomain(1, 0, 1), ["DomainAdded", "FundingPotAdded"]);
+      await expectAllEvents(colony.addDomain(1, X, 1), ["DomainAdded", "FundingPotAdded"]);
     });
   });
 

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -5,7 +5,6 @@ import bnChai from "bn-chai";
 import { ethers } from "ethers";
 
 import {
-  X,
   UINT256_MAX,
   MANAGER_RATING,
   WORKER_RATING,
@@ -144,7 +143,7 @@ contract("Colony", (accounts) => {
 
   describe("when adding domains", () => {
     it("should log DomainAdded and FundingPotAdded events", async () => {
-      await expectAllEvents(colony.addDomain(1, X, 1), ["DomainAdded", "FundingPotAdded"]);
+      await expectAllEvents(colony.addDomain(1, UINT256_MAX, 1), ["DomainAdded", "FundingPotAdded"]);
     });
   });
 

--- a/test/contracts-network/meta-colony.js
+++ b/test/contracts-network/meta-colony.js
@@ -2,7 +2,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 
 import { soliditySha3 } from "web3-utils";
-import { X, INITIAL_FUNDING, SPECIFICATION_HASH, GLOBAL_SKILL_ID } from "../../helpers/constants";
+import { UINT256_MAX, INITIAL_FUNDING, SPECIFICATION_HASH, GLOBAL_SKILL_ID } from "../../helpers/constants";
 import { checkErrorRevert, removeSubdomainLimit } from "../../helpers/test-helper";
 import { executeSignedTaskChange } from "../../helpers/task-review-signing";
 
@@ -55,7 +55,7 @@ contract("Meta Colony", (accounts) => {
     });
 
     it("should be able to add a new skill as a child of a domain", async () => {
-      await metaColony.addDomain(1, X, 1);
+      await metaColony.addDomain(1, UINT256_MAX, 1);
 
       const skillCount = await colonyNetwork.getSkillCount();
       expect(skillCount).to.eq.BN(4);
@@ -80,9 +80,9 @@ contract("Meta Colony", (accounts) => {
     });
 
     it("should be able to add multiple child skills to the skill corresponding to the root domain by adding child domains", async () => {
-      await metaColony.addDomain(1, X, 1);
-      await metaColony.addDomain(1, X, 1);
-      await metaColony.addDomain(1, X, 1);
+      await metaColony.addDomain(1, UINT256_MAX, 1);
+      await metaColony.addDomain(1, UINT256_MAX, 1);
+      await metaColony.addDomain(1, UINT256_MAX, 1);
 
       const skillCount = await colonyNetwork.getSkillCount();
       expect(skillCount).to.eq.BN(6);
@@ -114,10 +114,10 @@ contract("Meta Colony", (accounts) => {
 
     it("should NOT be able to add a domain that has a non existent parent", async () => {
       // Add 2 skill nodes to skill corresponding to root domain
-      await metaColony.addDomain(1, X, 1);
-      await metaColony.addDomain(1, X, 1);
+      await metaColony.addDomain(1, UINT256_MAX, 1);
+      await metaColony.addDomain(1, UINT256_MAX, 1);
 
-      await checkErrorRevert(metaColony.addDomain(1, X, 6), "ds-auth-child-domain-does-not-exist");
+      await checkErrorRevert(metaColony.addDomain(1, UINT256_MAX, 6), "ds-auth-child-domain-does-not-exist");
       const skillCount = await colonyNetwork.getSkillCount();
       expect(skillCount).to.eq.BN(5);
     });
@@ -136,7 +136,7 @@ contract("Meta Colony", (accounts) => {
       await metaColony.approveExitRecovery();
       await metaColony.exitRecoveryMode();
       // Try to add a child
-      await checkErrorRevert(metaColony.addDomain(1, X, 1), "colony-global-and-local-skill-trees-are-separate");
+      await checkErrorRevert(metaColony.addDomain(1, UINT256_MAX, 1), "colony-global-and-local-skill-trees-are-separate");
       const skillCount = await colonyNetwork.getSkillCount();
       expect(skillCount).to.eq.BN(3);
     });
@@ -145,8 +145,8 @@ contract("Meta Colony", (accounts) => {
       // Why this random addGlobalSkill in the middle? It means we can use effectively the same tests
       // below, but with skill ID 7 replaced with skill ID 2. While porting everything to the tag cloud
       // arrangement, I was very interested in changing tests as little as possible.
-      await metaColony.addDomain(1, X, 1); // Domain ID 2, skill id 4
-      await metaColony.addDomain(1, X, 1); // Domain ID 3, skill id 5
+      await metaColony.addDomain(1, UINT256_MAX, 1); // Domain ID 2, skill id 4
+      await metaColony.addDomain(1, UINT256_MAX, 1); // Domain ID 3, skill id 5
       await metaColony.addDomain(1, 2, 3); // Domain ID 4, skill id 6
       await metaColony.addGlobalSkill(); // Skill id 7
       await metaColony.addDomain(1, 1, 2); // Domain ID 5, skill id 8
@@ -218,7 +218,7 @@ contract("Meta Colony", (accounts) => {
     });
 
     it("should correctly ascend the skills tree to find parents", async () => {
-      await metaColony.addDomain(1, X, 1);
+      await metaColony.addDomain(1, UINT256_MAX, 1);
       await metaColony.addDomain(1, 1, 2);
       await metaColony.addDomain(1, 2, 3);
       await metaColony.addDomain(1, 3, 4);
@@ -279,13 +279,13 @@ contract("Meta Colony", (accounts) => {
       await metaColony.approveExitRecovery();
       await metaColony.exitRecoveryMode();
       // Try to add a child
-      await checkErrorRevert(metaColony.addDomain(1, X, 1), "colony-invalid-skill-id");
+      await checkErrorRevert(metaColony.addDomain(1, UINT256_MAX, 1), "colony-invalid-skill-id");
     });
   });
 
   describe("when adding domains in the meta colony", () => {
     it("should be able to add new domains as children to the root domain", async () => {
-      await metaColony.addDomain(1, X, 1);
+      await metaColony.addDomain(1, UINT256_MAX, 1);
       const newDomainId = await metaColony.getDomainCount();
 
       const skillCount = await colonyNetwork.getSkillCount();
@@ -308,7 +308,7 @@ contract("Meta Colony", (accounts) => {
     });
 
     it("should NOT be able to add a child domain more than one level away from the root domain", async () => {
-      await metaColony.addDomain(1, X, 1);
+      await metaColony.addDomain(1, UINT256_MAX, 1);
 
       // In position 1 because the mining skill occupies position 0
       await checkErrorRevert(metaColony.addDomain(1, 1, 2), "colony-parent-domain-not-root");
@@ -326,13 +326,13 @@ contract("Meta Colony", (accounts) => {
     });
 
     it("someone who does not have root role should not be able to add domains", async () => {
-      await checkErrorRevert(colony.addDomain(1, X, 1, { from: OTHER_ACCOUNT }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.addDomain(1, UINT256_MAX, 1, { from: OTHER_ACCOUNT }), "ds-auth-unauthorized");
     });
 
     it("should be able to add new domains as children to the root domain", async () => {
-      await colony.addDomain(1, X, 1);
-      await colony.addDomain(1, X, 1);
-      await colony.addDomain(1, X, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
 
       const skillCount = await colonyNetwork.getSkillCount();
       expect(skillCount).to.eq.BN(7);
@@ -390,7 +390,7 @@ contract("Meta Colony", (accounts) => {
     });
 
     it("should be able to set domain on task", async () => {
-      await colony.addDomain(1, X, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
 
       const { logs } = await colony.makeTask(1, 0, SPECIFICATION_HASH, 2, 0, 0);
       const { taskId } = logs[0].args;

--- a/test/contracts-network/meta-colony.js
+++ b/test/contracts-network/meta-colony.js
@@ -2,7 +2,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 
 import { soliditySha3 } from "web3-utils";
-import { INITIAL_FUNDING, SPECIFICATION_HASH, GLOBAL_SKILL_ID } from "../../helpers/constants";
+import { X, INITIAL_FUNDING, SPECIFICATION_HASH, GLOBAL_SKILL_ID } from "../../helpers/constants";
 import { checkErrorRevert, removeSubdomainLimit } from "../../helpers/test-helper";
 import { executeSignedTaskChange } from "../../helpers/task-review-signing";
 
@@ -55,7 +55,7 @@ contract("Meta Colony", (accounts) => {
     });
 
     it("should be able to add a new skill as a child of a domain", async () => {
-      await metaColony.addDomain(1, 0, 1);
+      await metaColony.addDomain(1, X, 1);
 
       const skillCount = await colonyNetwork.getSkillCount();
       expect(skillCount).to.eq.BN(4);
@@ -80,9 +80,9 @@ contract("Meta Colony", (accounts) => {
     });
 
     it("should be able to add multiple child skills to the skill corresponding to the root domain by adding child domains", async () => {
-      await metaColony.addDomain(1, 0, 1);
-      await metaColony.addDomain(1, 0, 1);
-      await metaColony.addDomain(1, 0, 1);
+      await metaColony.addDomain(1, X, 1);
+      await metaColony.addDomain(1, X, 1);
+      await metaColony.addDomain(1, X, 1);
 
       const skillCount = await colonyNetwork.getSkillCount();
       expect(skillCount).to.eq.BN(6);
@@ -114,10 +114,10 @@ contract("Meta Colony", (accounts) => {
 
     it("should NOT be able to add a domain that has a non existent parent", async () => {
       // Add 2 skill nodes to skill corresponding to root domain
-      await metaColony.addDomain(1, 0, 1);
-      await metaColony.addDomain(1, 0, 1);
+      await metaColony.addDomain(1, X, 1);
+      await metaColony.addDomain(1, X, 1);
 
-      await checkErrorRevert(metaColony.addDomain(1, 0, 6), "ds-auth-child-domain-does-not-exist");
+      await checkErrorRevert(metaColony.addDomain(1, X, 6), "ds-auth-child-domain-does-not-exist");
       const skillCount = await colonyNetwork.getSkillCount();
       expect(skillCount).to.eq.BN(5);
     });
@@ -136,7 +136,7 @@ contract("Meta Colony", (accounts) => {
       await metaColony.approveExitRecovery();
       await metaColony.exitRecoveryMode();
       // Try to add a child
-      await checkErrorRevert(metaColony.addDomain(1, 0, 1), "colony-global-and-local-skill-trees-are-separate");
+      await checkErrorRevert(metaColony.addDomain(1, X, 1), "colony-global-and-local-skill-trees-are-separate");
       const skillCount = await colonyNetwork.getSkillCount();
       expect(skillCount).to.eq.BN(3);
     });
@@ -145,8 +145,8 @@ contract("Meta Colony", (accounts) => {
       // Why this random addGlobalSkill in the middle? It means we can use effectively the same tests
       // below, but with skill ID 7 replaced with skill ID 2. While porting everything to the tag cloud
       // arrangement, I was very interested in changing tests as little as possible.
-      await metaColony.addDomain(1, 0, 1); // Domain ID 2, skill id 4
-      await metaColony.addDomain(1, 0, 1); // Domain ID 3, skill id 5
+      await metaColony.addDomain(1, X, 1); // Domain ID 2, skill id 4
+      await metaColony.addDomain(1, X, 1); // Domain ID 3, skill id 5
       await metaColony.addDomain(1, 2, 3); // Domain ID 4, skill id 6
       await metaColony.addGlobalSkill(); // Skill id 7
       await metaColony.addDomain(1, 1, 2); // Domain ID 5, skill id 8
@@ -218,7 +218,7 @@ contract("Meta Colony", (accounts) => {
     });
 
     it("should correctly ascend the skills tree to find parents", async () => {
-      await metaColony.addDomain(1, 0, 1);
+      await metaColony.addDomain(1, X, 1);
       await metaColony.addDomain(1, 1, 2);
       await metaColony.addDomain(1, 2, 3);
       await metaColony.addDomain(1, 3, 4);
@@ -279,13 +279,13 @@ contract("Meta Colony", (accounts) => {
       await metaColony.approveExitRecovery();
       await metaColony.exitRecoveryMode();
       // Try to add a child
-      await checkErrorRevert(metaColony.addDomain(1, 0, 1), "colony-invalid-skill-id");
+      await checkErrorRevert(metaColony.addDomain(1, X, 1), "colony-invalid-skill-id");
     });
   });
 
   describe("when adding domains in the meta colony", () => {
     it("should be able to add new domains as children to the root domain", async () => {
-      await metaColony.addDomain(1, 0, 1);
+      await metaColony.addDomain(1, X, 1);
       const newDomainId = await metaColony.getDomainCount();
 
       const skillCount = await colonyNetwork.getSkillCount();
@@ -308,7 +308,7 @@ contract("Meta Colony", (accounts) => {
     });
 
     it("should NOT be able to add a child domain more than one level away from the root domain", async () => {
-      await metaColony.addDomain(1, 0, 1);
+      await metaColony.addDomain(1, X, 1);
 
       // In position 1 because the mining skill occupies position 0
       await checkErrorRevert(metaColony.addDomain(1, 1, 2), "colony-parent-domain-not-root");
@@ -326,13 +326,13 @@ contract("Meta Colony", (accounts) => {
     });
 
     it("someone who does not have root role should not be able to add domains", async () => {
-      await checkErrorRevert(colony.addDomain(1, 0, 1, { from: OTHER_ACCOUNT }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.addDomain(1, X, 1, { from: OTHER_ACCOUNT }), "ds-auth-unauthorized");
     });
 
     it("should be able to add new domains as children to the root domain", async () => {
-      await colony.addDomain(1, 0, 1);
-      await colony.addDomain(1, 0, 1);
-      await colony.addDomain(1, 0, 1);
+      await colony.addDomain(1, X, 1);
+      await colony.addDomain(1, X, 1);
+      await colony.addDomain(1, X, 1);
 
       const skillCount = await colonyNetwork.getSkillCount();
       expect(skillCount).to.eq.BN(7);
@@ -390,7 +390,7 @@ contract("Meta Colony", (accounts) => {
     });
 
     it("should be able to set domain on task", async () => {
-      await colony.addDomain(1, 0, 1);
+      await colony.addDomain(1, X, 1);
 
       const { logs } = await colony.makeTask(1, 0, SPECIFICATION_HASH, 2, 0, 0);
       const { taskId } = logs[0].args;

--- a/test/contracts-network/reputation-update.js
+++ b/test/contracts-network/reputation-update.js
@@ -15,6 +15,7 @@ import {
 } from "../../helpers/test-data-generator";
 
 import {
+  X,
   INT256_MAX,
   INT128_MAX,
   INT128_MIN,
@@ -27,6 +28,7 @@ import {
   WORKER_PAYOUT,
   MAX_PAYOUT,
   SECONDS_PER_DAY,
+  GLOBAL_SKILL_ID,
   MANAGER_ROLE,
   WORKER_ROLE,
   RATING_1_SALT,
@@ -288,7 +290,7 @@ contract("Reputation Updates", (accounts) => {
 
     it("should calculate nUpdates correctly when making a log", async () => {
       await removeSubdomainLimit(colonyNetwork); // Temporary for tests until we allow subdomain depth > 1
-      await metaColony.addDomain(1, 0, 1);
+      await metaColony.addDomain(1, X, 1);
       await metaColony.addDomain(1, 1, 2);
       await metaColony.addDomain(1, 2, 3);
       await metaColony.addDomain(1, 3, 4);
@@ -346,12 +348,12 @@ contract("Reputation Updates", (accounts) => {
 
     it("should set the correct domain and skill reputation change amount in log for payments", async () => {
       const RECIPIENT = accounts[3];
-      await metaColony.addPayment(1, 0, RECIPIENT, clnyToken.address, WAD, 1, 3);
+      await metaColony.addPayment(1, X, RECIPIENT, clnyToken.address, WAD, 1, GLOBAL_SKILL_ID);
       const paymentId = await metaColony.getPaymentCount();
 
       const payment = await metaColony.getPayment(paymentId);
-      await metaColony.moveFundsBetweenPots(1, 0, 0, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), clnyToken.address);
-      await metaColony.finalizePayment(1, 0, paymentId);
+      await metaColony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), clnyToken.address);
+      await metaColony.finalizePayment(1, X, paymentId);
       await metaColony.claimPayment(paymentId, clnyToken.address);
 
       const reputationUpdateLogLength = await inactiveReputationMiningCycle.getReputationUpdateLogLength();
@@ -376,12 +378,12 @@ contract("Reputation Updates", (accounts) => {
       await otherToken.unlock();
       await fundColonyWithTokens(metaColony, otherToken, WAD.muln(2));
 
-      await metaColony.addPayment(1, 0, RECIPIENT, otherToken.address, WAD, 1, 3);
+      await metaColony.addPayment(1, X, RECIPIENT, otherToken.address, WAD, 1, GLOBAL_SKILL_ID);
       const paymentId = await metaColony.getPaymentCount();
 
       const payment = await metaColony.getPayment(paymentId);
-      await metaColony.moveFundsBetweenPots(1, 0, 0, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), otherToken.address);
-      await metaColony.finalizePayment(1, 0, paymentId);
+      await metaColony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), otherToken.address);
+      await metaColony.finalizePayment(1, X, paymentId);
       await metaColony.claimPayment(paymentId, otherToken.address);
 
       const reputationUpdateLogLength = await inactiveReputationMiningCycle.getReputationUpdateLogLength();

--- a/test/contracts-network/reputation-update.js
+++ b/test/contracts-network/reputation-update.js
@@ -15,7 +15,7 @@ import {
 } from "../../helpers/test-data-generator";
 
 import {
-  X,
+  UINT256_MAX,
   INT256_MAX,
   INT128_MAX,
   INT128_MIN,
@@ -290,7 +290,7 @@ contract("Reputation Updates", (accounts) => {
 
     it("should calculate nUpdates correctly when making a log", async () => {
       await removeSubdomainLimit(colonyNetwork); // Temporary for tests until we allow subdomain depth > 1
-      await metaColony.addDomain(1, X, 1);
+      await metaColony.addDomain(1, UINT256_MAX, 1);
       await metaColony.addDomain(1, 1, 2);
       await metaColony.addDomain(1, 2, 3);
       await metaColony.addDomain(1, 3, 4);
@@ -348,12 +348,12 @@ contract("Reputation Updates", (accounts) => {
 
     it("should set the correct domain and skill reputation change amount in log for payments", async () => {
       const RECIPIENT = accounts[3];
-      await metaColony.addPayment(1, X, RECIPIENT, clnyToken.address, WAD, 1, GLOBAL_SKILL_ID);
+      await metaColony.addPayment(1, UINT256_MAX, RECIPIENT, clnyToken.address, WAD, 1, GLOBAL_SKILL_ID);
       const paymentId = await metaColony.getPaymentCount();
 
       const payment = await metaColony.getPayment(paymentId);
-      await metaColony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), clnyToken.address);
-      await metaColony.finalizePayment(1, X, paymentId);
+      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), clnyToken.address);
+      await metaColony.finalizePayment(1, UINT256_MAX, paymentId);
       await metaColony.claimPayment(paymentId, clnyToken.address);
 
       const reputationUpdateLogLength = await inactiveReputationMiningCycle.getReputationUpdateLogLength();
@@ -378,12 +378,12 @@ contract("Reputation Updates", (accounts) => {
       await otherToken.unlock();
       await fundColonyWithTokens(metaColony, otherToken, WAD.muln(2));
 
-      await metaColony.addPayment(1, X, RECIPIENT, otherToken.address, WAD, 1, GLOBAL_SKILL_ID);
+      await metaColony.addPayment(1, UINT256_MAX, RECIPIENT, otherToken.address, WAD, 1, GLOBAL_SKILL_ID);
       const paymentId = await metaColony.getPaymentCount();
 
       const payment = await metaColony.getPayment(paymentId);
-      await metaColony.moveFundsBetweenPots(1, X, X, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), otherToken.address);
-      await metaColony.finalizePayment(1, X, paymentId);
+      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), otherToken.address);
+      await metaColony.finalizePayment(1, UINT256_MAX, paymentId);
       await metaColony.claimPayment(paymentId, otherToken.address);
 
       const reputationUpdateLogLength = await inactiveReputationMiningCycle.getReputationUpdateLogLength();

--- a/test/contracts-network/token-locking.js
+++ b/test/contracts-network/token-locking.js
@@ -127,7 +127,7 @@ contract("Token Locking", (addresses) => {
     it("should be able to deposit tokens while they are locked, into pendingBalance", async () => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       await tokenLocking.deposit(token.address, usersTokens, { from: userAddress });
       const info = await tokenLocking.getUserLock(token.address, userAddress);
@@ -144,7 +144,7 @@ contract("Token Locking", (addresses) => {
 
     it("should be able to deposit tokens for another user, even if they are locked", async () => {
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
 
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
@@ -201,7 +201,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.deposit(token.address, usersTokens, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       await checkErrorRevert(
         tokenLocking.methods["withdraw(address,uint256,bool)"](token.address, usersTokens, false, { from: userAddress }),
@@ -213,7 +213,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.deposit(token.address, usersTokens, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       await tokenLocking.methods["withdraw(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
     });
@@ -222,7 +222,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.deposit(token.address, usersTokens, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
       await tokenLocking.incrementLockCounterTo(token.address, payoutId, { from: userAddress });
@@ -248,7 +248,7 @@ contract("Token Locking", (addresses) => {
       await tokenLocking.deposit(token.address, usersTokens, { from: userAddress });
 
       await fundColonyWithTokens(colony, token);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
       await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
       await tokenLocking.transfer(token.address, usersTokens, otherUserAddress, true, { from: userAddress });
 
@@ -261,7 +261,7 @@ contract("Token Locking", (addresses) => {
       await tokenLocking.deposit(token.address, usersTokens, { from: userAddress });
 
       await fundColonyWithTokens(colony, token);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
       await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
 
       await checkErrorRevert(
@@ -275,7 +275,7 @@ contract("Token Locking", (addresses) => {
       await tokenLocking.deposit(token.address, usersTokens, { from: userAddress });
 
       await fundColonyWithTokens(colony, token);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
       await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
 
       await tokenLocking.transfer(token.address, usersTokens, otherUserAddress, true, { from: userAddress });
@@ -301,7 +301,7 @@ contract("Token Locking", (addresses) => {
       await tokenLocking.transfer(token.address, usersTokens, otherUserAddress, false, { from: userAddress });
 
       await fundColonyWithTokens(colony, token);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
       await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
 
       await checkErrorRevert(tokenLocking.claim(token.address, false, { from: otherUserAddress }), "colony-token-locking-token-locked");
@@ -313,7 +313,7 @@ contract("Token Locking", (addresses) => {
       await tokenLocking.transfer(token.address, usersTokens, otherUserAddress, false, { from: userAddress });
 
       await fundColonyWithTokens(colony, token);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
       await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
 
       await tokenLocking.claim(token.address, true, { from: otherUserAddress });
@@ -328,7 +328,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.deposit(token.address, usersTokens, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const totalLockCount = await tokenLocking.getTotalLockCount(token.address);
       expect(totalLockCount).to.eq.BN(1);
@@ -338,7 +338,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.deposit(token.address, usersTokens, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
 
@@ -349,7 +349,7 @@ contract("Token Locking", (addresses) => {
 
     it("should not be able to waive to id that does not exist", async () => {
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       await checkErrorRevert(tokenLocking.incrementLockCounterTo(token.address, 10, { from: userAddress }), "colony-token-locking-invalid-lock-id");
     });
@@ -364,7 +364,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.deposit(token.address, usersTokens, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
       await checkErrorRevert(
@@ -377,9 +377,9 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.deposit(token.address, usersTokens, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
-      await colony.moveFundsBetweenPots(1, 0, 0, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
 
       const totalLockCount = await tokenLocking.getTotalLockCount(token.address);

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -4,7 +4,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 import { ethers } from "ethers";
 
-import { X, WAD, INITIAL_FUNDING, GLOBAL_SKILL_ID } from "../../helpers/constants";
+import { UINT256_MAX, WAD, INITIAL_FUNDING, GLOBAL_SKILL_ID } from "../../helpers/constants";
 import { checkErrorRevert } from "../../helpers/test-helper";
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony, fundColonyWithTokens } from "../../helpers/test-data-generator";
 
@@ -39,16 +39,16 @@ contract("One transaction payments", (accounts) => {
     await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
 
     // Give a user colony administration rights (needed for one-tx)
-    await colony.setAdministrationRole(1, X, COLONY_ADMIN, 1, true);
-    await colony.setFundingRole(1, X, COLONY_ADMIN, 1, true);
+    await colony.setAdministrationRole(1, UINT256_MAX, COLONY_ADMIN, 1, true);
+    await colony.setFundingRole(1, UINT256_MAX, COLONY_ADMIN, 1, true);
 
     await oneTxExtensionFactory.deployExtension(colony.address);
     const oneTxExtensionAddress = await oneTxExtensionFactory.deployedExtensions(colony.address);
     oneTxExtension = await OneTxPayment.at(oneTxExtensionAddress);
 
     // Give oneTxExtension administration and funding rights
-    await colony.setAdministrationRole(1, X, oneTxExtension.address, 1, true);
-    await colony.setFundingRole(1, X, oneTxExtension.address, 1, true);
+    await colony.setAdministrationRole(1, UINT256_MAX, oneTxExtension.address, 1, true);
+    await colony.setFundingRole(1, UINT256_MAX, oneTxExtension.address, 1, true);
   });
 
   describe("under normal conditions", () => {
@@ -87,7 +87,9 @@ contract("One transaction payments", (accounts) => {
       const balanceBefore = await token.balanceOf(RECIPIENT);
       expect(balanceBefore).to.eq.BN(0);
       // This is the one transactions. Those ones above don't count...
-      await oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
+      await oneTxExtension.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, {
+        from: COLONY_ADMIN,
+      });
       // Check it completed
       const balanceAfter = await token.balanceOf(RECIPIENT);
       expect(balanceAfter).to.eq.BN(9);
@@ -98,9 +100,18 @@ contract("One transaction payments", (accounts) => {
       await colony.send(10); // NB 10 wei, not ten ether!
       await colony.claimColonyFunds(ethers.constants.AddressZero);
       // This is the one transactions. Those ones above don't count...
-      await oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [ethers.constants.AddressZero], [10], 1, GLOBAL_SKILL_ID, {
-        from: COLONY_ADMIN,
-      });
+      await oneTxExtension.makePaymentFundedFromDomain(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        [RECIPIENT],
+        [ethers.constants.AddressZero],
+        [10],
+        1,
+        GLOBAL_SKILL_ID,
+        { from: COLONY_ADMIN }
+      );
       // Check it completed
       const balanceAfter = await web3.eth.getBalance(RECIPIENT);
       // So only 9 here, because of the same rounding errors as applied to the token
@@ -108,25 +119,25 @@ contract("One transaction payments", (accounts) => {
     });
 
     it("should allow a single-transaction to occur in a child domain", async () => {
-      await colony.addDomain(1, X, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
       const d1 = await colony.getDomain(1);
       const d2 = await colony.getDomain(2);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      await colony.moveFundsBetweenPots(1, X, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
       await oneTxExtension.makePaymentFundedFromDomain(1, 0, 1, 0, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
     });
 
     it("should allow a single-transaction to occur in a child domain, paid out from the root domain", async () => {
-      await colony.addDomain(1, X, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await oneTxExtension.makePayment(1, 0, 1, 0, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
     });
 
     it("should allow a single-transaction to occur in a child domain that's not the first child, paid out from the root domain", async () => {
-      await colony.addDomain(1, X, 1);
-      await colony.addDomain(1, X, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await oneTxExtension.makePayment(1, 1, 1, 1, [RECIPIENT], [token.address], [10], 3, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
@@ -134,12 +145,14 @@ contract("One transaction payments", (accounts) => {
 
     it("should allow a single-transaction to occur in the root domain, paid out from the root domain", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      await oneTxExtension.makePayment(1, X, 1, X, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
+      await oneTxExtension.makePayment(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, {
+        from: COLONY_ADMIN,
+      });
     });
 
     it(`should not allow a single-transaction to occur in a child domain, paid out from the root domain
       if the user does not have permission to take funds from root domain`, async () => {
-      await colony.addDomain(1, X, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
       const USER = accounts[6];
 
       await colony.setAdministrationRole(1, 0, USER, 2, true);
@@ -147,43 +160,47 @@ contract("One transaction payments", (accounts) => {
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await checkErrorRevert(
-        oneTxExtension.makePayment(2, X, 2, X, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER }),
+        oneTxExtension.makePayment(2, UINT256_MAX, 2, UINT256_MAX, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER }),
         "colony-one-tx-payment-root-funding-not-authorized"
       );
     });
 
     it("should allow a single-transaction to occur when user has different permissions than contract", async () => {
-      await colony.addDomain(1, X, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
       const d1 = await colony.getDomain(1);
       const d2 = await colony.getDomain(2);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      await colony.moveFundsBetweenPots(1, X, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
 
       const USER = accounts[6];
       await colony.setAdministrationRole(1, 0, USER, 2, true);
       await colony.setFundingRole(1, 0, USER, 2, true);
-      await oneTxExtension.makePaymentFundedFromDomain(1, 0, 2, X, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER });
+      await oneTxExtension.makePaymentFundedFromDomain(1, 0, 2, UINT256_MAX, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER });
     });
 
     it("should not allow a non-admin to make a single-transaction payment", async () => {
       await checkErrorRevert(
-        oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, { from: accounts[10] }),
+        oneTxExtension.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, {
+          from: accounts[10],
+        }),
         "colony-one-tx-payment-administration-not-authorized"
       );
     });
 
     it("should not allow a non-funder to make a single-transaction payment", async () => {
-      await colony.setAdministrationRole(1, X, accounts[10], 1, true);
+      await colony.setAdministrationRole(1, UINT256_MAX, accounts[10], 1, true);
       await checkErrorRevert(
-        oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, { from: accounts[10] }),
+        oneTxExtension.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, {
+          from: accounts[10],
+        }),
         "colony-one-tx-payment-funding-not-authorized"
       );
     });
 
     it("should not allow an admin to specify a non-global skill", async () => {
       await checkErrorRevert(
-        oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [token.address], [10], 1, 2, { from: COLONY_ADMIN }),
+        oneTxExtension.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, 2, { from: COLONY_ADMIN }),
         "colony-not-global-skill"
       );
     });
@@ -194,28 +211,32 @@ contract("One transaction payments", (accounts) => {
       await metaColony.deprecateGlobalSkill(skillId);
 
       await checkErrorRevert(
-        oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [token.address], [10], 1, skillId, { from: COLONY_ADMIN }),
+        oneTxExtension.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, skillId, {
+          from: COLONY_ADMIN,
+        }),
         "colony-deprecated-global-skill"
       );
     });
 
     it("should not allow an admin to specify a non-existent domain", async () => {
       await checkErrorRevert(
-        oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [token.address], [10], 99, GLOBAL_SKILL_ID, { from: COLONY_ADMIN }),
+        oneTxExtension.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 99, GLOBAL_SKILL_ID, {
+          from: COLONY_ADMIN,
+        }),
         "colony-one-tx-payment-domain-does-not-exist"
       );
     });
 
     it("should not allow an admin to specify a non-existent skill", async () => {
       await checkErrorRevert(
-        oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [token.address], [10], 1, 99, { from: COLONY_ADMIN }),
+        oneTxExtension.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, 99, { from: COLONY_ADMIN }),
         "colony-skill-does-not-exist"
       );
     });
 
     it("should error if user permissions are bad", async () => {
-      await colony.addDomain(1, X, 1); // Adds domain 2 skillId 5
-      await colony.addDomain(1, X, 1); // Adds domain 3 skillId 6
+      await colony.addDomain(1, UINT256_MAX, 1); // Adds domain 2 skillId 5
+      await colony.addDomain(1, UINT256_MAX, 1); // Adds domain 3 skillId 6
 
       // Try to make a payment with the permissions in domain 1, child skill at index 1, i.e. skill 6
       // When actually domain 2 in which we are creating the task is skill 5
@@ -233,9 +254,9 @@ contract("One transaction payments", (accounts) => {
       // This is the one transactions. Those ones above don't count...
       await oneTxExtension.makePaymentFundedFromDomain(
         1,
-        0,
+        UINT256_MAX,
         1,
-        0,
+        UINT256_MAX,
         [RECIPIENT, RECIPIENT2],
         [token.address, token.address],
         [10, 5],
@@ -258,9 +279,9 @@ contract("One transaction payments", (accounts) => {
       // This is the one transactions. Those ones above don't count...
       await oneTxExtension.makePaymentFundedFromDomain(
         1,
-        0,
+        UINT256_MAX,
         1,
-        0,
+        UINT256_MAX,
         [RECIPIENT, RECIPIENT2],
         [ethers.constants.AddressZero, ethers.constants.AddressZero],
         [10, 5],
@@ -285,9 +306,9 @@ contract("One transaction payments", (accounts) => {
       // This is the one transactions. Those ones above don't count...
       await oneTxExtension.makePaymentFundedFromDomain(
         1,
-        0,
+        UINT256_MAX,
         1,
-        0,
+        UINT256_MAX,
         [RECIPIENT, RECIPIENT2],
         [token.address, ethers.constants.AddressZero],
         [10, 5],
@@ -312,9 +333,9 @@ contract("One transaction payments", (accounts) => {
       // This is the one transactions. Those ones above don't count...
       await oneTxExtension.makePaymentFundedFromDomain(
         1,
-        0,
+        UINT256_MAX,
         1,
-        0,
+        UINT256_MAX,
         [RECIPIENT2, RECIPIENT, RECIPIENT2],
         [ethers.constants.AddressZero, token.address, ethers.constants.AddressZero],
         [5, 10, 5],
@@ -331,7 +352,7 @@ contract("One transaction payments", (accounts) => {
     });
 
     it("should allow a single-transaction to occur in a child domain, paid out from the root domain to multiple workers", async () => {
-      await colony.addDomain(1, 0, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await oneTxExtension.makePayment(1, 0, 1, 0, [RECIPIENT, RECIPIENT2], [token.address, token.address], [10, 5], 2, GLOBAL_SKILL_ID, {
@@ -340,7 +361,7 @@ contract("One transaction payments", (accounts) => {
     });
 
     it("should not allow arrays of different sizes", async () => {
-      await colony.addDomain(1, 0, 1);
+      await colony.addDomain(1, UINT256_MAX, 1);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await checkErrorRevert(

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -4,7 +4,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 import { ethers } from "ethers";
 
-import { WAD, INITIAL_FUNDING, GLOBAL_SKILL_ID } from "../../helpers/constants";
+import { X, WAD, INITIAL_FUNDING, GLOBAL_SKILL_ID } from "../../helpers/constants";
 import { checkErrorRevert } from "../../helpers/test-helper";
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony, fundColonyWithTokens } from "../../helpers/test-data-generator";
 
@@ -39,16 +39,16 @@ contract("One transaction payments", (accounts) => {
     await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
 
     // Give a user colony administration rights (needed for one-tx)
-    await colony.setAdministrationRole(1, 0, COLONY_ADMIN, 1, true);
-    await colony.setFundingRole(1, 0, COLONY_ADMIN, 1, true);
+    await colony.setAdministrationRole(1, X, COLONY_ADMIN, 1, true);
+    await colony.setFundingRole(1, X, COLONY_ADMIN, 1, true);
 
     await oneTxExtensionFactory.deployExtension(colony.address);
     const oneTxExtensionAddress = await oneTxExtensionFactory.deployedExtensions(colony.address);
     oneTxExtension = await OneTxPayment.at(oneTxExtensionAddress);
 
     // Give oneTxExtension administration and funding rights
-    await colony.setAdministrationRole(1, 0, oneTxExtension.address, 1, true);
-    await colony.setFundingRole(1, 0, oneTxExtension.address, 1, true);
+    await colony.setAdministrationRole(1, X, oneTxExtension.address, 1, true);
+    await colony.setFundingRole(1, X, oneTxExtension.address, 1, true);
   });
 
   describe("under normal conditions", () => {
@@ -87,7 +87,7 @@ contract("One transaction payments", (accounts) => {
       const balanceBefore = await token.balanceOf(RECIPIENT);
       expect(balanceBefore).to.eq.BN(0);
       // This is the one transactions. Those ones above don't count...
-      await oneTxExtension.makePaymentFundedFromDomain(1, 0, 1, 0, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
+      await oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
       // Check it completed
       const balanceAfter = await token.balanceOf(RECIPIENT);
       expect(balanceAfter).to.eq.BN(9);
@@ -98,7 +98,7 @@ contract("One transaction payments", (accounts) => {
       await colony.send(10); // NB 10 wei, not ten ether!
       await colony.claimColonyFunds(ethers.constants.AddressZero);
       // This is the one transactions. Those ones above don't count...
-      await oneTxExtension.makePaymentFundedFromDomain(1, 0, 1, 0, [RECIPIENT], [ethers.constants.AddressZero], [10], 1, GLOBAL_SKILL_ID, {
+      await oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [ethers.constants.AddressZero], [10], 1, GLOBAL_SKILL_ID, {
         from: COLONY_ADMIN,
       });
       // Check it completed
@@ -108,25 +108,25 @@ contract("One transaction payments", (accounts) => {
     });
 
     it("should allow a single-transaction to occur in a child domain", async () => {
-      await colony.addDomain(1, 0, 1);
+      await colony.addDomain(1, X, 1);
       const d1 = await colony.getDomain(1);
       const d2 = await colony.getDomain(2);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      await colony.moveFundsBetweenPots(1, 0, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, X, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
       await oneTxExtension.makePaymentFundedFromDomain(1, 0, 1, 0, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
     });
 
     it("should allow a single-transaction to occur in a child domain, paid out from the root domain", async () => {
-      await colony.addDomain(1, 0, 1);
+      await colony.addDomain(1, X, 1);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await oneTxExtension.makePayment(1, 0, 1, 0, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
     });
 
     it("should allow a single-transaction to occur in a child domain that's not the first child, paid out from the root domain", async () => {
-      await colony.addDomain(1, 0, 1);
-      await colony.addDomain(1, 0, 1);
+      await colony.addDomain(1, X, 1);
+      await colony.addDomain(1, X, 1);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await oneTxExtension.makePayment(1, 1, 1, 1, [RECIPIENT], [token.address], [10], 3, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
@@ -134,12 +134,12 @@ contract("One transaction payments", (accounts) => {
 
     it("should allow a single-transaction to occur in the root domain, paid out from the root domain", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      await oneTxExtension.makePayment(1, 0, 1, 0, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
+      await oneTxExtension.makePayment(1, X, 1, X, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
     });
 
     it(`should not allow a single-transaction to occur in a child domain, paid out from the root domain
       if the user does not have permission to take funds from root domain`, async () => {
-      await colony.addDomain(1, 0, 1);
+      await colony.addDomain(1, X, 1);
       const USER = accounts[6];
 
       await colony.setAdministrationRole(1, 0, USER, 2, true);
@@ -147,43 +147,43 @@ contract("One transaction payments", (accounts) => {
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await checkErrorRevert(
-        oneTxExtension.makePayment(2, 0, 2, 0, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER }),
+        oneTxExtension.makePayment(2, X, 2, X, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER }),
         "colony-one-tx-payment-root-funding-not-authorized"
       );
     });
 
     it("should allow a single-transaction to occur when user has different permissions than contract", async () => {
-      await colony.addDomain(1, 0, 1);
+      await colony.addDomain(1, X, 1);
       const d1 = await colony.getDomain(1);
       const d2 = await colony.getDomain(2);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      await colony.moveFundsBetweenPots(1, 0, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, X, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
 
       const USER = accounts[6];
       await colony.setAdministrationRole(1, 0, USER, 2, true);
       await colony.setFundingRole(1, 0, USER, 2, true);
-      await oneTxExtension.makePaymentFundedFromDomain(1, 0, 2, 0, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER });
+      await oneTxExtension.makePaymentFundedFromDomain(1, 0, 2, X, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER });
     });
 
     it("should not allow a non-admin to make a single-transaction payment", async () => {
       await checkErrorRevert(
-        oneTxExtension.makePaymentFundedFromDomain(1, 0, 1, 0, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, { from: accounts[10] }),
+        oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, { from: accounts[10] }),
         "colony-one-tx-payment-administration-not-authorized"
       );
     });
 
     it("should not allow a non-funder to make a single-transaction payment", async () => {
-      await colony.setAdministrationRole(1, 0, accounts[10], 1, true);
+      await colony.setAdministrationRole(1, X, accounts[10], 1, true);
       await checkErrorRevert(
-        oneTxExtension.makePaymentFundedFromDomain(1, 0, 1, 0, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, { from: accounts[10] }),
+        oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, { from: accounts[10] }),
         "colony-one-tx-payment-funding-not-authorized"
       );
     });
 
     it("should not allow an admin to specify a non-global skill", async () => {
       await checkErrorRevert(
-        oneTxExtension.makePaymentFundedFromDomain(1, 0, 1, 0, [RECIPIENT], [token.address], [10], 1, 2, { from: COLONY_ADMIN }),
+        oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [token.address], [10], 1, 2, { from: COLONY_ADMIN }),
         "colony-not-global-skill"
       );
     });
@@ -194,33 +194,33 @@ contract("One transaction payments", (accounts) => {
       await metaColony.deprecateGlobalSkill(skillId);
 
       await checkErrorRevert(
-        oneTxExtension.makePaymentFundedFromDomain(1, 0, 1, 0, [RECIPIENT], [token.address], [10], 1, skillId, { from: COLONY_ADMIN }),
+        oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [token.address], [10], 1, skillId, { from: COLONY_ADMIN }),
         "colony-deprecated-global-skill"
       );
     });
 
     it("should not allow an admin to specify a non-existent domain", async () => {
       await checkErrorRevert(
-        oneTxExtension.makePaymentFundedFromDomain(1, 0, 1, 0, [RECIPIENT], [token.address], [10], 99, GLOBAL_SKILL_ID, { from: COLONY_ADMIN }),
+        oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [token.address], [10], 99, GLOBAL_SKILL_ID, { from: COLONY_ADMIN }),
         "colony-one-tx-payment-domain-does-not-exist"
       );
     });
 
     it("should not allow an admin to specify a non-existent skill", async () => {
       await checkErrorRevert(
-        oneTxExtension.makePaymentFundedFromDomain(1, 0, 1, 0, [RECIPIENT], [token.address], [10], 1, 99, { from: COLONY_ADMIN }),
+        oneTxExtension.makePaymentFundedFromDomain(1, X, 1, X, [RECIPIENT], [token.address], [10], 1, 99, { from: COLONY_ADMIN }),
         "colony-skill-does-not-exist"
       );
     });
 
     it("should error if user permissions are bad", async () => {
-      await colony.addDomain(1, 0, 1); // Adds domain 2 skillId 5
-      await colony.addDomain(1, 0, 1); // Adds domain 3 skillId 6
+      await colony.addDomain(1, X, 1); // Adds domain 2 skillId 5
+      await colony.addDomain(1, X, 1); // Adds domain 3 skillId 6
 
       // Try to make a payment with the permissions in domain 1, child skill at index 1, i.e. skill 6
       // When actually domain 2 in which we are creating the task is skill 5
       await checkErrorRevert(
-        oneTxExtension.makePaymentFundedFromDomain(1, 0, 1, 1, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: COLONY_ADMIN }),
+        oneTxExtension.makePaymentFundedFromDomain(1, 1, 1, 1, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: COLONY_ADMIN }),
         "colony-one-tx-payment-bad-child-skill"
       );
     });

--- a/test/reputation-system/client-calculations.js
+++ b/test/reputation-system/client-calculations.js
@@ -6,7 +6,7 @@ import { ethers } from "ethers";
 
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
-import { X, DEFAULT_STAKE, INITIAL_FUNDING, GLOBAL_SKILL_ID } from "../../helpers/constants";
+import { UINT256_MAX, DEFAULT_STAKE, INITIAL_FUNDING, GLOBAL_SKILL_ID } from "../../helpers/constants";
 import { advanceMiningCycleNoContest, getActiveRepCycle, finishReputationMiningCycle, removeSubdomainLimit } from "../../helpers/test-helper";
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
 
@@ -41,7 +41,7 @@ const setupNewNetworkInstance = async (MINER1, MINER2) => {
 
   // Initialise global skill: 3. Set up local skills tree 1 -> 4 -> 5
   //                                                       \-> 2
-  await metaColony.addDomain(1, X, 1);
+  await metaColony.addDomain(1, UINT256_MAX, 1);
   await metaColony.addDomain(1, 1, 2);
 
   await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);

--- a/test/reputation-system/client-calculations.js
+++ b/test/reputation-system/client-calculations.js
@@ -6,7 +6,7 @@ import { ethers } from "ethers";
 
 import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
-import { DEFAULT_STAKE, INITIAL_FUNDING, GLOBAL_SKILL_ID } from "../../helpers/constants";
+import { X, DEFAULT_STAKE, INITIAL_FUNDING, GLOBAL_SKILL_ID } from "../../helpers/constants";
 import { advanceMiningCycleNoContest, getActiveRepCycle, finishReputationMiningCycle, removeSubdomainLimit } from "../../helpers/test-helper";
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
 
@@ -41,7 +41,7 @@ const setupNewNetworkInstance = async (MINER1, MINER2) => {
 
   // Initialise global skill: 3. Set up local skills tree 1 -> 4 -> 5
   //                                                       \-> 2
-  await metaColony.addDomain(1, 0, 1);
+  await metaColony.addDomain(1, X, 1);
   await metaColony.addDomain(1, 1, 2);
 
   await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);

--- a/test/reputation-system/dispute-resolution-misbehaviour.js
+++ b/test/reputation-system/dispute-resolution-misbehaviour.js
@@ -29,7 +29,7 @@ import {
   fundColonyWithTokens,
 } from "../../helpers/test-data-generator";
 
-import { X, DEFAULT_STAKE, INITIAL_FUNDING, MINING_CYCLE_DURATION } from "../../helpers/constants";
+import { UINT256_MAX, DEFAULT_STAKE, INITIAL_FUNDING, MINING_CYCLE_DURATION } from "../../helpers/constants";
 
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
 import MaliciousReputationMinerExtraRep from "../../packages/reputation-miner/test/MaliciousReputationMinerExtraRep";
@@ -61,7 +61,7 @@ const setupNewNetworkInstance = async (MINER1, MINER2) => {
 
   // Initialise global skills tree: 3, local skills tree 1 -> 4 -> 5
   //                                                      \-> 2
-  await metaColony.addDomain(1, X, 1);
+  await metaColony.addDomain(1, UINT256_MAX, 1);
   await metaColony.addDomain(1, 1, 2);
 
   await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);

--- a/test/reputation-system/dispute-resolution-misbehaviour.js
+++ b/test/reputation-system/dispute-resolution-misbehaviour.js
@@ -29,7 +29,7 @@ import {
   fundColonyWithTokens,
 } from "../../helpers/test-data-generator";
 
-import { DEFAULT_STAKE, INITIAL_FUNDING, MINING_CYCLE_DURATION } from "../../helpers/constants";
+import { X, DEFAULT_STAKE, INITIAL_FUNDING, MINING_CYCLE_DURATION } from "../../helpers/constants";
 
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
 import MaliciousReputationMinerExtraRep from "../../packages/reputation-miner/test/MaliciousReputationMinerExtraRep";
@@ -61,7 +61,7 @@ const setupNewNetworkInstance = async (MINER1, MINER2) => {
 
   // Initialise global skills tree: 3, local skills tree 1 -> 4 -> 5
   //                                                      \-> 2
-  await metaColony.addDomain(1, 0, 1);
+  await metaColony.addDomain(1, X, 1);
   await metaColony.addDomain(1, 1, 2);
 
   await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);

--- a/test/reputation-system/disputes-over-child-reputation.js
+++ b/test/reputation-system/disputes-over-child-reputation.js
@@ -23,7 +23,7 @@ import {
   fundColonyWithTokens,
 } from "../../helpers/test-data-generator";
 
-import { DEFAULT_STAKE, INITIAL_FUNDING, MINING_CYCLE_DURATION } from "../../helpers/constants";
+import { X, DEFAULT_STAKE, INITIAL_FUNDING, MINING_CYCLE_DURATION } from "../../helpers/constants";
 
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
 import MaliciousReputationMinerExtraRep from "../../packages/reputation-miner/test/MaliciousReputationMinerExtraRep";
@@ -57,7 +57,7 @@ const setupNewNetworkInstance = async (MINER1, MINER2) => {
 
   // Initialise global skills tree: 3, local skills tree 1 -> 4 -> 5
   //                                                      \-> 2
-  await metaColony.addDomain(1, 0, 1);
+  await metaColony.addDomain(1, X, 1);
   await metaColony.addDomain(1, 1, 2);
 
   await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);

--- a/test/reputation-system/disputes-over-child-reputation.js
+++ b/test/reputation-system/disputes-over-child-reputation.js
@@ -23,7 +23,7 @@ import {
   fundColonyWithTokens,
 } from "../../helpers/test-data-generator";
 
-import { X, DEFAULT_STAKE, INITIAL_FUNDING, MINING_CYCLE_DURATION } from "../../helpers/constants";
+import { UINT256_MAX, DEFAULT_STAKE, INITIAL_FUNDING, MINING_CYCLE_DURATION } from "../../helpers/constants";
 
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
 import MaliciousReputationMinerExtraRep from "../../packages/reputation-miner/test/MaliciousReputationMinerExtraRep";
@@ -57,7 +57,7 @@ const setupNewNetworkInstance = async (MINER1, MINER2) => {
 
   // Initialise global skills tree: 3, local skills tree 1 -> 4 -> 5
   //                                                      \-> 2
-  await metaColony.addDomain(1, X, 1);
+  await metaColony.addDomain(1, UINT256_MAX, 1);
   await metaColony.addDomain(1, 1, 2);
 
   await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);

--- a/test/reputation-system/happy-paths.js
+++ b/test/reputation-system/happy-paths.js
@@ -29,7 +29,7 @@ import {
 } from "../../helpers/test-data-generator";
 
 import {
-  X,
+  UINT256_MAX,
   DEFAULT_STAKE,
   INITIAL_FUNDING,
   MINING_CYCLE_DURATION,
@@ -70,7 +70,7 @@ const setupNewNetworkInstance = async (MINER1, MINER2) => {
 
   // Initialise global skills tree: 1 -> 4 -> 5 -> 6 -> 7 -> 8 -> 9 -> 10
   // We're not resetting the global skills tree as the Network is not reset
-  await metaColony.addDomain(1, X, 1);
+  await metaColony.addDomain(1, UINT256_MAX, 1);
   await metaColony.addDomain(1, 1, 2);
   await metaColony.addDomain(1, 2, 3);
   await metaColony.addDomain(1, 3, 4);

--- a/test/reputation-system/happy-paths.js
+++ b/test/reputation-system/happy-paths.js
@@ -29,6 +29,7 @@ import {
 } from "../../helpers/test-data-generator";
 
 import {
+  X,
   DEFAULT_STAKE,
   INITIAL_FUNDING,
   MINING_CYCLE_DURATION,
@@ -69,7 +70,7 @@ const setupNewNetworkInstance = async (MINER1, MINER2) => {
 
   // Initialise global skills tree: 1 -> 4 -> 5 -> 6 -> 7 -> 8 -> 9 -> 10
   // We're not resetting the global skills tree as the Network is not reset
-  await metaColony.addDomain(1, 0, 1);
+  await metaColony.addDomain(1, X, 1);
   await metaColony.addDomain(1, 1, 2);
   await metaColony.addDomain(1, 2, 3);
   await metaColony.addDomain(1, 3, 4);

--- a/test/reputation-system/root-hash-submissions.js
+++ b/test/reputation-system/root-hash-submissions.js
@@ -689,7 +689,7 @@ contract("Reputation mining - root hash submissions", (accounts) => {
       await metaColony.claimColonyFunds(clnyToken.address);
       // Move all of them in to the reward pot
       const amount = await metaColony.getFundingPotBalance(1, clnyToken.address);
-      await metaColony.moveFundsBetweenPots(1, 0, 0, 1, 0, amount, clnyToken.address);
+      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, amount, clnyToken.address);
 
       const result = await metaColony.getDomain(1);
       const rootDomainSkill = result.skillId;


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->

<!--- Summary of changes including design decisions -->

### The issue

Taking DLP actions (see #553) requires submitting a "domain proof" of the form (`permissionDomainId, childSkillIndex, domainId`). These three inputs allow us to verify, in constant time, that both a) the user has the permission needed to take the action, and b) the domain of action is in the inheritance path of the domain of permission. There was one hiccup -- if `permissionDomainId` and `domainId` were the same (i.e. a user was taking an action in the same domain where they had the permission, a common occurrence), then the semantics of `childSkillIndex` became murky -- since children are 0-indexed, `childSkillIndex = 0` meant the "first child" -- there was no value which represented "the domain itself".

Our initial solution was to say, "alright, when `permissionDomainId == domainId`, we just ignore `childSkillIndex`" -- the user can put in whatever value they want, we just ignore it. That worked pretty well.

However, that degree of ambiguity, where `(permissionDomainId, childSkillIndex, domainId)` is not strictly unique, came back to bite us in the butt when implementing disputes.

Why? A confluence of two factors. First, in order to make disputes as general as possible, all actions are represented as `bytes` arrays, to be executed by the disputes extension. Second, in order to ensure that only appropriate reputation is voting on disputes, we must be able to infer, from the action, what domain it acts in. How to do this? By parsing the `bytes` array, extracting the `permissionDomainId` and `childSkillIndex` (which, by fortunate convention, are always the first two arguments), and using those to infer `domainId`.

Herein lies the problem: it is not always possible to exactly infer `domainId` from the other two arguments, as a `childSkillIndex` of 0 can be interpreted to mean EITHER `permissionDomainId` itself OR the first child. This creates a problem for disputes since it means that an action in a domain could potentially be voted on by the first child domain, a clear violation of the semantics of DLP.

### The answer

Fortunately, we have a solution, and it is relatively simple: adopt a new convention, where `UINT256_MAX` (the largest possible number) is passed as `childSkillIndex` whenever `permissionDomainId == domainId`. In a sense, it becomes a "pseudo index" for a non-existent value.

While a slight hack, this approach is justifiable in that there is no way for any domain to have `UINT256_MAX` child domains (for reasons of gas limits and also of time), so there will never be a case where `UINT256_MAX` actually indexes a child domain, making it's usefulness as a special index valid.

### The consequences

Fortunately, since `childSkillIndex` must almost always be supplied by users, this change will not* break any existing contracts. It may, however, require client updates to ensure that the correct value is being passed. These updates can be as simple as a line to the effect of:

```
const childSkillIndex = (permissionDomainId == domainId) ? UINT256_MAX : getIndex(permissionDomainId, domainId);
```

*Unfortunately, `OneTxPayment` will need to be updated, since that contract *does* have `childSkillIndex` hardcoded for the root domain.