### PR TITLE
Allow creation of colonies with earlier version

### DIFF
--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -129,7 +129,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
   returns (address)
   {
     require(colonyVersionResolver[_version] != address(0x00), "colony-network-invalid-version");
-    return createColonyFunctionality(_tokenAddress, _version);
+    return createColonyFromVersion(_tokenAddress, _version);
   }
 
   function createColony(address _tokenAddress) public
@@ -137,10 +137,10 @@ contract ColonyNetwork is ColonyNetworkStorage {
   returns (address)
   {
     require(currentColonyVersion > 0, "colony-network-not-initialised-cannot-create-colony");
-    return createColonyFunctionality(_tokenAddress, currentColonyVersion);
+    return createColonyFromVersion(_tokenAddress, currentColonyVersion);
   }
 
-  function createColonyFunctionality(address _tokenAddress, uint256 _version) internal
+  function createColonyFromVersion(address _tokenAddress, uint256 _version) internal
   stoppable
   returns (address)
   {

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -124,16 +124,31 @@ contract ColonyNetwork is ColonyNetworkStorage {
     emit MetaColonyCreated(metaColony, _tokenAddress, skillCount);
   }
 
+  function createColony(address _tokenAddress, uint256 _version) public
+  stoppable
+  returns (address)
+  {
+    require(colonyVersionResolver[_version] != address(0x00), "colony-network-invalid-version");
+    return createColonyFunctionality(_tokenAddress, _version);
+  }
+
   function createColony(address _tokenAddress) public
   stoppable
   returns (address)
   {
     require(currentColonyVersion > 0, "colony-network-not-initialised-cannot-create-colony");
+    return createColonyFunctionality(_tokenAddress, currentColonyVersion);
+  }
+
+  function createColonyFunctionality(address _tokenAddress, uint256 _version) internal
+  stoppable
+  returns (address)
+  {
     require(_tokenAddress != address(0x0), "colony-token-invalid-address");
     EtherRouter etherRouter = new EtherRouter();
     IColony colony = IColony(address(etherRouter));
-    address resolverForLatestColonyVersion = colonyVersionResolver[currentColonyVersion]; // ignore-swc-107
-    etherRouter.setResolver(resolverForLatestColonyVersion); // ignore-swc-113
+    address resolverForColonyVersion = colonyVersionResolver[_version]; // ignore-swc-107
+    etherRouter.setResolver(resolverForColonyVersion); // ignore-swc-113
 
     // Creating new instance of colony's authority
     ColonyAuthority colonyAuthority = new ColonyAuthority(address(colony));

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -126,13 +126,23 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @param _tokenAddress Address of the CLNY token
   function createMetaColony(address _tokenAddress) public;
 
-  /// @notice Creates a new colony in the network.
+  /// @notice Creates a new colony in the network with the latest version available
   /// Note that the token ownership (if there is one) has to be transferred to the newly created colony.
   /// @param _tokenAddress Address of an ERC20 token to serve as the colony token.
   /// Additionally token can optionally support `mint` as defined in `ERC20Extended`.
   /// Support for `mint` is mandatory only for the Meta Colony Token.
   /// @return colonyAddress Address of the newly created colony
   function createColony(address _tokenAddress) public returns (address colonyAddress);
+
+  /// @notice Creates a new colony in the network at a specific version. Not recommended unless you
+  /// are confident in what you're doing.
+  /// Note that the token ownership (if there is one) has to be transferred to the newly created colony.
+  /// @param _tokenAddress Address of an ERC20 token to serve as the colony token.
+  /// @param _version The version of colony to deploy.
+  /// Additionally token can optionally support `mint` as defined in `ERC20Extended`.
+  /// Support for `mint` is mandatory only for the Meta Colony Token.
+  /// @return colonyAddress Address of the newly created colony
+  function createColony(address _tokenAddress, uint256 _version) public returns (address colonyAddress);
 
   /// @notice Adds a new Colony contract version and the address of associated `_resolver` contract. Secured function to authorised members.
   /// Allowed to be called by the Meta Colony only.

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -90,7 +90,25 @@ Calculate raw miner weight in WADs.
 
 ### `createColony`
 
-Creates a new colony in the network. Note that the token ownership (if there is one) has to be transferred to the newly created colony.
+Creates a new colony in the network at a specific version. Not recommended unless you are confident in what you're doing. Note that the token ownership (if there is one) has to be transferred to the newly created colony.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_tokenAddress|address|Address of an ERC20 token to serve as the colony token.
+|_version|uint256|The version of colony to deploy. Additionally token can optionally support `mint` as defined in `ERC20Extended`. Support for `mint` is mandatory only for the Meta Colony Token.
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|colonyAddress|address|Address of the newly created colony
+
+### `createColony`
+
+Creates a new colony in the network with the latest version available Note that the token ownership (if there is one) has to be transferred to the newly created colony.
 
 
 **Parameters**

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -152,6 +152,54 @@ contract("Colony Network", accounts => {
     });
   });
 
+  describe("when creating new colonies at a specific version", () => {
+    beforeEach(async () => {
+      // The new resolver also needs to know a load of functions to let createColony work...
+      const copyWiring = async function(resolverFrom, resolverTo, functionSig) {
+        const sig = await resolverFrom.stringToSig(functionSig);
+        const functionLocation = await resolverFrom.lookup(sig);
+        await resolverTo.register(functionSig, functionLocation);
+      };
+
+      const metaColonyAsEtherRouter = await EtherRouter.at(metaColony.address);
+      const wiredResolverAddress = await metaColonyAsEtherRouter.resolver();
+      const wiredResolver = await Resolver.at(wiredResolverAddress);
+
+      const r = await Resolver.at(newResolverAddress);
+
+      await copyWiring(wiredResolver, r, "initialiseColony(address,address)");
+      await copyWiring(wiredResolver, r, "setRecoveryRole(address)");
+      await copyWiring(wiredResolver, r, "setRootRole(address,bool)");
+      await copyWiring(wiredResolver, r, "setArbitrationRole(uint256,uint256,address,uint256,bool)");
+      await copyWiring(wiredResolver, r, "setArchitectureRole(uint256,uint256,address,uint256,bool)");
+      await copyWiring(wiredResolver, r, "setFundingRole(uint256,uint256,address,uint256,bool)");
+      await copyWiring(wiredResolver, r, "setAdministrationRole(uint256,uint256,address,uint256,bool)");
+
+      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
+      const oldVersion = currentColonyVersion.subn(1);
+      await metaColony.addNetworkColonyVersion(oldVersion, newResolverAddress);
+    });
+
+    it("should allow users to create a new colony at a specific older version", async () => {
+      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
+      const oldVersion = currentColonyVersion.subn(1);
+
+      const token = await Token.new(...getTokenArgs());
+      await token.unlock();
+      await colonyNetwork.createColony(token.address, oldVersion);
+    });
+
+    it("should not users to create a new colony at a version that doesn't exist", async () => {
+      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
+      const nonexistentVersion = currentColonyVersion.addn(1);
+
+      const token = await Token.new(...getTokenArgs());
+      await token.unlock();
+      await checkErrorRevert(colonyNetwork.createColony(token.address, nonexistentVersion), "colony-network-invalid-version");
+      await checkErrorRevert(colonyNetwork.createColony(token.address, 0), "colony-network-invalid-version");
+    });
+  });
+
   describe("when creating new colonies", () => {
     it("should allow users to create new colonies", async () => {
       const { colony } = await setupRandomColony(colonyNetwork);

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -187,6 +187,12 @@ contract("Colony Network", accounts => {
       const token = await Token.new(...getTokenArgs());
       await token.unlock();
       await colonyNetwork.createColony(token.address, oldVersion);
+
+      const colonyAddress = await colonyNetwork.getColony(2);
+
+      const colonyEtherRouter = await EtherRouter.at(colonyAddress);
+      const colonyResolver = await colonyEtherRouter.resolver();
+      expect(colonyResolver.toLowerCase()).to.equal(newResolverAddress);
     });
 
     it("should not users to create a new colony at a version that doesn't exist", async () => {


### PR DESCRIPTION
Closes #783 

I've overloaded `createColony` rather than replacing it here (to aid our how-to-upgrade-everything process until we have it down pat), but otherwise, fairly straightforward. There are no limits here other than 'the version exists'; it's possible that in the future we'd have a minimum-supported version (especially as the app evolves) but for now this seems sufficient.