### PR TITLE
Update documentation for claimRewardPayout

### DIFF
--- a/contracts/ColonyFunding.sol
+++ b/contracts/ColonyFunding.sol
@@ -419,7 +419,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     require(userReputation > 0, "colony-reward-payout-invalid-user-reputation");
 
     // squareRoots[0] - square root of userReputation
-    // squareRoots[1] - square root of userTokens
+    // squareRoots[1] - square root of userTokens (deposited in TokenLocking)
     // squareRoots[2] - square root of payout.colonyWideReputation
     // squareRoots[3] - square root of totalTokens
     // squareRoots[4] - square root of numerator

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -641,7 +641,7 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @param _payoutId Id of the reward payout
   /// @param _squareRoots Square roots of values used in equation:
   /// `_squareRoots[0]` - square root of user reputation,
-  /// `_squareRoots[1]` - square root of user tokens,
+  /// `_squareRoots[1]` - square root of user tokens (deposited in TokenLocking),
   /// `_squareRoots[2]` - square root of total reputation,
   /// `_squareRoots[3]` - square root of total tokens,
   /// `_squareRoots[4]` - square root of numerator (user reputation * user tokens),

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -145,7 +145,7 @@ Claim the reward payout at `_payoutId`. User needs to provide their reputation a
 |Name|Type|Description|
 |---|---|---|
 |_payoutId|uint256|Id of the reward payout
-|_squareRoots|uint256[7]|Square roots of values used in equation: `_squareRoots[0]` - square root of user reputation, `_squareRoots[1]` - square root of user tokens, `_squareRoots[2]` - square root of total reputation, `_squareRoots[3]` - square root of total tokens, `_squareRoots[4]` - square root of numerator (user reputation * user tokens), `_squareRoots[5]` - square root of denominator (total reputation * total tokens), `_squareRoots[6]` - square root of payout amount.
+|_squareRoots|uint256[7]|Square roots of values used in equation: `_squareRoots[0]` - square root of user reputation, `_squareRoots[1]` - square root of user tokens (deposited in TokenLocking), `_squareRoots[2]` - square root of total reputation, `_squareRoots[3]` - square root of total tokens, `_squareRoots[4]` - square root of numerator (user reputation * user tokens), `_squareRoots[5]` - square root of denominator (total reputation * total tokens), `_squareRoots[6]` - square root of payout amount.
 |key|bytes|Some Reputation hash tree key
 |value|bytes|Reputation value
 |branchMask|uint256|The branchmask of the proof


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
An early user was having difficulty claiming rewards payouts, and part of the reason is that he believed that the relevant user token balance is their _entire_ balance, rather than the amount deposited in `tokenLocking`. This PR clarifies which balance is relevant.

<!--- Summary of changes including design decisions -->

