### PR TITLE
Reward users for responding during dispute

### DIFF
--- a/contracts/ReputationMiningCycleCommon.sol
+++ b/contracts/ReputationMiningCycleCommon.sol
@@ -1,0 +1,105 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity 0.5.8;
+pragma experimental "ABIEncoderV2";
+
+import "../lib/dappsys/math.sol";
+import "./PatriciaTree/PatriciaTreeProofs.sol";
+import "./ReputationMiningCycleStorage.sol";
+import "./ITokenLocking.sol";
+import "./IColonyNetwork.sol";
+
+
+contract ReputationMiningCycleCommon is ReputationMiningCycleStorage, PatriciaTreeProofs, DSMath {
+  /// @notice Minimum reputation mining stake in CLNY
+  uint256 constant MIN_STAKE = 2000 * WAD;
+
+  function rewardResponder(address _responder) internal returns (bytes32) {
+    respondedToChallenge[_responder] = true;
+    uint256 reward = disputeRewardIncrement();
+    ITokenLocking(tokenLockingAddress).reward(
+      _responder,
+      reward
+    );
+    rewardsPaidOut += reward;
+  }
+
+  function disputeRewardIncrement() internal view returns (uint256) {
+    // TODO: Is this worth calculating once, and then saving? Seems quite likely.
+    uint256 nLogEntries = reputationUpdateLog.length;
+
+    // If there's no log, it must be one of the first two reputation cycles - no reward.
+    if (nLogEntries == 0) {
+      return 0;
+    }
+
+    // No dispute, so no dispute reward
+    if (nUniqueSubmittedHashes <= 1) {
+      return 0;
+    }
+
+    uint256 reputationRootHashNNodes = IColonyNetwork(colonyNetworkAddress).getReputationRootHashNNodes();
+    uint jrhNnodes = reputationUpdateLog[nLogEntries-1].nUpdates +
+      reputationUpdateLog[nLogEntries-1].nPreviousUpdates + reputationRootHashNNodes + 1; // This is the number of nodes we expect in the justification tree
+
+    uint256 nByes = log2Ceiling(nUniqueSubmittedHashes); // We can have at most one bye per round, and this is the maximum number of rounds
+
+    // The maximum number of responses that need rewards
+    uint256 rewardDenominator = nByes + (nUniqueSubmittedHashes-1)*(2*(3 + log2Ceiling(jrhNnodes)) + 1);
+
+    // The minimum amount of stake to be lost
+    uint256 rewardNumerator = MIN_STAKE * (nUniqueSubmittedHashes - 1);
+    uint256 reward = rewardNumerator / rewardDenominator;
+    return reward;
+  }
+
+  // https://ethereum.stackexchange.com/questions/8086/logarithm-math-operation-in-solidity
+  // Some impressive de Bruijn sequence magic here...
+  function log2Ceiling(uint x) internal pure returns (uint y) {
+    assembly {
+        let arg := x
+        x := sub(x,1)
+        x := or(x, div(x, 0x02))
+        x := or(x, div(x, 0x04))
+        x := or(x, div(x, 0x10))
+        x := or(x, div(x, 0x100))
+        x := or(x, div(x, 0x10000))
+        x := or(x, div(x, 0x100000000))
+        x := or(x, div(x, 0x10000000000000000))
+        x := or(x, div(x, 0x100000000000000000000000000000000))
+        x := add(x, 1)
+        let m := mload(0x40)
+        mstore(m,           0xf8f9cbfae6cc78fbefe7cdc3a1793dfcf4f0e8bbd8cec470b6a28a7a5a3e1efd)
+        mstore(add(m,0x20), 0xf5ecf1b3e9debc68e1d9cfabc5997135bfb7a7a3938b7b606b5b4b3f2f1f0ffe)
+        mstore(add(m,0x40), 0xf6e4ed9ff2d6b458eadcdf97bd91692de2d4da8fd2d0ac50c6ae9a8272523616)
+        mstore(add(m,0x60), 0xc8c0b887b0a8a4489c948c7f847c6125746c645c544c444038302820181008ff)
+        mstore(add(m,0x80), 0xf7cae577eec2a03cf3bad76fb589591debb2dd67e0aa9834bea6925f6a4a2e0e)
+        mstore(add(m,0xa0), 0xe39ed557db96902cd38ed14fad815115c786af479b7e83247363534337271707)
+        mstore(add(m,0xc0), 0xc976c13bb96e881cb166a933a55e490d9d56952b8d4e801485467d2362422606)
+        mstore(add(m,0xe0), 0x753a6d1b65325d0c552a4d1345224105391a310b29122104190a110309020100)
+        mstore(0x40, add(m, 0x100))
+        let magic := 0x818283848586878898a8b8c8d8e8f929395969799a9b9d9e9faaeb6bedeeff
+        let shift := 0x100000000000000000000000000000000000000000000000000000000000000
+        let a := div(mul(x, magic), shift)
+        y := div(mload(add(m,sub(255,a))), shift)
+        y := add(y, mul(256, gt(arg, 0x8000000000000000000000000000000000000000000000000000000000000000)))
+    }
+  }
+
+
+}

--- a/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
+++ b/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
@@ -94,7 +94,7 @@ contract ColonyNetworkDataTypes {
   /// @param label The label registered
   event ColonyLabelRegistered(address indexed colony, bytes32 label);
 
-  event ReputationMinerPenalised(address miner, address beneficiary, uint256 tokensLost);
+  event ReputationMinerPenalised(address miner, uint256 tokensLost);
 
   struct Skill {
     // total number of parent skills

--- a/contracts/colonyNetwork/ColonyNetworkMining.sol
+++ b/contracts/colonyNetwork/ColonyNetworkMining.sol
@@ -210,8 +210,7 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
   function unstakeForMining(uint256 _amount) public stoppable {
     address clnyToken = IMetaColony(metaColony).getToken();
     // Prevent those involved in a mining cycle withdrawing stake during the mining process.
-    bool involved = IReputationMiningCycle(activeReputationMiningCycle).userInvolvedInMiningCycle(msg.sender);
-    require(!involved, "colony-token-locking-hash-submitted");
+    require(!IReputationMiningCycle(activeReputationMiningCycle).userInvolvedInMiningCycle(msg.sender), "colony-token-locking-hash-submitted");
     ITokenLocking(tokenLocking).deobligateStake(msg.sender, _amount, clnyToken);
     miningStakes[msg.sender].amount = sub(miningStakes[msg.sender].amount, _amount);
   }

--- a/contracts/colonyNetwork/ColonyNetworkMining.sol
+++ b/contracts/colonyNetwork/ColonyNetworkMining.sol
@@ -231,8 +231,8 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
     return miningStakes[_user];
   }
 
-  function burnUnneededRewards(uint256 _amount) public stoppable {
-    ITokenLocking(tokenLocking).claim(address(this), true);
+  function burnUnneededRewards(uint256 _amount) public stoppable onlyReputationMiningCycle() {
+    ITokenLocking(tokenLocking).claim(IMetaColony(metaColony).getToken(), true);
     ITokenLocking(tokenLocking).burn(_amount);
   }
 

--- a/contracts/colonyNetwork/ColonyNetworkMining.sol
+++ b/contracts/colonyNetwork/ColonyNetworkMining.sol
@@ -183,18 +183,16 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
     );
   }
 
-  function punishStakers(address[] memory _stakers, address _beneficiary, uint256 _amount) public stoppable onlyReputationMiningCycle {
+  function punishStakers(address[] memory _stakers, uint256 _amount) public stoppable onlyReputationMiningCycle {
     address clnyToken = IMetaColony(metaColony).getToken();
     uint256 lostStake;
     // Passing an array so that we don't incur the EtherRouter overhead for each staker if we looped over
     // it in ReputationMiningCycle.invalidateHash;
     for (uint256 i = 0; i < _stakers.length; i++) {
       lostStake = min(ITokenLocking(tokenLocking).getObligation(_stakers[i], clnyToken, address(this)), _amount);
-      ITokenLocking(tokenLocking).transferStake(_stakers[i], lostStake, clnyToken, _beneficiary);
-
+      ITokenLocking(tokenLocking).transferStake(_stakers[i], lostStake, clnyToken, address(this));
       // TODO: Lose rep?
-
-      emit ReputationMinerPenalised(_stakers[i], _beneficiary, lostStake);
+      emit ReputationMinerPenalised(_stakers[i], lostStake);
     }
   }
 
@@ -211,9 +209,9 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
 
   function unstakeForMining(uint256 _amount) public stoppable {
     address clnyToken = IMetaColony(metaColony).getToken();
-    // Prevent reputation miners from withdrawing stake during the mining process.
-    bytes32 submissionHash = IReputationMiningCycle(activeReputationMiningCycle).getReputationHashSubmission(msg.sender).proposedNewRootHash;
-    require(submissionHash == 0x0, "colony-network-hash-submitted");
+    // Prevent those involved in a mining cycle withdrawing stake during the mining process.
+    bool involved = IReputationMiningCycle(activeReputationMiningCycle).userInvolvedInMiningCycle(msg.sender);
+    require(!involved, "colony-token-locking-hash-submitted");
     ITokenLocking(tokenLocking).deobligateStake(msg.sender, _amount, clnyToken);
     miningStakes[msg.sender].amount = sub(miningStakes[msg.sender].amount, _amount);
   }

--- a/contracts/colonyNetwork/ColonyNetworkMining.sol
+++ b/contracts/colonyNetwork/ColonyNetworkMining.sol
@@ -236,6 +236,4 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
 
     return add(mul(prevWeight, _prevTime), mul(currWeight, _currTime)) / add(prevWeight, currWeight);
   }
-
-
 }

--- a/contracts/colonyNetwork/ColonyNetworkStorage.sol
+++ b/contracts/colonyNetwork/ColonyNetworkStorage.sol
@@ -86,6 +86,7 @@ contract ColonyNetworkStorage is CommonStorage, ColonyNetworkDataTypes, DSMath {
   mapping (address => mapping(uint256 => ReputationLogEntry)) replacementReputationUpdateLog; // Storage slot 31
   mapping (address => bool) replacementReputationUpdateLogsExist; // Storage slot 32
   mapping (address => MiningStake) miningStakes; // Storage slot 33
+  mapping (address => uint256) pendingMiningRewards; // Storage slot 34
 
   modifier calledByColony() {
     require(_isColony[msg.sender], "colony-caller-must-be-colony");

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -283,9 +283,8 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @notice Function called to punish people who staked against a new reputation root hash that turned out to be incorrect.
   /// @dev While public, it can only be called successfully by the current ReputationMiningCycle.
   /// @param _stakers Array of the addresses of stakers to punish
-  /// @param _beneficiary Address of beneficiary to receive forfeited stake
   /// @param _amount Amount of stake to slash
-  function punishStakers(address[] memory _stakers, address _beneficiary, uint256 _amount) public;
+  function punishStakers(address[] memory _stakers, uint256 _amount) public;
 
   /// @notice Stake CLNY to allow the staker to participate in reputation mining.
   /// @param _amount Amount of CLNY to stake for the purposes of mining
@@ -295,5 +294,24 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @param _amount Amount of CLNY staked for mining to unstake
   function unstakeForMining(uint256 _amount) public;
 
+  /// @notice returns how much CLNY _user has staked for the purposes of reputation mining
+  /// @param _user The user to query
+  /// @return _info The amount staked and the timestamp the stake was made at.
   function getMiningStake(address _user) public view returns (MiningStake memory _info);
+
+  /// @notice Used to track that a user is eligible to claim a reward
+  /// @dev Only callable by the active reputation mining cycle
+  /// @param _recipient The address receiving the award
+  /// @param _amount The amount of CLNY to be awarded
+  function reward(address _recipient, uint256 _amount) public;
+
+  /// @notice Used to burn tokens that are not needed to pay out rewards (because not every possible defence was made for all submissions)
+  /// @dev Only callable by the active reputation mining cycle
+  /// @param _amount The amount of CLNY to burn
+  function burnUnneededRewards(uint256 _amount) public;
+
+  /// @notice Used by a user to claim any mining rewards due to them. This will place them in their balance or pending balance, as appropriate.
+  /// @dev Can be called by anyone, not just _recipient
+  /// @param _recipient The user whose rewards to claim
+  function claimMiningReward(address _recipient) public;
 }

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -296,5 +296,4 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   function unstakeForMining(uint256 _amount) public;
 
   function getMiningStake(address _user) public view returns (MiningStake memory _info);
-
 }

--- a/contracts/reputationMiningCycle/IReputationMiningCycle.sol
+++ b/contracts/reputationMiningCycle/IReputationMiningCycle.sol
@@ -258,7 +258,7 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
 
   /// @notice Returns whether a particular address has been involved in the current mining cycle. This might be
   /// from submitting a hash, or from defending one during a dispute.
-  /// @param _user The address whose involvement being queried
+  /// @param _user The address whose involvement is being queried
   /// @return bool Whether the address has been involved in the current mining cycle
   function userInvolvedInMiningCycle(address _user) public view returns (bool involved);
 

--- a/contracts/reputationMiningCycle/IReputationMiningCycle.sol
+++ b/contracts/reputationMiningCycle/IReputationMiningCycle.sol
@@ -255,4 +255,14 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
   /// @param jrh The JRH of that was submitted
   /// @return count The number of submissions - should be 0-12, as up to twelve submissions can be made
   function getNSubmissionsForHash(bytes32 hash, uint256 nNodes, bytes32 jrh) public view returns (uint256 count);
+
+  /// @notice Returns whether a particular address has been involved in the current mining cycle. This might be
+  /// from submitting a hash, or from defending one during a dispute.
+  /// @param _user The address whose involvement being queried
+  /// @return bool Whether the address has been involved in the current mining cycle
+  function userInvolvedInMiningCycle(address _user) public view returns (bool involved);
+
+  /// @notice Returns the amount of CLNY given for defending a hash during the current dispute cycle
+  /// @return uint256 The amount of CLNY given.
+  function getDisputeRewardIncrement() public view returns (uint256 _reward);
 }

--- a/contracts/reputationMiningCycle/IReputationMiningCycle.sol
+++ b/contracts/reputationMiningCycle/IReputationMiningCycle.sol
@@ -264,5 +264,5 @@ contract IReputationMiningCycle is ReputationMiningCycleDataTypes {
 
   /// @notice Returns the amount of CLNY given for defending a hash during the current dispute cycle
   /// @return uint256 The amount of CLNY given.
-  function getDisputeRewardIncrement() public view returns (uint256 _reward);
+  function getDisputeRewardSize() public view returns (uint256 reward);
 }

--- a/contracts/reputationMiningCycle/ReputationMiningCycle.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycle.sol
@@ -214,8 +214,8 @@ contract ReputationMiningCycle is ReputationMiningCycleCommon {
     // take it in to account when calculating the reward for responders, which in turn means that the
     // calculation can be done from a purely pairwise dispute perspective.
     require(submissionWindowClosed(), "colony-reputation-mining-submission-window-still-open");
-    // Burn tokens that have been slashed, but not awarded to others as rewards.
-    ITokenLocking(tokenLockingAddress).burn(sub(stakeLost, rewardsPaidOut));
+    // Burn tokens that have been slashed, but will not be awarded to others as rewards.
+    IColonyNetwork(colonyNetworkAddress).burnUnneededRewards(sub(stakeLost, rewardsPaidOut));
 
     DisputedEntry storage winningDisputeEntry = disputeRounds[roundNumber][0];
     Submission storage submission = reputationHashSubmissions[winningDisputeEntry.firstSubmitter];

--- a/contracts/reputationMiningCycle/ReputationMiningCycle.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycle.sol
@@ -19,11 +19,12 @@ pragma solidity 0.5.8;
 pragma experimental "ABIEncoderV2";
 
 import "./../../lib/dappsys/math.sol";
-import "./../IColonyNetwork.sol";
+import "./../colonyNetwork/IColonyNetwork.sol";
 import "./../patriciaTree/PatriciaTreeProofs.sol";
-import "./../ITokenLocking.sol";
-import "./../ReputationMiningCycleStorage.sol";
-import "./../ReputationMiningCycleCommon.sol";
+import "./../tokenLocking/ITokenLocking.sol";
+import "./ReputationMiningCycleStorage.sol";
+import "./ReputationMiningCycleCommon.sol";
+
 
 contract ReputationMiningCycle is ReputationMiningCycleCommon {
   /// @notice Size of mining window in seconds
@@ -229,7 +230,7 @@ contract ReputationMiningCycle is ReputationMiningCycleCommon {
 
   function invalidateHash(uint256 round, uint256 idx) public {
     // What we do depends on our opponent, so work out which index it was at in disputeRounds[round]
-    uint256 opponentIdx = (idx % 2 == 1 ? idx-1 : idx + 1);
+    uint256 opponentIdx = opponentIdx(idx);
     uint256 nInNextRound;
 
     // We require either
@@ -277,7 +278,7 @@ contract ReputationMiningCycle is ReputationMiningCycleCommon {
       require(disputeRounds[round][opponentIdx].challengeStepCompleted >= disputeRounds[round][idx].challengeStepCompleted, "colony-reputation-mining-less-challenge-rounds-completed");
 
       // Require that it has failed a challenge (i.e. failed to respond in time)
-      require(disputeRounds[round][idx].lastResponseTimestamp < now && sub(now, disputeRounds[round][idx].lastResponseTimestamp) >= 600, "colony-reputation-mining-not-timed-out"); // Timeout is ten minutes here.
+      require(add(disputeRounds[round][idx].lastResponseTimestamp, 600) <= now, "colony-reputation-mining-not-timed-out"); // Timeout is ten minutes here.
 
       // Work out whether we are invalidating just the supplied idx or its opponent too.
       bool eliminateOpponent = false;
@@ -410,10 +411,6 @@ contract ReputationMiningCycle is ReputationMiningCycleCommon {
   {
     require(submissionWindowClosed(), "colony-reputation-mining-cycle-submissions-not-closed");
     require(index < disputeRounds[round].length, "colony-reputation-mining-index-beyond-round-length");
-
-    // We reward the submitter for this, so we better have an opponent so that someone gets slashed and can pay for it
-    uint256 opponentIdx = (index % 2 == 1 ? index-1 : index + 1);
-    require(opponentIdx < disputeRounds[round].length, "colony-reputation-mining-no-opponent-yet");
 
     Submission storage submission = reputationHashSubmissions[disputeRounds[round][index].firstSubmitter];
     // Require we've not confirmed the JRH already.
@@ -551,6 +548,24 @@ contract ReputationMiningCycle is ReputationMiningCycleCommon {
     return reputationMiningWindowOpenTimestamp;
   }
 
+  function getDisputeRewardSize() public view returns (uint256) {
+    return disputeRewardSize();
+  }
+
+  function expectedBranchMask(uint256 nNodes, uint256 node) public pure returns (uint256) {
+    // Gets the expected branchmask for a patricia tree which has nNodes, with keys from 0 to nNodes -1
+    // i.e. the tree is 'full' - there are no missing nodes
+    uint256 mask = sub(nNodes, 1); // Every branchmask in a full tree has at least these 1s set
+    uint256 xored = mask ^ node; // Where do mask and node differ?
+    // Set every bit in the mask from the first bit where they differ to 1
+    uint256 remainderMask = sub(nextPowerOfTwoInclusive(add(xored, 1)), 1);
+    return mask | remainderMask;
+  }
+
+  function userInvolvedInMiningCycle(address _user) public view returns (bool) {
+    return reputationHashSubmissions[_user].proposedNewRootHash != 0x00 || respondedToChallenge[_user];
+  }
+
   /////////////////////////
   // Internal functions
   /////////////////////////
@@ -581,7 +596,7 @@ contract ReputationMiningCycle is ReputationMiningCycleCommon {
     disputeRounds[round][idx].hash1 = lastSiblings[0];
     disputeRounds[round][idx].hash2 = lastSiblings[1];
 
-    uint256 opponentIdx = (idx % 2 == 1 ? idx-1 : idx + 1);
+    uint256 opponentIdx = opponentIdx(idx);
     if (disputeRounds[round][opponentIdx].challengeStepCompleted == disputeRounds[round][idx].challengeStepCompleted ) {
       // Our opponent answered this challenge already.
       // Compare our intermediateReputationHash to theirs to establish how to move the bounds.
@@ -590,7 +605,7 @@ contract ReputationMiningCycle is ReputationMiningCycleCommon {
   }
 
   function processBinaryChallengeSearchStep(uint256 round, uint256 idx) internal {
-    uint256 opponentIdx = (idx % 2 == 1 ? idx-1 : idx + 1);
+    uint256 opponentIdx = opponentIdx(idx);
     uint256 searchWidth = (disputeRounds[round][idx].upperBound - disputeRounds[round][idx].lowerBound) + 1;
     uint256 searchWidthNextPowerOfTwo = nextPowerOfTwoInclusive(searchWidth);
     if (
@@ -722,23 +737,8 @@ contract ReputationMiningCycle is ReputationMiningCycleCommon {
     return layers;
   }
 
-  function expectedBranchMask(uint256 nNodes, uint256 node) public pure returns (uint256) {
-    // Gets the expected branchmask for a patricia tree which has nNodes, with keys from 0 to nNodes -1
-    // i.e. the tree is 'full' - there are no missing nodes
-    uint256 mask = sub(nNodes, 1); // Every branchmask in a full tree has at least these 1s set
-    uint256 xored = mask ^ node; // Where do mask and node differ?
-    // Set every bit in the mask from the first bit where they differ to 1
-    uint256 remainderMask = sub(nextPowerOfTwoInclusive(add(xored, 1)), 1);
-    return mask | remainderMask;
+  function opponentIdx(uint256 _idx) private pure returns (uint256) {
+    return _idx % 2 == 1 ? _idx - 1 : _idx + 1;
   }
 
-  function userInvolvedInMiningCycle(address _user) public view returns (bool) {
-    if (
-      reputationHashSubmissions[_user].proposedNewRootHash != 0x00 ||
-      respondedToChallenge[_user] == true
-    ) {
-      return true;
-    }
-    return false;
-  }
 }

--- a/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
@@ -20,7 +20,6 @@ pragma experimental "ABIEncoderV2";
 
 import "./../../lib/dappsys/math.sol";
 import "./../patriciaTree/PatriciaTreeProofs.sol";
-import "./../tokenLocking/ITokenLocking.sol";
 import "./../colonyNetwork/IColonyNetwork.sol";
 import "./ReputationMiningCycleStorage.sol";
 
@@ -32,7 +31,7 @@ contract ReputationMiningCycleCommon is ReputationMiningCycleStorage, PatriciaTr
   function rewardResponder(address _responder) internal returns (bytes32) {
     respondedToChallenge[_responder] = true;
     uint256 reward = disputeRewardSize();
-    ITokenLocking(tokenLockingAddress).reward(_responder, reward);
+    IColonyNetwork(colonyNetworkAddress).reward(_responder, reward);
     rewardsPaidOut += reward;
   }
 

--- a/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
@@ -18,11 +18,11 @@
 pragma solidity 0.5.8;
 pragma experimental "ABIEncoderV2";
 
-import "../lib/dappsys/math.sol";
-import "./PatriciaTree/PatriciaTreeProofs.sol";
+import "./../../lib/dappsys/math.sol";
+import "./../patriciaTree/PatriciaTreeProofs.sol";
+import "./../tokenLocking/ITokenLocking.sol";
+import "./../colonyNetwork/IColonyNetwork.sol";
 import "./ReputationMiningCycleStorage.sol";
-import "./ITokenLocking.sol";
-import "./IColonyNetwork.sol";
 
 
 contract ReputationMiningCycleCommon is ReputationMiningCycleStorage, PatriciaTreeProofs, DSMath {
@@ -31,15 +31,12 @@ contract ReputationMiningCycleCommon is ReputationMiningCycleStorage, PatriciaTr
 
   function rewardResponder(address _responder) internal returns (bytes32) {
     respondedToChallenge[_responder] = true;
-    uint256 reward = disputeRewardIncrement();
-    ITokenLocking(tokenLockingAddress).reward(
-      _responder,
-      reward
-    );
+    uint256 reward = disputeRewardSize();
+    ITokenLocking(tokenLockingAddress).reward(_responder, reward);
     rewardsPaidOut += reward;
   }
 
-  function disputeRewardIncrement() internal view returns (uint256) {
+  function disputeRewardSize() internal view returns (uint256) {
     // TODO: Is this worth calculating once, and then saving? Seems quite likely.
     uint256 nLogEntries = reputationUpdateLog.length;
 
@@ -60,7 +57,7 @@ contract ReputationMiningCycleCommon is ReputationMiningCycleStorage, PatriciaTr
     uint256 nByes = log2Ceiling(nUniqueSubmittedHashes); // We can have at most one bye per round, and this is the maximum number of rounds
 
     // The maximum number of responses that need rewards
-    uint256 rewardDenominator = nByes + (nUniqueSubmittedHashes-1)*(2*(3 + log2Ceiling(jrhNnodes)) + 1);
+    uint256 rewardDenominator = nByes + (nUniqueSubmittedHashes - 1) * (2 * (3 + log2Ceiling(jrhNnodes)) + 1);
 
     // The minimum amount of stake to be lost
     uint256 rewardNumerator = MIN_STAKE * (nUniqueSubmittedHashes - 1);
@@ -100,6 +97,4 @@ contract ReputationMiningCycleCommon is ReputationMiningCycleStorage, PatriciaTr
         y := add(y, mul(256, gt(arg, 0x8000000000000000000000000000000000000000000000000000000000000000)))
     }
   }
-
-
 }

--- a/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
@@ -18,19 +18,17 @@
 pragma solidity 0.5.8;
 pragma experimental "ABIEncoderV2";
 
-import "./../../lib/dappsys/math.sol";
-import "./../colonyNetwork/IColonyNetwork.sol";
+import "./../IColonyNetwork.sol";
 import "./../patriciaTree/PatriciaTreeProofs.sol";
-import "./../reputationMiningCycle/ReputationMiningCycleStorage.sol";
-import "./../tokenLocking/ITokenLocking.sol";
+import "./../ITokenLocking.sol";
 import {Bits} from "./../patriciaTree/Bits.sol";
-
+import "./../ReputationMiningCycleCommon.sol";
 
 // TODO (post CCv1, possibly never): Can we handle all possible disputes regarding the very first hash that should be set?
 // Currently, at the very least, we can't handle a dispute if the very first entry is disputed.
 // A possible workaround would be to 'kick off' reputation mining with a known dummy state...
 // Given the approach we a taking for launch, we are able to guarantee that we are the only reputation miner for 100+ of the first cycles, even if we decided to lengthen a cycle length. As a result, maybe we just don't care about this special case?
-contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaTreeProofs, DSMath {
+contract ReputationMiningCycleRespond is ReputationMiningCycleCommon {
 
   /// @notice A modifier that checks if the challenge corresponding to the hash in the passed `round` and `id` is open
   /// @param round The round number of the hash under consideration
@@ -328,6 +326,9 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
     disputeRounds[u[U_ROUND]][u[U_IDX]].challengeStepCompleted += 1;
     disputeRounds[u[U_ROUND]][u[U_IDX]].lastResponseTimestamp = now;
     Submission storage submission = reputationHashSubmissions[disputeRounds[u[U_ROUND]][u[U_IDX]].firstSubmitter];
+
+    // And reward the user
+    rewardResponder(msg.sender);
 
     emit ChallengeCompleted(submission.proposedNewRootHash, submission.nNodes, submission.jrh);
   }
@@ -746,5 +747,9 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleStorage, PatriciaT
         mstore(add(reputationKey, 52), skill)
     }
     return reputationKey;
+  }
+
+  function getDisputeRewardIncrement() public view returns (uint256) {
+    return disputeRewardIncrement();
   }
 }

--- a/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
@@ -18,11 +18,12 @@
 pragma solidity 0.5.8;
 pragma experimental "ABIEncoderV2";
 
-import "./../IColonyNetwork.sol";
+import "./../colonyNetwork/IColonyNetwork.sol";
 import "./../patriciaTree/PatriciaTreeProofs.sol";
-import "./../ITokenLocking.sol";
+import "./../tokenLocking/ITokenLocking.sol";
 import {Bits} from "./../patriciaTree/Bits.sol";
-import "./../ReputationMiningCycleCommon.sol";
+import "./ReputationMiningCycleCommon.sol";
+
 
 // TODO (post CCv1, possibly never): Can we handle all possible disputes regarding the very first hash that should be set?
 // Currently, at the very least, we can't handle a dispute if the very first entry is disputed.
@@ -747,9 +748,5 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleCommon {
         mstore(add(reputationKey, 52), skill)
     }
     return reputationKey;
-  }
-
-  function getDisputeRewardIncrement() public view returns (uint256) {
-    return disputeRewardIncrement();
   }
 }

--- a/contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol
@@ -63,5 +63,11 @@ contract ReputationMiningCycleStorage is ReputationMiningCycleDataTypes, DSAuth 
   int256 constant MAX_INT128 = 2**127 - 1;
   int256 constant MIN_INT128 = (2**127)*(-1);
 
-  uint256 firstIncompleteRound;
+  uint256 firstIncompleteRound; // Storage slot 15
+
+  // Tracks whether the address in question has helped during a challenge / response process
+  mapping (address => bool) respondedToChallenge;  // Storage slot 16
+
+  uint256 stakeLost;// Storage slot 17
+  uint256 rewardsPaidOut;// Storage slot 18
 }

--- a/contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol
@@ -68,6 +68,7 @@ contract ReputationMiningCycleStorage is ReputationMiningCycleDataTypes, DSAuth 
   // Tracks whether the address in question has helped during a challenge / response process
   mapping (address => bool) respondedToChallenge;  // Storage slot 16
 
-  uint256 stakeLost;// Storage slot 17
-  uint256 rewardsPaidOut;// Storage slot 18
+  uint256 stakeLost; // Storage slot 17
+  uint256 rewardsPaidOut; // Storage slot 18
+  uint256 cachedDisputeRewardSize; // Storage slot 19
 }

--- a/contracts/tokenLocking/ITokenLocking.sol
+++ b/contracts/tokenLocking/ITokenLocking.sol
@@ -84,15 +84,11 @@ contract ITokenLocking is TokenLockingDataTypes {
   /// @param _force Pass true to forcibly unlock the token
   function withdraw(address _token, uint256 _amount, bool _force) public;
 
-  /// @notice Function called to reward people during reputation mining disputes in CLNY.
-  /// @dev While public, it can only be called successfully by the current ReputationMiningCycle.
-  /// @dev These tokens will not be able to be withdrawn until the current cycle is completed.
-  /// @param _recipient The address to reward
-  /// @param _amount Amount of CLNY to award
+  /// @notice This function is deprecated and only exists to aid upgrades.
   function reward(address _recipient, uint256 _amount) public;
 
   /// @notice Function called to burn CLNY tokens held by TokenLocking.
-  /// @dev While public, it can only be called successfully by the current ReputationMiningCycle.
+  /// @dev While public, it can only be called successfully by colonyNetwork and is only used for reputation mining.
   /// @param _amount Amount of CLNY to burn
   function burn(uint256 _amount) public;
 

--- a/contracts/tokenLocking/ITokenLocking.sol
+++ b/contracts/tokenLocking/ITokenLocking.sol
@@ -84,6 +84,18 @@ contract ITokenLocking is TokenLockingDataTypes {
   /// @param _force Pass true to forcibly unlock the token
   function withdraw(address _token, uint256 _amount, bool _force) public;
 
+  /// @notice Function called to reward people during reputation mining disputes in CLNY.
+  /// @dev While public, it can only be called successfully by the current ReputationMiningCycle.
+  /// @dev These tokens will not be able to be withdrawn until the current cycle is completed.
+  /// @param _recipient The address to reward
+  /// @param _amount Amount of CLNY to award
+  function reward(address _recipient, uint256 _amount) public;
+
+  /// @notice Function called to burn CLNY tokens held by TokenLocking.
+  /// @dev While public, it can only be called successfully by the current ReputationMiningCycle.
+  /// @param _amount Amount of CLNY to burn
+  function burn(uint256 _amount) public;
+
   /// @notice Allow the colony to obligate some amount of tokens as a stake.
   /// @dev Can only be called by a colony or colonyNetwork
   /// @param _user Address of the user that is allowing their holdings to be staked by the caller

--- a/contracts/tokenLocking/TokenLocking.sol
+++ b/contracts/tokenLocking/TokenLocking.sol
@@ -175,13 +175,12 @@ contract TokenLocking is TokenLockingStorage, DSMath { // ignore-swc-123
     makeConditionalDeposit(_token, _amount, _recipient);
   }
 
-  function reward(address _recipient, uint256 _amount) public onlyReputationMiningCycle {
-    address clnyToken = IMetaColony(IColonyNetwork(colonyNetwork).getMetaColony()).getToken();
-    // TODO: Gain rep?
-    userLocks[clnyToken][_recipient].balance = add(userLocks[clnyToken][_recipient].balance, _amount);
+  function reward(address _recipient, uint256 _amount) public pure {
+
   }
 
-  function burn(uint256 _amount) public onlyReputationMiningCycle {
+  function burn(uint256 _amount) public {
+    require(msg.sender==colonyNetwork, "colony-token-locking-not-colony-network");
     address clnyToken = IMetaColony(IColonyNetwork(colonyNetwork).getMetaColony()).getToken();
     ERC20Extended(clnyToken).burn(_amount);
   }

--- a/contracts/tokenLocking/TokenLocking.sol
+++ b/contracts/tokenLocking/TokenLocking.sol
@@ -175,6 +175,17 @@ contract TokenLocking is TokenLockingStorage, DSMath { // ignore-swc-123
     makeConditionalDeposit(_token, _amount, _recipient);
   }
 
+  function reward(address _recipient, uint256 _amount) public onlyReputationMiningCycle {
+    address clnyToken = IMetaColony(IColonyNetwork(colonyNetwork).getMetaColony()).getToken();
+    // TODO: Gain rep?
+    userLocks[clnyToken][_recipient].balance = add(userLocks[clnyToken][_recipient].balance, _amount);
+  }
+
+  function burn(uint256 _amount) public onlyReputationMiningCycle {
+    address clnyToken = IMetaColony(IColonyNetwork(colonyNetwork).getMetaColony()).getToken();
+    ERC20Extended(clnyToken).burn(_amount);
+  }
+
   function getTotalLockCount(address _token) public view returns (uint256) {
     return totalLockCount[_token];
   }

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -70,6 +70,19 @@ Adds a reputation update entry to log.
 |_skillId|uint256|The skill for the reputation update
 
 
+### `burnUnneededRewards`
+
+Used to burn tokens that are not needed to pay out rewards (because not every possible defence was made for all submissions)
+
+*Note: Only callable by the active reputation mining cycle*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_amount|uint256|The amount of CLNY to burn
+
+
 ### `calculateMinerWeight`
 
 Calculate raw miner weight in WADs.
@@ -87,6 +100,19 @@ Calculate raw miner weight in WADs.
 |Name|Type|Description|
 |---|---|---|
 |minerWeight|uint256|The weight of miner reward
+
+### `claimMiningReward`
+
+Used by a user to claim any mining rewards due to them. This will place them in their balance or pending balance, as appropriate.
+
+*Note: Can be called by anyone, not just _recipient*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_recipient|address|The user whose rewards to claim
+
 
 ### `createColony`
 
@@ -275,6 +301,23 @@ Get the resolver to be used by new instances of ReputationMiningCycle.
 |Name|Type|Description|
 |---|---|---|
 |miningResolverAddress|address|The address of the mining cycle resolver currently used by new instances
+
+### `getMiningStake`
+
+returns how much CLNY _user has staked for the purposes of reputation mining
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_user|address|The user to query
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_info|MiningStake|The amount staked and the timestamp the stake was made at.
 
 ### `getParentSkillId`
 
@@ -496,6 +539,20 @@ Reverse lookup a username from an address.
 |---|---|---|
 |domain|string|A string containing the colony-based ENS name corresponding to addr
 
+### `punishStakers`
+
+Function called to punish people who staked against a new reputation root hash that turned out to be incorrect.
+
+*Note: While public, it can only be called successfully by the current ReputationMiningCycle.*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_stakers|address[]|Array of the addresses of stakers to punish
+|_amount|uint256|Amount of stake to slash
+
+
 ### `registerColonyLabel`
 
 Register a "colony.joincolony.eth" label. Can only be called by a Colony.
@@ -520,6 +577,20 @@ Register a "user.joincolony.eth" label.
 |---|---|---|
 |username|string|The label to register
 |orbitdb|string|The path of the orbitDB database associated with the user profile
+
+
+### `reward`
+
+Used to track that a user is eligible to claim a reward
+
+*Note: Only callable by the active reputation mining cycle*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_recipient|address|The address receiving the award
+|_amount|uint256|The amount of CLNY to be awarded
 
 
 ### `setFeeInverse`
@@ -606,6 +677,18 @@ Setup registrar with ENS and root node.
 |_rootNode|bytes32|Namehash of the root node for the domain
 
 
+### `stakeForMining`
+
+Stake CLNY to allow the staker to participate in reputation mining.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_amount|uint256|Amount of CLNY to stake for the purposes of mining
+
+
 ### `startNextCycle`
 
 Starts a new Reputation Mining cycle. Explicitly called only the first time, subsequently called from within `setReputationRootHash`.
@@ -642,6 +725,18 @@ Query if a contract implements an interface
 |Name|Type|Description|
 |---|---|---|
 |status|bool|`true` if the contract implements `interfaceID`
+
+### `unstakeForMining`
+
+Unstake CLNY currently staked for reputation mining.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_amount|uint256|Amount of CLNY staked for mining to unstake
+
 
 ### `updateColonyOrbitDB`
 

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -90,6 +90,24 @@ Calculate raw miner weight in WADs.
 
 ### `createColony`
 
+Creates a new colony in the network, at version 3
+
+*Note: This is now deprecated and will be removed in a future version*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_tokenAddress|address|Address of an ERC20 token to serve as the colony token.
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|colonyAddress|address|Address of the newly created colony
+
+### `createColony`
+
 Overload of the simpler `createColony` -- creates a new colony in the network with a variety of options
 
 *Note: For the colony to mint tokens, token ownership must be transferred to the new colony*
@@ -103,24 +121,6 @@ Overload of the simpler `createColony` -- creates a new colony in the network wi
 |_colonyName|string|The label to register (if null, no label is registered)
 |_orbitdb|string|The path of the orbitDB database associated with the user profile
 |_useExtensionManager|bool|If true, give the ExtensionManager the root role in the colony
-
-**Return Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|colonyAddress|address|Address of the newly created colony
-
-### `createColony`
-
-Creates a new colony in the network, at version 3
-
-*Note: This is now deprecated and will be removed in a future version*
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_tokenAddress|address|Address of an ERC20 token to serve as the colony token.
 
 **Return Parameters**
 

--- a/docs/_Interface_IReputationMiningCycle.md
+++ b/docs/_Interface_IReputationMiningCycle.md
@@ -419,7 +419,7 @@ Returns whether a particular address has been involved in the current mining cyc
 
 |Name|Type|Description|
 |---|---|---|
-|_user|address|The address whose involvement being queried
+|_user|address|The address whose involvement is being queried
 
 **Return Parameters**
 

--- a/docs/_Interface_IReputationMiningCycle.md
+++ b/docs/_Interface_IReputationMiningCycle.md
@@ -97,6 +97,18 @@ Get the reputation decay constant.
 |numerator|uint256|The numerator of the decay constant
 |denominator|uint256|The denominator of the decay constant
 
+### `getDisputeRewardIncrement`
+
+Returns the amount of CLNY given for defending a hash during the current dispute cycle
+
+
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_reward|uint256|
+
 ### `getDisputeRound`
 
 The getter for the disputeRounds mapping.
@@ -396,3 +408,21 @@ Submit a new reputation root hash.
 |nNodes|uint256|Number of nodes in tree with root `newHash`
 |jrh|bytes32|The justifcation root hash for this submission
 |entryIndex|uint256|The entry number for the given `newHash` and `nNodes`
+
+
+### `userInvolvedInMiningCycle`
+
+Returns whether a particular address has been involved in the current mining cycle. This might be from submitting a hash, or from defending one during a dispute.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_user|address|The address whose involvement being queried
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|involved|bool|

--- a/docs/_Interface_IReputationMiningCycle.md
+++ b/docs/_Interface_IReputationMiningCycle.md
@@ -97,7 +97,7 @@ Get the reputation decay constant.
 |numerator|uint256|The numerator of the decay constant
 |denominator|uint256|The denominator of the decay constant
 
-### `getDisputeRewardIncrement`
+### `getDisputeRewardSize`
 
 Returns the amount of CLNY given for defending a hash during the current dispute cycle
 
@@ -107,7 +107,7 @@ Returns the amount of CLNY given for defending a hash during the current dispute
 
 |Name|Type|Description|
 |---|---|---|
-|_reward|uint256|
+|reward|uint256|
 
 ### `getDisputeRound`
 

--- a/docs/_Interface_ITokenLocking.md
+++ b/docs/_Interface_ITokenLocking.md
@@ -4,7 +4,7 @@ section: Interface
 order: 5
 ---
 
-  
+
 ## Interface Methods
 
 ### `approveStake`
@@ -19,6 +19,19 @@ Allow the colony to obligate some amount of tokens as a stake. Can only be calle
 |_colony|address|Address of the colony we are willing to let obligate us.
 |_amount|uint256|Amount of that colony's internal token up to which we are willing to be obligated.
 |_token|address|The colony's internal token address
+
+
+### `burn`
+
+Function called to burn CLNY tokens held by TokenLocking.
+
+*Note: While public, it can only be called successfully by the current ReputationMiningCycle.*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_amount|uint256|Amount of CLNY to burn
 
 
 ### `claim`
@@ -186,7 +199,7 @@ Obligate the user some amount of tokens as a stake. Can only be called by a colo
 
 ### `punishStakers`
 
-Function called to punish people who staked against a new reputation root hash that turned out to be incorrect.
+Function called to punish people who staked CLNY against a new reputation root hash that turned out to be incorrect.
 
 *Note: While public, it can only be called successfully by the current ReputationMiningCycle.*
 
@@ -195,8 +208,21 @@ Function called to punish people who staked against a new reputation root hash t
 |Name|Type|Description|
 |---|---|---|
 |_stakers|address[]|Array of the addresses of stakers to punish
-|_beneficiary|address|Address of beneficiary to receive forfeited stake
-|_amount|uint256|Amount of stake to slash
+|_amount|uint256|Amount of stake to slash (each)
+
+
+### `reward`
+
+Function called to reward people during reputation mining disputes in CLNY.
+
+*Note: While public, it can only be called successfully by the current ReputationMiningCycle.*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_recipient|address|The address to reward
+|_amount|uint256|Amount of CLNY to award
 
 
 ### `setColonyNetwork`
@@ -258,6 +284,19 @@ Increments the lock counter to `_lockId` for the `_user` if user's lock count is
 
 ### `withdraw`
 
+DEPRECATED Withdraw `_amount` of deposited tokens. Can only be called if user tokens are not locked.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_token|address|Address of the token to withdraw from
+|_amount|uint256|Amount to withdraw
+
+
+### `withdraw`
+
 Withdraw `_amount` of deposited tokens. Can only be called if user tokens are not locked.
 
 
@@ -268,16 +307,3 @@ Withdraw `_amount` of deposited tokens. Can only be called if user tokens are no
 |_token|address|Address of the token to withdraw from
 |_amount|uint256|Amount to withdraw
 |_force|bool|Pass true to forcibly unlock the token
-
-
-### `withdraw`
-
-DEPRECATED Withdraw `_amount` of deposited tokens. Can only be called if user tokens are not locked.
-
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_token|address|Address of the token to withdraw from
-|_amount|uint256|Amount to withdraw

--- a/docs/_Interface_ITokenLocking.md
+++ b/docs/_Interface_ITokenLocking.md
@@ -4,19 +4,20 @@ section: Interface
 order: 5
 ---
 
-
+  
 ## Interface Methods
 
 ### `approveStake`
 
-Allow the colony to obligate some amount of tokens as a stake. Can only be called by a colony.
+Allow the colony to obligate some amount of tokens as a stake.
 
+*Note: Can only be called by a colony or colonyNetwork*
 
 **Parameters**
 
 |Name|Type|Description|
 |---|---|---|
-|_colony|address|Address of the colony we are willing to let obligate us.
+|_user|address|Address of the user that is allowing their holdings to be staked by the caller
 |_amount|uint256|Amount of that colony's internal token up to which we are willing to be obligated.
 |_token|address|The colony's internal token address
 
@@ -25,7 +26,7 @@ Allow the colony to obligate some amount of tokens as a stake. Can only be calle
 
 Function called to burn CLNY tokens held by TokenLocking.
 
-*Note: While public, it can only be called successfully by the current ReputationMiningCycle.*
+*Note: While public, it can only be called successfully by colonyNetwork and is only used for reputation mining.*
 
 **Parameters**
 
@@ -49,7 +50,7 @@ Claim any pending tokens. Can only be called if user tokens are not locked.
 
 ### `deobligateStake`
 
-Deobligate the user some amount of tokens, releasing the stake. Can only be called by a colony.
+Deobligate the user some amount of tokens, releasing the stake. Can only be called by a colony or colonyNetwork.
 
 
 **Parameters**
@@ -88,6 +89,25 @@ Deposit `_amount` of colony tokens in the recipient's account. Goes into pending
 |_recipient|address|User to receive the tokens
 
 
+### `getApproval`
+
+See the total amount of a user's obligation.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_user|address|Address of the account that has approved _approvee to obligate their funds.
+|_token|address|The token for which the user has provided the approval.
+|_obligator|address|The address that has been approved to obligate the funds.
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|uint256|uint256|
+
 ### `getColonyNetwork`
 
 Get ColonyNetwork address.
@@ -99,6 +119,25 @@ Get ColonyNetwork address.
 |Name|Type|Description|
 |---|---|---|
 |networkAddress|address|ColonyNetwork address
+
+### `getObligation`
+
+See the total amount of a user's obligation.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_user|address|Address of the account that has had their funds obligated.
+|_token|address|The token for which the user has provided the approval.
+|_obligator|address|The address that obligated the funds (and therefore can slash or return them).
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|uint256|uint256|
 
 ### `getTotalLockCount`
 
@@ -185,7 +224,7 @@ Locks everyones' tokens on `_token` address.
 
 ### `obligateStake`
 
-Obligate the user some amount of tokens as a stake. Can only be called by a colony.
+Obligate the user some amount of tokens as a stake. Can only be called by a colony or colonyNetwork.
 
 
 **Parameters**
@@ -197,32 +236,17 @@ Obligate the user some amount of tokens as a stake. Can only be called by a colo
 |_token|address|The colony's internal token address
 
 
-### `punishStakers`
-
-Function called to punish people who staked CLNY against a new reputation root hash that turned out to be incorrect.
-
-*Note: While public, it can only be called successfully by the current ReputationMiningCycle.*
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_stakers|address[]|Array of the addresses of stakers to punish
-|_amount|uint256|Amount of stake to slash (each)
-
-
 ### `reward`
 
-Function called to reward people during reputation mining disputes in CLNY.
+This function is deprecated and only exists to aid upgrades.
 
-*Note: While public, it can only be called successfully by the current ReputationMiningCycle.*
 
 **Parameters**
 
 |Name|Type|Description|
 |---|---|---|
-|_recipient|address|The address to reward
-|_amount|uint256|Amount of CLNY to award
+|_recipient|address|
+|_amount|uint256|
 
 
 ### `setColonyNetwork`
@@ -255,7 +279,7 @@ Transfer tokens to a recipient's pending balance. Can only be called if user tok
 
 ### `transferStake`
 
-Transfer some amount of staked tokens. Can only be called by a colony.
+Transfer some amount of staked tokens. Can only be called by a colony or colonyNetwork.
 
 
 **Parameters**
@@ -284,19 +308,6 @@ Increments the lock counter to `_lockId` for the `_user` if user's lock count is
 
 ### `withdraw`
 
-DEPRECATED Withdraw `_amount` of deposited tokens. Can only be called if user tokens are not locked.
-
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_token|address|Address of the token to withdraw from
-|_amount|uint256|Amount to withdraw
-
-
-### `withdraw`
-
 Withdraw `_amount` of deposited tokens. Can only be called if user tokens are not locked.
 
 
@@ -307,3 +318,16 @@ Withdraw `_amount` of deposited tokens. Can only be called if user tokens are no
 |_token|address|Address of the token to withdraw from
 |_amount|uint256|Amount to withdraw
 |_force|bool|Pass true to forcibly unlock the token
+
+
+### `withdraw`
+
+DEPRECATED Withdraw `_amount` of deposited tokens. Can only be called if user tokens are not locked.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_token|address|Address of the token to withdraw from
+|_amount|uint256|Amount to withdraw

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -56,6 +56,7 @@ const FINALIZED_TASK_STATE = 2;
 const SECONDS_PER_DAY = 86400;
 
 const MINING_CYCLE_DURATION = 60 * 60 * 24; // 24 hours
+const MINING_CYCLE_TIMEOUT = 600; // Ten minutes
 const DECAY_RATE = {
   NUMERATOR:    new BN("992327946262944"), // eslint-disable-line prettier/prettier
   DENOMINATOR: new BN("1000000000000000"),
@@ -102,6 +103,7 @@ module.exports = {
   FINALIZED_TASK_STATE,
   SECONDS_PER_DAY,
   MINING_CYCLE_DURATION,
+  MINING_CYCLE_TIMEOUT,
   DECAY_RATE,
   GLOBAL_SKILL_ID,
 };

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -56,7 +56,7 @@ const FINALIZED_TASK_STATE = 2;
 const SECONDS_PER_DAY = 86400;
 
 const MINING_CYCLE_DURATION = 60 * 60 * 24; // 24 hours
-const MINING_CYCLE_TIMEOUT = 600; // Ten minutes
+const MINING_CYCLE_TIMEOUT = 60 * 10; // Ten minutes
 const DECAY_RATE = {
   NUMERATOR:    new BN("992327946262944"), // eslint-disable-line prettier/prettier
   DENOMINATOR: new BN("1000000000000000"),

--- a/scripts/generate-test-contracts.sh
+++ b/scripts/generate-test-contracts.sh
@@ -34,10 +34,8 @@ sed -i.bak "s/contract IColony/contract IUpdatedColony/g" ./contracts/colony/IUp
 sed -i.bak "s/ColonyDataTypes/UpdatedColonyDataTypes/g" ./contracts/colony/IUpdatedColony.sol
 sed -i.bak "s/contract IUpdatedColony is UpdatedColonyDataTypes, IRecovery {/contract IUpdatedColony is UpdatedColonyDataTypes, IRecovery {function isUpdated() public pure returns(bool);/g" ./contracts/colony/IUpdatedColony.sol
 # Modify UpdatedReputationMiningCycle contract
-echo 'UpdatedReputationMiningCycle'
 sed -i.bak "s/contract ReputationMiningCycle/contract UpdatedReputationMiningCycle/g" ./contracts/reputationMiningCycle/UpdatedReputationMiningCycle.sol
-sed -i.bak "s/WAD;/WAD;function isUpdated() public pure returns(bool) {return true;}/g" ./contracts/reputationMiningCycle/UpdatedReputationMiningCycle.sol
-echo 'IReputationMiningCycle'
+sed -i.bak "s|// 24 hours|// 24 hours\nfunction isUpdated() public pure returns(bool) {return true;}|g" ./contracts/reputationMiningCycle/UpdatedReputationMiningCycle.sol
 # Modify IReputationMiningCycle contract
 sed -i.bak "s/contract IReputationMiningCycle/contract IUpdatedReputationMiningCycle/g" ./contracts/reputationMiningCycle/IUpdatedReputationMiningCycle.sol
 sed -i.bak "s/function resetWindow() public;/function resetWindow() public; function isUpdated() public pure returns(bool);/g" ./contracts/reputationMiningCycle/IUpdatedReputationMiningCycle.sol

--- a/scripts/generate-test-contracts.sh
+++ b/scripts/generate-test-contracts.sh
@@ -35,7 +35,7 @@ sed -i.bak "s/ColonyDataTypes/UpdatedColonyDataTypes/g" ./contracts/colony/IUpda
 sed -i.bak "s/contract IUpdatedColony is UpdatedColonyDataTypes, IRecovery {/contract IUpdatedColony is UpdatedColonyDataTypes, IRecovery {function isUpdated() public pure returns(bool);/g" ./contracts/colony/IUpdatedColony.sol
 # Modify UpdatedReputationMiningCycle contract
 sed -i.bak "s/contract ReputationMiningCycle/contract UpdatedReputationMiningCycle/g" ./contracts/reputationMiningCycle/UpdatedReputationMiningCycle.sol
-sed -i.bak "s|// 24 hours|// 24 hours\nfunction isUpdated() public pure returns(bool) {return true;}|g" ./contracts/reputationMiningCycle/UpdatedReputationMiningCycle.sol
+sed -i.bak "s| is ReputationMiningCycleCommon {| is ReputationMiningCycleCommon {\nfunction isUpdated() public pure returns(bool) {return true;}|g" ./contracts/reputationMiningCycle/UpdatedReputationMiningCycle.sol
 # Modify IReputationMiningCycle contract
 sed -i.bak "s/contract IReputationMiningCycle/contract IUpdatedReputationMiningCycle/g" ./contracts/reputationMiningCycle/IUpdatedReputationMiningCycle.sol
 sed -i.bak "s/function resetWindow() public;/function resetWindow() public; function isUpdated() public pure returns(bool);/g" ./contracts/reputationMiningCycle/IUpdatedReputationMiningCycle.sol

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -142,7 +142,7 @@ contract("Colony Network", (accounts) => {
 
     it('should not allow "punishStakers" to be called from an account that is not the mining cycle', async () => {
       await checkErrorRevert(
-        colonyNetwork.punishStakers([accounts[0], accounts[1]], ethers.constants.AddressZero, MIN_STAKE),
+        colonyNetwork.punishStakers([accounts[0], accounts[1]], MIN_STAKE),
         "colony-reputation-mining-sender-not-active-reputation-cycle"
       );
     });

--- a/test/contracts-network/colony-staking.js
+++ b/test/contracts-network/colony-staking.js
@@ -66,14 +66,19 @@ contract("Colony Staking", (accounts) => {
       await colony.approveStake(USER0, 1, WAD, { from: USER1 });
 
       approval = await colony.getApproval(USER1, USER0, 1);
+      const tokenLockingApproval = await tokenLocking.getApproval(USER1, token.address, colony.address);
       expect(approval).to.eq.BN(WAD);
+      expect(tokenLockingApproval).to.eq.BN(WAD);
 
       await colony.obligateStake(USER1, 1, WAD, { from: USER0 });
 
       approval = await colony.getApproval(USER1, USER0, 1);
       obligation = await colony.getObligation(USER1, USER0, 1);
+      const tokenLockingObligation = await tokenLocking.getObligation(USER1, token.address, colony.address);
+
       expect(approval).to.be.zero;
       expect(obligation).to.eq.BN(WAD);
+      expect(tokenLockingObligation).to.eq.BN(WAD);
 
       await colony.deobligateStake(USER1, 1, WAD, { from: USER0 });
 

--- a/test/contracts-network/reputation-basic-functionality.js
+++ b/test/contracts-network/reputation-basic-functionality.js
@@ -7,7 +7,7 @@ import { ethers } from "ethers";
 
 import { giveUserCLNYTokens, giveUserCLNYTokensAndStake } from "../../helpers/test-data-generator";
 import { MIN_STAKE, MINING_CYCLE_DURATION, DECAY_RATE } from "../../helpers/constants";
-import { forwardTime, checkErrorRevert, getActiveRepCycle, getBlockTime } from "../../helpers/test-helper";
+import { forwardTime, checkErrorRevert, getActiveRepCycle, advanceMiningCycleNoContest, getBlockTime } from "../../helpers/test-helper";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
@@ -20,8 +20,10 @@ const Token = artifacts.require("Token");
 const IReputationMiningCycle = artifacts.require("IReputationMiningCycle");
 
 contract("Reputation mining - basic functionality", (accounts) => {
-  const MINER1 = accounts[5];
-  const MINER2 = accounts[6];
+  // Not using accounts[5] here otherwise the afterEach breaks reputation mining, which we need
+  // for one of the tests.
+  const MINER1 = accounts[6];
+  const MINER2 = accounts[7];
 
   let colonyNetwork;
   let tokenLocking;
@@ -224,6 +226,20 @@ contract("Reputation mining - basic functionality", (accounts) => {
       const decay = await repCycle.getDecayConstant();
       expect(decay.numerator).to.eq.BN(DECAY_RATE.NUMERATOR);
       expect(decay.denominator).to.eq.BN(DECAY_RATE.DENOMINATOR);
+    });
+
+    it("when there are no logs, getDisputeRewardIncrement returns 0", async () => {
+      const repCycle = await getActiveRepCycle(colonyNetwork);
+      const rewardIncrement = await repCycle.getDisputeRewardIncrement();
+      expect(rewardIncrement.toString(), "RewardIncrement was nonzero").to.equal("0");
+    });
+
+    it("when no dispute is yet required, getDisputeRewardIncrement returns 0", async () => {
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this });
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this });
+      const repCycle = await getActiveRepCycle(colonyNetwork);
+      const rewardIncrement = await repCycle.getDisputeRewardIncrement();
+      expect(rewardIncrement.toString(), "RewardIncrement was nonzero").to.equal("0");
     });
   });
 });

--- a/test/contracts-network/reputation-basic-functionality.js
+++ b/test/contracts-network/reputation-basic-functionality.js
@@ -228,17 +228,17 @@ contract("Reputation mining - basic functionality", (accounts) => {
       expect(decay.denominator).to.eq.BN(DECAY_RATE.DENOMINATOR);
     });
 
-    it("when there are no logs, getDisputeRewardIncrement returns 0", async () => {
+    it("when there are no logs, getDisputeRewardSize returns 0", async () => {
       const repCycle = await getActiveRepCycle(colonyNetwork);
-      const rewardIncrement = await repCycle.getDisputeRewardIncrement();
+      const rewardIncrement = await repCycle.getDisputeRewardSize();
       expect(rewardIncrement.toString(), "RewardIncrement was nonzero").to.equal("0");
     });
 
-    it("when no dispute is yet required, getDisputeRewardIncrement returns 0", async () => {
+    it("when no dispute is yet required, getDisputeRewardSize returns 0", async () => {
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
       const repCycle = await getActiveRepCycle(colonyNetwork);
-      const rewardIncrement = await repCycle.getDisputeRewardIncrement();
+      const rewardIncrement = await repCycle.getDisputeRewardSize();
       expect(rewardIncrement.toString(), "RewardIncrement was nonzero").to.equal("0");
     });
   });

--- a/test/contracts-network/token-locking.js
+++ b/test/contracts-network/token-locking.js
@@ -186,6 +186,17 @@ contract("Token Locking", (addresses) => {
       expect(userBalance).to.eq.BN(usersTokens);
     });
 
+    it("should correctly withdraw tokens via the deprecated interface", async () => {
+      await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
+      await tokenLocking.deposit(token.address, usersTokens, { from: userAddress });
+      await tokenLocking.methods["withdraw(address,uint256)"](token.address, usersTokens, { from: userAddress });
+
+      const info = await tokenLocking.getUserLock(token.address, userAddress);
+      expect(info.balance).to.be.zero;
+      const userBalance = await token.balanceOf(userAddress);
+      expect(userBalance).to.eq.BN(usersTokens);
+    });
+
     it("should not be able to withdraw tokens while they are locked", async () => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.deposit(token.address, usersTokens, { from: userAddress });

--- a/test/reputation-system/dispute-resolution-misbehaviour.js
+++ b/test/reputation-system/dispute-resolution-misbehaviour.js
@@ -305,7 +305,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", (accounts) => {
         // churning away at once, I *think* it's slower.
         await clients[i].addLogContentsToReputationTree();
         await clients[i].submitRootHash();
-        await clients[i].confirmJustificationRootHash();
         console.log("Submitted for client ", i);
       }
 

--- a/test/reputation-system/dispute-resolution-misbehaviour.js
+++ b/test/reputation-system/dispute-resolution-misbehaviour.js
@@ -125,7 +125,17 @@ contract("Reputation Mining - disputes resolution misbehaviour", (accounts) => {
       await repCycle.confirmNewHash(0);
 
       repCycle = await getActiveRepCycle(colonyNetwork);
-      await submitAndForwardTimeToDispute([goodClient, badClient], this);
+
+      await forwardTime(MINING_CYCLE_DURATION / 2, this);
+      await goodClient.addLogContentsToReputationTree();
+      await goodClient.submitRootHash();
+      await badClient.addLogContentsToReputationTree();
+      await badClient.submitRootHash();
+
+      // Check we can't confirm the JRH before the submission window is closed
+      await checkErrorRevertEthers(goodClient.confirmJustificationRootHash(), "colony-reputation-mining-cycle-submissions-not-closed");
+
+      await forwardTime(MINING_CYCLE_DURATION / 2, this);
 
       // Check we can't start binary search before we've confirmed JRH
       await checkErrorRevertEthers(goodClient.respondToBinarySearchForChallenge(), "colony-reputation-mining-challenge-not-active");

--- a/test/reputation-system/dispute-resolution-misbehaviour.js
+++ b/test/reputation-system/dispute-resolution-misbehaviour.js
@@ -323,9 +323,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", (accounts) => {
       await accommodateChallengeAndInvalidateHashViaTimeout(colonyNetwork, this, clients[0], clients[1]);
       await accommodateChallengeAndInvalidateHashViaTimeout(colonyNetwork, this, clients[2], clients[3]);
       await accommodateChallengeAndInvalidateHashViaTimeout(colonyNetwork, this, clients[4], clients[5]);
-      for (let i = 0; i < 8; i += 1) {
-        await clients[i].confirmJustificationRootHash();
-      }
 
       console.log("Starting round 2");
 

--- a/test/reputation-system/dispute-resolution-misbehaviour.js
+++ b/test/reputation-system/dispute-resolution-misbehaviour.js
@@ -258,10 +258,10 @@ contract("Reputation Mining - disputes resolution misbehaviour", (accounts) => {
 
       await checkErrorRevert(repCycle.invalidateHash(0, 3), "colony-reputation-mining-submission-window-still-open");
       // Cleanup
+      await forwardTime(MINING_CYCLE_DURATION / 2, this);
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-increased-reputation-value-incorrect" },
       });
-      await forwardTime(MINING_CYCLE_DURATION / 2, this);
       await repCycle.invalidateHash(0, 3);
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient2, {
         client2: { respondToChallenge: "colony-reputation-mining-increased-reputation-value-incorrect" },
@@ -323,6 +323,9 @@ contract("Reputation Mining - disputes resolution misbehaviour", (accounts) => {
       await accommodateChallengeAndInvalidateHashViaTimeout(colonyNetwork, this, clients[0], clients[1]);
       await accommodateChallengeAndInvalidateHashViaTimeout(colonyNetwork, this, clients[2], clients[3]);
       await accommodateChallengeAndInvalidateHashViaTimeout(colonyNetwork, this, clients[4], clients[5]);
+      for (let i = 0; i < 8; i += 1) {
+        await clients[i].confirmJustificationRootHash();
+      }
 
       console.log("Starting round 2");
 
@@ -408,12 +411,12 @@ contract("Reputation Mining - disputes resolution misbehaviour", (accounts) => {
       // Round 1 finished. Move to round 2
 
       await accommodateChallengeAndInvalidateHashViaTimeout(colonyNetwork, this, clients[0], clients[2]);
-      await accommodateChallengeAndInvalidateHashViaTimeout(colonyNetwork, this, clients[8], clients[4]);
+      await accommodateChallengeAndInvalidateHashViaTimeout(colonyNetwork, this, clients[4], clients[8]);
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, clients[6]);
 
       // Round 2 finished.
 
-      await accommodateChallengeAndInvalidateHashViaTimeout(colonyNetwork, this, clients[0], clients[8]);
+      await accommodateChallengeAndInvalidateHashViaTimeout(colonyNetwork, this, clients[0], clients[4]);
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, clients[6]);
       await accommodateChallengeAndInvalidateHashViaTimeout(colonyNetwork, this, clients[0], clients[6]);
       await repCycle.confirmNewHash(4);

--- a/test/reputation-system/happy-paths.js
+++ b/test/reputation-system/happy-paths.js
@@ -125,22 +125,6 @@ contract("Reputation Mining - happy paths", (accounts) => {
   });
 
   describe("when executing intended behaviours", () => {
-    it.only("before a dispute is required, disputeRewardIncrement returns 0", async () => {
-      let repCycle = await getActiveRepCycle(colonyNetwork);
-      let rewardIncrement = await repCycle.disputeRewardIncrement();
-      expect(rewardIncrement.toString(), "RewardIncrement was nonzero").to.equal("0");
-      await giveUserCLNYTokensAndStake(colonyNetwork, accounts[3], DEFAULT_STAKE);
-      await giveUserCLNYTokensAndStake(colonyNetwork, accounts[4], DEFAULT_STAKE);
-      await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(30));
-
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this });
-
-      repCycle = await getActiveRepCycle(colonyNetwork);
-      rewardIncrement = await repCycle.disputeRewardIncrement();
-
-      expect(rewardIncrement.toString(), "RewardIncrement was nonzero").to.equal("0");
-    });
-
     it("should cope with many hashes being submitted and eliminated before a winner is assigned", async function manySubmissionTest() {
       this.timeout(100000000);
 

--- a/test/reputation-system/happy-paths.js
+++ b/test/reputation-system/happy-paths.js
@@ -125,6 +125,22 @@ contract("Reputation Mining - happy paths", (accounts) => {
   });
 
   describe("when executing intended behaviours", () => {
+    it.only("before a dispute is required, disputeRewardIncrement returns 0", async () => {
+      let repCycle = await getActiveRepCycle(colonyNetwork);
+      let rewardIncrement = await repCycle.disputeRewardIncrement();
+      expect(rewardIncrement.toString(), "RewardIncrement was nonzero").to.equal("0");
+      await giveUserCLNYTokensAndStake(colonyNetwork, accounts[3], DEFAULT_STAKE);
+      await giveUserCLNYTokensAndStake(colonyNetwork, accounts[4], DEFAULT_STAKE);
+      await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(30));
+
+      await advanceMiningCycleNoContest({ colonyNetwork, test: this });
+
+      repCycle = await getActiveRepCycle(colonyNetwork);
+      rewardIncrement = await repCycle.disputeRewardIncrement();
+
+      expect(rewardIncrement.toString(), "RewardIncrement was nonzero").to.equal("0");
+    });
+
     it("should cope with many hashes being submitted and eliminated before a winner is assigned", async function manySubmissionTest() {
       this.timeout(100000000);
 

--- a/test/reputation-system/happy-paths.js
+++ b/test/reputation-system/happy-paths.js
@@ -17,7 +17,7 @@ import {
   finishReputationMiningCycle,
   makeReputationKey,
   makeReputationValue,
-  removeSubdomainLimit
+  removeSubdomainLimit,
 } from "../../helpers/test-helper";
 
 import {

--- a/test/reputation-system/happy-paths.js
+++ b/test/reputation-system/happy-paths.js
@@ -17,8 +17,7 @@ import {
   finishReputationMiningCycle,
   makeReputationKey,
   makeReputationValue,
-  removeSubdomainLimit,
-  checkSuccessEthers,
+  removeSubdomainLimit
 } from "../../helpers/test-helper";
 
 import {
@@ -264,50 +263,6 @@ contract("Reputation Mining - happy paths", (accounts) => {
       await badClient.confirmBinarySearchResult();
 
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
-      await goodClient.respondToChallenge();
-      await repCycle.invalidateHash(0, 1);
-      await repCycle.confirmNewHash(1);
-    });
-
-    it("should allow hashes in a dispute to have more people back them during the dispute if window still open", async () => {
-      const badClient = new MaliciousReputationMinerExtraRep({ loader, realProviderPort, useJsTree, minerAddress: MINER2 }, 1, 0xfffffffff);
-      await badClient.initialise(colonyNetwork.address);
-
-      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
-      await advanceMiningCycleNoContest({ colonyNetwork, test: this });
-
-      const repCycle = await getActiveRepCycle(colonyNetwork);
-      await goodClient.addLogContentsToReputationTree();
-      await badClient.addLogContentsToReputationTree();
-
-      await forwardTime(MINING_CYCLE_DURATION / 2, this);
-      await checkSuccessEthers(goodClient.submitRootHash());
-
-      const hash = await goodClient.getRootHash();
-      const nNodes = await goodClient.getRootHashNNodes();
-      const jrh = await goodClient.justificationTree.getRootHash();
-      let nSubmissions = await repCycle.getNSubmissionsForHash(hash, nNodes, jrh);
-      expect(nSubmissions).to.eq.BN(1);
-
-      await badClient.submitRootHash();
-      await goodClient.confirmJustificationRootHash();
-      await badClient.confirmJustificationRootHash();
-
-      await checkSuccessEthers(goodClient.submitRootHash());
-      nSubmissions = await repCycle.getNSubmissionsForHash(hash, nNodes, jrh);
-      expect(nSubmissions).to.eq.BN(2);
-
-      await runBinarySearch(goodClient, badClient);
-      await goodClient.submitRootHash();
-      await goodClient.confirmBinarySearchResult();
-      await goodClient.submitRootHash();
-      await badClient.confirmBinarySearchResult();
-
-      await goodClient.submitRootHash();
-      nSubmissions = await repCycle.getNSubmissionsForHash(hash, nNodes, jrh);
-      expect(nSubmissions).to.eq.BN(5);
-
-      await forwardTime(MINING_CYCLE_DURATION / 2, this);
       await goodClient.respondToChallenge();
       await repCycle.invalidateHash(0, 1);
       await repCycle.confirmNewHash(1);

--- a/test/reputation-system/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-system/reputation-mining-client/client-auto-functionality.js
@@ -382,6 +382,10 @@ process.env.SOLIDITY_COVERAGE
           });
 
           await badClient.submitRootHash();
+
+          // Forward time again so clients can start responding to challenges
+          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
+
           await goodClientConfirmedJRH;
           await badClient.confirmJustificationRootHash();
 
@@ -444,8 +448,6 @@ process.env.SOLIDITY_COVERAGE
             }, 30000);
           });
 
-          // Forward time again, so the submission window is closed
-          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
           // Good client should realise it can confirm new hash. So we wait for that event.
           await newCycleStart;
 

--- a/test/reputation-system/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-system/reputation-mining-client/client-auto-functionality.js
@@ -283,7 +283,8 @@ process.env.SOLIDITY_COVERAGE
           const receive12Submissions = getWaitForNSubmissionsPromise(repCycleEthers, rootHash, nNodes, jrh, 12);
 
           // Make a submission from the second client and then await the remaining 11 submissions from the first client
-          await goodClient.loadState(rootHash);
+          await goodClient.loadState(oldHash);
+          await goodClient.addLogContentsToReputationTree();
 
           // Forward time and wait for the client to submit all 12 allowed entries
           await forwardTime(MINING_CYCLE_DURATION * 0.5, this);

--- a/test/reputation-system/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-system/reputation-mining-client/client-auto-functionality.js
@@ -233,7 +233,7 @@ process.env.SOLIDITY_COVERAGE
           const receive2Submissions = getWaitForNSubmissionsPromise(repCycleEthers, rootHash, nNodes, jrh, 2);
 
           // Forward through half of the cycle duration and wait for the client to submit some entries
-          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
+          await forwardTime(MINING_CYCLE_DURATION / 2, this);
           await receive2Submissions; // It might submit a couple more, but that's fine for the purposes of this test.
           await reputationMinerClient.close();
 
@@ -287,7 +287,7 @@ process.env.SOLIDITY_COVERAGE
           await goodClient.addLogContentsToReputationTree();
 
           // Forward time and wait for the client to submit all 12 allowed entries
-          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
+          await forwardTime(MINING_CYCLE_DURATION / 2, this);
           await checkSuccessEthers(goodClient.submitRootHash());
           await receive12Submissions;
 
@@ -308,7 +308,7 @@ process.env.SOLIDITY_COVERAGE
           });
 
           // Forward time to the end of the mining cycle and since we are the only miner, check the client confirmed our hash correctly
-          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
+          await forwardTime(MINING_CYCLE_DURATION / 2, this);
           await miningCycleComplete;
         });
 
@@ -335,7 +335,7 @@ process.env.SOLIDITY_COVERAGE
           const receive12Submissions = getWaitForNSubmissionsPromise(repCycleEthers, rootHash, nNodes, jrh, 12);
 
           // Forward through most of the cycle duration
-          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
+          await forwardTime(MINING_CYCLE_DURATION / 2, this);
           await receive12Submissions;
 
           const goodClientConfirmedJRH = new Promise(function (resolve, reject) {
@@ -384,7 +384,7 @@ process.env.SOLIDITY_COVERAGE
           await badClient.submitRootHash();
 
           // Forward time again so clients can start responding to challenges
-          await forwardTime(MINING_CYCLE_DURATION * 0.5, this);
+          await forwardTime(MINING_CYCLE_DURATION / 2, this);
 
           await goodClientConfirmedJRH;
           await badClient.confirmJustificationRootHash();

--- a/test/reputation-system/root-hash-submissions.js
+++ b/test/reputation-system/root-hash-submissions.js
@@ -8,7 +8,7 @@ import { TruffleLoader } from "@colony/colony-js-contract-loader-fs";
 
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, giveUserCLNYTokensAndStake } from "../../helpers/test-data-generator";
 
-import { MINING_CYCLE_DURATION, DEFAULT_STAKE, REWARD, UINT256_MAX, MIN_STAKE } from "../../helpers/constants";
+import { MINING_CYCLE_DURATION, MINING_CYCLE_TIMEOUT, DEFAULT_STAKE, REWARD, UINT256_MAX, MIN_STAKE } from "../../helpers/constants";
 
 import {
   forwardTime,
@@ -489,6 +489,7 @@ contract("Reputation mining - root hash submissions", (accounts) => {
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([badClient, badClient2, goodClient], this);
+      await forwardTime(MINING_CYCLE_TIMEOUT, this);
       await repCycle.invalidateHash(0, 1);
 
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient);

--- a/test/reputation-system/root-hash-submissions.js
+++ b/test/reputation-system/root-hash-submissions.js
@@ -21,7 +21,7 @@ import {
   finishReputationMiningCycle,
   runBinarySearch,
   checkErrorRevertEthers,
-  currentBlock
+  currentBlock,
 } from "../../helpers/test-helper";
 
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
@@ -576,7 +576,7 @@ contract("Reputation mining - root hash submissions", (accounts) => {
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
-      const rewardIncrement = await repCycle.getDisputeRewardIncrement();
+      const rewardIncrement = await repCycle.getDisputeRewardSize();
 
       const blockBeforeChallenge = await currentBlock();
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {


### PR DESCRIPTION
Okay, this has been long enough coming! First off, this is based on #810, so marking as draft until then is merged - it is probably otherwise ready for review.

Before this PR, none of the calls during dispute resolution provided rewards, so there was going to be little incentive for responses to occur; while those that made the good submission are incentivised to defend their submission (because they don't want to lose their stake), if more than one person has made the submission then there is incentive to just wait for other people to defend the submission (and not pay gas) and still claim the rewards at the end. 

So, the fundamental question is how large the reward is. The reward is being paid for by slashed stakes (if a submission you made is found invalid, you lose `MIN_STAKE`), so the minimum pool of rewards we have available is `(NSubmissions - 1)*MIN_STAKE`.

The next question is how many responses we need to award. We want to reward people who call:

* `confirmJustificationRootHash`
* `respondtoBinarySearchForChallenge`
* `confirmBinarySearchResult`
* `eliminateHash`

I opted to not reward people who call `confirmNewHash` - this is the transaction that rewards the people who staked originally, so they are already incentivised to call it. I have also made the assumption we are going to reward all of the above calls equally, even though they have different gas costs.

For each pairwise dispute, `confirmJustificationRootHash`, `confirmBinarySearchResult` are each called up to twice, `eliminateHash` is called once, and `respondToBinarySearchForChallenge` is called up to a number of times based on how long the binary search can take, which in turn is based on the number of leaves in the `justificationTree`. Specifically, it can take `ceil(log_2(JRHLeaves))` transactions for each party.

Unfortunately, we cannot just consider the pairwise disputes. Some submissions can also be awarded byes, which involves a call to `eliminateHash`, and should get a reward, but there isn't a corresponding opposing submission being slashed. We therefore have to consider these rewards across the whole reputation cycle, not just on a pairwise basis. At most, a bye can be awarded in each round of disputes, so the total number of byes (`nByes`) we have to be able to pay out is `ceil(log_2(nSubmissions))`.

As this is based on the number of submissions, we have to know how many submissions there are before any rewards are paid out - so we now prevent any disputes from starting before the submission window is closed. Pairwise disputes can still operate independently of each other, however.

How many pairwise disputes can there be? In each pairwise dispute, either one or two submissions can be eliminated, and every submission bar one has to lose one pairwise dispute. So there can be at most `nSubmissions-1` pairwise disputes.

Putting this all together, this means we have to be able to reward:
```
nByes + (nSubmissions-1) * (2 * (3 + ceil(log_2(JRHLeaves))) + 1)
```

responses during the dispute cycle. `(NSubmissions - 1)*MIN_STAKE` divided by this number gives us the largest reward we are able to guarantee we will be able to cover with the slashed stakes.

The rewards given are locked until the end of the mining cycle because the stakes that are paying for them haven't been slashed at the time they're being paid out. This requires the changes to `TokenLocking` around who has been 'involved' in the mining cycle. There's also been a separatation of `reward` and `punish` functions in Token Locking as a result of these changes.