### PR TITLE
Pin deprecated createColony version to 3

### DIFF
--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -116,7 +116,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
   {
     require(metaColony == address(0x0), "colony-meta-colony-exists-already");
 
-    metaColony = createColony(_tokenAddress);
+    metaColony = createColony(_tokenAddress, currentColonyVersion, "", "", false);
 
     // Add the special mining skill
     reputationMiningSkillId = this.addSkill(skillCount);
@@ -124,11 +124,12 @@ contract ColonyNetwork is ColonyNetworkStorage {
     emit MetaColonyCreated(metaColony, _tokenAddress, skillCount);
   }
 
+  // DEPRECATED, only deploys version 3 colonies.
   function createColony(address _tokenAddress) public
   stoppable
   returns (address)
   {
-    address colonyAddress = deployColony(_tokenAddress, currentColonyVersion);
+    address colonyAddress = deployColony(_tokenAddress, 3);
     setFounderPermissions(colonyAddress);
     return colonyAddress;
   }

--- a/contracts/IColonyNetwork.sol
+++ b/contracts/IColonyNetwork.sol
@@ -126,7 +126,7 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @param _tokenAddress Address of the CLNY token
   function createMetaColony(address _tokenAddress) public;
 
-  /// @notice Creates a new colony in the network with the latest version available
+  /// @notice Creates a new colony in the network, at version 3
   /// @dev This is now deprecated and will be removed in a future version
   /// @dev For the colony to mint tokens, token ownership must be transferred to the new colony
   /// @param _tokenAddress Address of an ERC20 token to serve as the colony token.

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -112,7 +112,7 @@ Overload of the simpler `createColony` -- creates a new colony in the network wi
 
 ### `createColony`
 
-Creates a new colony in the network with the latest version available
+Creates a new colony in the network, at version 3
 
 *Note: This is now deprecated and will be removed in a future version*
 

--- a/migrations/8_setup_meta_colony.js
+++ b/migrations/8_setup_meta_colony.js
@@ -48,6 +48,11 @@ module.exports = async function(deployer, network, accounts) {
 
   await metaColony.addGlobalSkill();
 
+  // Also set up the pinned version (3)... TODO: remove along with the deprecated `createColony`
+  const version = await metaColony.version();
+  const resolverAddress = await colonyNetwork.getColonyVersionResolver(version);
+  await metaColony.addNetworkColonyVersion(3, resolverAddress);
+
   await colonyNetwork.initialiseReputationMining();
   await colonyNetwork.startNextCycle();
 


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->

Part of #811, pins the version used for new colonies to 3 when created using the now-deprecated `createColony`.

This makes it possible for ColonyJS + (d)app to work with the upgraded network without needing to be upgraded themselves.

