### PR TITLE
Remove transferExpenditure overload

### DIFF
--- a/contracts/Colony.sol
+++ b/contracts/Colony.sol
@@ -304,7 +304,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
   // Introducing the expenditure
   bytes4 constant SIG_B0 = bytes4(keccak256("makeExpenditure(uint256,uint256,uint256)"));
-  bytes4 constant SIG_B1 = bytes4(keccak256("transferExpenditure(uint256,uint256,uint256,address)"));
+  bytes4 constant SIG_B1 = bytes4(keccak256("transferExpenditureViaArbitration(uint256,uint256,uint256,address)"));
   bytes4 constant SIG_B2 = bytes4(keccak256("setExpenditurePayoutModifier(uint256,uint256,uint256,uint256,int256)"));
   bytes4 constant SIG_B3 = bytes4(keccak256("setExpenditureClaimDelay(uint256,uint256,uint256,uint256,uint256)"));
 

--- a/contracts/ColonyAuthority.sol
+++ b/contracts/ColonyAuthority.sol
@@ -81,7 +81,7 @@ contract ColonyAuthority is CommonAuthority {
 
     // Added in colony v4
     addRoleCapability(ADMINISTRATION_ROLE, "makeExpenditure(uint256,uint256,uint256)");
-    addRoleCapability(ARBITRATION_ROLE, "transferExpenditure(uint256,uint256,uint256,address)");
+    addRoleCapability(ARBITRATION_ROLE, "transferExpenditureViaArbitration(uint256,uint256,uint256,address)");
     addRoleCapability(ARBITRATION_ROLE, "setExpenditurePayoutModifier(uint256,uint256,uint256,uint256,int256)");
     addRoleCapability(ARBITRATION_ROLE, "setExpenditureClaimDelay(uint256,uint256,uint256,uint256,uint256)");
   }

--- a/contracts/ColonyExpenditure.sol
+++ b/contracts/ColonyExpenditure.sol
@@ -68,7 +68,12 @@ contract ColonyExpenditure is ColonyStorage {
     emit ExpenditureTransferred(_id, _newOwner);
   }
 
-  function transferExpenditure(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, address _newOwner)
+  function transferExpenditureViaArbitration(
+    uint256 _permissionDomainId,
+    uint256 _childSkillIndex,
+    uint256 _id,
+    address _newOwner
+  )
     public
     stoppable
     authDomain(_permissionDomainId, _childSkillIndex, expenditures[_id].domainId)

--- a/contracts/ColonyNetwork.sol
+++ b/contracts/ColonyNetwork.sol
@@ -129,9 +129,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
   stoppable
   returns (address)
   {
-    address colonyAddress = deployColony(_tokenAddress, 3);
-    setFounderPermissions(colonyAddress);
-    return colonyAddress;
+    return createColony(_tokenAddress, 3, "", "", false);
   }
 
   function createColony(

--- a/contracts/IColony.sol
+++ b/contracts/IColony.sol
@@ -203,7 +203,7 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// (only used if `_permissionDomainId` is different to `_domainId`)
   /// @param _id Expenditure identifier
   /// @param _newOwner New owner of expenditure
-  function transferExpenditure(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, address _newOwner) public;
+  function transferExpenditureViaArbitration(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, address _newOwner) public;
 
   /// @notice Cancels the expenditure and prevents further editing. Can only be called by expenditure owner.
   /// @param _id Expenditure identifier

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -1309,7 +1309,7 @@ Updates the expenditure owner. Can only be called by expenditure owner.
 |_newOwner|address|New owner of expenditure
 
 
-### `transferExpenditure`
+### `transferExpenditureViaArbitration`
 
 Updates the expenditure owner. Can only be called by Arbitration role.
 

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -90,6 +90,24 @@ Calculate raw miner weight in WADs.
 
 ### `createColony`
 
+Creates a new colony in the network, at version 3
+
+*Note: This is now deprecated and will be removed in a future version*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_tokenAddress|address|Address of an ERC20 token to serve as the colony token.
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|colonyAddress|address|Address of the newly created colony
+
+### `createColony`
+
 Overload of the simpler `createColony` -- creates a new colony in the network with a variety of options
 
 *Note: For the colony to mint tokens, token ownership must be transferred to the new colony*
@@ -103,24 +121,6 @@ Overload of the simpler `createColony` -- creates a new colony in the network wi
 |_colonyName|string|The label to register (if null, no label is registered)
 |_orbitdb|string|The path of the orbitDB database associated with the user profile
 |_useExtensionManager|bool|If true, give the ExtensionManager the root role in the colony
-
-**Return Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|colonyAddress|address|Address of the newly created colony
-
-### `createColony`
-
-Creates a new colony in the network, at version 3
-
-*Note: This is now deprecated and will be removed in a future version*
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_tokenAddress|address|Address of an ERC20 token to serve as the colony token.
 
 **Return Parameters**
 

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -102,9 +102,8 @@ contract("Colony Expenditure", (accounts) => {
       let expenditure = await colony.getExpenditure(expenditureId);
       expect(expenditure.owner).to.equal(ADMIN);
 
-      const transferSig = "transferExpenditure(uint256,address)"; // Overloaded function
-      await checkErrorRevert(colony.methods[transferSig](expenditureId, USER), "colony-expenditure-not-owner");
-      await colony.methods[transferSig](expenditureId, USER, { from: ADMIN });
+      await checkErrorRevert(colony.transferExpenditure(expenditureId, USER), "colony-expenditure-not-owner");
+      await colony.transferExpenditure(expenditureId, USER, { from: ADMIN });
 
       expenditure = await colony.getExpenditure(expenditureId);
       expect(expenditure.owner).to.equal(USER);
@@ -117,9 +116,8 @@ contract("Colony Expenditure", (accounts) => {
       let expenditure = await colony.getExpenditure(expenditureId);
       expect(expenditure.owner).to.equal(ADMIN);
 
-      const transferSig = "transferExpenditure(uint256,uint256,uint256,address)"; // Overloaded function
-      await checkErrorRevert(colony.methods[transferSig](1, 0, expenditureId, USER, { from: ADMIN }), "ds-auth-unauthorized");
-      await colony.methods[transferSig](1, 0, expenditureId, USER, { from: ARBITRATOR });
+      await checkErrorRevert(colony.transferExpenditureViaArbitration(1, 0, expenditureId, USER, { from: ADMIN }), "ds-auth-unauthorized");
+      await colony.transferExpenditureViaArbitration(1, 0, expenditureId, USER, { from: ARBITRATOR });
 
       expenditure = await colony.getExpenditure(expenditureId);
       expect(expenditure.owner).to.equal(USER);


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->

Remove the `transferExpenditure` overload and introduce `transferExpenditureViaArbitration`.

Also update the implementation of the deprecated `createColony` to explicitly call into the multi-argument overload.

Also that doc inversion thing happened again but I'm still not worried about it.