### PR TITLE
Revert PayoutClaimed event totally

### DIFF
--- a/contracts/ColonyDataTypes.sol
+++ b/contracts/ColonyDataTypes.sol
@@ -171,7 +171,7 @@ contract ColonyDataTypes {
   /// @param fundingPotId Id of the funding pot where payout comes from
   /// @param token Token of the payout claim
   /// @param amount Amount of the payout claimed, after network fee was deducted
-  event PayoutClaimed(uint256 indexed fundingPotId, address indexed token, uint256 amount);
+  event PayoutClaimed(uint256 indexed fundingPotId, address token, uint256 amount);
 
   /// @notice Event logged when a task has been canceled
   /// @param taskId Id of the canceled task


### PR DESCRIPTION
This isn't the clever solution, but it is the easiest one, I believe.

To be honest, I'm not 100% sure of the consequences of what's going on here, or what the clever solution would look like. Even though adding the index doesn't change the signature, it does change how the 'parsed' event looks to tools higher up the stack which is causing grief, because this event is fired by (and in the interface for) `OneTxPayment` which is not getting upgraded on chain. Events support overloads in general, but because this change doesn't change the signature, if we made _only_ this change, we couldn't put both in the interface to be parsed by tools. If we added the `recipient` field as we did originally, we could have both via an overload and everything would work on the contract level, but there'd still likely be issues further up the stack (as we've seen elsewhere).

So for now, let's keep it simple, and just not change this at all out of practicality. This isn't indexed on-chain currently, so we're not breaking anything, things just might be harder down the line (I do agree the `token` parameter should be indexed, we just didn't have the foresight :cry: )