### PR TITLE
Fix blockchain start script error on process termination

### DIFF
--- a/scripts/stop-blockchain-client.sh
+++ b/scripts/stop-blockchain-client.sh
@@ -3,4 +3,4 @@
 pid=$(lsof -i:8545 -sTCP:LISTEN -t); 
 
 echo "Killing blockchain client process $pid on port 8545"
-kill -TERM $pid || kill -KILL $pid
+kill -INT $pid


### PR DESCRIPTION
I was always getting an error like this when running tests.

```
npm ERR! code ELIFECYCLE
npm ERR! errno 143
npm ERR! @colony.io/colony-network-contracts@1.0.0 start:blockchain:client: `bash ./scripts/start-blockchain-client.sh`
npm ERR! Exit status 143
```

These changes fixes it.