### PR TITLE
Fix accounting of nonRewardPotsTotal

### DIFF
--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -239,6 +239,10 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
       updatePayoutsWeCannotMakeAfterPotChange(_toPot, _token, toPotPreviousAmount);
     }
 
+    if (_toPot == 0 ) {
+      nonRewardPotsTotal[_token] = sub(nonRewardPotsTotal[_token], _amount);
+    }
+
     emit ColonyFundsMovedBetweenFundingPots(_fromPot, _toPot, _amount, _token);
   }
 

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -90,24 +90,6 @@ Calculate raw miner weight in WADs.
 
 ### `createColony`
 
-Creates a new colony in the network, at version 3
-
-*Note: This is now deprecated and will be removed in a future version*
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_tokenAddress|address|Address of an ERC20 token to serve as the colony token.
-
-**Return Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|colonyAddress|address|Address of the newly created colony
-
-### `createColony`
-
 Overload of the simpler `createColony` -- creates a new colony in the network with a variety of options
 
 *Note: For the colony to mint tokens, token ownership must be transferred to the new colony*
@@ -121,6 +103,24 @@ Overload of the simpler `createColony` -- creates a new colony in the network wi
 |_colonyName|string|The label to register (if null, no label is registered)
 |_orbitdb|string|The path of the orbitDB database associated with the user profile
 |_useExtensionManager|bool|If true, give the ExtensionManager the root role in the colony
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|colonyAddress|address|Address of the newly created colony
+
+### `createColony`
+
+Creates a new colony in the network, at version 3
+
+*Note: This is now deprecated and will be removed in a future version*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_tokenAddress|address|Address of an ERC20 token to serve as the colony token.
 
 **Return Parameters**
 


### PR DESCRIPTION
We stupidly didn't account for this properly (i.e. at all) in the event that people are manually moving funds in to their reward pots. The only consequence is that it becomes difficult to `claim`, thankfully - this isn't accounting that would put funds at risk, as far as I can tell.
