### PR TITLE
Use expenditure to handle multiple token payments

### DIFF
--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -218,7 +218,7 @@ contract("All", function (accounts) {
       await colony.setAdministrationRole(1, 0, oneTxExtension.address, 1, true);
       await colony.setFundingRole(1, 0, oneTxExtension.address, 1, true);
 
-      await oneTxExtension.makePayment(1, 0, 1, 0, WORKER, token.address, 10, 1, GLOBAL_SKILL_ID);
+      await oneTxExtension.makePayment(1, 0, 1, 0, [WORKER], [token.address], [10], 1, GLOBAL_SKILL_ID);
     });
 
     it("when working with staking", async function () {


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #[806]
Implements expenditure for multiple token payments in one-tx-payment extension for #806

<!--- Summary of changes including design decisions -->

See https://github.com/JoinColony/colonyNetwork/pull/817