### PR TITLE
Use staking functionality for mining

### DIFF
--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -421,10 +421,8 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     require(block.timestamp - payout.blockTimestamp <= 60 days, "colony-reward-payout-not-active");
 
     ITokenLocking tokenLocking = ITokenLocking(IColonyNetwork(colonyNetworkAddress).getTokenLocking());
-    uint256 userDepositLockCount = tokenLocking.getUserLock(token, msg.sender).lockCount;
     uint256 userTokens = tokenLocking.getUserLock(token, msg.sender).balance;
 
-    require(userDepositLockCount < payoutId, "colony-reward-payout-lock-count-too-high");
     require(userTokens > 0, "colony-reward-payout-invalid-user-tokens");
     require(userReputation > 0, "colony-reward-payout-invalid-user-reputation");
 

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -421,10 +421,10 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     require(block.timestamp - payout.blockTimestamp <= 60 days, "colony-reward-payout-not-active");
 
     ITokenLocking tokenLocking = ITokenLocking(IColonyNetwork(colonyNetworkAddress).getTokenLocking());
-    uint256 userDepositTimestamp = tokenLocking.getUserLock(token, msg.sender).timestamp;
+    uint256 userDepositLockCount = tokenLocking.getUserLock(token, msg.sender).lockCount;
     uint256 userTokens = tokenLocking.getUserLock(token, msg.sender).balance;
 
-    require(userDepositTimestamp < payout.blockTimestamp, "colony-reward-payout-deposit-too-recent");
+    require(userDepositLockCount < payoutId, "colony-reward-payout-lock-count-too-high");
     require(userTokens > 0, "colony-reward-payout-invalid-user-tokens");
     require(userReputation > 0, "colony-reward-payout-invalid-user-reputation");
 

--- a/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
+++ b/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
@@ -124,4 +124,9 @@ contract ColonyNetworkDataTypes {
     uint128 nUpdates;
     uint128 nPreviousUpdates;
   }
+
+  struct MiningStakeInfo {
+    uint256 amount;
+    uint256 timestamp;
+  }
 }

--- a/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
+++ b/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
@@ -125,7 +125,7 @@ contract ColonyNetworkDataTypes {
     uint128 nPreviousUpdates;
   }
 
-  struct MiningStakeInfo {
+  struct MiningStake {
     uint256 amount;
     uint256 timestamp;
   }

--- a/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
+++ b/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
@@ -94,6 +94,8 @@ contract ColonyNetworkDataTypes {
   /// @param label The label registered
   event ColonyLabelRegistered(address indexed colony, bytes32 label);
 
+  event ReputationMinerPenalised(address miner, address beneficiary, uint256 tokensLost);
+
   struct Skill {
     // total number of parent skills
     uint128 nParents;

--- a/contracts/colonyNetwork/ColonyNetworkMining.sol
+++ b/contracts/colonyNetwork/ColonyNetworkMining.sol
@@ -153,7 +153,7 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
     uint256[] memory minerWeights = new uint256[](stakers.length);
 
     for (i = 0; i < stakers.length; i++) {
-      timeStaked = miningStakeInfo[stakers[i]].timestamp;
+      timeStaked = miningStakes[stakers[i]].timestamp;
       minerWeights[i] = calculateMinerWeight(now - timeStaked, i);
       minerWeightsTotal = add(minerWeightsTotal, minerWeights[i]);
     }
@@ -205,8 +205,8 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
     ITokenLocking(tokenLocking).approveStake(msg.sender, _amount, clnyToken);
     ITokenLocking(tokenLocking).obligateStake(msg.sender, _amount, clnyToken);
 
-    miningStakeInfo[msg.sender].timestamp = getNewTimestamp(existingObligation, _amount, miningStakeInfo[msg.sender].timestamp, now);
-    miningStakeInfo[msg.sender].amount = add(miningStakeInfo[msg.sender].amount, _amount);
+    miningStakes[msg.sender].timestamp = getNewTimestamp(existingObligation, _amount, miningStakes[msg.sender].timestamp, now);
+    miningStakes[msg.sender].amount = add(miningStakes[msg.sender].amount, _amount);
   }
 
   function unstakeForMining(uint256 _amount) public stoppable {
@@ -215,11 +215,11 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
     bytes32 submissionHash = IReputationMiningCycle(activeReputationMiningCycle).getReputationHashSubmission(msg.sender).proposedNewRootHash;
     require(submissionHash == 0x0, "colony-network-hash-submitted");
     ITokenLocking(tokenLocking).deobligateStake(msg.sender, _amount, clnyToken);
-    miningStakeInfo[msg.sender].amount = sub(miningStakeInfo[msg.sender].amount, _amount);
+    miningStakes[msg.sender].amount = sub(miningStakes[msg.sender].amount, _amount);
   }
 
-  function getMiningStakeInfo(address _user) public stoppable returns (MiningStakeInfo memory) {
-    return miningStakeInfo[_user];
+  function getMiningStake(address _user) public stoppable returns (MiningStake memory) {
+    return miningStakes[_user];
   }
 
   uint256 constant UINT192_MAX = 2**192 - 1; // Used for updating the stake timestamp

--- a/contracts/colonyNetwork/ColonyNetworkMining.sol
+++ b/contracts/colonyNetwork/ColonyNetworkMining.sol
@@ -153,7 +153,7 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
     uint256[] memory minerWeights = new uint256[](stakers.length);
 
     for (i = 0; i < stakers.length; i++) {
-      timeStaked = ITokenLocking(tokenLocking).getUserLock(clnyToken, stakers[i]).timestamp;
+      timeStaked = miningStakeInfo[stakers[i]].timestamp;
       minerWeights[i] = calculateMinerWeight(now - timeStaked, i);
       minerWeightsTotal = add(minerWeightsTotal, minerWeights[i]);
     }
@@ -189,7 +189,7 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
     // Passing an array so that we don't incur the EtherRouter overhead for each staker if we looped over
     // it in ReputationMiningCycle.invalidateHash;
     for (uint256 i = 0; i < _stakers.length; i++) {
-      lostStake = min(ITokenLocking(tokenLocking).getTotalObligation(_stakers[i], clnyToken), _amount);
+      lostStake = min(ITokenLocking(tokenLocking).getObligation(_stakers[i], clnyToken, address(this)), _amount);
       ITokenLocking(tokenLocking).transferStake(_stakers[i], lostStake, clnyToken, _beneficiary);
 
       // TODO: Lose rep?
@@ -200,8 +200,13 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
 
   function stakeForMining(uint256 _amount) public stoppable {
     address clnyToken = IMetaColony(metaColony).getToken();
+    uint256 existingObligation = ITokenLocking(tokenLocking).getObligation(msg.sender, clnyToken, address(this));
+
     ITokenLocking(tokenLocking).approveStake(msg.sender, _amount, clnyToken);
     ITokenLocking(tokenLocking).obligateStake(msg.sender, _amount, clnyToken);
+
+    miningStakeInfo[msg.sender].timestamp = getNewTimestamp(existingObligation, _amount, miningStakeInfo[msg.sender].timestamp, now);
+    miningStakeInfo[msg.sender].amount = add(miningStakeInfo[msg.sender].amount, _amount);
   }
 
   function unstakeForMining(uint256 _amount) public stoppable {
@@ -210,6 +215,27 @@ contract ColonyNetworkMining is ColonyNetworkStorage {
     bytes32 submissionHash = IReputationMiningCycle(activeReputationMiningCycle).getReputationHashSubmission(msg.sender).proposedNewRootHash;
     require(submissionHash == 0x0, "colony-network-hash-submitted");
     ITokenLocking(tokenLocking).deobligateStake(msg.sender, _amount, clnyToken);
+    miningStakeInfo[msg.sender].amount = sub(miningStakeInfo[msg.sender].amount, _amount);
   }
+
+  function getMiningStakeInfo(address _user) public stoppable returns (MiningStakeInfo memory) {
+    return miningStakeInfo[_user];
+  }
+
+  uint256 constant UINT192_MAX = 2**192 - 1; // Used for updating the stake timestamp
+
+  function getNewTimestamp(uint256 _prevWeight, uint256 _currWeight, uint256 _prevTime, uint256 _currTime) internal pure returns (uint256) {
+    uint256 prevWeight = _prevWeight;
+    uint256 currWeight = _currWeight;
+
+    // Needed to prevent overflows in the timestamp calculation
+    while ((prevWeight >= UINT192_MAX) || (currWeight >= UINT192_MAX)) {
+      prevWeight /= 2;
+      currWeight /= 2;
+    }
+
+    return add(mul(prevWeight, _prevTime), mul(currWeight, _currTime)) / add(prevWeight, currWeight);
+  }
+
 
 }

--- a/contracts/colonyNetwork/ColonyNetworkStorage.sol
+++ b/contracts/colonyNetwork/ColonyNetworkStorage.sol
@@ -85,7 +85,7 @@ contract ColonyNetworkStorage is CommonStorage, ColonyNetworkDataTypes, DSMath {
   mapping (bytes32 => ENSRecord) records; // Storage slot 30
   mapping (address => mapping(uint256 => ReputationLogEntry)) replacementReputationUpdateLog; // Storage slot 31
   mapping (address => bool) replacementReputationUpdateLogsExist; // Storage slot 32
-  mapping (address => MiningStakeInfo) miningStakeInfo; // Storage slot 33
+  mapping (address => MiningStake) miningStakes; // Storage slot 33
 
   modifier calledByColony() {
     require(_isColony[msg.sender], "colony-caller-must-be-colony");

--- a/contracts/colonyNetwork/ColonyNetworkStorage.sol
+++ b/contracts/colonyNetwork/ColonyNetworkStorage.sol
@@ -85,6 +85,7 @@ contract ColonyNetworkStorage is CommonStorage, ColonyNetworkDataTypes, DSMath {
   mapping (bytes32 => ENSRecord) records; // Storage slot 30
   mapping (address => mapping(uint256 => ReputationLogEntry)) replacementReputationUpdateLog; // Storage slot 31
   mapping (address => bool) replacementReputationUpdateLogsExist; // Storage slot 32
+  mapping (address => MiningStakeInfo) miningStakeInfo; // Storage slot 33
 
   modifier calledByColony() {
     require(_isColony[msg.sender], "colony-caller-must-be-colony");

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -295,6 +295,6 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @param _amount Amount of CLNY staked for mining to unstake
   function unstakeForMining(uint256 _amount) public;
 
-  function getMiningStakeInfo(address _user) public view returns (MiningStakeInfo memory _info);
+  function getMiningStake(address _user) public view returns (MiningStake memory _info);
 
 }

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -295,4 +295,6 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @param _amount Amount of CLNY staked for mining to unstake
   function unstakeForMining(uint256 _amount) public;
 
+  function getMiningStakeInfo(address _user) public view returns (MiningStakeInfo memory _info);
+
 }

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -279,4 +279,20 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @notice Set the colony network fee to pay. e.g. if the fee is 1% (or 0.01), pass 100 as `_feeInverse`.
   /// @param _feeInverse The inverse of the network fee to set
   function setFeeInverse(uint256 _feeInverse) public;
+
+  /// @notice Function called to punish people who staked against a new reputation root hash that turned out to be incorrect.
+  /// @dev While public, it can only be called successfully by the current ReputationMiningCycle.
+  /// @param _stakers Array of the addresses of stakers to punish
+  /// @param _beneficiary Address of beneficiary to receive forfeited stake
+  /// @param _amount Amount of stake to slash
+  function punishStakers(address[] memory _stakers, address _beneficiary, uint256 _amount) public;
+
+  /// @notice Stake CLNY to allow the staker to participate in reputation mining.
+  /// @param _amount Amount of CLNY to stake for the purposes of mining
+  function stakeForMining(uint256 _amount) public;
+
+  /// @notice Unstake CLNY currently staked for reputation mining.
+  /// @param _amount Amount of CLNY staked for mining to unstake
+  function unstakeForMining(uint256 _amount) public;
+
 }

--- a/contracts/reputationMiningCycle/ReputationMiningCycle.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycle.sol
@@ -58,8 +58,8 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     require(entryIndex <= lockBalance / MIN_STAKE, "colony-reputation-mining-stake-minimum-not-met-for-index");
     require(entryIndex > 0, "colony-reputation-mining-zero-entry-index-passed");
 
-    uint256 lockTimestamp = ITokenLocking(tokenLockingAddress).getUserLock(clnyTokenAddress, msg.sender).timestamp;
-    require(reputationMiningWindowOpenTimestamp >= lockTimestamp, "colony-reputation-mining-stake-too-recent");
+    uint256 stakeTimestamp = IColonyNetwork(colonyNetworkAddress).getMiningStakeInfo(msg.sender).timestamp;
+    require(reputationMiningWindowOpenTimestamp >= stakeTimestamp, "colony-reputation-mining-stake-too-recent");
 
     // If this user has submitted before during this round...
     if (reputationHashSubmissions[msg.sender].proposedNewRootHash != bytes32(0)) {

--- a/contracts/reputationMiningCycle/ReputationMiningCycle.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycle.sol
@@ -58,7 +58,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
     require(entryIndex <= lockBalance / MIN_STAKE, "colony-reputation-mining-stake-minimum-not-met-for-index");
     require(entryIndex > 0, "colony-reputation-mining-zero-entry-index-passed");
 
-    uint256 stakeTimestamp = IColonyNetwork(colonyNetworkAddress).getMiningStakeInfo(msg.sender).timestamp;
+    uint256 stakeTimestamp = IColonyNetwork(colonyNetworkAddress).getMiningStake(msg.sender).timestamp;
     require(reputationMiningWindowOpenTimestamp >= stakeTimestamp, "colony-reputation-mining-stake-too-recent");
 
     // If this user has submitted before during this round...

--- a/contracts/reputationMiningCycle/ReputationMiningCycle.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycle.sol
@@ -54,7 +54,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
   /// @param jrh The justification root hash for the application of the log being processed.
   /// @param entryIndex The number of the entry the submitter hash asked us to consider.
   modifier entryQualifies(bytes32 newHash, uint256 nNodes, bytes32 jrh, uint256 entryIndex) {
-    uint256 lockBalance = ITokenLocking(tokenLockingAddress).getUserLock(clnyTokenAddress, msg.sender).balance;
+    uint256 lockBalance = ITokenLocking(tokenLockingAddress).getObligation(msg.sender, clnyTokenAddress, colonyNetworkAddress);
     require(entryIndex <= lockBalance / MIN_STAKE, "colony-reputation-mining-stake-minimum-not-met-for-index");
     require(entryIndex > 0, "colony-reputation-mining-zero-entry-index-passed");
 
@@ -298,7 +298,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
         // Our opponent completed the same number of challenge rounds, and both have now timed out.
         nInvalidatedHashes += 2;
         // Punish the people who proposed our opponent
-        ITokenLocking(tokenLockingAddress).punishStakers(
+        IColonyNetwork(colonyNetworkAddress).punishStakers(
           submittedHashes[opponentSubmission.proposedNewRootHash][opponentSubmission.nNodes][opponentSubmission.jrh],
           msg.sender,
           MIN_STAKE
@@ -311,7 +311,7 @@ contract ReputationMiningCycle is ReputationMiningCycleStorage, PatriciaTreeProo
       nHashesCompletedChallengeRound[round] += 2;
 
       // Punish the people who proposed the hash that was rejected
-      ITokenLocking(tokenLockingAddress).punishStakers(
+      IColonyNetwork(colonyNetworkAddress).punishStakers(
         submittedHashes[submission.proposedNewRootHash][submission.nNodes][submission.jrh],
         msg.sender,
         MIN_STAKE

--- a/contracts/tokenLocking/ITokenLocking.sol
+++ b/contracts/tokenLocking/ITokenLocking.sol
@@ -84,36 +84,29 @@ contract ITokenLocking is TokenLockingDataTypes {
   /// @param _force Pass true to forcibly unlock the token
   function withdraw(address _token, uint256 _amount, bool _force) public;
 
-  /// @notice Function called to punish people who staked against a new reputation root hash that turned out to be incorrect.
-  /// @dev While public, it can only be called successfully by the current ReputationMiningCycle.
-  /// @param _stakers Array of the addresses of stakers to punish
-  /// @param _beneficiary Address of beneficiary to receive forfeited stake
-  /// @param _amount Amount of stake to slash
-  function punishStakers(address[] memory _stakers, address _beneficiary, uint256 _amount) public;
-
   /// @notice Allow the colony to obligate some amount of tokens as a stake.
-  /// Can only be called by a colony.
-  /// @param _colony Address of the colony we are willing to let obligate us.
+  /// @dev Can only be called by a colony or colonyNetwork
+  /// @param _user Address of the user that is allowing their holdings to be staked by the caller
   /// @param _amount Amount of that colony's internal token up to which we are willing to be obligated.
   /// @param _token The colony's internal token address
-  function approveStake(address _colony, uint256 _amount, address _token) public;
+  function approveStake(address _user, uint256 _amount, address _token) public;
 
   /// @notice Obligate the user some amount of tokens as a stake.
-  /// Can only be called by a colony.
+  /// Can only be called by a colony or colonyNetwork.
   /// @param _user Address of the account we are obligating.
   /// @param _amount Amount of the colony's internal token we are obligating.
   /// @param _token The colony's internal token address
   function obligateStake(address _user, uint256 _amount, address _token) public;
 
   /// @notice Deobligate the user some amount of tokens, releasing the stake.
-  /// Can only be called by a colony.
+  /// Can only be called by a colony or colonyNetwork.
   /// @param _user Address of the account we are deobligating.
   /// @param _amount Amount of colony's internal token we are deobligating.
   /// @param _token The colony's internal token address
   function deobligateStake(address _user, uint256 _amount, address _token) public;
 
   /// @notice Transfer some amount of staked tokens.
-  /// Can only be called by a colony.
+  /// Can only be called by a colony or colonyNetwork.
   /// @param _user Address of the account we are taking.
   /// @param _amount Amount of colony's internal token we are taking.
   /// @param _token The colony's internal token address
@@ -138,4 +131,16 @@ contract ITokenLocking is TokenLockingDataTypes {
   /// @param _user Address of the obligated account.
   /// @param _token The token for which the user is obligated.
   function getTotalObligation(address _user, address _token) public view returns (uint256);
+
+  /// @notice See the total amount of a user's obligation.
+  /// @param _user Address of the account that has approved _approvee to obligate their funds.
+  /// @param _token The token for which the user has provided the approval.
+  /// @param _obligator The address that has been approved to obligate the funds.
+  function getApproval(address _user, address _token, address _obligator) public view returns (uint256);
+
+  /// @notice See the total amount of a user's obligation.
+  /// @param _user Address of the account that has had their funds obligated.
+  /// @param _token The token for which the user has provided the approval.
+  /// @param _obligator The address that obligated the funds (and therefore can slash or return them).
+  function getObligation(address _user, address _token, address _obligator) public view returns (uint256);
 }

--- a/contracts/tokenLocking/TokenLockingDataTypes.sol
+++ b/contracts/tokenLocking/TokenLockingDataTypes.sol
@@ -27,7 +27,6 @@ contract TokenLockingDataTypes {
   event UserTokenClaimed(address token, address user, uint256 amount, uint256 timestamp);
   event UserTokenTransferred(address token, address user, address recipient, uint256 amount);
   event UserTokenWithdrawn(address token, address user, uint256 amount);
-  event ReputationMinerPenalised(address miner, address beneficiary, uint256 tokensLost);
 
   struct Lock {
     // User's lock count

--- a/contracts/tokenLocking/TokenLockingDataTypes.sol
+++ b/contracts/tokenLocking/TokenLockingDataTypes.sol
@@ -23,8 +23,8 @@ contract TokenLockingDataTypes {
   event ColonyNetworkSet(address colonyNetwork);
   event TokenLocked(address token, uint256 lockCount);
   event UserTokenUnlocked(address token, address user, uint256 lockId);
-  event UserTokenDeposited(address token, address user, uint256 amount, uint256 timestamp);
-  event UserTokenClaimed(address token, address user, uint256 amount, uint256 timestamp);
+  event UserTokenDeposited(address token, address user, uint256 amount);
+  event UserTokenClaimed(address token, address user, uint256 amount);
   event UserTokenTransferred(address token, address user, address recipient, uint256 amount);
   event UserTokenWithdrawn(address token, address user, uint256 amount);
 
@@ -33,8 +33,8 @@ contract TokenLockingDataTypes {
     uint256 lockCount;
     // Deposited balance
     uint256 balance;
-    // Weighted average of deposit timestamps
-    uint256 timestamp;
+    // Weighted average of deposit timestamps (no longer used)
+    uint256 DEPRECATED_timestamp;
     // Pending balance, can claim once unlocked
     uint256 pendingBalance;
   }

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -270,6 +270,7 @@ export async function giveUserCLNYTokensAndStake(colonyNetwork, user, _amount) {
   const tokenLocking = await ITokenLocking.at(tokenLockingAddress);
   await clnyToken.approve(tokenLocking.address, amount, { from: user });
   await tokenLocking.deposit(clnyToken.address, amount, { from: user });
+  await colonyNetwork.stakeForMining(amount, { from: user });
 }
 
 export async function fundColonyWithTokens(colony, token, tokenAmount = INITIAL_FUNDING) {

--- a/migrations/8_setup_meta_colony.js
+++ b/migrations/8_setup_meta_colony.js
@@ -45,7 +45,7 @@ module.exports = async function (deployer, network, accounts) {
   assert.equal(mainAccountBalance.toString(), DEFAULT_STAKE.toString());
   const tokenLocking = await ITokenLocking.at(tokenLockingAddress);
   await tokenLocking.deposit(clnyToken.address, DEFAULT_STAKE, { from: MAIN_ACCOUNT });
-
+  await colonyNetwork.stakeForMining(DEFAULT_STAKE, { from: MAIN_ACCOUNT });
   await metaColony.addGlobalSkill();
 
   // Also set up the pinned version (3)... TODO: remove along with the deprecated `createColony`

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -654,7 +654,7 @@ class ReputationMiner {
 
   async getEntryIndex(startIndex = 1) {
     // Get how much we've staked, and thefore how many entries we have
-    const [stakeAmount] = await this.colonyNetwork.getMiningStakeInfo(this.minerAddress);
+    const [stakeAmount] = await this.colonyNetwork.getMiningStake(this.minerAddress);
 
     for (let i = ethers.utils.bigNumberify(startIndex); i.lte(stakeAmount.div(minStake)); i = i.add(1)) {
       const submissionPossible = await this.submissionPossible(i);
@@ -689,7 +689,7 @@ class ReputationMiner {
     }
 
     // Check the proposed entry is eligible (emulates entryQualifies modifier behaviour)
-    const [stakeAmount, stakeTimestamp] = await this.colonyNetwork.getMiningStakeInfo(this.minerAddress);
+    const [stakeAmount, stakeTimestamp] = await this.colonyNetwork.getMiningStake(this.minerAddress);
 
     if (ethers.utils.bigNumberify(entryIndex).gt(stakeAmount.div(minStake))) {
       return false;

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -654,9 +654,9 @@ class ReputationMiner {
 
   async getEntryIndex(startIndex = 1) {
     // Get how much we've staked, and thefore how many entries we have
-    const [, balance] = await this.tokenLocking.getUserLock(this.clnyAddress, this.minerAddress);
+    const [stakeAmount] = await this.colonyNetwork.getMiningStakeInfo(this.minerAddress);
 
-    for (let i = ethers.utils.bigNumberify(startIndex); i.lte(balance.div(minStake)); i = i.add(1)) {
+    for (let i = ethers.utils.bigNumberify(startIndex); i.lte(stakeAmount.div(minStake)); i = i.add(1)) {
       const submissionPossible = await this.submissionPossible(i);
       if (submissionPossible) {
         return i;
@@ -689,12 +689,13 @@ class ReputationMiner {
     }
 
     // Check the proposed entry is eligible (emulates entryQualifies modifier behaviour)
-    const lock = await this.tokenLocking.getUserLock(this.clnyAddress, this.minerAddress);
-    if (ethers.utils.bigNumberify(entryIndex).gt(lock.balance.div(minStake))) {
+    const [stakeAmount, stakeTimestamp] = await this.colonyNetwork.getMiningStakeInfo(this.minerAddress);
+
+    if (ethers.utils.bigNumberify(entryIndex).gt(stakeAmount.div(minStake))) {
       return false;
     }
 
-    if(reputationMiningWindowOpenTimestamp.lt(lock.timestamp)) {
+    if(reputationMiningWindowOpenTimestamp.lt(stakeTimestamp)) {
       return false;
     }
 

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -487,7 +487,13 @@ class ReputationMinerClient {
   async getTwelveBestSubmissions() {
     const addr = await this._miner.colonyNetwork.getReputationMiningCycle(true);
     const repCycle = new ethers.Contract(addr, this._miner.repCycleContractDef.abi, this._miner.realWallet);
-    const [, balance] = await this._miner.tokenLocking.getUserLock(this._miner.clnyAddress, this._miner.minerAddress);
+
+    const balance = await this._miner.tokenLocking.getObligation(
+      this._miner.minerAddress,
+      this._miner.clnyAddress,
+      this._miner.colonyNetwork.address
+    );
+
     const reputationMiningWindowOpenTimestamp = await repCycle.getReputationMiningWindowOpenTimestamp();
     const rootHash = await this._miner.getRootHash();
 

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -268,6 +268,7 @@ contract("All", function (accounts) {
 
       // withdraw
       const clnyToken = await metaColony.getToken();
+      await colonyNetwork.unstakeForMining(DEFAULT_STAKE.divn(4), { from: STAKER1 });
       await tokenLocking.methods["withdraw(address,uint256,bool)"](clnyToken, DEFAULT_STAKE.divn(4), false, { from: STAKER1 });
     });
 

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -4,7 +4,7 @@ import bnChai from "bn-chai";
 import { ethers } from "ethers";
 
 import { getTokenArgs, web3GetNetwork, web3GetBalance, checkErrorRevert, expectEvent, getColonyEditable } from "../../helpers/test-helper";
-import { CURR_VERSION, GLOBAL_SKILL_ID, ROOT_ROLE } from "../../helpers/constants";
+import { CURR_VERSION, GLOBAL_SKILL_ID, ROOT_ROLE, MIN_STAKE } from "../../helpers/constants";
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony } from "../../helpers/test-data-generator";
 import { setupENSRegistrar } from "../../helpers/upgradable-contracts";
 
@@ -138,6 +138,13 @@ contract("Colony Network", (accounts) => {
       await metaColonyUnderRecovery.setStorageSlot(7, ethers.constants.AddressZero);
 
       await checkErrorRevert(colonyNetwork.startNextCycle(), "colony-reputation-mining-clny-token-invalid-address");
+    });
+
+    it('should not allow "punishStakers" to be called from an account that is not the mining cycle', async () => {
+      await checkErrorRevert(
+        colonyNetwork.punishStakers([accounts[0], accounts[1]], ethers.constants.AddressZero, MIN_STAKE),
+        "colony-reputation-mining-sender-not-active-reputation-cycle"
+      );
     });
   });
 

--- a/test/contracts-network/colony-reward-payouts.js
+++ b/test/contracts-network/colony-reward-payouts.js
@@ -514,7 +514,7 @@ contract("Colony Reward Payouts", (accounts) => {
 
       await checkErrorRevert(
         colony.claimRewardPayout(payoutId, initialSquareRoots, ...userReputationProof1, { from: userAddress1 }),
-        "colony-reward-payout-lock-count-too-high"
+        "colony-token-already-unlocked"
       );
     });
 
@@ -610,7 +610,7 @@ contract("Colony Reward Payouts", (accounts) => {
 
       await checkErrorRevert(
         colony.claimRewardPayout(payoutId, initialSquareRoots, ...userReputationProof1, { from: userAddress1 }),
-        "colony-reward-payout-lock-count-too-high"
+        "colony-token-already-unlocked"
       );
     });
 
@@ -626,7 +626,7 @@ contract("Colony Reward Payouts", (accounts) => {
 
       await checkErrorRevert(
         colony.claimRewardPayout(payoutId, initialSquareRoots, ...userReputationProof1, { from: userAddress1 }),
-        "colony-reward-payout-lock-count-too-high"
+        "colony-token-already-unlocked"
       );
     });
 

--- a/test/contracts-network/colony-reward-payouts.js
+++ b/test/contracts-network/colony-reward-payouts.js
@@ -514,7 +514,7 @@ contract("Colony Reward Payouts", (accounts) => {
 
       await checkErrorRevert(
         colony.claimRewardPayout(payoutId, initialSquareRoots, ...userReputationProof1, { from: userAddress1 }),
-        "colony-token-already-unlocked"
+        "colony-reward-payout-lock-count-too-high"
       );
     });
 
@@ -610,7 +610,7 @@ contract("Colony Reward Payouts", (accounts) => {
 
       await checkErrorRevert(
         colony.claimRewardPayout(payoutId, initialSquareRoots, ...userReputationProof1, { from: userAddress1 }),
-        "colony-token-already-unlocked"
+        "colony-reward-payout-lock-count-too-high"
       );
     });
 
@@ -626,7 +626,7 @@ contract("Colony Reward Payouts", (accounts) => {
 
       await checkErrorRevert(
         colony.claimRewardPayout(payoutId, initialSquareRoots, ...userReputationProof1, { from: userAddress1 }),
-        "colony-reward-payout-deposit-too-recent"
+        "colony-reward-payout-lock-count-too-high"
       );
     });
 

--- a/test/contracts-network/reputation-basic-functionality.js
+++ b/test/contracts-network/reputation-basic-functionality.js
@@ -43,11 +43,15 @@ contract("Reputation mining - basic functionality", (accounts) => {
     // Ensure consistent state of token locking and clnyToken balance for two test accounts
     const miner1Lock = await tokenLocking.getUserLock(clnyToken.address, MINER1);
     if (miner1Lock.balance > 0) {
+      const obligation = await tokenLocking.getObligation(MINER1, clnyToken.address, colonyNetwork.address);
+      await colonyNetwork.unstakeForMining(obligation, { from: MINER1 });
       await tokenLocking.methods["withdraw(address,uint256,bool)"](clnyToken.address, miner1Lock.balance, false, { from: MINER1 });
     }
 
     const miner2Lock = await tokenLocking.getUserLock(clnyToken.address, MINER2);
     if (miner2Lock.balance > 0) {
+      const obligation = await tokenLocking.getObligation(MINER2, clnyToken.address, colonyNetwork.address);
+      await colonyNetwork.unstakeForMining(obligation, { from: MINER2 });
       await tokenLocking.methods["withdraw(address,uint256,bool)"](clnyToken.address, miner2Lock.balance, false, { from: MINER2 });
     }
 
@@ -75,6 +79,7 @@ contract("Reputation mining - basic functionality", (accounts) => {
     it("should allow miners to withdraw staked CLNY", async () => {
       await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, 5000);
 
+      await colonyNetwork.unstakeForMining(5000, { from: MINER2 });
       await tokenLocking.methods["withdraw(address,uint256,bool)"](clnyToken.address, 5000, false, { from: MINER2 });
 
       const info = await tokenLocking.getUserLock(clnyToken.address, MINER2);

--- a/test/contracts-network/reputation-basic-functionality.js
+++ b/test/contracts-network/reputation-basic-functionality.js
@@ -7,7 +7,7 @@ import { ethers } from "ethers";
 
 import { giveUserCLNYTokens, giveUserCLNYTokensAndStake } from "../../helpers/test-data-generator";
 import { MIN_STAKE, MINING_CYCLE_DURATION, DECAY_RATE } from "../../helpers/constants";
-import { forwardTime, checkErrorRevert, getActiveRepCycle } from "../../helpers/test-helper";
+import { forwardTime, checkErrorRevert, getActiveRepCycle, getBlockTime } from "../../helpers/test-helper";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
@@ -125,6 +125,34 @@ contract("Reputation mining - basic functionality", (accounts) => {
 
       const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
       expect(nUniqueSubmittedHashes).to.be.zero;
+    });
+
+    it("should correctly set deposit timestamp", async () => {
+      const usersTokens = 10000;
+      await giveUserCLNYTokens(colonyNetwork, MINER2, usersTokens);
+      await clnyToken.approve(tokenLocking.address, usersTokens, { from: MINER2 });
+      const quarter = Math.floor(usersTokens / 4);
+
+      let tx;
+      await tokenLocking.deposit(clnyToken.address, quarter * 3, { from: MINER2 });
+      tx = await colonyNetwork.stakeForMining(quarter * 3, { from: MINER2 });
+      const time1 = await getBlockTime(tx.receipt.blockNumber);
+      const [stakedAmount, stakedTimestamp] = await colonyNetwork.getMiningStakeInfo(MINER2);
+      console.log(stakedAmount, stakedTimestamp);
+      expect(stakedAmount).to.eq.BN(quarter * 3);
+      expect(stakedTimestamp).to.eq.BN(time1);
+
+      await forwardTime(3600);
+
+      await tokenLocking.deposit(clnyToken.address, quarter, { from: MINER2 });
+      tx = await colonyNetwork.stakeForMining(quarter, { from: MINER2 });
+      const time2 = await getBlockTime(tx.receipt.blockNumber);
+
+      const [stakedAmount2, stakedTimestamp2] = await colonyNetwork.getMiningStakeInfo(MINER2);
+
+      const weightedAvgTime = Math.floor((time1 * 3 + time2) / 4);
+      expect(stakedAmount2).to.eq.BN(quarter * 4);
+      expect(stakedTimestamp2).to.eq.BN(weightedAvgTime);
     });
   });
 

--- a/test/contracts-network/reputation-basic-functionality.js
+++ b/test/contracts-network/reputation-basic-functionality.js
@@ -137,7 +137,7 @@ contract("Reputation mining - basic functionality", (accounts) => {
       await tokenLocking.deposit(clnyToken.address, quarter * 3, { from: MINER2 });
       tx = await colonyNetwork.stakeForMining(quarter * 3, { from: MINER2 });
       const time1 = await getBlockTime(tx.receipt.blockNumber);
-      const [stakedAmount, stakedTimestamp] = await colonyNetwork.getMiningStakeInfo(MINER2);
+      const [stakedAmount, stakedTimestamp] = await colonyNetwork.getMiningStake(MINER2);
       console.log(stakedAmount, stakedTimestamp);
       expect(stakedAmount).to.eq.BN(quarter * 3);
       expect(stakedTimestamp).to.eq.BN(time1);
@@ -148,7 +148,7 @@ contract("Reputation mining - basic functionality", (accounts) => {
       tx = await colonyNetwork.stakeForMining(quarter, { from: MINER2 });
       const time2 = await getBlockTime(tx.receipt.blockNumber);
 
-      const [stakedAmount2, stakedTimestamp2] = await colonyNetwork.getMiningStakeInfo(MINER2);
+      const [stakedAmount2, stakedTimestamp2] = await colonyNetwork.getMiningStake(MINER2);
 
       const weightedAvgTime = Math.floor((time1 * 3 + time2) / 4);
       expect(stakedAmount2).to.eq.BN(quarter * 4);

--- a/test/contracts-network/token-locking.js
+++ b/test/contracts-network/token-locking.js
@@ -5,7 +5,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 import { ethers } from "ethers";
 
-import { getTokenArgs, checkErrorRevert, forwardTime, makeReputationKey, getBlockTime, advanceMiningCycleNoContest } from "../../helpers/test-helper";
+import { getTokenArgs, checkErrorRevert, makeReputationKey, advanceMiningCycleNoContest } from "../../helpers/test-helper";
 import { giveUserCLNYTokensAndStake, setupRandomColony, fundColonyWithTokens } from "../../helpers/test-data-generator";
 import { UINT256_MAX, DEFAULT_STAKE } from "../../helpers/constants";
 
@@ -106,28 +106,6 @@ contract("Token Locking", (addresses) => {
 
       const tokenLockingContractBalance = await otherToken.balanceOf(tokenLocking.address);
       expect(tokenLockingContractBalance).to.eq.BN(UINT256_MAX);
-    });
-
-    it("should correctly set deposit timestamp", async () => {
-      await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
-      const quarter = Math.floor(usersTokens / 4);
-
-      let tx;
-      tx = await tokenLocking.deposit(token.address, quarter * 3, { from: userAddress });
-      const time1 = await getBlockTime(tx.receipt.blockNumber);
-      const info1 = await tokenLocking.getUserLock(token.address, userAddress);
-      expect(info1.balance).to.eq.BN(quarter * 3);
-      expect(info1.timestamp).to.eq.BN(time1);
-
-      await forwardTime(3600);
-
-      tx = await tokenLocking.deposit(token.address, quarter, { from: userAddress });
-      const time2 = await getBlockTime(tx.receipt.blockNumber);
-      const info2 = await tokenLocking.getUserLock(token.address, userAddress);
-
-      const weightedAvgTime = Math.floor((time1 * 3 + time2) / 4);
-      expect(info2.balance).to.eq.BN(quarter * 4);
-      expect(info2.timestamp).to.eq.BN(weightedAvgTime);
     });
 
     it("should not be able to deposit tokens if they are not approved", async () => {

--- a/test/reputation-system/root-hash-submissions.js
+++ b/test/reputation-system/root-hash-submissions.js
@@ -308,11 +308,9 @@ contract("Reputation mining - root hash submissions", (accounts) => {
       await forwardTime(MINING_CYCLE_DURATION, this);
       await repCycle.submitRootHash("0x12345678", 10, "0x00", 10, { from: MINER1 });
 
-      const userLock = await tokenLocking.getUserLock(clnyToken.address, MINER1);
-      await checkErrorRevert(
-        tokenLocking.methods["withdraw(address,uint256,bool)"](clnyToken.address, userLock.balance, false, { from: MINER1 }),
-        "colony-token-locking-hash-submitted"
-      );
+      const obligation = await tokenLocking.getObligation(MINER1, clnyToken.address, colonyNetwork.address);
+
+      await checkErrorRevert(colonyNetwork.unstakeForMining(obligation, { from: MINER1 }), "colony-network-hash-submitted");
     });
 
     it("should allow a new reputation hash to be set if only one was submitted", async () => {


### PR DESCRIPTION
With staking merged, it makes sense to use it wherever it's appropriate - and a big place where it would be appropriate and is not currently used is reputation mining. 

This PR moves all 'knowledge' of mining up to the `ColonyNetwork` contract which is much better than having that on `TokenLocking`. So to mine, you obligate CLNY through `ColonyNetwork`, and otherwise everything is the same as before. Instead of not being allowed to withdraw during mining if you've submitted, you're not allowed to unstake if you've submitted. 

The only thing I'm not happy with here is the timestamp stuff; are we planning on using that anywhere other than with mining? If not, it should just be elevated to `ColonyNetwork` as well, specific to staking for mining.

I've taken the liberty of adding `getApproval` and `getObligation` to `TokenLocking` as well.