### PR TITLE
Arbitration Reputation Penalties

### DIFF
--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -85,8 +85,10 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ARBITRATION_ROLE, "setExpenditurePayoutModifier(uint256,uint256,uint256,uint256,int256)");
     addRoleCapability(ARBITRATION_ROLE, "setExpenditureClaimDelay(uint256,uint256,uint256,uint256,uint256)");
 
-    // Added in colony v5
+    // Added in colony v5 (current version)
     addRoleCapability(ARBITRATION_ROLE, "transferStake(uint256,uint256,address,address,uint256,uint256,address)");
+    addRoleCapability(ARBITRATION_ROLE, "emitDomainReputationPenalty(uint256,uint256,uint256,address,int256)");
+    addRoleCapability(ARBITRATION_ROLE, "emitSkillReputationPenalty(uint256,address,int256)");
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -127,6 +127,26 @@ contract IColony is ColonyDataTypes, IRecovery {
   /// @return roles bytes32 representation of the roles
   function getUserRoles(address who, uint256 where) public view returns (bytes32 roles);
 
+  /// @notice Emit a negative domain reputation update. Available only to Arbitration role holders
+  /// @param _permissionDomainId The domainId in which I hold the Arbitration role
+  /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`
+  /// @param _domainId The domain where the user will lose reputation
+  /// @param _user The user who will lose reputation
+  /// @param _amount The (negative) amount of reputation to lose
+  function emitDomainReputationPenalty(
+    uint256 _permissionDomainId,
+    uint256 _childSkillIndex,
+    uint256 _domainId,
+    address _user,
+    int256 _amount
+    ) public;
+
+  /// @notice Emit a negative skill reputation update. Available only to Arbitration role holders in the root domain
+  /// @param _skillId The skill where the user will lose reputation
+  /// @param _user The user who will lose reputation
+  /// @param _amount The (negative) amount of reputation to lose
+  function emitSkillReputationPenalty(uint256 _skillId, address _user, int256 _amount) public;
+
   /// @notice Called once when the colony is created to initialise certain storage slot values.
   /// @dev Sets the reward inverse to the uint max 2**256 - 1.
   /// @param _colonyNetworkAddress Address of the colony network

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -206,6 +206,36 @@ Deobligate the user some amount of tokens, releasing the stake.
 |_amount|uint256|Amount of internal token we are deobligating.
 
 
+### `emitDomainReputationPenalty`
+
+Emit a negative domain reputation update. Available only to Arbitration role holders
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_permissionDomainId|uint256|The domainId in which I hold the Arbitration role
+|_childSkillIndex|uint256|The index that the `_domainId` is relative to `_permissionDomainId`
+|_domainId|uint256|The domain where the user will lose reputation
+|_user|address|The user who will lose reputation
+|_amount|int256|The (negative) amount of reputation to lose
+
+
+### `emitSkillReputationPenalty`
+
+Emit a negative skill reputation update. Available only to Arbitration role holders in the root domain
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_skillId|uint256|The skill where the user will lose reputation
+|_user|address|The user who will lose reputation
+|_amount|int256|The (negative) amount of reputation to lose
+
+
 ### `executeTaskChange`
 
 Executes a task update transaction `_data` which is approved and signed by two of its roles (e.g. manager and worker) using the detached signatures for these users.


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Prerequisite for #644, #717

<!--- Summary of changes including design decisions -->

Introduce functionality allowing Arbitrators to emit reputation penalties:

- `emitDomainReputationPenalty`, which requires a domain proof, and
- `emitSkillReputationPenalty `, which does not, but is restricted to root arbitrators.

In both cases the given `int256` value must be less than or equal to 0.