### PR TITLE
OneTxPayment Refactor

### DIFF
--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -222,18 +222,24 @@ contract OneTxPayment is ColonyExtension, DSMath {
     uint256[] memory uniqueAmounts = new uint256[](_tokens.length);
 
     for (uint256 i; i < _tokens.length; i++) {
+
       bool isMatch;
-      for (uint256 j; j < uniqueTokensIdx && !isMatch; j++) {
+      uint256 j;
+
+      while (j < uniqueTokensIdx && !isMatch) {
         if (_tokens[i] == uniqueTokens[j]) {
           isMatch = true;
           uniqueAmounts[j] = add(uniqueAmounts[j], _amounts[i]);
         }
+        j++;
       }
+
       if (!isMatch) {
         uniqueTokens[uniqueTokensIdx] = _tokens[i];
         uniqueAmounts[uniqueTokensIdx] = _amounts[i];
         uniqueTokensIdx++;
       }
+
     }
 
     return (uniqueTokensIdx, uniqueTokens, uniqueAmounts);

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -76,12 +76,12 @@ contract OneTxPayment is ColonyExtension {
   )
     public
   {
-    require(_workers.length == _tokens.length && _workers.length == _amounts.length, "colony-one-tx-payment-invalid-input");
+    require(_workers.length == _tokens.length && _workers.length == _amounts.length, "one-tx-payment-invalid-input");
 
     require(
       colony.hasInheritedUserRole(msg.sender, 1, FUNDING, _childSkillIndex, _domainId) &&
       colony.hasInheritedUserRole(msg.sender, _callerPermissionDomainId, ADMINISTRATION, _callerChildSkillIndex, _domainId),
-      "colony-one-tx-payment-not-authorized"
+      "one-tx-payment-not-authorized"
     );
 
     if (_workers.length == 1) {
@@ -107,12 +107,16 @@ contract OneTxPayment is ColonyExtension {
 
          // If a new worker, start a new slot
         if (idx == 0 || _workers[idx] != _workers[idx-1]) {
+          require(idx == 0 || _workers[idx] > _workers[idx-1], "one-tx-payment-bad-worker-order");
+
           slot++;
           colony.setExpenditureRecipient(expenditureId, slot, _workers[idx]);
 
           if (_skillId != 0) {
             colony.setExpenditureSkill(expenditureId, slot, _skillId);
           }
+        } else {
+          require(_tokens[idx] > _tokens[idx-1], "one-tx-payment-bad-token-order");
         }
 
         colony.setExpenditurePayout(expenditureId, slot, _tokens[idx], _amounts[idx]);
@@ -149,13 +153,12 @@ contract OneTxPayment is ColonyExtension {
   )
     public
   {
-    require(_workers.length == _tokens.length && _workers.length == _amounts.length, "colony-one-tx-payment-invalid-input");
-    validatePermissions(_callerPermissionDomainId, _callerChildSkillIndex, _domainId);
+    require(_workers.length == _tokens.length && _workers.length == _amounts.length, "one-tx-payment-invalid-input");
 
     require(
       colony.hasInheritedUserRole(msg.sender, _callerPermissionDomainId, FUNDING, _callerChildSkillIndex, _domainId) &&
       colony.hasInheritedUserRole(msg.sender, _callerPermissionDomainId, ADMINISTRATION, _callerChildSkillIndex, _domainId),
-      "colony-one-tx-payment-not-authorized"
+      "one-tx-payment-not-authorized"
     );
 
     if (_workers.length == 1) {
@@ -183,12 +186,16 @@ contract OneTxPayment is ColonyExtension {
 
          // If a new worker, start a new slot
         if (idx == 0 || _workers[idx] != _workers[idx-1]) {
+          require(idx == 0 || _workers[idx] > _workers[idx-1], "one-tx-payment-bad-worker-order");
+
           slot++;
           colony.setExpenditureRecipient(expenditureId, slot, _workers[idx]);
 
           if (_skillId != 0) {
             colony.setExpenditureSkill(expenditureId, slot, _skillId);
           }
+        } else {
+          require(_tokens[idx] > _tokens[idx-1], "one-tx-payment-bad-token-order");
         }
 
         colony.setExpenditurePayout(expenditureId, slot, _tokens[idx], _amounts[idx]);
@@ -223,16 +230,5 @@ contract OneTxPayment is ColonyExtension {
       }
       colony.claimExpenditurePayout(_expenditureId, slot, _tokens[idx]);
     }
-  }
-
-  function validatePermissions(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _domainId)
-    internal
-    view
-  {
-    require(
-      colony.hasInheritedUserRole(msg.sender, _permissionDomainId, ColonyDataTypes.ColonyRole.Funding, _childSkillIndex, _domainId) &&
-      colony.hasInheritedUserRole(msg.sender, _permissionDomainId, ColonyDataTypes.ColonyRole.Administration, _childSkillIndex, _domainId),
-      "colony-one-tx-payment-not-authorized"
-    );
   }
 }

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -169,6 +169,7 @@ contract OneTxPayment is ColonyExtension, DSMath {
       uint256 fundingPotId = colony.getPayment(paymentId).fundingPotId;
       uint256 domainPotId = colony.getDomain(_domainId).fundingPotId;
 
+      // We use a separate function to get around the local variable limit :(
       moveFundsWithinDomain(_permissionDomainId, _childSkillIndex, domainPotId, fundingPotId, _amounts[0], _tokens[0]);
 
       colony.finalizePayment(_permissionDomainId, _childSkillIndex, paymentId);

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -4,7 +4,7 @@ section: Interface
 order: 2
 ---
 
-
+  
 ## Interface Methods
 
 ### `addColonyVersion`

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -4,7 +4,7 @@ section: Interface
 order: 2
 ---
 
-  
+
 ## Interface Methods
 
 ### `addColonyVersion`

--- a/test/extensions/coin-machine.js
+++ b/test/extensions/coin-machine.js
@@ -31,7 +31,6 @@ contract("Coin Machine", (accounts) => {
   let token;
   let purchaseToken;
   let colonyNetwork;
-  let metaColony;
   let coinMachine;
 
   const USER0 = accounts[0];
@@ -39,7 +38,7 @@ contract("Coin Machine", (accounts) => {
 
   before(async () => {
     colonyNetwork = await setupColonyNetwork();
-    ({ metaColony } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
+    const { metaColony } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork);
 
     const coinMachineImplementation = await CoinMachine.new();
     const resolver = await Resolver.new();

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -7,14 +7,16 @@ import { soliditySha3 } from "web3-utils";
 
 import { UINT256_MAX, WAD, INITIAL_FUNDING, GLOBAL_SKILL_ID, FUNDING_ROLE, ADMINISTRATION_ROLE } from "../../helpers/constants";
 import { checkErrorRevert, web3GetCode, rolesToBytes32 } from "../../helpers/test-helper";
-import { setupEtherRouter } from "../../helpers/upgradable-contracts";
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony, fundColonyWithTokens } from "../../helpers/test-data-generator";
+import { setupEtherRouter } from "../../helpers/upgradable-contracts";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
 
 const OneTxPayment = artifacts.require("OneTxPayment");
 const Resolver = artifacts.require("Resolver");
+
+const ONE_TX_PAYMENT = soliditySha3("OneTxPayment");
 
 contract("One transaction payments", (accounts) => {
   let colony;
@@ -23,66 +25,78 @@ contract("One transaction payments", (accounts) => {
   let metaColony;
   let oneTxPayment;
 
-  const ONE_TX_PAYMENT = soliditySha3("OneTxPayment");
-  const ROLES = rolesToBytes32([FUNDING_ROLE, ADMINISTRATION_ROLE]);
+  const USER0 = accounts[0];
+  const USER1 = accounts[1];
 
   const RECIPIENT = accounts[3];
   const RECIPIENT2 = accounts[4];
   const COLONY_ADMIN = accounts[5];
 
+  const ROLES = rolesToBytes32([FUNDING_ROLE, ADMINISTRATION_ROLE]);
+
   before(async () => {
     colonyNetwork = await setupColonyNetwork();
     ({ metaColony } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
+    await colonyNetwork.initialiseReputationMining();
+    await colonyNetwork.startNextCycle();
 
     const oneTxPaymentImplementation = await OneTxPayment.new();
     const resolver = await Resolver.new();
     await setupEtherRouter("OneTxPayment", { OneTxPayment: oneTxPaymentImplementation.address }, resolver);
     await metaColony.addExtensionToNetwork(ONE_TX_PAYMENT, resolver.address);
-
-    await colonyNetwork.initialiseReputationMining();
-    await colonyNetwork.startNextCycle();
   });
 
   beforeEach(async () => {
     ({ colony, token } = await setupRandomColony(colonyNetwork));
+    await colony.addDomain(1, UINT256_MAX, 1); // Domain 2, skillId 5
+    await colony.addDomain(1, UINT256_MAX, 1); // Domain 3, skillId 6
+
     await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
 
     await colony.installExtension(ONE_TX_PAYMENT, 1);
-
     const oneTxPaymentAddress = await colonyNetwork.getExtensionInstallation(ONE_TX_PAYMENT, colony.address);
     oneTxPayment = await OneTxPayment.at(oneTxPaymentAddress);
 
+    // Give a user and extension funding and administration rights
     await colony.setUserRoles(1, UINT256_MAX, oneTxPayment.address, 1, ROLES);
-    // Give a user colony administration rights (needed for one-tx)
     await colony.setUserRoles(1, UINT256_MAX, COLONY_ADMIN, 1, ROLES);
   });
 
-  describe("one tx payments", () => {
-    it("should implement the ColonyExtension interface", async () => {
-      const extension = await OneTxPayment.new();
+  describe("managing the extension", async () => {
+    it("can install the extension manually", async () => {
+      oneTxPayment = await OneTxPayment.new();
+      await oneTxPayment.install(colony.address);
 
-      const version = await extension.version();
-      expect(version).to.eq.BN(1);
+      await checkErrorRevert(oneTxPayment.install(colony.address), "extension-already-installed");
 
-      await extension.install(colony.address);
-      await checkErrorRevert(extension.install(colony.address), "extension-already-installed");
+      await oneTxPayment.finishUpgrade();
+      await oneTxPayment.deprecate(true);
+      await oneTxPayment.uninstall();
 
-      await extension.finishUpgrade();
-      await extension.deprecate(true);
-      await extension.uninstall();
-
-      const code = await web3GetCode(extension.address);
+      const code = await web3GetCode(oneTxPayment.address);
       expect(code).to.equal("0x");
     });
 
+    it("can install the extension with the extension manager", async () => {
+      ({ colony } = await setupRandomColony(colonyNetwork));
+      await colony.installExtension(ONE_TX_PAYMENT, 1, { from: USER0 });
+
+      await checkErrorRevert(colony.installExtension(ONE_TX_PAYMENT, 1, { from: USER0 }), "colony-network-extension-already-installed");
+      await checkErrorRevert(colony.uninstallExtension(ONE_TX_PAYMENT, { from: USER1 }), "ds-auth-unauthorized");
+
+      await colony.uninstallExtension(ONE_TX_PAYMENT, { from: USER0 });
+    });
+  });
+
+  describe("using the extension", async () => {
     it("should allow a single-transaction payment of tokens to occur", async () => {
       const balanceBefore = await token.balanceOf(RECIPIENT);
-      expect(balanceBefore).to.eq.BN(0);
-      // This is the one transactions. Those ones above don't count...
+      expect(balanceBefore).to.be.zero;
+
       await oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, {
         from: COLONY_ADMIN,
       });
-      // Check it completed
+
       const balanceAfter = await token.balanceOf(RECIPIENT);
       expect(balanceAfter).to.eq.BN(9);
     });
@@ -91,7 +105,7 @@ contract("One transaction payments", (accounts) => {
       const balanceBefore = await web3.eth.getBalance(RECIPIENT);
       await colony.send(10); // NB 10 wei, not ten ether!
       await colony.claimColonyFunds(ethers.constants.AddressZero);
-      // This is the one transactions. Those ones above don't count...
+
       await oneTxPayment.makePaymentFundedFromDomain(
         1,
         UINT256_MAX,
@@ -104,14 +118,13 @@ contract("One transaction payments", (accounts) => {
         GLOBAL_SKILL_ID,
         { from: COLONY_ADMIN }
       );
-      // Check it completed
+
       const balanceAfter = await web3.eth.getBalance(RECIPIENT);
       // So only 9 here, because of the same rounding errors as applied to the token
       expect(new web3.utils.BN(balanceAfter).sub(new web3.utils.BN(balanceBefore))).to.eq.BN(9);
     });
 
     it("should allow a single-transaction to occur in a child domain", async () => {
-      await colony.addDomain(1, UINT256_MAX, 1);
       const d1 = await colony.getDomain(1);
       const d2 = await colony.getDomain(2);
 
@@ -121,16 +134,11 @@ contract("One transaction payments", (accounts) => {
     });
 
     it("should allow a single-transaction to occur in a child domain, paid out from the root domain", async () => {
-      await colony.addDomain(1, UINT256_MAX, 1);
-
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await oneTxPayment.makePayment(1, 0, 1, 0, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
     });
 
     it("should allow a single-transaction to occur in a child domain that's not the first child, paid out from the root domain", async () => {
-      await colony.addDomain(1, UINT256_MAX, 1);
-      await colony.addDomain(1, UINT256_MAX, 1);
-
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await oneTxPayment.makePayment(1, 1, 1, 1, [RECIPIENT], [token.address], [10], 3, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
     });
@@ -144,49 +152,55 @@ contract("One transaction payments", (accounts) => {
 
     it(`should not allow a single-transaction to occur in a child domain, paid out from the root domain
       if the user does not have permission to take funds from root domain`, async () => {
-      await colony.addDomain(1, UINT256_MAX, 1);
-      const USER = accounts[6];
-
-      await colony.setAdministrationRole(1, 0, USER, 2, true);
-      await colony.setFundingRole(1, 0, USER, 2, true);
+      // Set funding, administration in child
+      await colony.setAdministrationRole(1, 0, USER1, 2, true);
+      await colony.setFundingRole(1, 0, USER1, 2, true);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await checkErrorRevert(
-        oneTxPayment.makePayment(2, UINT256_MAX, 2, UINT256_MAX, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER }),
-        "colony-one-tx-payment-root-funding-not-authorized"
+        oneTxPayment.makePayment(2, UINT256_MAX, 2, UINT256_MAX, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER1 }),
+        "colony-one-tx-payment-not-authorized"
       );
     });
 
+    it(`should allow a single-transaction to occur in a child  domain, paid out from the root domain
+      when user has funding in the root domain and administration in a child domain`, async () => {
+      // Set funding in root, administration in child
+      await colony.setFundingRole(1, UINT256_MAX, USER1, 1, true);
+      await colony.setAdministrationRole(1, 0, USER1, 2, true);
+
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+      await oneTxPayment.makePayment(1, 0, 2, UINT256_MAX, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER1 });
+    });
+
     it("should allow a single-transaction to occur when user has different permissions than contract", async () => {
-      await colony.addDomain(1, UINT256_MAX, 1);
       const d1 = await colony.getDomain(1);
       const d2 = await colony.getDomain(2);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
 
-      const USER = accounts[6];
-      await colony.setAdministrationRole(1, 0, USER, 2, true);
-      await colony.setFundingRole(1, 0, USER, 2, true);
-      await oneTxPayment.makePaymentFundedFromDomain(1, 0, 2, UINT256_MAX, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER });
+      await colony.setAdministrationRole(1, 0, USER1, 2, true);
+      await colony.setFundingRole(1, 0, USER1, 2, true);
+      await oneTxPayment.makePaymentFundedFromDomain(1, 0, 2, UINT256_MAX, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER1 });
     });
 
     it("should not allow a non-admin to make a single-transaction payment", async () => {
       await checkErrorRevert(
         oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, {
-          from: accounts[10],
+          from: USER1,
         }),
-        "colony-one-tx-payment-administration-not-authorized"
+        "colony-one-tx-payment-not-authorized"
       );
     });
 
     it("should not allow a non-funder to make a single-transaction payment", async () => {
-      await colony.setAdministrationRole(1, UINT256_MAX, accounts[10], 1, true);
+      await colony.setAdministrationRole(1, UINT256_MAX, USER1, 1, true);
       await checkErrorRevert(
         oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, {
-          from: accounts[10],
+          from: USER1,
         }),
-        "colony-one-tx-payment-funding-not-authorized"
+        "colony-one-tx-payment-not-authorized"
       );
     });
 
@@ -215,7 +229,7 @@ contract("One transaction payments", (accounts) => {
         oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 99, GLOBAL_SKILL_ID, {
           from: COLONY_ADMIN,
         }),
-        "colony-one-tx-payment-domain-does-not-exist"
+        "colony-network-out-of-range-child-skill-index"
       );
     });
 
@@ -227,23 +241,20 @@ contract("One transaction payments", (accounts) => {
     });
 
     it("should error if user permissions are bad", async () => {
-      await colony.addDomain(1, UINT256_MAX, 1); // Adds domain 2 skillId 5
-      await colony.addDomain(1, UINT256_MAX, 1); // Adds domain 3 skillId 6
-
       // Try to make a payment with the permissions in domain 1, child skill at index 1, i.e. skill 6
       // When actually domain 2 in which we are creating the task is skill 5
       await checkErrorRevert(
         oneTxPayment.makePaymentFundedFromDomain(1, 1, 1, 1, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: COLONY_ADMIN }),
-        "colony-one-tx-payment-bad-child-skill"
+        "colony-one-tx-payment-not-authorized"
       );
     });
 
     it("should allow a single-transaction payment to multiple workers", async () => {
       const balanceBefore = await token.balanceOf(RECIPIENT);
       const balanceBefore2 = await token.balanceOf(RECIPIENT2);
-      expect(balanceBefore).to.eq.BN(0);
-      expect(balanceBefore2).to.eq.BN(0);
-      // This is the one transactions. Those ones above don't count...
+      expect(balanceBefore).to.be.zero;
+      expect(balanceBefore2).to.be.zero;
+
       await oneTxPayment.makePaymentFundedFromDomain(
         1,
         UINT256_MAX,
@@ -256,7 +267,7 @@ contract("One transaction payments", (accounts) => {
         GLOBAL_SKILL_ID,
         { from: COLONY_ADMIN }
       );
-      // Check it completed
+
       const balanceAfter = await token.balanceOf(RECIPIENT);
       const balanceAfter2 = await token.balanceOf(RECIPIENT2);
       expect(balanceAfter).to.eq.BN(9);
@@ -268,7 +279,7 @@ contract("One transaction payments", (accounts) => {
       const balanceBefore2 = await web3.eth.getBalance(RECIPIENT2);
       await colony.send(15); // NB 15 wei, not ten ether!
       await colony.claimColonyFunds(ethers.constants.AddressZero);
-      // This is the one transactions. Those ones above don't count...
+
       await oneTxPayment.makePaymentFundedFromDomain(
         1,
         UINT256_MAX,
@@ -281,7 +292,7 @@ contract("One transaction payments", (accounts) => {
         GLOBAL_SKILL_ID,
         { from: COLONY_ADMIN }
       );
-      // Check it completed
+
       const balanceAfter = await web3.eth.getBalance(RECIPIENT);
       const balanceAfter2 = await web3.eth.getBalance(RECIPIENT2);
       // So only 9 and 4 here, because of the same rounding errors as applied to the token
@@ -292,10 +303,10 @@ contract("One transaction payments", (accounts) => {
     it("should allow a single-transaction payment to multiple workers of different tokens", async () => {
       const balanceTokenBefore = await token.balanceOf(RECIPIENT);
       const balanceEthBefore2 = await web3.eth.getBalance(RECIPIENT2);
-      expect(balanceTokenBefore).to.eq.BN(0);
+      expect(balanceTokenBefore).to.be.zero;
       await colony.send(5); // NB 10 wei, not ten ether!
       await colony.claimColonyFunds(ethers.constants.AddressZero);
-      // This is the one transactions. Those ones above don't count...
+
       await oneTxPayment.makePaymentFundedFromDomain(
         1,
         UINT256_MAX,
@@ -308,7 +319,7 @@ contract("One transaction payments", (accounts) => {
         GLOBAL_SKILL_ID,
         { from: COLONY_ADMIN }
       );
-      // Check it completed
+
       const balanceTokenAfter = await token.balanceOf(RECIPIENT);
       const balanceEthAfter2 = await web3.eth.getBalance(RECIPIENT2);
       // So only 9 and 4 here, because of the same rounding errors as applied to the token
@@ -319,23 +330,24 @@ contract("One transaction payments", (accounts) => {
     it("should allow a single-transaction payment to multiple workers using different slots", async () => {
       const balanceTokenBefore = await token.balanceOf(RECIPIENT);
       const balanceEthBefore2 = await web3.eth.getBalance(RECIPIENT2);
-      expect(balanceTokenBefore).to.eq.BN(0);
+      expect(balanceTokenBefore).to.be.zero;
+
       await colony.send(10); // NB 10 wei, not ten ether!
       await colony.claimColonyFunds(ethers.constants.AddressZero);
-      // This is the one transactions. Those ones above don't count...
+
       await oneTxPayment.makePaymentFundedFromDomain(
         1,
         UINT256_MAX,
         1,
         UINT256_MAX,
-        [RECIPIENT2, RECIPIENT, RECIPIENT2],
-        [ethers.constants.AddressZero, token.address, ethers.constants.AddressZero],
-        [5, 10, 5],
+        [RECIPIENT2, RECIPIENT2, RECIPIENT, RECIPIENT2],
+        [ethers.constants.AddressZero, token.address, token.address, ethers.constants.AddressZero],
+        [5, 5, 10, 5],
         1,
         GLOBAL_SKILL_ID,
         { from: COLONY_ADMIN }
       );
-      // Check it completed
+
       const balanceTokenAfter = await token.balanceOf(RECIPIENT);
       const balanceEthAfter2 = await web3.eth.getBalance(RECIPIENT2);
       // So only 9 and 8 here, because of the same rounding errors as applied to the token
@@ -344,23 +356,47 @@ contract("One transaction payments", (accounts) => {
     });
 
     it("should allow a single-transaction to occur in a child domain, paid out from the root domain to multiple workers", async () => {
-      await colony.addDomain(1, UINT256_MAX, 1);
+      const balanceTokenBefore = await token.balanceOf(RECIPIENT);
+      const balanceEthBefore2 = await web3.eth.getBalance(RECIPIENT2);
+      expect(balanceTokenBefore).to.be.zero;
 
+      await colony.send(10); // NB 10 wei, not ten ether!
+      await colony.claimColonyFunds(ethers.constants.AddressZero);
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      await oneTxPayment.makePayment(1, 0, 1, 0, [RECIPIENT, RECIPIENT2], [token.address, token.address], [10, 5], 2, GLOBAL_SKILL_ID, {
-        from: COLONY_ADMIN,
-      });
+
+      await oneTxPayment.makePayment(
+        1,
+        0,
+        1,
+        0,
+        [RECIPIENT2, RECIPIENT2, RECIPIENT, RECIPIENT2],
+        [ethers.constants.AddressZero, token.address, token.address, ethers.constants.AddressZero],
+        [5, 5, 10, 5],
+        2,
+        GLOBAL_SKILL_ID,
+        { from: COLONY_ADMIN }
+      );
+
+      const balanceTokenAfter = await token.balanceOf(RECIPIENT);
+      const balanceEthAfter2 = await web3.eth.getBalance(RECIPIENT2);
+      // So only 9 and 8 here, because of the same rounding errors as applied to the token
+      expect(balanceTokenAfter).to.eq.BN(9);
+      expect(new web3.utils.BN(balanceEthAfter2).sub(new web3.utils.BN(balanceEthBefore2))).to.eq.BN(8);
     });
 
     it("should not allow arrays of different sizes", async () => {
-      await colony.addDomain(1, UINT256_MAX, 1);
-
-      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await checkErrorRevert(
         oneTxPayment.makePayment(1, 0, 1, 0, [RECIPIENT2], [token.address, token.address], [10, 5], 2, GLOBAL_SKILL_ID, {
           from: COLONY_ADMIN,
         }),
-        "colony-one-tx-payment-arrays-must-be-equal-length"
+        "colony-one-tx-payment-invalid-input"
+      );
+
+      await checkErrorRevert(
+        oneTxPayment.makePaymentFundedFromDomain(1, 0, 1, 0, [RECIPIENT2], [token.address, token.address], [10, 5], 2, GLOBAL_SKILL_ID, {
+          from: COLONY_ADMIN,
+        }),
+        "colony-one-tx-payment-invalid-input"
       );
     });
   });

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -227,7 +227,7 @@ contract("One transaction payments", (accounts) => {
     });
 
     it("should allow a single-transaction payment to multiple workers", async () => {
-      const balanceBefore = await token.balanceOf(USER1);
+      const balanceBefore1 = await token.balanceOf(USER1);
       const balanceBefore2 = await token.balanceOf(USER2);
 
       await oneTxPayment.makePaymentFundedFromDomain(
@@ -242,15 +242,16 @@ contract("One transaction payments", (accounts) => {
         GLOBAL_SKILL_ID
       );
 
-      const balanceAfter = await token.balanceOf(USER1);
+      const balanceAfter1 = await token.balanceOf(USER1);
       const balanceAfter2 = await token.balanceOf(USER2);
-      expect(balanceAfter.sub(balanceBefore)).to.eq.BN(9);
+      expect(balanceAfter1.sub(balanceBefore1)).to.eq.BN(9);
       expect(balanceAfter2.sub(balanceBefore2)).to.eq.BN(4);
     });
 
     it("should allow a single-transaction payment to multiple workers of ETH to occur", async () => {
-      const balanceBefore = await web3.eth.getBalance(USER1);
+      const balanceBefore1 = await web3.eth.getBalance(USER1);
       const balanceBefore2 = await web3.eth.getBalance(USER2);
+
       await colony.send(15); // NB 15 wei, not ten ether!
       await colony.claimColonyFunds(ADDRESS_ZERO);
 
@@ -266,16 +267,17 @@ contract("One transaction payments", (accounts) => {
         GLOBAL_SKILL_ID
       );
 
-      const balanceAfter = await web3.eth.getBalance(USER1);
+      const balanceAfter1 = await web3.eth.getBalance(USER1);
       const balanceAfter2 = await web3.eth.getBalance(USER2);
       // So only 9 and 4 here, because of the same rounding errors as applied to the token
-      expect(new web3.utils.BN(balanceAfter).sub(new web3.utils.BN(balanceBefore))).to.eq.BN(9);
+      expect(new web3.utils.BN(balanceAfter1).sub(new web3.utils.BN(balanceBefore1))).to.eq.BN(9);
       expect(new web3.utils.BN(balanceAfter2).sub(new web3.utils.BN(balanceBefore2))).to.eq.BN(4);
     });
 
     it("should allow a single-transaction payment to multiple workers of different tokens", async () => {
-      const balanceTokenBefore = await token.balanceOf(USER1);
+      const balanceTokenBefore1 = await token.balanceOf(USER1);
       const balanceEthBefore2 = await web3.eth.getBalance(USER2);
+
       await colony.send(5); // NB 10 wei, not ten ether!
       await colony.claimColonyFunds(ADDRESS_ZERO);
 
@@ -291,15 +293,17 @@ contract("One transaction payments", (accounts) => {
         GLOBAL_SKILL_ID
       );
 
-      const balanceTokenAfter = await token.balanceOf(USER1);
+      const balanceTokenAfter1 = await token.balanceOf(USER1);
       const balanceEthAfter2 = await web3.eth.getBalance(USER2);
       // So only 9 and 4 here, because of the same rounding errors as applied to the token
-      expect(balanceTokenAfter.sub(balanceTokenBefore)).to.eq.BN(9);
+      expect(balanceTokenAfter1.sub(balanceTokenBefore1)).to.eq.BN(9);
       expect(new web3.utils.BN(balanceEthAfter2).sub(new web3.utils.BN(balanceEthBefore2))).to.eq.BN(4);
     });
 
     it("should allow a single-transaction payment to multiple workers in multiple tokens", async () => {
-      const balanceTokenBefore = await token.balanceOf(USER1);
+      const balanceTokenBefore1 = await token.balanceOf(USER1);
+      const balanceTokenBefore2 = await token.balanceOf(USER2);
+      const balanceEthBefore1 = await web3.eth.getBalance(USER1);
       const balanceEthBefore2 = await web3.eth.getBalance(USER2);
 
       await colony.send(10); // NB 10 wei, not ten ether!
@@ -317,15 +321,22 @@ contract("One transaction payments", (accounts) => {
         GLOBAL_SKILL_ID
       );
 
-      const balanceTokenAfter = await token.balanceOf(USER1);
+      const balanceTokenAfter1 = await token.balanceOf(USER1);
+      const balanceTokenAfter2 = await token.balanceOf(USER2);
+      const balanceEthAfter1 = await web3.eth.getBalance(USER1);
       const balanceEthAfter2 = await web3.eth.getBalance(USER2);
+
       // So only 9 and 4 here, because of the same rounding errors as applied to the token
-      expect(balanceTokenAfter.sub(balanceTokenBefore)).to.eq.BN(9);
+      expect(balanceTokenAfter1.sub(balanceTokenBefore1)).to.eq.BN(9);
+      expect(balanceTokenAfter2.sub(balanceTokenBefore2)).to.eq.BN(4);
+      expect(new web3.utils.BN(balanceEthAfter1).sub(new web3.utils.BN(balanceEthBefore1))).to.eq.BN(4);
       expect(new web3.utils.BN(balanceEthAfter2).sub(new web3.utils.BN(balanceEthBefore2))).to.eq.BN(4);
     });
 
     it("should allow a single-transaction to occur in a child domain, paid out from the root domain to multiple workers", async () => {
-      const balanceTokenBefore = await token.balanceOf(USER1);
+      const balanceTokenBefore1 = await token.balanceOf(USER1);
+      const balanceTokenBefore2 = await token.balanceOf(USER2);
+      const balanceEthBefore1 = await web3.eth.getBalance(USER1);
       const balanceEthBefore2 = await web3.eth.getBalance(USER2);
 
       await colony.send(10); // NB 10 wei, not ten ether!
@@ -344,21 +355,26 @@ contract("One transaction payments", (accounts) => {
         GLOBAL_SKILL_ID
       );
 
-      const balanceTokenAfter = await token.balanceOf(USER1);
+      const balanceTokenAfter1 = await token.balanceOf(USER1);
+      const balanceTokenAfter2 = await token.balanceOf(USER2);
+      const balanceEthAfter1 = await web3.eth.getBalance(USER1);
       const balanceEthAfter2 = await web3.eth.getBalance(USER2);
+
       // So only 9 and 4 here, because of the same rounding errors as applied to the token
-      expect(balanceTokenAfter.sub(balanceTokenBefore)).to.eq.BN(9);
+      expect(balanceTokenAfter1.sub(balanceTokenBefore1)).to.eq.BN(9);
+      expect(balanceTokenAfter2.sub(balanceTokenBefore2)).to.eq.BN(4);
+      expect(new web3.utils.BN(balanceEthAfter1).sub(new web3.utils.BN(balanceEthBefore1))).to.eq.BN(4);
       expect(new web3.utils.BN(balanceEthAfter2).sub(new web3.utils.BN(balanceEthBefore2))).to.eq.BN(4);
     });
 
     it("should not allow arrays of different sizes", async () => {
       await checkErrorRevert(
-        oneTxPayment.makePayment(1, 0, 1, 0, [USER2], [token.address, token.address], [10, 5], 2, GLOBAL_SKILL_ID),
+        oneTxPayment.makePayment(1, 0, 1, 0, [USER2], [token.address, token.address], [10, 5], 2, 0),
         "one-tx-payment-invalid-input"
       );
 
       await checkErrorRevert(
-        oneTxPayment.makePaymentFundedFromDomain(1, 0, 1, 0, [USER2], [token.address, token.address], [10, 5], 2, GLOBAL_SKILL_ID),
+        oneTxPayment.makePaymentFundedFromDomain(1, 0, 1, 0, [USER2], [token.address, token.address], [10, 5], 2, 0),
         "one-tx-payment-invalid-input"
       );
     });

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -25,14 +25,11 @@ contract("One transaction payments", (accounts) => {
   let metaColony;
   let oneTxPayment;
 
-  const USER0 = accounts[0];
-  const USER1 = accounts[1];
-
-  const RECIPIENT = accounts[3];
-  const RECIPIENT2 = accounts[4];
-  const COLONY_ADMIN = accounts[5];
+  const USER1 = accounts[1] < accounts[2] ? accounts[1] : accounts[2];
+  const USER2 = accounts[1] < accounts[2] ? accounts[2] : accounts[1];
 
   const ROLES = rolesToBytes32([FUNDING_ROLE, ADMINISTRATION_ROLE]);
+  const ADDRESS_ZERO = ethers.constants.AddressZero;
 
   before(async () => {
     colonyNetwork = await setupColonyNetwork();
@@ -57,9 +54,8 @@ contract("One transaction payments", (accounts) => {
     const oneTxPaymentAddress = await colonyNetwork.getExtensionInstallation(ONE_TX_PAYMENT, colony.address);
     oneTxPayment = await OneTxPayment.at(oneTxPaymentAddress);
 
-    // Give a user and extension funding and administration rights
+    // Give extension funding and administration rights
     await colony.setUserRoles(1, UINT256_MAX, oneTxPayment.address, 1, ROLES);
-    await colony.setUserRoles(1, UINT256_MAX, COLONY_ADMIN, 1, ROLES);
   });
 
   describe("managing the extension", async () => {
@@ -79,47 +75,34 @@ contract("One transaction payments", (accounts) => {
 
     it("can install the extension with the extension manager", async () => {
       ({ colony } = await setupRandomColony(colonyNetwork));
-      await colony.installExtension(ONE_TX_PAYMENT, 1, { from: USER0 });
+      await colony.installExtension(ONE_TX_PAYMENT, 1);
 
-      await checkErrorRevert(colony.installExtension(ONE_TX_PAYMENT, 1, { from: USER0 }), "colony-network-extension-already-installed");
+      await checkErrorRevert(colony.installExtension(ONE_TX_PAYMENT, 1), "colony-network-extension-already-installed");
       await checkErrorRevert(colony.uninstallExtension(ONE_TX_PAYMENT, { from: USER1 }), "ds-auth-unauthorized");
 
-      await colony.uninstallExtension(ONE_TX_PAYMENT, { from: USER0 });
+      await colony.uninstallExtension(ONE_TX_PAYMENT);
     });
   });
 
   describe("using the extension", async () => {
     it("should allow a single-transaction payment of tokens to occur", async () => {
-      const balanceBefore = await token.balanceOf(RECIPIENT);
+      const balanceBefore = await token.balanceOf(USER1);
       expect(balanceBefore).to.be.zero;
 
-      await oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, {
-        from: COLONY_ADMIN,
-      });
+      await oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, GLOBAL_SKILL_ID);
 
-      const balanceAfter = await token.balanceOf(RECIPIENT);
+      const balanceAfter = await token.balanceOf(USER1);
       expect(balanceAfter).to.eq.BN(9);
     });
 
     it("should allow a single-transaction payment of ETH to occur", async () => {
-      const balanceBefore = await web3.eth.getBalance(RECIPIENT);
+      const balanceBefore = await web3.eth.getBalance(USER1);
       await colony.send(10); // NB 10 wei, not ten ether!
-      await colony.claimColonyFunds(ethers.constants.AddressZero);
+      await colony.claimColonyFunds(ADDRESS_ZERO);
 
-      await oneTxPayment.makePaymentFundedFromDomain(
-        1,
-        UINT256_MAX,
-        1,
-        UINT256_MAX,
-        [RECIPIENT],
-        [ethers.constants.AddressZero],
-        [10],
-        1,
-        GLOBAL_SKILL_ID,
-        { from: COLONY_ADMIN }
-      );
+      await oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [ADDRESS_ZERO], [10], 1, GLOBAL_SKILL_ID);
 
-      const balanceAfter = await web3.eth.getBalance(RECIPIENT);
+      const balanceAfter = await web3.eth.getBalance(USER1);
       // So only 9 here, because of the same rounding errors as applied to the token
       expect(new web3.utils.BN(balanceAfter).sub(new web3.utils.BN(balanceBefore))).to.eq.BN(9);
     });
@@ -130,24 +113,22 @@ contract("One transaction payments", (accounts) => {
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
-      await oneTxPayment.makePaymentFundedFromDomain(1, 0, 1, 0, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
+      await oneTxPayment.makePaymentFundedFromDomain(1, 0, 1, 0, [USER1], [token.address], [10], 2, GLOBAL_SKILL_ID);
     });
 
     it("should allow a single-transaction to occur in a child domain, paid out from the root domain", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      await oneTxPayment.makePayment(1, 0, 1, 0, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
+      await oneTxPayment.makePayment(1, 0, 1, 0, [USER1], [token.address], [10], 2, GLOBAL_SKILL_ID);
     });
 
     it("should allow a single-transaction to occur in a child domain that's not the first child, paid out from the root domain", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      await oneTxPayment.makePayment(1, 1, 1, 1, [RECIPIENT], [token.address], [10], 3, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
+      await oneTxPayment.makePayment(1, 1, 1, 1, [USER1], [token.address], [10], 3, GLOBAL_SKILL_ID);
     });
 
     it("should allow a single-transaction to occur in the root domain, paid out from the root domain", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      await oneTxPayment.makePayment(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, {
-        from: COLONY_ADMIN,
-      });
+      await oneTxPayment.makePayment(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, GLOBAL_SKILL_ID);
     });
 
     it(`should not allow a single-transaction to occur in a child domain, paid out from the root domain
@@ -158,8 +139,8 @@ contract("One transaction payments", (accounts) => {
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       await checkErrorRevert(
-        oneTxPayment.makePayment(2, UINT256_MAX, 2, UINT256_MAX, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER1 }),
-        "colony-one-tx-payment-not-authorized"
+        oneTxPayment.makePayment(2, UINT256_MAX, 2, UINT256_MAX, [USER1], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER1 }),
+        "one-tx-payment-not-authorized"
       );
     });
 
@@ -170,7 +151,7 @@ contract("One transaction payments", (accounts) => {
       await colony.setAdministrationRole(1, 0, USER1, 2, true);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      await oneTxPayment.makePayment(1, 0, 2, UINT256_MAX, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER1 });
+      await oneTxPayment.makePayment(1, 0, 2, UINT256_MAX, [USER1], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER1 });
     });
 
     it("should allow a single-transaction to occur when user has different permissions than contract", async () => {
@@ -182,31 +163,31 @@ contract("One transaction payments", (accounts) => {
 
       await colony.setAdministrationRole(1, 0, USER1, 2, true);
       await colony.setFundingRole(1, 0, USER1, 2, true);
-      await oneTxPayment.makePaymentFundedFromDomain(1, 0, 2, UINT256_MAX, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER1 });
+      await oneTxPayment.makePaymentFundedFromDomain(1, 0, 2, UINT256_MAX, [USER1], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: USER1 });
     });
 
     it("should not allow a non-admin to make a single-transaction payment", async () => {
       await checkErrorRevert(
-        oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, {
+        oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, GLOBAL_SKILL_ID, {
           from: USER1,
         }),
-        "colony-one-tx-payment-not-authorized"
+        "one-tx-payment-not-authorized"
       );
     });
 
     it("should not allow a non-funder to make a single-transaction payment", async () => {
       await colony.setAdministrationRole(1, UINT256_MAX, USER1, 1, true);
       await checkErrorRevert(
-        oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, GLOBAL_SKILL_ID, {
+        oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, GLOBAL_SKILL_ID, {
           from: USER1,
         }),
-        "colony-one-tx-payment-not-authorized"
+        "one-tx-payment-not-authorized"
       );
     });
 
     it("should not allow an admin to specify a non-global skill", async () => {
       await checkErrorRevert(
-        oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, 2, { from: COLONY_ADMIN }),
+        oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, 2),
         "colony-not-global-skill"
       );
     });
@@ -217,25 +198,21 @@ contract("One transaction payments", (accounts) => {
       await metaColony.deprecateGlobalSkill(skillId);
 
       await checkErrorRevert(
-        oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, skillId, {
-          from: COLONY_ADMIN,
-        }),
+        oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, skillId),
         "colony-deprecated-global-skill"
       );
     });
 
     it("should not allow an admin to specify a non-existent domain", async () => {
       await checkErrorRevert(
-        oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 99, GLOBAL_SKILL_ID, {
-          from: COLONY_ADMIN,
-        }),
+        oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 99, GLOBAL_SKILL_ID),
         "colony-network-out-of-range-child-skill-index"
       );
     });
 
     it("should not allow an admin to specify a non-existent skill", async () => {
       await checkErrorRevert(
-        oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [RECIPIENT], [token.address], [10], 1, 99, { from: COLONY_ADMIN }),
+        oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, 99),
         "colony-skill-does-not-exist"
       );
     });
@@ -244,124 +221,115 @@ contract("One transaction payments", (accounts) => {
       // Try to make a payment with the permissions in domain 1, child skill at index 1, i.e. skill 6
       // When actually domain 2 in which we are creating the task is skill 5
       await checkErrorRevert(
-        oneTxPayment.makePaymentFundedFromDomain(1, 1, 1, 1, [RECIPIENT], [token.address], [10], 2, GLOBAL_SKILL_ID, { from: COLONY_ADMIN }),
-        "colony-one-tx-payment-not-authorized"
+        oneTxPayment.makePaymentFundedFromDomain(1, 1, 1, 1, [USER1], [token.address], [10], 2, GLOBAL_SKILL_ID),
+        "one-tx-payment-not-authorized"
       );
     });
 
     it("should allow a single-transaction payment to multiple workers", async () => {
-      const balanceBefore = await token.balanceOf(RECIPIENT);
-      const balanceBefore2 = await token.balanceOf(RECIPIENT2);
-      expect(balanceBefore).to.be.zero;
-      expect(balanceBefore2).to.be.zero;
+      const balanceBefore = await token.balanceOf(USER1);
+      const balanceBefore2 = await token.balanceOf(USER2);
 
       await oneTxPayment.makePaymentFundedFromDomain(
         1,
         UINT256_MAX,
         1,
         UINT256_MAX,
-        [RECIPIENT, RECIPIENT2],
+        [USER1, USER2],
         [token.address, token.address],
         [10, 5],
         1,
-        GLOBAL_SKILL_ID,
-        { from: COLONY_ADMIN }
+        GLOBAL_SKILL_ID
       );
 
-      const balanceAfter = await token.balanceOf(RECIPIENT);
-      const balanceAfter2 = await token.balanceOf(RECIPIENT2);
-      expect(balanceAfter).to.eq.BN(9);
-      expect(balanceAfter2).to.eq.BN(4);
+      const balanceAfter = await token.balanceOf(USER1);
+      const balanceAfter2 = await token.balanceOf(USER2);
+      expect(balanceAfter.sub(balanceBefore)).to.eq.BN(9);
+      expect(balanceAfter2.sub(balanceBefore2)).to.eq.BN(4);
     });
 
     it("should allow a single-transaction payment to multiple workers of ETH to occur", async () => {
-      const balanceBefore = await web3.eth.getBalance(RECIPIENT);
-      const balanceBefore2 = await web3.eth.getBalance(RECIPIENT2);
+      const balanceBefore = await web3.eth.getBalance(USER1);
+      const balanceBefore2 = await web3.eth.getBalance(USER2);
       await colony.send(15); // NB 15 wei, not ten ether!
-      await colony.claimColonyFunds(ethers.constants.AddressZero);
+      await colony.claimColonyFunds(ADDRESS_ZERO);
 
       await oneTxPayment.makePaymentFundedFromDomain(
         1,
         UINT256_MAX,
         1,
         UINT256_MAX,
-        [RECIPIENT, RECIPIENT2],
-        [ethers.constants.AddressZero, ethers.constants.AddressZero],
+        [USER1, USER2],
+        [ADDRESS_ZERO, ADDRESS_ZERO],
         [10, 5],
         1,
-        GLOBAL_SKILL_ID,
-        { from: COLONY_ADMIN }
+        GLOBAL_SKILL_ID
       );
 
-      const balanceAfter = await web3.eth.getBalance(RECIPIENT);
-      const balanceAfter2 = await web3.eth.getBalance(RECIPIENT2);
+      const balanceAfter = await web3.eth.getBalance(USER1);
+      const balanceAfter2 = await web3.eth.getBalance(USER2);
       // So only 9 and 4 here, because of the same rounding errors as applied to the token
       expect(new web3.utils.BN(balanceAfter).sub(new web3.utils.BN(balanceBefore))).to.eq.BN(9);
       expect(new web3.utils.BN(balanceAfter2).sub(new web3.utils.BN(balanceBefore2))).to.eq.BN(4);
     });
 
     it("should allow a single-transaction payment to multiple workers of different tokens", async () => {
-      const balanceTokenBefore = await token.balanceOf(RECIPIENT);
-      const balanceEthBefore2 = await web3.eth.getBalance(RECIPIENT2);
-      expect(balanceTokenBefore).to.be.zero;
+      const balanceTokenBefore = await token.balanceOf(USER1);
+      const balanceEthBefore2 = await web3.eth.getBalance(USER2);
       await colony.send(5); // NB 10 wei, not ten ether!
-      await colony.claimColonyFunds(ethers.constants.AddressZero);
+      await colony.claimColonyFunds(ADDRESS_ZERO);
 
       await oneTxPayment.makePaymentFundedFromDomain(
         1,
         UINT256_MAX,
         1,
         UINT256_MAX,
-        [RECIPIENT, RECIPIENT2],
-        [token.address, ethers.constants.AddressZero],
+        [USER1, USER2],
+        [token.address, ADDRESS_ZERO],
         [10, 5],
         1,
-        GLOBAL_SKILL_ID,
-        { from: COLONY_ADMIN }
+        GLOBAL_SKILL_ID
       );
 
-      const balanceTokenAfter = await token.balanceOf(RECIPIENT);
-      const balanceEthAfter2 = await web3.eth.getBalance(RECIPIENT2);
+      const balanceTokenAfter = await token.balanceOf(USER1);
+      const balanceEthAfter2 = await web3.eth.getBalance(USER2);
       // So only 9 and 4 here, because of the same rounding errors as applied to the token
-      expect(balanceTokenAfter).to.eq.BN(9);
+      expect(balanceTokenAfter.sub(balanceTokenBefore)).to.eq.BN(9);
       expect(new web3.utils.BN(balanceEthAfter2).sub(new web3.utils.BN(balanceEthBefore2))).to.eq.BN(4);
     });
 
-    it("should allow a single-transaction payment to multiple workers using different slots", async () => {
-      const balanceTokenBefore = await token.balanceOf(RECIPIENT);
-      const balanceEthBefore2 = await web3.eth.getBalance(RECIPIENT2);
-      expect(balanceTokenBefore).to.be.zero;
+    it("should allow a single-transaction payment to multiple workers in multiple tokens", async () => {
+      const balanceTokenBefore = await token.balanceOf(USER1);
+      const balanceEthBefore2 = await web3.eth.getBalance(USER2);
 
       await colony.send(10); // NB 10 wei, not ten ether!
-      await colony.claimColonyFunds(ethers.constants.AddressZero);
+      await colony.claimColonyFunds(ADDRESS_ZERO);
 
       await oneTxPayment.makePaymentFundedFromDomain(
         1,
         UINT256_MAX,
         1,
         UINT256_MAX,
-        [RECIPIENT2, RECIPIENT2, RECIPIENT, RECIPIENT2],
-        [ethers.constants.AddressZero, token.address, token.address, ethers.constants.AddressZero],
-        [5, 5, 10, 5],
+        [USER1, USER1, USER2, USER2],
+        [ADDRESS_ZERO, token.address, ADDRESS_ZERO, token.address],
+        [5, 10, 5, 5],
         1,
-        GLOBAL_SKILL_ID,
-        { from: COLONY_ADMIN }
+        GLOBAL_SKILL_ID
       );
 
-      const balanceTokenAfter = await token.balanceOf(RECIPIENT);
-      const balanceEthAfter2 = await web3.eth.getBalance(RECIPIENT2);
-      // So only 9 and 8 here, because of the same rounding errors as applied to the token
-      expect(balanceTokenAfter).to.eq.BN(9);
-      expect(new web3.utils.BN(balanceEthAfter2).sub(new web3.utils.BN(balanceEthBefore2))).to.eq.BN(8);
+      const balanceTokenAfter = await token.balanceOf(USER1);
+      const balanceEthAfter2 = await web3.eth.getBalance(USER2);
+      // So only 9 and 4 here, because of the same rounding errors as applied to the token
+      expect(balanceTokenAfter.sub(balanceTokenBefore)).to.eq.BN(9);
+      expect(new web3.utils.BN(balanceEthAfter2).sub(new web3.utils.BN(balanceEthBefore2))).to.eq.BN(4);
     });
 
     it("should allow a single-transaction to occur in a child domain, paid out from the root domain to multiple workers", async () => {
-      const balanceTokenBefore = await token.balanceOf(RECIPIENT);
-      const balanceEthBefore2 = await web3.eth.getBalance(RECIPIENT2);
-      expect(balanceTokenBefore).to.be.zero;
+      const balanceTokenBefore = await token.balanceOf(USER1);
+      const balanceEthBefore2 = await web3.eth.getBalance(USER2);
 
       await colony.send(10); // NB 10 wei, not ten ether!
-      await colony.claimColonyFunds(ethers.constants.AddressZero);
+      await colony.claimColonyFunds(ADDRESS_ZERO);
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
 
       await oneTxPayment.makePayment(
@@ -369,34 +337,71 @@ contract("One transaction payments", (accounts) => {
         0,
         1,
         0,
-        [RECIPIENT2, RECIPIENT2, RECIPIENT, RECIPIENT2],
-        [ethers.constants.AddressZero, token.address, token.address, ethers.constants.AddressZero],
-        [5, 5, 10, 5],
+        [USER1, USER1, USER2, USER2],
+        [ADDRESS_ZERO, token.address, ADDRESS_ZERO, token.address],
+        [5, 10, 5, 5],
         2,
-        GLOBAL_SKILL_ID,
-        { from: COLONY_ADMIN }
+        GLOBAL_SKILL_ID
       );
 
-      const balanceTokenAfter = await token.balanceOf(RECIPIENT);
-      const balanceEthAfter2 = await web3.eth.getBalance(RECIPIENT2);
-      // So only 9 and 8 here, because of the same rounding errors as applied to the token
-      expect(balanceTokenAfter).to.eq.BN(9);
-      expect(new web3.utils.BN(balanceEthAfter2).sub(new web3.utils.BN(balanceEthBefore2))).to.eq.BN(8);
+      const balanceTokenAfter = await token.balanceOf(USER1);
+      const balanceEthAfter2 = await web3.eth.getBalance(USER2);
+      // So only 9 and 4 here, because of the same rounding errors as applied to the token
+      expect(balanceTokenAfter.sub(balanceTokenBefore)).to.eq.BN(9);
+      expect(new web3.utils.BN(balanceEthAfter2).sub(new web3.utils.BN(balanceEthBefore2))).to.eq.BN(4);
     });
 
     it("should not allow arrays of different sizes", async () => {
       await checkErrorRevert(
-        oneTxPayment.makePayment(1, 0, 1, 0, [RECIPIENT2], [token.address, token.address], [10, 5], 2, GLOBAL_SKILL_ID, {
-          from: COLONY_ADMIN,
-        }),
-        "colony-one-tx-payment-invalid-input"
+        oneTxPayment.makePayment(1, 0, 1, 0, [USER2], [token.address, token.address], [10, 5], 2, GLOBAL_SKILL_ID),
+        "one-tx-payment-invalid-input"
       );
 
       await checkErrorRevert(
-        oneTxPayment.makePaymentFundedFromDomain(1, 0, 1, 0, [RECIPIENT2], [token.address, token.address], [10, 5], 2, GLOBAL_SKILL_ID, {
-          from: COLONY_ADMIN,
-        }),
-        "colony-one-tx-payment-invalid-input"
+        oneTxPayment.makePaymentFundedFromDomain(1, 0, 1, 0, [USER2], [token.address, token.address], [10, 5], 2, GLOBAL_SKILL_ID),
+        "one-tx-payment-invalid-input"
+      );
+    });
+
+    it("should not allow a single-transaction payment from root to multiple workers if out-of-order", async () => {
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+
+      await checkErrorRevert(
+        oneTxPayment.makePayment(1, UINT256_MAX, 1, UINT256_MAX, [USER2, USER1], [token.address, token.address], [5, 5], 1, 0),
+        "one-tx-payment-bad-worker-order"
+      );
+    });
+
+    it("should not allow a single-transaction payment from root in multiple tokens if out-of-order", async () => {
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+
+      await colony.send(100);
+      await colony.claimColonyFunds(ADDRESS_ZERO);
+
+      await checkErrorRevert(
+        oneTxPayment.makePayment(1, UINT256_MAX, 1, UINT256_MAX, [USER1, USER1], [token.address, ADDRESS_ZERO], [5, 5], 1, 0),
+        "one-tx-payment-bad-token-order"
+      );
+    });
+
+    it("should not allow a single-transaction payment to multiple workers if out-of-order", async () => {
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+
+      await checkErrorRevert(
+        oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER2, USER1], [token.address, token.address], [5, 5], 1, 0),
+        "one-tx-payment-bad-worker-order"
+      );
+    });
+
+    it("should not allow a single-transaction payment in multiple tokens if out-of-order", async () => {
+      await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
+
+      await colony.send(100);
+      await colony.claimColonyFunds(ADDRESS_ZERO);
+
+      await checkErrorRevert(
+        oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1, USER1], [token.address, ADDRESS_ZERO], [5, 5], 1, 0),
+        "one-tx-payment-bad-token-order"
       );
     });
   });


### PR DESCRIPTION
An exploratory PR for reducing the gas costs associated with making one-transaction payments.

| Iteration | Gas Cost | % Change |
|---------|----------|------------|
| Baseline | 728475 | --- |
| Baseline w/o Skill | 534130 | -27% |
| Baseline w/ Payment delete | 642582 | -12% |
| Refactor | 726804 | -0% |
| Refactor w/o Skill | 532459 | -27% |
| Refactor w/o Payments | 817814 | +12% |
| Refactor w/o Payments & Skill | 598809 | -18% |
| Refactor w/ new FundingPot | 715110 | -2% |
| Refactor w/ Payment delete | 640911 | -12% |
| Refactor w/ new FundingPot & Payment delete | 651677 | -11% (?) |

Ultimately, we are going to leave this functionality mostly alone for now, and only merge the refactor without any other gas optimizations.