### PR TITLE
Use payments rather than tasks in reputation tests where appropriate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,22 @@ step_setup_slither: &step_setup_slither
         sudo pip install slither-analyzer
 
 jobs:
+  reputation-test:
+    <<: *job_common
+    steps:
+      - checkout
+      - <<: *step_restore_cache
+      - setup_remote_docker
+      - <<: *step_pull_solc_docker
+      - <<: *step_setup_global_packages
+      - run:
+          name: "Install lsof"
+          command: |
+            sudo apt-get update
+            sudo apt-get install lsof
+      - run:
+          name: "Running reputation system unit tests"
+          command: yarn run test:reputation
   lint-and-unit-test:
     <<: *job_common
     steps:
@@ -97,9 +113,6 @@ jobs:
       - run:
           name: "Running network contracts unit tests"
           command: yarn run test:contracts
-      - run:
-          name: "Running reputation system unit tests"
-          command: yarn run test:reputation
       - run:
           name: "Running upgrade tests"
           command: yarn run test:contracts:upgrade:parity && yarn run test:contracts:upgrade:ganache
@@ -200,6 +213,7 @@ workflows:
   commit:
     jobs:
       - lint-and-unit-test
+      - reputation-test
       - test-contracts-coverage
       - test-reputation-coverage
       - check-coverage:

--- a/test/reputation-system/dispute-resolution-misbehaviour.js
+++ b/test/reputation-system/dispute-resolution-misbehaviour.js
@@ -282,11 +282,16 @@ contract("Reputation Mining - disputes resolution misbehaviour", (accounts) => {
     async function setUpNMiners(n) {
       expect(accounts.length, "Not enough accounts for test to run").to.be.at.least(n + 3);
       const accountsForTest = accounts.slice(3, n + 3);
-
       await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(n));
       for (let i = 0; i < n; i += 1) {
         await giveUserCLNYTokensAndStake(colonyNetwork, accountsForTest[i], DEFAULT_STAKE);
-        await setupFinalizedTask({ colonyNetwork, colony: metaColony, worker: accountsForTest[i] });
+        // await setupFinalizedTask({ colonyNetwork, colony: metaColony, worker: accountsForTest[i] });
+        await metaColony.addPayment(1, UINT256_MAX, accountsForTest[i], clnyToken.address, 40, 1, 0);
+        const paymentId = await metaColony.getPaymentCount();
+        const payment = await metaColony.getPayment(paymentId);
+        await metaColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, INITIAL_FUNDING, clnyToken.address);
+        await metaColony.finalizePayment(1, UINT256_MAX, paymentId);
+
         // These have to be done sequentially because this function uses the total number of tasks as a proxy for getting the
         // right taskId, so if they're all created at once it messes up.
       }

--- a/test/reputation-system/dispute-resolution-misbehaviour.js
+++ b/test/reputation-system/dispute-resolution-misbehaviour.js
@@ -479,7 +479,8 @@ contract("Reputation Mining - disputes resolution misbehaviour", (accounts) => {
       await repCycle.confirmNewHash(4);
     });
 
-    it("should not allow stages to be skipped even if the number of updates is a power of 2", async () => {
+    it("should not allow stages to be skipped even if the number of updates is a power of 2", async function powerOfTwoTest() {
+      this.timeout(600000);
       // Note that our jrhNNodes can never be a power of two, because we always have an even number of updates (because every reputation change
       // has a user-specific an a colony-specific effect, and we always have one extra state in the Justification Tree because we include the last
       // accepted hash as the first node. jrhNNodes is always odd, therefore, and can never be a power of two.

--- a/test/reputation-system/happy-paths.js
+++ b/test/reputation-system/happy-paths.js
@@ -269,7 +269,8 @@ contract("Reputation Mining - happy paths", (accounts) => {
       await repCycle.confirmNewHash(1);
     });
 
-    it("should cope if someone's existing reputation would go negative, setting it to zero instead", async () => {
+    it("should cope if someone's existing reputation would go negative, setting it to zero instead", async function noNegativeRep() {
+      this.timeout(600000);
       await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
       // Create reputation


### PR DESCRIPTION
As part of trying to make our tests better (because they have started randomly failing on Circle right now which is really cramping our style), I decided to take a look at some of the heavier tests in the hope that by making some tests lighter, Circle would be happier.

Far and away the biggest / most intensive tests are some of the reputation ones with many clients, with single tests taking nearly 30 minutes on Circle - clearly dominating the reputation coverage test runs. In these tests, many (up to fourteen) reputation miners are created, and they all process the reputation log generated for that test. While for some of these tests, we do need this many miners, this log was four times longer than it needed to be for the tests to work, as we created a task (and four reputation log entries) for each miner, when we only need one reputation log entry for each miner for the tests to behave correctly.

This PR creates payments rather than tasks, which create one log entry each, and dramatically reduces the runtime of these tests. 

On CircleCI [before](https://circleci.com/gh/JoinColony/colonyNetwork/12087):

```
✓ should prevent a hash from advancing if it might still get an opponent,
     even if that opponent is from more than one round ago (1737172ms)
```

and with [this change](https://circleci.com/gh/JoinColony/colonyNetwork/12108):
```
      ✓ should prevent a hash from advancing if it might still get an opponent,
     even if that opponent is from more than one round ago (404934ms)
```

Intending to run multiple instances of this workflow to see if this results in consistently green tests. [First one was green](https://circleci.com/workflow-run/3d036eb7-54f3-4d9f-a831-7f6d505301ab).
