### PR TITLE
Improve before(each) speed for some tests

### DIFF
--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -15,6 +15,7 @@ const NoLimitSubdomains = artifacts.require("NoLimitSubdomains");
 const TaskSkillEditing = artifacts.require("TaskSkillEditing");
 const Resolver = artifacts.require("Resolver");
 const ContractEditing = artifacts.require("ContractEditing");
+const Colony = artifacts.require("Colony");
 
 const { expect } = chai;
 
@@ -688,6 +689,14 @@ export async function removeSubdomainLimit(colonyNetwork) {
   const resolverAddress = await colonyNetwork.getColonyVersionResolver(latestVersion);
   const resolver = await Resolver.at(resolverAddress);
   await resolver.register("addDomain(uint256,uint256,uint256)", noLimitSubdomains.address);
+}
+
+export async function restoreSubdomainLimit(colonyNetwork) {
+  const originalSubdomains = await Colony.new();
+  const latestVersion = await colonyNetwork.getCurrentColonyVersion();
+  const resolverAddress = await colonyNetwork.getColonyVersionResolver(latestVersion);
+  const resolver = await Resolver.at(resolverAddress);
+  await resolver.register("addDomain(uint256,uint256,uint256)", originalSubdomains.address);
 }
 
 export async function addTaskSkillEditingFunctions(colonyNetwork) {

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -15,7 +15,7 @@ import {
   WAD,
 } from "../../helpers/constants";
 import { getTokenArgs, web3GetBalance, checkErrorRevert, expectAllEvents } from "../../helpers/test-helper";
-import { makeTask, setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony } from "../../helpers/test-data-generator";
+import { makeTask, setupRandomColony } from "../../helpers/test-data-generator";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
@@ -23,6 +23,8 @@ chai.use(bnChai(web3.utils.BN));
 const Token = artifacts.require("Token");
 const IReputationMiningCycle = artifacts.require("IReputationMiningCycle");
 const TransferTest = artifacts.require("TransferTest");
+const EtherRouter = artifacts.require("EtherRouter");
+const IColonyNetwork = artifacts.require("IColonyNetwork");
 
 contract("Colony", (accounts) => {
   let colony;
@@ -30,10 +32,8 @@ contract("Colony", (accounts) => {
   let colonyNetwork;
 
   before(async () => {
-    colonyNetwork = await setupColonyNetwork();
-    await setupMetaColonyWithLockedCLNYToken(colonyNetwork);
-    await colonyNetwork.initialiseReputationMining();
-    await colonyNetwork.startNextCycle();
+    const etherRouter = await EtherRouter.deployed();
+    colonyNetwork = await IColonyNetwork.at(etherRouter.address);
   });
 
   beforeEach(async () => {

--- a/test/contracts-network/meta-colony.js
+++ b/test/contracts-network/meta-colony.js
@@ -3,7 +3,7 @@ import bnChai from "bn-chai";
 
 import { soliditySha3 } from "web3-utils";
 import { UINT256_MAX, INITIAL_FUNDING, SPECIFICATION_HASH, GLOBAL_SKILL_ID } from "../../helpers/constants";
-import { checkErrorRevert, removeSubdomainLimit } from "../../helpers/test-helper";
+import { checkErrorRevert, removeSubdomainLimit, restoreSubdomainLimit } from "../../helpers/test-helper";
 import { executeSignedTaskChange } from "../../helpers/task-review-signing";
 
 import {
@@ -50,8 +50,12 @@ contract("Meta Colony", (accounts) => {
   });
 
   describe("when adding skills to the tree by adding domains", () => {
-    beforeEach(async () => {
+    before(async () => {
       await removeSubdomainLimit(colonyNetwork); // Temporary for tests until we allow subdomain depth > 1
+    });
+
+    after(async () => {
+      await restoreSubdomainLimit(colonyNetwork);
     });
 
     it("should be able to add a new skill as a child of a domain", async () => {


### PR DESCRIPTION
Been seeing the `before(Each)` for some tests failing repeatedly on Circle for taking too long, so decided to take a crack at improving them.

The tests in question often set up a whole new set of resolvers, which were taking more time than necessary when most tests use the same shortcut of using the `colonyNetwork` deployed during migrations, so where possible I did the same.

The one case where the same couldn't be done was the metaColony specific tests, because the metacolony attached to that `colonyNetwork` might have detritus from previous tests. So I have reworked the `setupColonyNetwork` so that it reuses the resolvers, at least, to speed that up. Given that the resolvers are now reused between all tests, I've also added the `restoreSubdomainLimit` function which is called in the `after()` block for the tests that have the subdomain nesting limit removed, so it's correctly disabled in any tests that happen to run afterwards.

This seems to roughly half the time taken for the `yarn run test:contracts` command

Before:
[57:29](https://circleci.com/gh/JoinColony/colonyNetwork/12221)
[56:24](https://circleci.com/gh/JoinColony/colonyNetwork/12195)

After:
[33:19](https://circleci.com/gh/JoinColony/colonyNetwork/12232)
[30:29](https://circleci.com/gh/JoinColony/colonyNetwork/12236)
[32:18](https://circleci.com/gh/JoinColony/colonyNetwork/12243)