### PR TITLE
Add option to disable docker if desired

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -2,6 +2,8 @@ require("@babel/register");
 require("@babel/polyfill");
 const HDWalletProvider = require("truffle-hdwallet-provider");
 
+const DISABLE_DOCKER = !process.env.DISABLE_DOCKER;
+
 module.exports = {
   networks: {
     development: {
@@ -62,7 +64,7 @@ module.exports = {
   compilers: {
     solc: {
       version: "0.5.8",
-      docker: true,
+      docker: DISABLE_DOCKER,
       settings: {
         optimizer: {
           enabled: true,


### PR DESCRIPTION
If we're just working on the dapp, we don't really care about docker compilation as it seems to work quite fine without it. This is in lieu of making it easier for people to run a version of the dapp stack for development.

Could there be any problems related to this? Which `solc` version is used when docker is disabled? Does the user have to install that manually?
