### PR TITLE
Add CLNY issuance control / automation mechanisms

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -245,6 +245,22 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     return colonyNetwork.setFeeInverse(_feeInverse); // ignore-swc-107
   }
 
+  function setAnnualMetaColonyStipend(uint256 _amount) public
+  stoppable
+  auth
+  {
+    IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
+    return colonyNetwork.setAnnualMetaColonyStipend(_amount); // ignore-swc-107
+  }
+
+  function setReputationMiningCycleReward(uint256 _amount) public
+  stoppable
+  auth
+  {
+    IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
+    return colonyNetwork.setReputationMiningCycleReward(_amount); // ignore-swc-107
+  }
+
   function addNetworkColonyVersion(uint256 _version, address _resolver) public
   stoppable
   auth
@@ -339,6 +355,12 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Arbitration), address(this), sig, true);
     sig = bytes4(keccak256("emitSkillReputationPenalty(uint256,address,int256)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Arbitration), address(this), sig, true);
+
+    // Add CLNY issuance functionality
+    sig = bytes4(keccak256("setAnnualMetaColonyStipend(uint256)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
+    sig = bytes4(keccak256("setReputationMiningCycleReward(uint256)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
   }
 
   function checkNotAdditionalProtectedVariable(uint256 _slot) public view recovery {

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -90,6 +90,9 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ARBITRATION_ROLE, "transferStake(uint256,uint256,address,address,uint256,uint256,address)");
     addRoleCapability(ARBITRATION_ROLE, "emitDomainReputationPenalty(uint256,uint256,uint256,address,int256)");
     addRoleCapability(ARBITRATION_ROLE, "emitSkillReputationPenalty(uint256,address,int256)");
+
+    addRoleCapability(ROOT_ROLE, "setAnnualMetaColonyStipend(uint256)");
+    addRoleCapability(ROOT_ROLE, "setReputationMiningCycleReward(uint256)");
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {

--- a/contracts/colony/IMetaColony.sol
+++ b/contracts/colony/IMetaColony.sol
@@ -49,4 +49,13 @@ contract IMetaColony is IColony {
   /// @param _version The new Colony contract version
   /// @param _resolver Address of the `Resolver` contract which will be used with the underlying `EtherRouter` contract
   function addNetworkColonyVersion(uint256 _version, address _resolver) public;
+
+  /// @notice Called to set the metaColony stipend. This value will be the total amount of CLNY created for the metacolony in a single year.
+  /// @param _amount The amount of CLNY to issue to the metacolony every year
+  /// @dev Calls the corresponding function on the ColonyNetwork.
+  function setAnnualMetaColonyStipend(uint256 _amount) public;
+
+  /// @notice Called to set the total per-cycle reputation reward, which will be split between all miners.
+  /// @dev Calls the corresponding function on the ColonyNetwork.
+  function setReputationMiningCycleReward(uint256 _amount) public;
 }

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -19,8 +19,10 @@ pragma solidity 0.5.8;
 pragma experimental "ABIEncoderV2";
 
 import "./../common/EtherRouter.sol";
+import "./../common/ERC20Extended.sol";
 import "./../colony/ColonyAuthority.sol";
 import "./../colony/IColony.sol";
+import "./../colony/IMetaColony.sol";
 import "./../reputationMiningCycle/IReputationMiningCycle.sol";
 import "./ColonyNetworkStorage.sol";
 
@@ -298,6 +300,33 @@ contract ColonyNetwork is ColonyNetworkStorage {
     feeInverse = _feeInverse;
 
     emit NetworkFeeInverseSet(_feeInverse);
+  }
+
+  function issueMetaColonyStipend() public stoppable {
+    // Can be called by anyone
+    require(lastMetaColonyStipendIssued > 0, "colony-network-metacolony-stipend-not-set");
+    // When was the last one issued
+    // How much in total should have been issued since then
+    uint256 amountToIssue = mul(annualMetaColonyStipend, sub(now,lastMetaColonyStipendIssued)) / (60*60*24*365);
+    lastMetaColonyStipendIssued = now;
+    // amountToIssue = 0;
+    IMetaColony meta = IMetaColony(metaColony);
+
+    // mintTokensFor is coming in #835, use that instead of this.
+    meta.mintTokensForColonyNetwork(amountToIssue);
+    ERC20Extended clnyToken = ERC20Extended(IColony(metaColony).getToken());
+    clnyToken.transfer(metaColony, amountToIssue);
+  }
+
+  function setAnnualMetaColonyStipend(uint256 amount) public stoppable
+  calledByMetaColony
+  {
+    if (lastMetaColonyStipendIssued == 0) { lastMetaColonyStipendIssued = now; }
+    annualMetaColonyStipend = amount;
+  }
+
+  function getAnnualMetaColonyStipend() public view returns (uint256) {
+    return annualMetaColonyStipend;
   }
 
   function deployColony(address _tokenAddress, uint256 _version) internal returns (address) {

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -305,11 +305,9 @@ contract ColonyNetwork is ColonyNetworkStorage {
   function issueMetaColonyStipend() public stoppable {
     // Can be called by anyone
     require(lastMetaColonyStipendIssued > 0, "colony-network-metacolony-stipend-not-set");
-    // When was the last one issued
     // How much in total should have been issued since then
     uint256 amountToIssue = mul(annualMetaColonyStipend, sub(now, lastMetaColonyStipendIssued)) / (365 days);
     lastMetaColonyStipendIssued = now;
-    // amountToIssue = 0;
 
     // mintTokensFor is coming in #835, use that instead of this.
     IMetaColony(metaColony).mintTokensForColonyNetwork(amountToIssue);

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -307,13 +307,12 @@ contract ColonyNetwork is ColonyNetworkStorage {
     require(lastMetaColonyStipendIssued > 0, "colony-network-metacolony-stipend-not-set");
     // When was the last one issued
     // How much in total should have been issued since then
-    uint256 amountToIssue = mul(annualMetaColonyStipend, sub(now,lastMetaColonyStipendIssued)) / (60*60*24*365);
+    uint256 amountToIssue = mul(annualMetaColonyStipend, sub(now, lastMetaColonyStipendIssued)) / (365 days);
     lastMetaColonyStipendIssued = now;
     // amountToIssue = 0;
-    IMetaColony meta = IMetaColony(metaColony);
 
     // mintTokensFor is coming in #835, use that instead of this.
-    meta.mintTokensForColonyNetwork(amountToIssue);
+    IMetaColony(metaColony).mintTokensForColonyNetwork(amountToIssue);
     ERC20Extended clnyToken = ERC20Extended(IColony(metaColony).getToken());
     clnyToken.transfer(metaColony, amountToIssue);
   }

--- a/contracts/colonyNetwork/ColonyNetworkStorage.sol
+++ b/contracts/colonyNetwork/ColonyNetworkStorage.sol
@@ -88,6 +88,10 @@ contract ColonyNetworkStorage is CommonStorage, ColonyNetworkDataTypes, DSMath {
   mapping (address => MiningStake) miningStakes; // Storage slot 33
   mapping (address => uint256) pendingMiningRewards; // Storage slot 34
 
+  uint256 totalMinerRewardPerCycle; // Storage slot 35
+  uint256 annualMetaColonyStipend; // Storage slot 36
+  uint256 lastMetaColonyStipendIssued; // Storage slot 37
+
   modifier calledByColony() {
     require(_isColony[msg.sender], "colony-caller-must-be-colony");
     _;

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -195,12 +195,19 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @return resolverAddress Address of the `Resolver` contract
   function getColonyVersionResolver(uint256 _version) public view returns (address resolverAddress);
 
+  /// @notice This version of setReputationRootHash is deprecated and will be removed in a future release. It transparently
+  /// calls the new version if it is called (essentially, removing the `reward` parameter.
+  /// @param newHash The reputation root hash
+  /// @param newNLeaves The updated leaves count value
+  /// @param stakers Array of users who submitted or backed the hash, being accepted here as the new reputation root hash
+  /// @param reward Amount of CLNY to be distributed as reward to miners (not used)
+  function setReputationRootHash(bytes32 newHash, uint256 newNLeaves, address[] memory stakers, uint256 reward) public;
+
   /// @notice Set a new Reputation root hash and starts a new mining cycle. Can only be called by the ReputationMiningCycle contract.
   /// @param newHash The reputation root hash
   /// @param newNLeaves The updated leaves count value
   /// @param stakers Array of users who submitted or backed the hash, being accepted here as the new reputation root hash
-  /// @param reward Amount of CLNY to be distributed as reward to miners
-  function setReputationRootHash(bytes32 newHash, uint256 newNLeaves, address[] memory stakers, uint256 reward) public;
+  function setReputationRootHash(bytes32 newHash, uint256 newNLeaves, address[] memory stakers) public;
 
   /// @notice Starts a new Reputation Mining cycle. Explicitly called only the first time,
   /// subsequently called from within `setReputationRootHash`.
@@ -320,4 +327,26 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @dev Can be called by anyone, not just _recipient
   /// @param _recipient The user whose rewards to claim
   function claimMiningReward(address _recipient) public;
+
+  /// @notice Called to set the metaColony stipend. This value will be the total amount of CLNY created for the metacolony in a single year. The
+  /// corresponding `issueMetaColonyStipend` function can be called at any interval.
+  /// @param _amount The amount of CLNY to issue to the metacolony every year
+  /// @dev Can only be called by the MetaColony.
+  function setAnnualMetaColonyStipend(uint256 _amount) public;
+
+  /// @notice Called to issue the metaColony stipend. This public function can be called by anyone at any interval, and an appropriate amount of CLNY will
+  /// be minted based on the time since the last time it was called.
+  function issueMetaColonyStipend() public;
+
+  /// @notice Called to set the total per-cycle reputation reward, which will be split between all miners.
+  /// @dev Can only be called by the MetaColony.
+  function setReputationMiningCycleReward(uint256 _amount) public;
+
+  /// @notice Called to get the total per-cycle reputation mining reward.
+  /// @return The CLNY awarded per mining cycle to the miners.
+  function getReputationMiningCycleReward() public view returns (uint256);
+
+  /// @notice Called to get the total per-cycle reputation mining reward.
+  /// @return The CLNY awarded per year to the metacolony.
+  function getAnnualMetaColonyStipend() public view returns (uint256);
 }

--- a/contracts/reputationMiningCycle/ReputationMiningCycle.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycle.sol
@@ -218,8 +218,7 @@ contract ReputationMiningCycle is ReputationMiningCycleCommon {
     IColonyNetwork(colonyNetworkAddress).setReputationRootHash(
       submission.proposedNewRootHash,
       submission.nLeaves,
-      submittedHashes[submission.proposedNewRootHash][submission.nLeaves][submission.jrh],
-      0 * WAD // TODO: Make this a function of reputation state
+      submittedHashes[submission.proposedNewRootHash][submission.nLeaves][submission.jrh]
     );
     selfdestruct(colonyNetworkAddress);
   }

--- a/contracts/tokenLocking/ITokenLocking.sol
+++ b/contracts/tokenLocking/ITokenLocking.sol
@@ -131,8 +131,10 @@ contract ITokenLocking is TokenLockingDataTypes {
   /// @param _user Address of the user
   /// @return lock Lock object containing:
   ///   `lockCount` User's token lock count,
-  ///   `amount` User's deposited amount,
-  ///   `timestamp` Timestamp of deposit.
+  ///   `balance` User's deposited amount,
+  ///   `DEPRECATED_timestamp` Timestamp of deposit (deprecated)
+  ///   `pendingBalance` Tokens that have been sent to them, but are inaccessible until all locks are cleared and then these
+  ///                    tokens are claimed
   function getUserLock(address _token, address _user) public view returns (Lock memory lock);
 
   /// @notice See the total amount of a user's obligation.

--- a/test/contracts-network/meta-colony.js
+++ b/test/contracts-network/meta-colony.js
@@ -5,7 +5,7 @@ import bnChai from "bn-chai";
 import BN from "bn.js";
 
 import { soliditySha3 } from "web3-utils";
-import { UINT256_MAX, INITIAL_FUNDING, SPECIFICATION_HASH, GLOBAL_SKILL_ID, WAD } from "../../helpers/constants";
+import { UINT256_MAX, INITIAL_FUNDING, SPECIFICATION_HASH, GLOBAL_SKILL_ID, WAD, SECONDS_PER_DAY } from "../../helpers/constants";
 import { checkErrorRevert, removeSubdomainLimit, restoreSubdomainLimit, makeTxAtTimestamp, currentBlockTime } from "../../helpers/test-helper";
 import { executeSignedTaskChange } from "../../helpers/task-review-signing";
 
@@ -548,7 +548,7 @@ contract("Meta Colony", (accounts) => {
   describe("when setting the metaColony stipend", () => {
     it("should allow the metacolony stipend to be set", async () => {
       const stipendBefore = await colonyNetwork.getAnnualMetaColonyStipend();
-      expect(stipendBefore).to.eq.BN(0);
+      expect(stipendBefore).to.be.zero;
       await metaColony.setAnnualMetaColonyStipend(WAD);
       const stipendAfter = await colonyNetwork.getAnnualMetaColonyStipend();
       expect(stipendAfter).to.eq.BN(WAD);
@@ -568,7 +568,7 @@ contract("Meta Colony", (accounts) => {
       await metaColony.setAnnualMetaColonyStipend(WAD);
       // In a year, we should get the full reward
       let time = await currentBlockTime();
-      time = new BN(time).addn(24 * 3600 * 365);
+      time = new BN(time).addn(SECONDS_PER_DAY * 365);
       await makeTxAtTimestamp(colonyNetwork.issueMetaColonyStipend, [], time.toNumber(), this);
       let potBefore = await metaColony.getFundingPotBalance(1, clnyToken.address);
       await metaColony.claimColonyFunds(clnyToken.address);
@@ -590,7 +590,7 @@ contract("Meta Colony", (accounts) => {
   describe("when setting the per-cycle miner reward", () => {
     it("should allow the reward to be set", async () => {
       const rewardBefore = await colonyNetwork.getReputationMiningCycleReward();
-      expect(rewardBefore).to.eq.BN(0);
+      expect(rewardBefore).to.be.zero;
       await metaColony.setReputationMiningCycleReward(WAD);
       const rewardAfter = await colonyNetwork.getReputationMiningCycleReward();
       expect(rewardAfter).to.eq.BN(WAD);

--- a/test/contracts-network/meta-colony.js
+++ b/test/contracts-network/meta-colony.js
@@ -1,9 +1,12 @@
+/* globals artifacts */
+
 import chai from "chai";
 import bnChai from "bn-chai";
+import BN from "bn.js";
 
 import { soliditySha3 } from "web3-utils";
-import { UINT256_MAX, INITIAL_FUNDING, SPECIFICATION_HASH, GLOBAL_SKILL_ID } from "../../helpers/constants";
-import { checkErrorRevert, removeSubdomainLimit, restoreSubdomainLimit } from "../../helpers/test-helper";
+import { UINT256_MAX, INITIAL_FUNDING, SPECIFICATION_HASH, GLOBAL_SKILL_ID, WAD } from "../../helpers/constants";
+import { checkErrorRevert, removeSubdomainLimit, restoreSubdomainLimit, makeTxAtTimestamp, currentBlockTime } from "../../helpers/test-helper";
 import { executeSignedTaskChange } from "../../helpers/task-review-signing";
 
 import {
@@ -14,6 +17,8 @@ import {
   setupMetaColonyWithLockedCLNYToken,
   setupRandomColony,
 } from "../../helpers/test-data-generator";
+
+const IMetaColony = artifacts.require("IMetaColony");
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
@@ -538,5 +543,69 @@ contract("Meta Colony", (accounts) => {
     it("should NOT allow anyone but the Network to call mintTokensForColonyNetwork", async () => {
       await checkErrorRevert(metaColony.mintTokensForColonyNetwork(100), "colony-access-denied-only-network-allowed");
     });
+  });
+
+  describe("when setting the metaColony stipend", () => {
+    it("should allow the metacolony stipend to be set", async () => {
+      const stipendBefore = await colonyNetwork.getAnnualMetaColonyStipend();
+      expect(stipendBefore).to.eq.BN(0);
+      await metaColony.setAnnualMetaColonyStipend(WAD);
+      const stipendAfter = await colonyNetwork.getAnnualMetaColonyStipend();
+      expect(stipendAfter).to.eq.BN(WAD);
+    });
+
+    it("setting the metacolony stipend should be a permissioned function", async () => {
+      await checkErrorRevert(metaColony.setAnnualMetaColonyStipend(0, { from: OTHER_ACCOUNT }), "ds-auth-unauthorized");
+    });
+
+    it("a non-meta colony should not be able to set the stipend", async () => {
+      ({ colony } = await setupRandomColony(colonyNetwork));
+      const colonyAsMetaColony = await IMetaColony.at(colony.address);
+      await checkErrorRevert(colonyAsMetaColony.setAnnualMetaColonyStipend(0), "colony-caller-must-be-meta-colony");
+    });
+
+    it("should allow the metacolony stipend to be claimed, and the amount minted changes based on when it is last claimed", async () => {
+      await metaColony.setAnnualMetaColonyStipend(WAD);
+      // In a year, we should get the full reward
+      let time = await currentBlockTime();
+      time = new BN(time).addn(24 * 3600 * 365);
+      await makeTxAtTimestamp(colonyNetwork.issueMetaColonyStipend, [], time.toNumber(), this);
+      let potBefore = await metaColony.getFundingPotBalance(1, clnyToken.address);
+      await metaColony.claimColonyFunds(clnyToken.address);
+      let potAfter = await metaColony.getFundingPotBalance(1, clnyToken.address);
+      expect(potAfter.sub(potBefore)).to.eq.BN(WAD);
+      // If we claim again a minute later...
+      potBefore = potAfter;
+      await makeTxAtTimestamp(colonyNetwork.issueMetaColonyStipend, [], time.addn(60).toNumber(), this);
+      await metaColony.claimColonyFunds(clnyToken.address);
+      potAfter = await metaColony.getFundingPotBalance(1, clnyToken.address);
+      expect(potAfter.sub(potBefore)).to.eq.BN(WAD.divn(365 * 24 * 60));
+    });
+
+    it("the metacolony stipend cannot be claimed before it is set", async () => {
+      await checkErrorRevert(colonyNetwork.issueMetaColonyStipend(), "colony-network-metacolony-stipend-not-set");
+    });
+  });
+
+  describe("when setting the per-cycle miner reward", () => {
+    it("should allow the reward to be set", async () => {
+      const rewardBefore = await colonyNetwork.getReputationMiningCycleReward();
+      expect(rewardBefore).to.eq.BN(0);
+      await metaColony.setReputationMiningCycleReward(WAD);
+      const rewardAfter = await colonyNetwork.getReputationMiningCycleReward();
+      expect(rewardAfter).to.eq.BN(WAD);
+    });
+
+    it("setting the reward should be a permissioned function", async () => {
+      await checkErrorRevert(metaColony.setReputationMiningCycleReward(0, { from: OTHER_ACCOUNT }), "ds-auth-unauthorized");
+    });
+
+    it("a non-meta colony should not be able to set the reward", async () => {
+      ({ colony } = await setupRandomColony(colonyNetwork));
+      const colonyAsMetaColony = await IMetaColony.at(colony.address);
+      await checkErrorRevert(colonyAsMetaColony.setReputationMiningCycleReward(0), "colony-caller-must-be-meta-colony");
+    });
+
+    // Checking that the rewards are paid out is done in tests in root-hash-submissions.js
   });
 });

--- a/test/reputation-system/root-hash-submissions.js
+++ b/test/reputation-system/root-hash-submissions.js
@@ -198,7 +198,7 @@ contract("Reputation mining - root hash submissions", (accounts) => {
       );
     });
 
-    it.only("should allow a user to back the same hash more than once in a same cycle with different entries, and be rewarded", async () => {
+    it("should allow a user to back the same hash more than once in a same cycle with different entries, and be rewarded", async () => {
       await metaColony.setReputationMiningCycleReward(WAD.muln(10));
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION / 2, this);


### PR DESCRIPTION
CLNY will be issued via three mechanisms:

* CoinMachine
* A stipend for the metacolony to pay for tasks
* Rewards for reputation miners.

Coinmachine is being dealt with in #835; this PR deals with the other two mechanisms.

### Metacolony stipend
Set via `setAnnualMetaColonyStipend`. An absolute value, given that none of these mechanisms react to each other - we trust the metacolony to set the values appropriately. This function is permissioned, but the `issueMetaColonyStipend` that awards the stipend can be called by anyone, as often as is desired, which will result in the appropriate pro-rata'd amount being awarded.

### Reputation mining cycle reward
Set via `setReputationMiningCycleReward` on the metacolony. This reward will be split between all entries that were submitted for the reputation hash that was ultimately accepted. The natural place to store this is on `colonyNetwork`, where previously the implication was that it was stored in `ReputationMiningCycle` (though has been set to zero until now). As a result, there are now two `setReputationRootHash` functions on `ColonyNetworkMining` to ease the transition - the one with `reward` as a parameter is deprecated, and will be removed after whatever upgrade these changes were included in.

### Notes

This PR also includes the `makeTxAtTimestamp` functionality I wrote for colonyNetwork#842, but I needed it here in order to write some of the tests. Obviously only one of these PRs will ultimately contain that functionality :smile: 