### PR TITLE
Deploy CoinMachineFactory on local migration

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -9,6 +9,7 @@ const ReputationMiningCycle = artifacts.require("./ReputationMiningCycle");
 const ReputationMiningCycleRespond = artifacts.require("./ReputationMiningCycleRespond");
 const ReputationMiningCycleBinarySearch = artifacts.require("./ReputationMiningCycleBinarySearch");
 const OneTxPaymentFactory = artifacts.require("./extensions/OneTxPaymentFactory");
+const CoinMachineFactory = artifacts.require("./extensions/CoinMachineFactory");
 
 const EtherRouter = artifacts.require("./EtherRouter");
 const Resolver = artifacts.require("./Resolver");
@@ -32,4 +33,5 @@ module.exports = (deployer, network) => {
   deployer.deploy(Resolver);
   deployer.deploy(ContractRecovery);
   deployer.deploy(OneTxPaymentFactory);
+  deployer.deploy(CoinMachineFactory);
 };


### PR DESCRIPTION
For local development the dapp people would like to have the `CoinMachineFactory` contract deployed when running the migration locally.

