### PR TITLE
Change glob choosing tests to run under coverage

### DIFF
--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -116,24 +116,6 @@ Used by a user to claim any mining rewards due to them. This will place them in 
 
 ### `createColony`
 
-Creates a new colony in the network, at version 3
-
-*Note: This is now deprecated and will be removed in a future version*
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_tokenAddress|address|Address of an ERC20 token to serve as the colony token.
-
-**Return Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|colonyAddress|address|Address of the newly created colony
-
-### `createColony`
-
 Overload of the simpler `createColony` -- creates a new colony in the network with a variety of options
 
 *Note: For the colony to mint tokens, token ownership must be transferred to the new colony*
@@ -147,6 +129,24 @@ Overload of the simpler `createColony` -- creates a new colony in the network wi
 |_colonyName|string|The label to register (if null, no label is registered)
 |_orbitdb|string|The path of the orbitDB database associated with the user profile
 |_useExtensionManager|bool|If true, give the ExtensionManager the root role in the colony
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|colonyAddress|address|Address of the newly created colony
+
+### `createColony`
+
+Creates a new colony in the network, at version 3
+
+*Note: This is now deprecated and will be removed in a future version*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_tokenAddress|address|Address of an ERC20 token to serve as the colony token.
 
 **Return Parameters**
 

--- a/docs/_Interface_IReputationMiningCycle.md
+++ b/docs/_Interface_IReputationMiningCycle.md
@@ -33,7 +33,7 @@ Get whether a challenge round is complete.
 
 |Name|Type|Description|
 |---|---|---|
-|round|uint256|The round number to check
+|_round|uint256|The round number to check
 
 **Return Parameters**
 
@@ -50,10 +50,10 @@ This function ensures that the intermediate hashes saved are correct.
 
 |Name|Type|Description|
 |---|---|---|
-|round|uint256|The round number the hash we are responding on behalf of is in
-|idx|uint256|The index in the round that the hash we are responding on behalf of is in
-|jhIntermediateValue|bytes|The contents of the Justification Tree at the key given by `targetLeaf` (see function description). The value of `targetLeaf` is computed locally to establish what to submit to this function.
-|siblings|bytes32[]|The siblings of the Merkle proof that `jhIntermediateValue` is the value at key `targetLeaf`
+|_round|uint256|The round number the hash we are responding on behalf of is in
+|_idx|uint256|The index in the round that the hash we are responding on behalf of is in
+|_jhIntermediateValue|bytes|The contents of the Justification Tree at the key given by `targetLeaf` (see function description). The value of `targetLeaf` is computed locally to establish what to submit to this function.
+|_siblings|bytes32[]|The siblings of the Merkle proof that `jhIntermediateValue` is the value at key `targetLeaf`
 
 
 ### `confirmJustificationRootHash`
@@ -66,10 +66,10 @@ Verify the Justification Root Hash (JRH) for a submitted reputation hash is plau
 
 |Name|Type|Description|
 |---|---|---|
-|round|uint256|The round that the hash is currently in.
-|index|uint256|The index in the round that the hash is currently in
-|siblings1|bytes32[]|The siblings for the same Merkle proof
-|siblings2|bytes32[]|The siblings for the same Merkle proof
+|_round|uint256|The round that the hash is currently in.
+|_index|uint256|The index in the round that the hash is currently in
+|_siblings1|bytes32[]|The siblings for the same Merkle proof
+|_siblings2|bytes32[]|The siblings for the same Merkle proof
 
 
 ### `confirmNewHash`
@@ -81,7 +81,7 @@ Confirm a new reputation hash. The hash in question is either the only one that 
 
 |Name|Type|Description|
 |---|---|---|
-|roundNumber|uint256|The round number that the hash being confirmed is in as the only contendender. If only one hash was submitted, then this is zero.
+|_roundNumber|uint256|The round number that the hash being confirmed is in as the only contendender. If only one hash was submitted, then this is zero.
 
 
 ### `getDecayConstant`
@@ -107,7 +107,7 @@ Returns the amount of CLNY given for defending a hash during the current dispute
 
 |Name|Type|Description|
 |---|---|---|
-|_reward|uint256|uint256 The amount of CLNY given.
+|reward|uint256|uint256 The amount of CLNY given.
 
 ### `getDisputeRound`
 
@@ -135,9 +135,9 @@ Get the hash for the corresponding entry.
 
 |Name|Type|Description|
 |---|---|---|
-|submitter|address|The address that submitted the hash
-|entryIndex|uint256|The index of the entry that they used to submit the hash
-|newHash|bytes32|The hash that they submitted
+|_submitter|address|The address that submitted the hash
+|_entryIndex|uint256|The index of the entry that they used to submit the hash
+|_newHash|bytes32|The hash that they submitted
 
 **Return Parameters**
 
@@ -190,9 +190,9 @@ Get the number of submissions miners made of a particular hash / nLeaves / jrh c
 
 |Name|Type|Description|
 |---|---|---|
-|hash|bytes32|The hash that was submitted
-|nLeaves|uint256|The number of leaves that was submitted
-|jrh|bytes32|The JRH of that was submitted
+|_hash|bytes32|The hash that was submitted
+|_nLeaves|uint256|The number of leaves that was submitted
+|_jrh|bytes32|The JRH of that was submitted
 
 **Return Parameters**
 
@@ -279,8 +279,8 @@ Returns whether the caller is able to currently respond to a dispute stage.
 
 |Name|Type|Description|
 |---|---|---|
-|stage|disputeStages|The dispute stage in question. Practically, this is a number that indexes in to the corresponding enum in ReputationMiningCycleDataTypes
-|since|uint256|The timestamp the last response for the submission in the dispute in question was made at.
+|_stage|DisputeStages|The dispute stage in question. Practically, this is a number that indexes in to the corresponding enum in ReputationMiningCycleDataTypes
+|_since|uint256|The timestamp the last response for the submission in the dispute in question was made at.
 
 **Return Parameters**
 
@@ -297,10 +297,10 @@ Get the address that made a particular submission.
 
 |Name|Type|Description|
 |---|---|---|
-|hash|bytes32|The hash that was submitted
-|nLeaves|uint256|The number of leaves that was submitted
-|jrh|bytes32|The JRH of that was submitted
-|index|uint256|The index of the submission - should be 0-11, as up to twelve submissions can be made.
+|_hash|bytes32|The hash that was submitted
+|_nLeaves|uint256|The number of leaves that was submitted
+|_jrh|bytes32|The JRH of that was submitted
+|_index|uint256|The index of the submission - should be 0-11, as up to twelve submissions can be made.
 
 **Return Parameters**
 
@@ -318,8 +318,8 @@ Initialise this reputation mining cycle.
 
 |Name|Type|Description|
 |---|---|---|
-|tokenLocking|address|Address of the TokenLocking contract
-|clnyToken|address|Address of the CLNY token
+|_tokenLocking|address|Address of the TokenLocking contract
+|_clnyToken|address|Address of the CLNY token
 
 
 ### `invalidateHash`
@@ -331,8 +331,8 @@ Invalidate a hash that has timed out relative to its opponent its current challe
 
 |Name|Type|Description|
 |---|---|---|
-|round|uint256|The round number the hash being invalidated is in
-|idx|uint256|The index in the round that the hash being invalidated is in
+|_round|uint256|The round number the hash being invalidated is in
+|_idx|uint256|The index in the round that the hash being invalidated is in
 
 
 ### `minerSubmittedEntryIndex`
@@ -370,10 +370,10 @@ Respond to a binary search step, to eventually discover where two submitted hash
 
 |Name|Type|Description|
 |---|---|---|
-|round|uint256|The round number the hash we are responding on behalf of is in
-|idx|uint256|The index in the round that the hash we are responding on behalf of is in
-|jhIntermediateValue|bytes|The contents of the Justification Tree at the key given by `targetLeaf` (see function description). The value of `targetLeaf` is computed locally to establish what to submit to this function.
-|siblings|bytes32[]|The siblings of the Merkle proof that `jhIntermediateValue` is the value at key `targetLeaf`
+|_round|uint256|The round number the hash we are responding on behalf of is in
+|_idx|uint256|The index in the round that the hash we are responding on behalf of is in
+|_jhIntermediateValue|bytes|The contents of the Justification Tree at the key given by `targetLeaf` (see function description). The value of `targetLeaf` is computed locally to establish what to submit to this function.
+|_siblings|bytes32[]|The siblings of the Merkle proof that `jhIntermediateValue` is the value at key `targetLeaf`
 
 
 ### `respondToChallenge`
@@ -386,14 +386,14 @@ Respond to challenge, to establish which (if either) of the two submissions faci
 
 |Name|Type|Description|
 |---|---|---|
-|u|uint256[26]|A `uint256[27]` array. The elements of this array, in order are: * 1. The current round of the hash being responded on behalf of * 2. The current index in the round of the hash being responded on behalf of * 3. The branchMask of the proof that the reputation is in the reputation state tree for the reputation with the disputed change * 4. The number of leaves in the last reputation state that both submitted hashes agree on * 5. The branchMask of the proof that the last reputation state the submitted hashes agreed on is in this submitted hash's justification tree * 6. The number of leaves this hash considers to be present in the first reputation state the two hashes in this challenge disagree on * 7. The branchMask of the proof that reputation root hash of the first reputation state the two hashes in this challenge disagree on is in this submitted hash's justification tree * 8. The index of the log entry that the update in question was implied by. Each log entry can imply multiple reputation updates, and so we expect the clients to pass      the log entry index corresponding to the update to avoid us having to iterate over the log. * 9. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code. * 10. Origin skill reputation branch mask. Nonzero for child reputation updates. * 11. The amount of reputation that the entry in the tree under dispute has in the agree state * 12. The UID that the entry in the tree under dispute has in the agree state * 13. The amount of reputation that the entry in the tree under dispute has in the disagree state * 14. The UID that the entry in the tree under dispute has in the disagree state * 15. The amount of reputation that the user's origin reputation entry in the tree has in the state being disputed * 16. The UID that the user's origin reputation entry in the tree has in the state being disputed * 17. The branchMask of the proof that the child reputation for the user being updated is in the agree state * 18. The amount of reputation that the child reputation for the user being updated is in the agree state * 19. The UID of the child reputation for the user being updated in the agree state * 20. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code. * 21. The branchMask of the proof that the reputation adjacent to the new reputation being inserted is in the agree state * 22. The amount of reputation that the reputation adjacent to a new reputation being inserted has in the agree state * 23. The UID of the reputation adjacent to the new reputation being inserted * 24. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code. * 25. The value of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree * 26. The value of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
-|b32|bytes32[7]|A `bytes32[8]` array. The elements of this array, in order are: * 1. The colony address in the key of the reputation being changed that the disagreement is over. * 2. The skillid in the key of the reputation being changed that the disagreement is over. * 3. The user address in the key of the reputation being changed that the disagreement is over. * 4. The keccak256 hash of the key of the reputation being changed that the disagreement is over. * 5. The keccak256 hash of the key for a reputation already in the tree adjacent to the new reputation being inserted, if required. * 6. The keccak256 hash of the key of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree * 7. The keccak256 hash of the key of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
-|reputationSiblings|bytes32[]|The siblings of the Merkle proof that the reputation corresponding to `_reputationKey` is in the reputation state before and after the disagreement
-|agreeStateSiblings|bytes32[]|The siblings of the Merkle proof that the last reputation state the submitted hashes agreed on is in this submitted hash's justification tree
-|disagreeStateSiblings|bytes32[]|The siblings of the Merkle proof that the first reputation state the submitted hashes disagreed on is in this submitted hash's justification tree
-|userOriginReputationSiblings|bytes32[]|Nonzero for child updates only. The siblings of the Merkle proof of the user's origin skill reputation added to the reputation tree in the last reputation state the submitted hashes agree on
-|childReputationSiblings|bytes32[]|Nonzero for child updates of a colony-wide global skill. The siblings of the Merkle proof of the child skill reputation of the user in the same skill this global update is for
-|adjacentReputationSiblings|bytes32[]|Nonzero for updates involving insertion of a new skill. The siblings of the Merkle proof of a reputation in the agree state that ends adjacent to the new reputation
+|_u|uint256[26]|A `uint256[27]` array. The elements of this array, in order are: * 1. The current round of the hash being responded on behalf of * 2. The current index in the round of the hash being responded on behalf of * 3. The branchMask of the proof that the reputation is in the reputation state tree for the reputation with the disputed change * 4. The number of leaves in the last reputation state that both submitted hashes agree on * 5. The branchMask of the proof that the last reputation state the submitted hashes agreed on is in this submitted hash's justification tree * 6. The number of leaves this hash considers to be present in the first reputation state the two hashes in this challenge disagree on * 7. The branchMask of the proof that reputation root hash of the first reputation state the two hashes in this challenge disagree on is in this submitted hash's justification tree * 8. The index of the log entry that the update in question was implied by. Each log entry can imply multiple reputation updates, and so we expect the clients to pass      the log entry index corresponding to the update to avoid us having to iterate over the log. * 9. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code. * 10. Origin skill reputation branch mask. Nonzero for child reputation updates. * 11. The amount of reputation that the entry in the tree under dispute has in the agree state * 12. The UID that the entry in the tree under dispute has in the agree state * 13. The amount of reputation that the entry in the tree under dispute has in the disagree state * 14. The UID that the entry in the tree under dispute has in the disagree state * 15. The amount of reputation that the user's origin reputation entry in the tree has in the state being disputed * 16. The UID that the user's origin reputation entry in the tree has in the state being disputed * 17. The branchMask of the proof that the child reputation for the user being updated is in the agree state * 18. The amount of reputation that the child reputation for the user being updated is in the agree state * 19. The UID of the child reputation for the user being updated in the agree state * 20. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code. * 21. The branchMask of the proof that the reputation adjacent to the new reputation being inserted is in the agree state * 22. The amount of reputation that the reputation adjacent to a new reputation being inserted has in the agree state * 23. The UID of the reputation adjacent to the new reputation being inserted * 24. A dummy variable that should be set to 0. If nonzero, transaction will still work but be slightly more expensive. For an explanation of why this is present, look at the corresponding solidity code. * 25. The value of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree * 26. The value of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
+|_b32|bytes32[7]|A `bytes32[8]` array. The elements of this array, in order are: * 1. The colony address in the key of the reputation being changed that the disagreement is over. * 2. The skillid in the key of the reputation being changed that the disagreement is over. * 3. The user address in the key of the reputation being changed that the disagreement is over. * 4. The keccak256 hash of the key of the reputation being changed that the disagreement is over. * 5. The keccak256 hash of the key for a reputation already in the tree adjacent to the new reputation being inserted, if required. * 6. The keccak256 hash of the key of the reputation that would be origin-adjacent that proves that the origin reputation does not exist in the tree * 7. The keccak256 hash of the key of the reputation that would be child-adjacent that proves that the child reputation does not exist in the tree
+|_reputationSiblings|bytes32[]|The siblings of the Merkle proof that the reputation corresponding to `_reputationKey` is in the reputation state before and after the disagreement
+|_agreeStateSiblings|bytes32[]|The siblings of the Merkle proof that the last reputation state the submitted hashes agreed on is in this submitted hash's justification tree
+|_disagreeStateSiblings|bytes32[]|The siblings of the Merkle proof that the first reputation state the submitted hashes disagreed on is in this submitted hash's justification tree
+|_userOriginReputationSiblings|bytes32[]|Nonzero for child updates only. The siblings of the Merkle proof of the user's origin skill reputation added to the reputation tree in the last reputation state the submitted hashes agree on
+|_childReputationSiblings|bytes32[]|Nonzero for child updates of a colony-wide global skill. The siblings of the Merkle proof of the child skill reputation of the user in the same skill this global update is for
+|_adjacentReputationSiblings|bytes32[]|Nonzero for updates involving insertion of a new skill. The siblings of the Merkle proof of a reputation in the agree state that ends adjacent to the new reputation
 
 
 ### `rewardStakersWithReputation`
@@ -406,11 +406,11 @@ Start the reputation log with the rewards for the stakers who backed the accepte
 
 |Name|Type|Description|
 |---|---|---|
-|stakers|address[]|The array of stakers addresses to receive the reward.
-|weights|uint256[]|The array of weights determining the proportion of reward to go to each staker
-|metaColonyAddress|address|The address of the meta colony, which the special mining skill is earned in
-|reward|uint256|The amount of reputation to be rewarded to each staker
-|miningSkillId|uint256|Skill id of the special mining skill
+|_stakers|address[]|The array of stakers addresses to receive the reward.
+|_weights|uint256[]|The array of weights determining the proportion of reward to go to each staker
+|_metaColonyAddress|address|The address of the meta colony, which the special mining skill is earned in
+|_reward|uint256|The amount of reputation to be rewarded to each staker
+|_miningSkillId|uint256|Skill id of the special mining skill
 
 
 ### `submitRootHash`
@@ -422,10 +422,10 @@ Submit a new reputation root hash.
 
 |Name|Type|Description|
 |---|---|---|
-|newHash|bytes32|The proposed new reputation root hash
-|nLeaves|uint256|Number of leaves in tree with root `newHash`
-|jrh|bytes32|The justifcation root hash for this submission
-|entryIndex|uint256|The entry number for the given `newHash` and `nLeaves`
+|_newHash|bytes32|The proposed new reputation root hash
+|_nLeaves|uint256|Number of leaves in tree with root `newHash`
+|_jrh|bytes32|The justifcation root hash for this submission
+|_entryIndex|uint256|The entry number for the given `newHash` and `nLeaves`
 
 
 ### `userInvolvedInMiningCycle`

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:contracts:upgrade:ganache": "npm run start:blockchain:client & npm run generate:test:contracts && truffle migrate --reset --compile-all && truffle test ./test-upgrade/* --network development",
     "test:contracts:gasCosts": "npm run start:blockchain:client & truffle migrate --reset --compile-all && truffle test test-gas-costs/gasCosts.js --network development",
     "test:contracts:patricia": "npm run start:blockchain:client parity & truffle migrate --reset --compile-all && truffle test packages/reputation-miner/patricia-test.js --network development",
-    "test:contracts:coverage": "SOLIDITY_COVERAGE=1 truffle run coverage --network coverage --temp build --file='./test/*[!m]/*'",
+    "test:contracts:coverage": "SOLIDITY_COVERAGE=1 truffle run coverage --network coverage --temp build --file='./test/{c,e}*/*'",
     "test:contracts:watch": "npm run start:blockchain:client & truffle migrate --reset --compile-all && truffle watch --network development",
     "test:contracts:e2e": "npm run start:blockchain:client & truffle migrate --reset --compile-all && truffle test test-system/end-to-end.js --network development",
     "test:security:slither": "slither contracts/ --solc-disable-warnings --exclude-low --exclude-informational --exclude-optimization --exclude uninitialized-state-variables,uninitialized-local-variables,reentrancy-no-eth,constant-function --filter-paths lib",


### PR DESCRIPTION
Not sure why, but this stopped working, even handing it directly to `globby`, the underlying package used by `solidity-coverage`. The 'positive' glob seems to still work but will need extra upkeep if we add more folders.