### PR TITLE
Add TokenSupplier

### DIFF
--- a/contracts/extensions/CoinMachine.sol
+++ b/contracts/extensions/CoinMachine.sol
@@ -52,8 +52,8 @@ contract CoinMachine is ColonyExtension {
 
   // Modifiers
 
-  modifier root() {
-    require(colony.hasUserRole(msg.sender, 1, ColonyDataTypes.ColonyRole.Root), "coin-machine-not-root");
+  modifier onlyRoot() {
+    require(colony.hasUserRole(msg.sender, 1, ColonyDataTypes.ColonyRole.Root), "coin-machine-caller-not-root");
     _;
   }
 
@@ -106,7 +106,7 @@ contract CoinMachine is ColonyExtension {
     uint256 _startingPrice
   )
     public
-    root
+    onlyRoot
   {
     require(activePeriod == 0, "coin-machine-already-initialised");
 

--- a/contracts/extensions/CoinMachine.sol
+++ b/contracts/extensions/CoinMachine.sol
@@ -18,16 +18,13 @@
 pragma solidity 0.7.3;
 pragma experimental ABIEncoderV2;
 
-import "./../../lib/dappsys/math.sol";
-import "./../colony/ColonyDataTypes.sol";
-import "./../colony/IColony.sol";
 import "./../common/ERC20Extended.sol";
 import "./ColonyExtension.sol";
 
 // ignore-file-swc-108
 
 
-contract CoinMachine is DSMath, ColonyExtension {
+contract CoinMachine is ColonyExtension {
 
   // Events
 
@@ -52,6 +49,13 @@ contract CoinMachine is DSMath, ColonyExtension {
   uint256 activeIntake; // Payment received in the active period
 
   uint256 emaIntake; // Averaged payment intake
+
+  // Modifiers
+
+  modifier root() {
+    require(colony.hasUserRole(msg.sender, 1, ColonyDataTypes.ColonyRole.Root), "coin-machine-not-root");
+    _;
+  }
 
   // Public
 
@@ -102,8 +106,8 @@ contract CoinMachine is DSMath, ColonyExtension {
     uint256 _startingPrice
   )
     public
+    root
   {
-    require(colony.hasUserRole(msg.sender, 1, ColonyDataTypes.ColonyRole.Root), "coin-machine-not-root");
     require(activePeriod == 0, "coin-machine-already-initialised");
 
     require(_periodLength > 0, "coin-machine-period-too-small");

--- a/contracts/extensions/ColonyExtension.sol
+++ b/contracts/extensions/ColonyExtension.sol
@@ -18,10 +18,13 @@
 pragma solidity 0.7.3;
 pragma experimental ABIEncoderV2;
 
+import "./../../lib/dappsys/math.sol";
 import "./../common/EtherRouter.sol";
 import "./../colony/IColony.sol";
+import "./../colony/ColonyDataTypes.sol";
 
-abstract contract ColonyExtension is DSAuth {
+
+abstract contract ColonyExtension is DSAuth, DSMath {
 
   event ExtensionInitialised();
 

--- a/contracts/extensions/FundingQueue.sol
+++ b/contracts/extensions/FundingQueue.sol
@@ -18,17 +18,14 @@
 pragma solidity 0.7.3;
 pragma experimental ABIEncoderV2;
 
-import "./../../lib/dappsys/math.sol";
-import "./../colony/IColony.sol";
 import "./../colonyNetwork/IColonyNetwork.sol";
 import "./../common/ERC20Extended.sol";
 import "./../patriciaTree/PatriciaTreeProofs.sol";
 import "./../tokenLocking/ITokenLocking.sol";
-
 import "./ColonyExtension.sol";
 
 
-contract FundingQueue is ColonyExtension, DSMath, PatriciaTreeProofs {
+contract FundingQueue is ColonyExtension, PatriciaTreeProofs {
 
   // Events
   event ProposalCreated(uint256 id, uint256 indexed fromPot, uint256 indexed toPot, address indexed token, uint256 amount);

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -18,13 +18,12 @@
 pragma solidity 0.7.3;
 pragma experimental ABIEncoderV2;
 
-import "./../../lib/dappsys/math.sol";
 import "./ColonyExtension.sol";
 
 // ignore-file-swc-108
 
 
-contract OneTxPayment is ColonyExtension, DSMath {
+contract OneTxPayment is ColonyExtension {
   uint256 constant UINT256_MAX = 2**256 - 1;
   ColonyDataTypes.ColonyRole constant ADMINISTRATION = ColonyDataTypes.ColonyRole.Administration;
   ColonyDataTypes.ColonyRole constant FUNDING = ColonyDataTypes.ColonyRole.Funding;

--- a/contracts/extensions/TokenSupplier.sol
+++ b/contracts/extensions/TokenSupplier.sol
@@ -1,0 +1,96 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity 0.5.8;
+pragma experimental ABIEncoderV2;
+
+import "./../../lib/dappsys/auth.sol";
+import "./../../lib/dappsys/math.sol";
+import "./../colony/ColonyDataTypes.sol";
+import "./../colony/IColony.sol";
+
+
+contract TokenSupplier is DSMath, DSAuth {
+
+  uint256 constant PERIOD = 1 days;
+
+  // Events
+
+  event TokenSupplyCeilingSet(uint256 tokenSupplyCeiling);
+  event TokenIssuanceRateSet(uint256 tokenIssuanceRate);
+  event TokensIssued(uint256 numTokens);
+
+  IColony colony;
+
+  constructor(address _colony) public {
+    colony = IColony(_colony);
+  }
+
+  // Storage
+
+  uint256 public tokenSupply;
+  uint256 public tokenSupplyCeiling;
+  uint256 public tokenIssuanceRate;
+  uint256 public lastPinged;
+
+  // Authed
+
+  function initialise(uint256 _tokenSupplyCeiling, uint256 _tokenIssuanceRate) public auth {
+    require(lastPinged == 0, "token-supplier-already-initialised");
+
+    tokenSupplyCeiling = _tokenSupplyCeiling;
+    tokenIssuanceRate = _tokenIssuanceRate;
+    lastPinged = now;
+  }
+
+  function setTokenSupplyCeiling(uint256 _tokenSupplyCeiling) public {
+    require(colony.hasUserRole(msg.sender, 1, ColonyDataTypes.ColonyRole.Root), "token-supplier-not-root");
+
+    tokenSupplyCeiling = _tokenSupplyCeiling;
+
+    emit TokenSupplyCeilingSet(tokenSupplyCeiling);
+  }
+
+  function setTokenIssuanceRate(uint256 _tokenIssuanceRate) public {
+    require(colony.hasUserRole(msg.sender, 1, ColonyDataTypes.ColonyRole.Root), "token-supplier-not-root");
+
+    tokenIssuanceRate = _tokenIssuanceRate;
+
+    emit TokenIssuanceRateSet(tokenIssuanceRate);
+  }
+
+  // Public
+
+  function issueTokens() public {
+    uint256 newSupply = min(
+      tokenSupplyCeiling - tokenSupply,
+      wmul(tokenIssuanceRate, wdiv((now - lastPinged), PERIOD))
+    );
+
+    require(newSupply > 0, "token-supplier-nothing-to-issue");
+
+    tokenSupply = add(tokenSupply, newSupply);
+    lastPinged = now;
+
+    assert(tokenSupply <= tokenSupplyCeiling);
+
+    colony.mintTokens(newSupply);
+
+    emit TokensIssued(newSupply);
+  }
+
+}

--- a/contracts/extensions/TokenSupplier.sol
+++ b/contracts/extensions/TokenSupplier.sol
@@ -18,12 +18,15 @@
 pragma solidity 0.7.3;
 pragma experimental ABIEncoderV2;
 
+import "./../colonyNetwork/IColonyNetwork.sol";
 import "./ColonyExtension.sol";
 
 
 contract TokenSupplier is ColonyExtension {
 
   uint256 constant PERIOD = 1 days;
+  bytes32 constant VOTING_REPUTATION = keccak256("VotingReputation");
+  bytes32 constant VOTING_HYBRID = keccak256("VotingHybrid");
 
   // Events
 
@@ -31,18 +34,26 @@ contract TokenSupplier is ColonyExtension {
   event TokenIssuanceRateSet(uint256 tokenIssuanceRate);
   event TokensIssued(uint256 numTokens);
 
-
   // Storage
 
   uint256 public tokenSupply;
   uint256 public tokenSupplyCeiling;
   uint256 public tokenIssuanceRate;
   uint256 public lastPinged;
+  uint256 public lastRateUpdate;
 
   // Modifiers
 
-  modifier root() {
+  modifier isRoot() {
     require(colony.hasUserRole(msg.sender, 1, ColonyDataTypes.ColonyRole.Root), "token-supplier-not-root");
+    _;
+  }
+
+  modifier isContract() {
+    uint256 size;
+    address msgSender = msg.sender;
+    assembly { size := extcodesize(msgSender) }
+    require(size > 0, "token-supplier-caller-must-be-contract");
     _;
   }
 
@@ -80,17 +91,27 @@ contract TokenSupplier is ColonyExtension {
   /// @notice Initialise the extension, must be called before any tokens can be issued
   /// @param _tokenSupplyCeiling Total amount of tokens to issue
   /// @param _tokenIssuanceRate Number of tokens to issue per day
-  function initialise(uint256 _tokenSupplyCeiling, uint256 _tokenIssuanceRate) public root {
+  function initialise(uint256 _tokenSupplyCeiling, uint256 _tokenIssuanceRate) public isRoot {
     require(lastPinged == 0, "token-supplier-already-initialised");
 
     tokenSupplyCeiling = _tokenSupplyCeiling;
     tokenIssuanceRate = _tokenIssuanceRate;
     lastPinged = block.timestamp;
+    lastRateUpdate = block.timestamp;
   }
 
   /// @notice Update the tokenSupplyCeiling, cannot set below current tokenSupply
   /// @param _tokenSupplyCeiling Total amount of tokens to issue
-  function setTokenSupplyCeiling(uint256 _tokenSupplyCeiling) public root {
+  function setTokenSupplyCeiling(uint256 _tokenSupplyCeiling) public isRoot isContract {
+    try ColonyExtension(msg.sender).identifier() returns (bytes32 extensionId) {
+      IColonyNetwork colonyNetwork = IColonyNetwork(colony.getColonyNetwork());
+      address installation = colonyNetwork.getExtensionInstallation(extensionId, address(colony));
+      require(installation == msg.sender, "token-supplier-not-managed-extension");
+      require(extensionId == VOTING_HYBRID, "token-supplier-cannot-set-value");
+    } catch {
+      require(false, "token-supplier-no-identifier");
+    }
+
     tokenSupplyCeiling = max(_tokenSupplyCeiling, tokenSupply);
 
     emit TokenSupplyCeilingSet(tokenSupplyCeiling);
@@ -98,8 +119,26 @@ contract TokenSupplier is ColonyExtension {
 
   /// @notice Update the tokenIssuanceRate
   /// @param _tokenIssuanceRate Number of tokens to issue per day
-  function setTokenIssuanceRate(uint256 _tokenIssuanceRate) public root {
+  function setTokenIssuanceRate(uint256 _tokenIssuanceRate) public isRoot isContract {
+    try ColonyExtension(msg.sender).identifier() returns (bytes32 extensionId) {
+      IColonyNetwork colonyNetwork = IColonyNetwork(colony.getColonyNetwork());
+      address installation = colonyNetwork.getExtensionInstallation(extensionId, address(colony));
+      require(installation == msg.sender, "token-supplier-not-managed-extension");
+      require(
+        extensionId == VOTING_HYBRID || (
+          extensionId == VOTING_REPUTATION &&
+          block.timestamp - lastRateUpdate >= 4 weeks &&
+          _tokenIssuanceRate <= add(tokenIssuanceRate, tokenIssuanceRate / 10) &&
+          _tokenIssuanceRate >= sub(tokenIssuanceRate, tokenIssuanceRate / 10)
+        ),
+        "token-supplier-cannot-set-value"
+      );
+    } catch {
+      require(false, "token-supplier-no-identifier");
+    }
+
     tokenIssuanceRate = _tokenIssuanceRate;
+    lastRateUpdate = block.timestamp;
 
     emit TokenIssuanceRateSet(tokenIssuanceRate);
   }

--- a/contracts/extensions/TokenSupplier.sol
+++ b/contracts/extensions/TokenSupplier.sol
@@ -48,6 +48,11 @@ contract TokenSupplier is ColonyExtension {
 
   // Public
 
+  /// @notice Returns the identifier of the extension
+  function identifier() public override pure returns (bytes32) {
+    return keccak256("TokenSupplier");
+  }
+
   /// @notice Returns the version of the extension
   function version() public override pure returns (uint256) {
     return 1;

--- a/contracts/extensions/TokenSupplier.sol
+++ b/contracts/extensions/TokenSupplier.sol
@@ -15,7 +15,7 @@
   along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.5.8;
+pragma solidity 0.7.3;
 pragma experimental ABIEncoderV2;
 
 import "./ColonyExtension.sol";
@@ -49,26 +49,26 @@ contract TokenSupplier is ColonyExtension {
   // Public
 
   /// @notice Returns the version of the extension
-  function version() public pure returns (uint256) {
+  function version() public override pure returns (uint256) {
     return 1;
   }
 
   /// @notice Configures the extension
   /// @param _colony The colony in which the extension holds permissions
-  function install(address _colony) public auth {
+  function install(address _colony) public override auth {
     require(address(colony) == address(0x0), "extension-already-installed");
 
     colony = IColony(_colony);
   }
 
   /// @notice Called when upgrading the extension (currently a no-op)
-  function finishUpgrade() public auth {}
+  function finishUpgrade() public override auth {}
 
   /// @notice Called when deprecating (or undeprecating) the extension (currently a no-op)
-  function deprecate(bool _deprecated) public auth {}
+  function deprecate(bool _deprecated) public override auth {}
 
   /// @notice Called when uninstalling the extension
-  function uninstall() public auth {
+  function uninstall() public override auth {
     selfdestruct(address(uint160(address(colony))));
   }
 
@@ -80,7 +80,7 @@ contract TokenSupplier is ColonyExtension {
 
     tokenSupplyCeiling = _tokenSupplyCeiling;
     tokenIssuanceRate = _tokenIssuanceRate;
-    lastPinged = now;
+    lastPinged = block.timestamp;
   }
 
   /// @notice Update the tokenSupplyCeiling, cannot set below current tokenSupply
@@ -105,13 +105,13 @@ contract TokenSupplier is ColonyExtension {
 
     uint256 newSupply = min(
       tokenSupplyCeiling - tokenSupply,
-      wmul(tokenIssuanceRate, wdiv((now - lastPinged), PERIOD))
+      wmul(tokenIssuanceRate, wdiv((block.timestamp - lastPinged), PERIOD))
     );
 
     require(newSupply > 0, "token-supplier-nothing-to-issue");
 
     tokenSupply = add(tokenSupply, newSupply);
-    lastPinged = now;
+    lastPinged = block.timestamp;
 
     assert(tokenSupply <= tokenSupplyCeiling);
 

--- a/contracts/extensions/TokenSupplier.sol
+++ b/contracts/extensions/TokenSupplier.sol
@@ -159,11 +159,11 @@ contract TokenSupplier is ColonyExtension {
     uint256 tokenSupply = ERC20Extended(token).totalSupply();
 
     uint256 newSupply = min(
-      sub(tokenSupplyCeiling, tokenSupply),
+      (tokenSupplyCeiling > tokenSupply) ? sub(tokenSupplyCeiling, tokenSupply) : 0,
       wmul(tokenIssuanceRate, wdiv((block.timestamp - lastIssue), ISSUANCE_PERIOD))
     );
 
-    assert(add(tokenSupply, newSupply) <= tokenSupplyCeiling);
+    assert(newSupply == 0 || add(tokenSupply, newSupply) <= tokenSupplyCeiling);
 
     // Don't update lastIssue if we aren't actually issuing tokens
     if (newSupply > 0) {

--- a/contracts/extensions/VotingReputation.sol
+++ b/contracts/extensions/VotingReputation.sol
@@ -18,19 +18,14 @@
 pragma solidity 0.7.3;
 pragma experimental ABIEncoderV2;
 
-import "./../../lib/dappsys/math.sol";
-import "./../../lib/dappsys/roles.sol";
-import "./../colony/ColonyDataTypes.sol";
-import "./../colony/IColony.sol";
 import "./../colonyNetwork/IColonyNetwork.sol";
 import "./../common/ERC20Extended.sol";
 import "./../patriciaTree/PatriciaTreeProofs.sol";
 import "./../tokenLocking/ITokenLocking.sol";
-
 import "./ColonyExtension.sol";
 
 
-contract VotingReputation is ColonyExtension, DSMath, PatriciaTreeProofs {
+contract VotingReputation is ColonyExtension, PatriciaTreeProofs {
 
   // Events
   event MotionCreated(uint256 indexed motionId, address creator, uint256 indexed domainId);
@@ -92,6 +87,15 @@ contract VotingReputation is ColonyExtension, DSMath, PatriciaTreeProofs {
   uint256 revealPeriod; // Length of time for revealing votes
   uint256 escalationPeriod; // Length of time for escalating after a vote
 
+  // Modifiers
+
+  modifier root() {
+    require(colony.hasUserRole(msg.sender, 1, ColonyDataTypes.ColonyRole.Root), "voting-rep-not-root");
+    _;
+  }
+
+  // Public
+
   /// @notice Returns the identifier of the extension
   function identifier() public override pure returns (bytes32) {
     return keccak256("VotingReputation");
@@ -134,12 +138,8 @@ contract VotingReputation is ColonyExtension, DSMath, PatriciaTreeProofs {
     uint256 _escalationPeriod
   )
     public
+    root
   {
-    require(
-      colony.hasUserRole(msg.sender, 1, ColonyDataTypes.ColonyRole.Root),
-      "voting-rep-user-not-root"
-    );
-
     require(state == ExtensionState.Deployed, "voting-rep-already-initialised");
 
     require(_totalStakeFraction <= WAD / 2, "voting-rep-greater-than-half-wad");

--- a/contracts/extensions/VotingReputation.sol
+++ b/contracts/extensions/VotingReputation.sol
@@ -89,8 +89,8 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs {
 
   // Modifiers
 
-  modifier root() {
-    require(colony.hasUserRole(msg.sender, 1, ColonyDataTypes.ColonyRole.Root), "voting-rep-not-root");
+  modifier onlyRoot() {
+    require(colony.hasUserRole(msg.sender, 1, ColonyDataTypes.ColonyRole.Root), "voting-rep-caller-not-root");
     _;
   }
 
@@ -138,7 +138,7 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs {
     uint256 _escalationPeriod
   )
     public
-    root
+    onlyRoot
   {
     require(state == ExtensionState.Deployed, "voting-rep-already-initialised");
 

--- a/contracts/testHelpers/RequireExecuteCall.sol
+++ b/contracts/testHelpers/RequireExecuteCall.sol
@@ -1,0 +1,28 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity 0.7.3;
+pragma experimental ABIEncoderV2;
+
+
+contract RequireExecuteCall {
+  function executeCall(address target, bytes memory action) public {
+    bool success;
+    assembly { success := call(gas(), target, 0, add(action, 0x20), mload(action), 0, 0) }
+    require(success, "transaction-failed");
+  }
+}

--- a/contracts/testHelpers/TestExtensions.sol
+++ b/contracts/testHelpers/TestExtensions.sol
@@ -22,10 +22,6 @@ import "../extensions/ColonyExtension.sol";
 
 
 abstract contract TestExtension is ColonyExtension {
-  function identifier() public override pure returns (bytes32) {
-    return keccak256("TestExtension");
-  }
-
   function install(address _colony) public override auth {
     require(address(colony) == address(0x0), "extension-already-installed");
 
@@ -45,11 +41,13 @@ abstract contract TestExtension is ColonyExtension {
 
 
 contract TestExtension0 is TestExtension {
+  function identifier() public override pure returns (bytes32) { return keccak256("TestExtension"); }
   function version() public override pure returns (uint256) { return 0; }
 }
 
 
 contract TestExtension1 is TestExtension {
+  function identifier() public override pure returns (bytes32) { return keccak256("TestExtension"); }
   function version() public pure override returns (uint256) { return 1; }
   function receiveEther() external payable {} // solhint-disable-line no-empty-blocks
   function foo() public notDeprecated {} // solhint-disable-line no-empty-blocks
@@ -57,10 +55,32 @@ contract TestExtension1 is TestExtension {
 
 
 contract TestExtension2 is TestExtension {
+  function identifier() public override pure returns (bytes32) { return keccak256("TestExtension"); }
   function version() public pure override returns (uint256) { return 2; }
 }
 
 
 contract TestExtension3 is TestExtension {
+  function identifier() public override pure returns (bytes32) { return keccak256("TestExtension"); }
   function version() public pure override returns (uint256) { return 3; }
+}
+
+contract TestVotingReputation is TestExtension {
+  function identifier() public pure override returns (bytes32) { return keccak256("VotingReputation"); }
+  function version() public pure override returns (uint256) { return 1; }
+  function executeCall(address target, bytes memory action) public {
+    bool success;
+    assembly { success := call(gas(), target, 0, add(action, 0x20), mload(action), 0, 0) }
+    require(success, "transaction-failed");
+  }
+}
+
+contract TestVotingHybrid is TestExtension {
+  function identifier() public pure override returns (bytes32) { return keccak256("VotingHybrid"); }
+  function version() public pure override returns (uint256) { return 1; }
+  function executeCall(address target, bytes memory action) public {
+    bool success;
+    assembly { success := call(gas(), target, 0, add(action, 0x20), mload(action), 0, 0) }
+    require(success, "transaction-failed");
+  }
 }

--- a/scripts/check-recovery.js
+++ b/scripts/check-recovery.js
@@ -65,6 +65,7 @@ walkSync("./contracts/").forEach((contractName) => {
       "contracts/testHelpers/FunctionsNotAvailableOnColony.sol",
       "contracts/testHelpers/TestExtensions.sol",
       "contracts/testHelpers/TransferTest.sol",
+      "contracts/testHelpers/RequireExecuteCall.sol",
       "contracts/tokenLocking/ITokenLocking.sol",
       "contracts/tokenLocking/TokenLocking.sol",
       "contracts/tokenLocking/TokenLockingStorage.sol",

--- a/scripts/check-recovery.js
+++ b/scripts/check-recovery.js
@@ -43,6 +43,7 @@ walkSync("./contracts/").forEach((contractName) => {
       "contracts/extensions/FundingQueue.sol",
       "contracts/extensions/ColonyExtension.sol",
       "contracts/extensions/OneTxPayment.sol",
+      "contracts/extensions/TokenSupplier.sol",
       "contracts/extensions/VotingReputation.sol",
       "contracts/gnosis/MultiSigWallet.sol",
       "contracts/patriciaTree/Bits.sol",

--- a/scripts/check-storage.js
+++ b/scripts/check-storage.js
@@ -28,6 +28,7 @@ walkSync("./contracts/").forEach((contractName) => {
       "contracts/extensions/FundingQueue.sol",
       "contracts/extensions/ColonyExtension.sol",
       "contracts/extensions/OneTxPayment.sol",
+      "contracts/extensions/TokenSupplier.sol",
       "contracts/extensions/VotingReputation.sol",
       "contracts/gnosis/MultiSigWallet.sol", // Not directly used by any colony contracts
       "contracts/patriciaTree/PatriciaTreeBase.sol", // Only used by mining clients

--- a/test/extensions/coin-machine.js
+++ b/test/extensions/coin-machine.js
@@ -132,7 +132,7 @@ contract("Coin Machine", (accounts) => {
     });
 
     it("cannot initialise if not root", async () => {
-      await checkErrorRevert(coinMachine.initialise(purchaseToken.address, 60, 511, 10, 10, 0, { from: USER1 }), "coin-machine-not-root");
+      await checkErrorRevert(coinMachine.initialise(purchaseToken.address, 60, 511, 10, 10, 0, { from: USER1 }), "coin-machine-caller-not-root");
     });
   });
 

--- a/test/extensions/token-supplier.js
+++ b/test/extensions/token-supplier.js
@@ -211,7 +211,7 @@ contract("Token Supplier", (accounts) => {
       const balancePost = await token.balanceOf(colony.address);
       expect(balancePost.sub(balancePre)).to.eq.BN(WAD);
 
-      const tokenSupply = await tokenSupplier.tokenSupply();
+      const tokenSupply = await token.totalSupply();
       expect(tokenSupply).to.eq.BN(WAD);
     });
 
@@ -226,7 +226,7 @@ contract("Token Supplier", (accounts) => {
       const balancePost = await token.balanceOf(colony.address);
       expect(balancePost.sub(balancePre)).to.eq.BN(SUPPLY_CEILING);
 
-      const tokenSupply = await tokenSupplier.tokenSupply();
+      const tokenSupply = await token.totalSupply();
       expect(tokenSupply).to.eq.BN(SUPPLY_CEILING);
 
       await checkErrorRevert(tokenSupplier.issueTokens(), "token-supplier-nothing-to-issue");

--- a/test/extensions/token-supplier.js
+++ b/test/extensions/token-supplier.js
@@ -287,5 +287,18 @@ contract("Token Supplier", (accounts) => {
       const tokenSupply = await token.totalSupply();
       expect(tokenSupply).to.eq.BN(SUPPLY_CEILING);
     });
+
+    it("can claim no tokens if the supply is larger than the ceiling", async () => {
+      token.mint(SUPPLY_CEILING.addn(1));
+
+      const balancePre = await token.balanceOf(colony.address);
+
+      await forwardTime(SECONDS_PER_DAY, this);
+
+      await tokenSupplier.issueTokens();
+
+      const balancePost = await token.balanceOf(colony.address);
+      expect(balancePost.sub(balancePre)).to.be.zero;
+    });
   });
 });

--- a/test/extensions/token-supplier.js
+++ b/test/extensions/token-supplier.js
@@ -3,15 +3,20 @@
 import BN from "bn.js";
 import chai from "chai";
 import bnChai from "bn-chai";
+import { soliditySha3 } from "web3-utils";
 
 import { WAD, SECONDS_PER_DAY } from "../../helpers/constants";
 import { checkErrorRevert, currentBlockTime, makeTxAtTimestamp } from "../../helpers/test-helper";
-import { setupColonyNetwork, setupRandomColony } from "../../helpers/test-data-generator";
+import { setupColonyNetwork, setupRandomColony, setupMetaColonyWithLockedCLNYToken } from "../../helpers/test-data-generator";
+import { setupEtherRouter } from "../../helpers/upgradable-contracts";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
 
 const TokenSupplier = artifacts.require("TokenSupplier");
+const Resolver = artifacts.require("Resolver");
+
+const TOKEN_SUPPLIER = soliditySha3("TokenSupplier");
 
 contract("Token Supplier", (accounts) => {
   let colony;
@@ -27,16 +32,46 @@ contract("Token Supplier", (accounts) => {
 
   before(async () => {
     colonyNetwork = await setupColonyNetwork();
+    const { metaColony } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork);
+
+    const tokenSupplierImplementation = await TokenSupplier.new();
+    const resolver = await Resolver.new();
+    await setupEtherRouter("TokenSupplier", { TokenSupplier: tokenSupplierImplementation.address }, resolver);
+    await metaColony.addExtensionToNetwork(TOKEN_SUPPLIER, resolver.address);
   });
 
   beforeEach(async () => {
     ({ colony, token } = await setupRandomColony(colonyNetwork));
+    await colony.installExtension(TOKEN_SUPPLIER, 1);
 
-    tokenSupplier = await TokenSupplier.new(colony.address);
+    const tokenSupplierAddress = await colonyNetwork.getExtensionInstallation(TOKEN_SUPPLIER, colony.address);
+    tokenSupplier = await TokenSupplier.at(tokenSupplierAddress);
+
     await colony.setRootRole(tokenSupplier.address, true);
   });
 
   describe("managing the extension", async () => {
+    it("can install the extension manually", async () => {
+      tokenSupplier = await TokenSupplier.new();
+      await tokenSupplier.install(colony.address);
+
+      await checkErrorRevert(tokenSupplier.install(colony.address), "extension-already-installed");
+
+      await tokenSupplier.finishUpgrade();
+      await tokenSupplier.deprecate(true);
+      await tokenSupplier.uninstall();
+    });
+
+    it("can install the extension with the extension manager", async () => {
+      ({ colony } = await setupRandomColony(colonyNetwork));
+      await colony.installExtension(TOKEN_SUPPLIER, 1, { from: USER0 });
+
+      await checkErrorRevert(colony.installExtension(TOKEN_SUPPLIER, 1, { from: USER0 }), "colony-network-extension-already-installed");
+      await checkErrorRevert(colony.uninstallExtension(TOKEN_SUPPLIER, { from: USER1 }), "ds-auth-unauthorized");
+
+      await colony.uninstallExtension(TOKEN_SUPPLIER, { from: USER0 });
+    });
+
     it("can initialise", async () => {
       await tokenSupplier.initialise(SUPPLY_CEILING, WAD, { from: USER0 });
     });
@@ -47,7 +82,11 @@ contract("Token Supplier", (accounts) => {
     });
 
     it("cannot initialise if not owner", async () => {
-      await checkErrorRevert(tokenSupplier.initialise(SUPPLY_CEILING, WAD, { from: USER1 }), "ds-auth-unauthorized");
+      await checkErrorRevert(tokenSupplier.initialise(SUPPLY_CEILING, WAD, { from: USER1 }), "token-supplier-not-root");
+    });
+
+    it("cannot issues tokens if not initialised", async () => {
+      await checkErrorRevert(tokenSupplier.issueTokens(), "token-supplier-not-initialised");
     });
 
     it("can update the tokenSupplyCeiling if root", async () => {

--- a/test/extensions/token-supplier.js
+++ b/test/extensions/token-supplier.js
@@ -1,0 +1,109 @@
+/* globals artifacts */
+
+import BN from "bn.js";
+import chai from "chai";
+import bnChai from "bn-chai";
+
+import { WAD, SECONDS_PER_DAY } from "../../helpers/constants";
+import { checkErrorRevert, currentBlockTime, makeTxAtTimestamp } from "../../helpers/test-helper";
+import { setupColonyNetwork, setupRandomColony } from "../../helpers/test-data-generator";
+
+const { expect } = chai;
+chai.use(bnChai(web3.utils.BN));
+
+const TokenSupplier = artifacts.require("TokenSupplier");
+
+contract("Token Supplier", (accounts) => {
+  let colony;
+  let token;
+  let colonyNetwork;
+
+  let tokenSupplier;
+
+  const USER0 = accounts[0];
+  const USER1 = accounts[1];
+
+  const SUPPLY_CEILING = WAD.muln(10);
+
+  before(async () => {
+    colonyNetwork = await setupColonyNetwork();
+  });
+
+  beforeEach(async () => {
+    ({ colony, token } = await setupRandomColony(colonyNetwork));
+
+    tokenSupplier = await TokenSupplier.new(colony.address);
+    await colony.setRootRole(tokenSupplier.address, true);
+  });
+
+  describe("managing the extension", async () => {
+    it("can initialise", async () => {
+      await tokenSupplier.initialise(SUPPLY_CEILING, WAD, { from: USER0 });
+    });
+
+    it("cannot initialise twice", async () => {
+      await tokenSupplier.initialise(SUPPLY_CEILING, WAD, { from: USER0 });
+      await checkErrorRevert(tokenSupplier.initialise(SUPPLY_CEILING, WAD), "token-supplier-already-initialised");
+    });
+
+    it("cannot initialise if not owner", async () => {
+      await checkErrorRevert(tokenSupplier.initialise(SUPPLY_CEILING, WAD, { from: USER1 }), "ds-auth-unauthorized");
+    });
+
+    it("can update the tokenSupplyCeiling if root", async () => {
+      await tokenSupplier.setTokenSupplyCeiling(SUPPLY_CEILING.muln(2), { from: USER0 });
+
+      const tokenSupplyCeiling = await tokenSupplier.tokenSupplyCeiling();
+      expect(tokenSupplyCeiling).to.eq.BN(SUPPLY_CEILING.muln(2));
+
+      await checkErrorRevert(tokenSupplier.setTokenSupplyCeiling(SUPPLY_CEILING, { from: USER1 }), "token-supplier-not-root");
+    });
+
+    it("can update the tokenIssuanceRate if root", async () => {
+      await tokenSupplier.setTokenIssuanceRate(WAD.muln(2), { from: USER0 });
+
+      const tokenIssuanceRate = await tokenSupplier.tokenIssuanceRate();
+      expect(tokenIssuanceRate).to.eq.BN(WAD.muln(2));
+
+      await checkErrorRevert(tokenSupplier.setTokenIssuanceRate(WAD, { from: USER1 }), "token-supplier-not-root");
+    });
+  });
+
+  describe("issuing tokens", async () => {
+    beforeEach(async () => {
+      await tokenSupplier.initialise(SUPPLY_CEILING, WAD, { from: USER0 });
+    });
+
+    it("can claim tokenIssuanceRate tokens per day", async () => {
+      const balancePre = await token.balanceOf(colony.address);
+
+      let time = await currentBlockTime();
+      time = new BN(time).addn(SECONDS_PER_DAY);
+
+      await makeTxAtTimestamp(tokenSupplier.issueTokens, [], time.toNumber(), this);
+
+      const balancePost = await token.balanceOf(colony.address);
+      expect(balancePost.sub(balancePre)).to.eq.BN(WAD);
+
+      const tokenSupply = await tokenSupplier.tokenSupply();
+      expect(tokenSupply).to.eq.BN(WAD);
+    });
+
+    it("can claim up to the tokenSupplyCeiling", async () => {
+      const balancePre = await token.balanceOf(colony.address);
+
+      let time = await currentBlockTime();
+      time = new BN(time).addn(SECONDS_PER_DAY * 10);
+
+      await makeTxAtTimestamp(tokenSupplier.issueTokens, [], time.toNumber(), this);
+
+      const balancePost = await token.balanceOf(colony.address);
+      expect(balancePost.sub(balancePre)).to.eq.BN(SUPPLY_CEILING);
+
+      const tokenSupply = await tokenSupplier.tokenSupply();
+      expect(tokenSupply).to.eq.BN(SUPPLY_CEILING);
+
+      await checkErrorRevert(tokenSupplier.issueTokens(), "token-supplier-nothing-to-issue");
+    });
+  });
+});

--- a/test/extensions/token-supplier.js
+++ b/test/extensions/token-supplier.js
@@ -122,10 +122,12 @@ contract("Token Supplier", (accounts) => {
 
       // Cannot set if not a network-managed extension
       const unofficialVotingHybrid = await VotingHybrid.new(colony.address);
+      await colony.setRootRole(unofficialVotingHybrid.address, true);
       await checkErrorRevert(unofficialVotingHybrid.executeCall(tokenSupplier.address, action), "transaction-failed");
 
       // Cannot set if the caller does not implement `identifier()`
       const requireExecuteCall = await RequireExecuteCall.new();
+      await colony.setRootRole(requireExecuteCall.address, true);
       await checkErrorRevert(requireExecuteCall.executeCall(tokenSupplier.address, action), "transaction-failed");
 
       // Cannot set if not VotingHybrid
@@ -153,10 +155,12 @@ contract("Token Supplier", (accounts) => {
 
       // Cannot set if not a network-managed extension
       const unofficialVotingHybrid = await VotingHybrid.new(colony.address);
+      await colony.setRootRole(unofficialVotingHybrid.address, true);
       await checkErrorRevert(unofficialVotingHybrid.executeCall(tokenSupplier.address, action), "transaction-failed");
 
       // Cannot set if the caller does not implement `identifier()`
       const requireExecuteCall = await RequireExecuteCall.new();
+      await colony.setRootRole(requireExecuteCall.address, true);
       await checkErrorRevert(requireExecuteCall.executeCall(tokenSupplier.address, action), "transaction-failed");
     });
 

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -291,7 +291,7 @@ contract("Voting Reputation", (accounts) => {
 
     it("cannot initialise twice or if not root", async () => {
       await checkErrorRevert(voting.initialise(HALF, HALF, WAD, WAD, YEAR, YEAR, YEAR, YEAR), "voting-rep-already-initialised");
-      await checkErrorRevert(voting.initialise(HALF, HALF, WAD, WAD, YEAR, YEAR, YEAR, YEAR, { from: USER2 }), "voting-rep-user-not-root");
+      await checkErrorRevert(voting.initialise(HALF, HALF, WAD, WAD, YEAR, YEAR, YEAR, YEAR, { from: USER2 }), "voting-rep-not-root");
     });
 
     it("cannot initialise with invalid values", async () => {

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -291,7 +291,7 @@ contract("Voting Reputation", (accounts) => {
 
     it("cannot initialise twice or if not root", async () => {
       await checkErrorRevert(voting.initialise(HALF, HALF, WAD, WAD, YEAR, YEAR, YEAR, YEAR), "voting-rep-already-initialised");
-      await checkErrorRevert(voting.initialise(HALF, HALF, WAD, WAD, YEAR, YEAR, YEAR, YEAR, { from: USER2 }), "voting-rep-not-root");
+      await checkErrorRevert(voting.initialise(HALF, HALF, WAD, WAD, YEAR, YEAR, YEAR, YEAR, { from: USER2 }), "voting-rep-caller-not-root");
     });
 
     it("cannot initialise with invalid values", async () => {


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #25 
Depends on #876 for the extension identifier lookup.

<!--- Summary of changes including design decisions -->

Simple extension to manage a colony's token supply. Allows root users to call `setTokenSupplyCeiling` and `setTokenIssuanceRate`, most likely via a Voting extension.

This PR also includes a mild refactor of the `ColonyExtension` to include more shared functionality.

```
3.5.1 Token management

While root users can mint tokens at-will, in many cases it will be desirable to mediate this ability
via an extension contract. Here we describe such an extension.
Token generation and initial supply

When the extension is deployed, the TokenSupplyCeiling and the TokenIssuanceRate are set.
The former is the total number of colony tokens that will be created and the latter is the rate at
which they become available to the root domain to assign to subdomains or expenditures. The
number of tokens available to the root domain can be updated at any time by a transaction from
any user (i.e. a public function will determine the pro-rated amount of tokens to generate since the
last distribution).

Increasing the TokenSupplyCeiling

It is advised that new tokens not be generated without widespread consensus — especially if tokens
have a financial value. Consequently, such decisions require a vote with high quorum and majority
requirements involving both the token holders and reputation holders.

Changing the TokenIssuanceRate

The TokenSupplyCeiling represents the total number of tokens that the token holders have granted
to the colony in order to conduct business: to fund domains and expenditures, and to incentivize
workers and contributors.

The TokenIssuanceRate controls how rapidly the colony receives the new tokens. If the rate
is ‘too high’, tokens will accumulate in the funding pot of the root domain (or other funding pots
lower in the hierarchy). If the rate is too low, this signals that the colony has a healthy amount of
activity and that the issuance rate has become a bottleneck. In such situations it may be desirable
to increase the rate of issuance without necessarily increasing the maximum supply.
Increasing and decreasing the TokenIssuanceRate by up to 10% can be done by the reputation
holders alone and this action can be taken no more than once every 4 weeks. Larger changes to the
issuance rate should additionally require the agreement of existing token holders.
```
