### PR TITLE
Add support for arbitrary transactions

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -56,7 +56,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     require(sig != APPROVE_SIG, "colony-cannot-call-erc20-approve");
     require(sig != TRANSFER_SIG, "colony-cannot-call-erc20-transfer");
 
-    // Prevent transactions to network-managed extensions
+    // Prevent transactions to network-managed extensions installed in this colony
     try ColonyExtension(_to).identifier() returns (bytes32 extensionId) {
       require(
         IColonyNetwork(colonyNetworkAddress).getExtensionInstallation(extensionId, address(this)) != _to,

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -37,8 +37,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     return token;
   }
 
+  bytes4 constant APPROVE_SIG = bytes4(keccak256("approve(address,uint256)"));
   bytes4 constant TRANSFER_SIG = bytes4(keccak256("transfer(address,uint256)"));
-  bytes4 constant TRANSFER_FROM_SIG = bytes4(keccak256("transferFrom(address,address,uint256)"));
 
   function makeArbitraryTransaction(address _to, uint256 _value, bytes memory _action)
   public stoppable auth
@@ -50,8 +50,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     bytes4 sig;
     assembly { sig := mload(add(_action, 0x20)) }
 
+    require(sig != APPROVE_SIG, "colony-cannot-call-erc20-approve");
     require(sig != TRANSFER_SIG, "colony-cannot-call-erc20-transfer");
-    require(sig != TRANSFER_FROM_SIG, "colony-cannot-call-erc20-transfer-from");
 
     return executeCall(_to, _value, _action);
   }

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -41,7 +41,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   bytes4 constant APPROVE_SIG = bytes4(keccak256("approve(address,uint256)"));
   bytes4 constant TRANSFER_SIG = bytes4(keccak256("transfer(address,uint256)"));
 
-  function makeArbitraryTransaction(address _to, uint256 _value, bytes memory _action)
+  function makeArbitraryTransaction(address _to, bytes memory _action)
   public stoppable auth
   returns (bool)
   {
@@ -64,7 +64,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
       );
     } catch {}
 
-    return executeCall(_to, _value, _action);
+    return executeCall(_to, 0, _action);
   }
 
   function emitDomainReputationPenalty(
@@ -369,7 +369,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Architecture), address(this), sig, true);
 
     // Add arbitrary tx functionality
-    sig = bytes4(keccak256("makeArbitraryTransaction(address,uint256,bytes)"));
+    sig = bytes4(keccak256("makeArbitraryTransaction(address,bytes)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
   }
 

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -45,6 +45,11 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   public stoppable auth
   returns (bool)
   {
+    // Ensure _to is a contract
+    uint256 size;
+    assembly { size := extcodesize(_to) }
+    require(size > 0, "colony-to-must-be-contract");
+
     // Prevent transactions to network contracts
     require(_to != colonyNetworkAddress, "colony-cannot-target-network");
     require(_to != tokenLockingAddress, "colony-cannot-target-token-locking");

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -95,7 +95,7 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ROOT_ROLE, "upgradeExtension(bytes32,uint256)");
     addRoleCapability(ROOT_ROLE, "deprecateExtension(bytes32,bool)");
     addRoleCapability(ROOT_ROLE, "uninstallExtension(bytes32)");
-    addRoleCapability(ROOT_ROLE, "makeArbitraryTransaction(address,uint256,bytes)");
+    addRoleCapability(ROOT_ROLE, "makeArbitraryTransaction(address,bytes)");
     addRoleCapability(ARBITRATION_ROLE, "transferStake(uint256,uint256,address,address,uint256,uint256,address)");
     addRoleCapability(ARBITRATION_ROLE, "emitDomainReputationPenalty(uint256,uint256,uint256,address,int256)");
     addRoleCapability(ARBITRATION_ROLE, "emitSkillReputationPenalty(uint256,address,int256)");

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -95,6 +95,7 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ROOT_ROLE, "upgradeExtension(bytes32,uint256)");
     addRoleCapability(ROOT_ROLE, "deprecateExtension(bytes32,bool)");
     addRoleCapability(ROOT_ROLE, "uninstallExtension(bytes32)");
+    addRoleCapability(ROOT_ROLE, "makeArbitraryTransaction(address,uint256,bytes)");
     addRoleCapability(ARBITRATION_ROLE, "transferStake(uint256,uint256,address,address,uint256,uint256,address)");
     addRoleCapability(ARBITRATION_ROLE, "emitDomainReputationPenalty(uint256,uint256,uint256,address,int256)");
     addRoleCapability(ARBITRATION_ROLE, "emitSkillReputationPenalty(uint256,address,int256)");

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -253,4 +253,15 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, ColonyNetworkDataTypes
   function domainExists(uint256 domainId) internal view returns (bool) {
     return domainId > 0 && domainId <= domainCount;
   }
+
+  function executeCall(address to, uint256 value, bytes memory data) internal returns (bool success) {
+    assembly {
+              // call contract at address a with input mem[in…(in+insize))
+              //   providing g gas and v wei and output area mem[out…(out+outsize))
+              //   returning 0 on error (eg. out of gas) and 1 on success
+
+              // call(g,     a,  v,     in,              insize,      out, outsize)
+      success := call(gas(), to, value, add(data, 0x20), mload(data), 0, 0)
+    }
+  }
 }

--- a/contracts/colony/ColonyTask.sol
+++ b/contracts/colony/ColonyTask.sol
@@ -536,17 +536,6 @@ contract ColonyTask is ColonyStorage {
     return reviewerAddresses;
   }
 
-<<<<<<< HEAD
-  // The address.call() syntax is no longer recommended, see:
-  // https://github.com/ethereum/solidity/issues/2884
-  function executeCall(address to, uint256 value, bytes memory data) internal returns (bool success) {
-    assembly {
-      success := call(gas(), to, value, add(data, 0x20), mload(data), 0, 0)
-      }
-  }
-
-=======
->>>>>>> Add support for arbitrary transactions
   // Get the function signature and task id from the transaction bytes data
   // Note: Relies on the encoded function's first parameter to be the uint256 taskId
   function deconstructCall(bytes memory _data) internal pure returns (bytes4 sig, uint256 taskId) {

--- a/contracts/colony/ColonyTask.sol
+++ b/contracts/colony/ColonyTask.sol
@@ -536,6 +536,7 @@ contract ColonyTask is ColonyStorage {
     return reviewerAddresses;
   }
 
+<<<<<<< HEAD
   // The address.call() syntax is no longer recommended, see:
   // https://github.com/ethereum/solidity/issues/2884
   function executeCall(address to, uint256 value, bytes memory data) internal returns (bool success) {
@@ -544,6 +545,8 @@ contract ColonyTask is ColonyStorage {
       }
   }
 
+=======
+>>>>>>> Add support for arbitrary transactions
   // Get the function signature and task id from the transaction bytes data
   // Note: Relies on the encoded function's first parameter to be the uint256 taskId
   function deconstructCall(bytes memory _data) internal pure returns (bytes4 sig, uint256 taskId) {

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -60,6 +60,13 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @return tokenAddress Address of the token contract
   function getToken() external view returns (address tokenAddress);
 
+  /// @notice Execute arbitrary transaction on behalf of the Colony
+  /// @param _to Contract to receive the function call (cannot be network or token locking)
+  /// @param _value Value in wei to inclue with the transaction
+  /// @param _action Bytes array encoding the function call and arguments
+  /// @return success Boolean indicating whether the transaction succeeded
+  function makeArbitraryTransaction(address _to, uint256 _value, bytes memory _action) public returns (bool success);
+
   /// @notice Set new colony root role.
   /// Can be called by root role only.
   /// @param _user User we want to give an root role to

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -64,7 +64,7 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _to Contract to receive the function call (cannot be network or token locking)
   /// @param _action Bytes array encoding the function call and arguments
   /// @return success Boolean indicating whether the transaction succeeded
-  function makeArbitraryTransaction(address _to, bytes memory _action) public returns (bool success);
+  function makeArbitraryTransaction(address _to, bytes memory _action) external returns (bool success);
 
   /// @notice Set new colony root role.
   /// Can be called by root role only.

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -62,10 +62,9 @@ interface IColony is ColonyDataTypes, IRecovery {
 
   /// @notice Execute arbitrary transaction on behalf of the Colony
   /// @param _to Contract to receive the function call (cannot be network or token locking)
-  /// @param _value Value in wei to inclue with the transaction
   /// @param _action Bytes array encoding the function call and arguments
   /// @return success Boolean indicating whether the transaction succeeded
-  function makeArbitraryTransaction(address _to, uint256 _value, bytes memory _action) public returns (bool success);
+  function makeArbitraryTransaction(address _to, bytes memory _action) public returns (bool success);
 
   /// @notice Set new colony root role.
   /// Can be called by root role only.

--- a/contracts/colonyNetwork/ColonyNetworkExtensions.sol
+++ b/contracts/colonyNetwork/ColonyNetworkExtensions.sol
@@ -35,6 +35,9 @@ contract ColonyNetworkExtensions is ColonyNetworkStorage {
   {
     require(_resolver != address(0x0), "colony-network-extension-bad-resolver");
 
+    bytes32 extensionId = getExtensionId(_resolver);
+    require(_extensionId == extensionId, "colony-network-extension-bad-identifier");
+
     uint256 version = getResolverVersion(_resolver);
     require(resolvers[_extensionId][version] == address(0x0), "colony-network-extension-already-set");
     require(
@@ -125,6 +128,13 @@ contract ColonyNetworkExtensions is ColonyNetworkStorage {
   }
 
   // Internal functions
+
+  bytes4 constant IDENTIFIER_SIG = bytes4(keccak256("identifier()"));
+
+  function getExtensionId(address _resolver) internal returns (bytes32) {
+    address extension = Resolver(_resolver).lookup(IDENTIFIER_SIG);
+    return ColonyExtension(extension).identifier();
+  }
 
   bytes4 constant VERSION_SIG = bytes4(keccak256("version()"));
 

--- a/contracts/extensions/CoinMachine.sol
+++ b/contracts/extensions/CoinMachine.sol
@@ -55,6 +55,11 @@ contract CoinMachine is DSMath, ColonyExtension {
 
   // Public
 
+  /// @notice Returns the identifier of the extension
+  function identifier() public override pure returns (bytes32) {
+    return keccak256("CoinMachine");
+  }
+
   /// @notice Returns the version of the extension
   function version() public override pure returns (uint256) {
     return 1;

--- a/contracts/extensions/ColonyExtension.sol
+++ b/contracts/extensions/ColonyExtension.sol
@@ -32,6 +32,7 @@ abstract contract ColonyExtension is DSAuth {
     _;
   }
 
+  function identifier() public pure virtual returns (bytes32);
   function version() public pure virtual returns (uint256);
   function install(address _colony) public virtual;
   function finishUpgrade() public virtual;

--- a/contracts/extensions/FundingQueue.sol
+++ b/contracts/extensions/FundingQueue.sol
@@ -77,6 +77,12 @@ contract FundingQueue is ColonyExtension, DSMath, PatriciaTreeProofs {
   mapping (uint256 => uint256) queue; // proposalId => nextProposalId
 
   // Public functions
+
+  /// @notice Returns the identifier of the extension
+  function identifier() public override pure returns (bytes32) {
+    return keccak256("FundingQueue");
+  }
+
   /// @notice Returns the version of the extension
   function version() public override pure returns (uint256) {
     return 1;

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -29,6 +29,11 @@ contract OneTxPayment is ColonyExtension, DSMath {
   ColonyDataTypes.ColonyRole constant ADMINISTRATION = ColonyDataTypes.ColonyRole.Administration;
   ColonyDataTypes.ColonyRole constant FUNDING = ColonyDataTypes.ColonyRole.Funding;
 
+  /// @notice Returns the identifier of the extension
+  function identifier() public override pure returns (bytes32) {
+    return keccak256("OneTxPayment");
+  }
+
   /// @notice Returns the version of the extension
   function version() public override pure returns (uint256) {
     return 1;

--- a/contracts/extensions/VotingReputation.sol
+++ b/contracts/extensions/VotingReputation.sol
@@ -93,6 +93,11 @@ contract VotingReputation is ColonyExtension, DSMath, PatriciaTreeProofs {
   uint256 revealPeriod; // Length of time for revealing votes
   uint256 escalationPeriod; // Length of time for escalating after a vote
 
+  /// @notice Returns the identifier of the extension
+  function identifier() public override pure returns (bytes32) {
+    return keccak256("VotingReputation");
+  }
+
   /// @notice Return the version number
   /// @return The version number
   function version() public pure override returns (uint256) {

--- a/contracts/testHelpers/TestExtensions.sol
+++ b/contracts/testHelpers/TestExtensions.sol
@@ -22,6 +22,10 @@ import "../extensions/ColonyExtension.sol";
 
 
 abstract contract TestExtension is ColonyExtension {
+  function identifier() public override pure returns (bytes32) {
+    return keccak256("TestExtension");
+  }
+
   function install(address _colony) public override auth {
     require(address(colony) == address(0x0), "extension-already-installed");
 

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -907,6 +907,25 @@ Install an extension to the colony. Secured function to authorised members.
 |version|uint256|The new extension version to install
 
 
+### `makeArbitraryTransaction`
+
+Execute arbitrary transaction on behalf of the Colony
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_to|address|Contract to receive the function call (cannot be network or token locking)
+|_value|uint256|Value in wei to inclue with the transaction
+|_action|bytes|Bytes array encoding the function call and arguments
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|success|bool|Boolean indicating whether the transaction succeeded
+
 ### `makeExpenditure`
 
 Add a new expenditure in the colony. Secured function to authorised members.

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -917,7 +917,6 @@ Execute arbitrary transaction on behalf of the Colony
 |Name|Type|Description|
 |---|---|---|
 |_to|address|Contract to receive the function call (cannot be network or token locking)
-|_value|uint256|Value in wei to inclue with the transaction
 |_action|bytes|Bytes array encoding the function call and arguments
 
 **Return Parameters**

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -153,11 +153,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("d74a226d8ca1bd524548860759ed53c3ada38aba89fe2e9f33e9cbc65146585f");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("344ecc02bf9adc343db72750d1aa1957b70eba28aa16b7feb22555ec4d26030c");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("f54806d4c084ce6051d732e2a853f87da96e5d747f3ed9c0daf6024194df6f51");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("6e06f76ad3caff1649fad8e2ae3f42eef7bb9c55dab13e6514d45ec65864993f");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("27ec15478ee91943b5d98205085f20fa7255f4b77747931fbf488c5d0d0bfbaa");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("2db6495013c230cadab7dfe0557305f1d65a0de772375d06dd63ecdb58b5d709");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("3183c6269d0f20f9e9d19f28332674ca929b19121a8504c19d4fb0a392950d1c");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("dde1dd7452e9f4037ab8eb491a9e95e6a81a8e0a17c1a8e59b40c1b67086fe43");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("5a5d76a9bb4a761f4cbd0da4b729bd8143efd7ffe0f42daff9ac5381cb5e9524");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("ed2f5717a69310d3cb20cfdcbcf44ed53111731fa783752e492d949bbc92fe9b");
     });
   });
 });

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -29,7 +29,7 @@ const ITokenLocking = artifacts.require("ITokenLocking");
 const TransferTest = artifacts.require("TransferTest");
 const Token = artifacts.require("Token");
 
-contract("Colony", (accounts) => {
+contract.only("Colony", (accounts) => {
   let colony;
   let token;
   let colonyNetwork;
@@ -127,7 +127,7 @@ contract("Colony", (accounts) => {
       const action = await encodeTxData(token, "mint", [WAD]);
       const balancePre = await token.balanceOf(colony.address);
 
-      await colony.makeArbitraryTransaction(token.address, 0, action);
+      await colony.makeArbitraryTransaction(token.address, action);
 
       const balancePost = await token.balanceOf(colony.address);
       expect(balancePost.sub(balancePre)).to.eq.BN(WAD);
@@ -136,7 +136,7 @@ contract("Colony", (accounts) => {
     it("should not be able to make arbitrary transactions if not root", async () => {
       const action = await encodeTxData(token, "mint", [WAD]);
 
-      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, 0, action, { from: accounts[1] }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action, { from: accounts[1] }), "ds-auth-unauthorized");
     });
 
     it("should not be able to make arbitrary transactions to network or token locking", async () => {
@@ -146,16 +146,16 @@ contract("Colony", (accounts) => {
       const action1 = await encodeTxData(colonyNetwork, "addSkill", [0]);
       const action2 = await encodeTxData(tokenLocking, "lockToken", [token.address]);
 
-      await checkErrorRevert(colony.makeArbitraryTransaction(colonyNetwork.address, 0, action1), "colony-cannot-target-network");
-      await checkErrorRevert(colony.makeArbitraryTransaction(tokenLocking.address, 0, action2), "colony-cannot-target-token-locking");
+      await checkErrorRevert(colony.makeArbitraryTransaction(colonyNetwork.address, action1), "colony-cannot-target-network");
+      await checkErrorRevert(colony.makeArbitraryTransaction(tokenLocking.address, action2), "colony-cannot-target-token-locking");
     });
 
     it("should not be able to make arbitrary transactions to transfer tokens", async () => {
       const action1 = await encodeTxData(token, "approve", [USER0, WAD]);
       const action2 = await encodeTxData(token, "transfer", [USER0, WAD]);
 
-      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, 0, action1), "colony-cannot-call-erc20-approve");
-      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, 0, action2), "colony-cannot-call-erc20-transfer");
+      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action1), "colony-cannot-call-erc20-approve");
+      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action2), "colony-cannot-call-erc20-transfer");
     });
 
     it("should not be able to make arbitrary transactions to the colony's own extensions", async () => {
@@ -168,11 +168,11 @@ contract("Colony", (accounts) => {
 
       const action = await encodeTxData(coinMachine, "buyTokens", [WAD]);
 
-      await checkErrorRevert(colony.makeArbitraryTransaction(coinMachine.address, 0, action), "colony-cannot-target-extensions");
+      await checkErrorRevert(colony.makeArbitraryTransaction(coinMachine.address, action), "colony-cannot-target-extensions");
 
       // But other colonies can
       const { colony: otherColony } = await setupRandomColony(colonyNetwork);
-      await otherColony.makeArbitraryTransaction(coinMachine.address, 0, action);
+      await otherColony.makeArbitraryTransaction(coinMachine.address, action);
     });
 
     it("should let funding pot information be read", async () => {

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -14,13 +14,14 @@ import {
   RATING_2_SECRET,
   WAD,
 } from "../../helpers/constants";
-import { getTokenArgs, web3GetBalance, checkErrorRevert, expectAllEvents } from "../../helpers/test-helper";
+import { getTokenArgs, web3GetBalance, checkErrorRevert, encodeTxData, expectAllEvents } from "../../helpers/test-helper";
 import { makeTask, setupRandomColony } from "../../helpers/test-data-generator";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
 
 const Token = artifacts.require("Token");
+const ITokenLocking = artifacts.require("ITokenLocking");
 const IReputationMiningCycle = artifacts.require("IReputationMiningCycle");
 const TransferTest = artifacts.require("TransferTest");
 const EtherRouter = artifacts.require("EtherRouter");
@@ -30,6 +31,8 @@ contract("Colony", (accounts) => {
   let colony;
   let token;
   let colonyNetwork;
+
+  const USER0 = accounts[0];
 
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
@@ -116,6 +119,41 @@ contract("Colony", (accounts) => {
       // A root skill should have been created for the Colony
       const rootLocalSkillId = await colonyNetwork.getSkillCount();
       expect(domain.skillId).to.eq.BN(rootLocalSkillId);
+    });
+
+    it("should be able to make arbitrary transactions", async () => {
+      const action = await encodeTxData(token, "mint", [WAD]);
+      const balancePre = await token.balanceOf(colony.address);
+
+      await colony.makeArbitraryTransaction(token.address, 0, action);
+
+      const balancePost = await token.balanceOf(colony.address);
+      expect(balancePost.sub(balancePre)).to.eq.BN(WAD);
+    });
+
+    it("should not be able to make arbitrary transactions if not root", async () => {
+      const action = await encodeTxData(token, "mint", [WAD]);
+
+      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, 0, action, { from: accounts[1] }), "ds-auth-unauthorized");
+    });
+
+    it("should not be able to make arbitrary transactions to network or token locking", async () => {
+      const tokenLockingAddress = await colonyNetwork.getTokenLocking();
+      const tokenLocking = await ITokenLocking.at(tokenLockingAddress);
+
+      const action1 = await encodeTxData(colonyNetwork, "addSkill", [0]);
+      const action2 = await encodeTxData(tokenLocking, "lockToken", [token.address]);
+
+      await checkErrorRevert(colony.makeArbitraryTransaction(colonyNetwork.address, 0, action1), "colony-cannot-target-network");
+      await checkErrorRevert(colony.makeArbitraryTransaction(tokenLocking.address, 0, action2), "colony-cannot-target-token-locking");
+    });
+
+    it("should not be able to make arbitrary transactions to transfer tokens", async () => {
+      const action1 = await encodeTxData(token, "transfer", [USER0, WAD]);
+      const action2 = await encodeTxData(token, "transferFrom", [colony.address, USER0, WAD]);
+
+      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, 0, action1), "colony-cannot-call-erc20-transfer");
+      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, 0, action2), "colony-cannot-call-erc20-transfer-from");
     });
 
     it("should let funding pot information be read", async () => {

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -149,11 +149,11 @@ contract("Colony", (accounts) => {
     });
 
     it("should not be able to make arbitrary transactions to transfer tokens", async () => {
-      const action1 = await encodeTxData(token, "transfer", [USER0, WAD]);
-      const action2 = await encodeTxData(token, "transferFrom", [colony.address, USER0, WAD]);
+      const action1 = await encodeTxData(token, "approve", [USER0, WAD]);
+      const action2 = await encodeTxData(token, "transfer", [USER0, WAD]);
 
-      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, 0, action1), "colony-cannot-call-erc20-transfer");
-      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, 0, action2), "colony-cannot-call-erc20-transfer-from");
+      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, 0, action1), "colony-cannot-call-erc20-approve");
+      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, 0, action2), "colony-cannot-call-erc20-transfer");
     });
 
     it("should let funding pot information be read", async () => {

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -139,6 +139,10 @@ contract("Colony", (accounts) => {
       await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action, { from: accounts[1] }), "ds-auth-unauthorized");
     });
 
+    it("should not be able to make arbitrary transactions to a user address", async () => {
+      await checkErrorRevert(colony.makeArbitraryTransaction(accounts[0], "0x0"), "colony-to-must-be-contract");
+    });
+
     it("should not be able to make arbitrary transactions to network or token locking", async () => {
       const tokenLockingAddress = await colonyNetwork.getTokenLocking();
       const tokenLocking = await ITokenLocking.at(tokenLockingAddress);

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -29,7 +29,7 @@ const ITokenLocking = artifacts.require("ITokenLocking");
 const TransferTest = artifacts.require("TransferTest");
 const Token = artifacts.require("Token");
 
-contract.only("Colony", (accounts) => {
+contract("Colony", (accounts) => {
   let colony;
   let token;
   let colonyNetwork;

--- a/test/extensions/coin-machine.js
+++ b/test/extensions/coin-machine.js
@@ -8,7 +8,17 @@ import { soliditySha3 } from "web3-utils";
 
 import { WAD } from "../../helpers/constants";
 import { setupEtherRouter } from "../../helpers/upgradable-contracts";
-import { checkErrorRevert, forwardTime, web3GetBalance, makeTxAtTimestamp, currentBlockTime, forwardTimeTo } from "../../helpers/test-helper";
+
+import {
+  checkErrorRevert,
+  web3GetCode,
+  forwardTime,
+  web3GetBalance,
+  makeTxAtTimestamp,
+  currentBlockTime,
+  forwardTimeTo,
+} from "../../helpers/test-helper";
+
 import {
   setupColonyNetwork,
   setupRandomToken,
@@ -70,9 +80,17 @@ contract("Coin Machine", (accounts) => {
 
       await checkErrorRevert(coinMachine.install(colony.address), "extension-already-installed");
 
+      const identifier = await coinMachine.identifier();
+      const version = await coinMachine.version();
+      expect(identifier).to.equal(COIN_MACHINE);
+      expect(version).to.eq.BN(1);
+
       await coinMachine.finishUpgrade();
       await coinMachine.deprecate(true);
       await coinMachine.uninstall();
+
+      const code = await web3GetCode(coinMachine.address);
+      expect(code).to.equal("0x");
     });
 
     it("can install the extension with the extension manager", async () => {

--- a/test/extensions/funding-queue.js
+++ b/test/extensions/funding-queue.js
@@ -6,7 +6,16 @@ import bnChai from "bn-chai";
 import { soliditySha3 } from "web3-utils";
 
 import { UINT256_MAX, WAD, MINING_CYCLE_DURATION, DEFAULT_STAKE, SECONDS_PER_DAY, SUBMITTER_ONLY_WINDOW } from "../../helpers/constants";
-import { checkErrorRevert, makeReputationKey, makeReputationValue, getActiveRepCycle, forwardTime, getBlockTime } from "../../helpers/test-helper";
+
+import {
+  checkErrorRevert,
+  web3GetCode,
+  makeReputationKey,
+  makeReputationValue,
+  getActiveRepCycle,
+  forwardTime,
+  getBlockTime,
+} from "../../helpers/test-helper";
 
 import {
   setupColonyNetwork,
@@ -154,9 +163,17 @@ contract("Funding Queues", (accounts) => {
 
       await checkErrorRevert(fundingQueue.install(colony.address), "extension-already-installed");
 
+      const identifier = await fundingQueue.identifier();
+      const version = await fundingQueue.version();
+      expect(identifier).to.equal(FUNDING_QUEUE);
+      expect(version).to.eq.BN(1);
+
       await fundingQueue.finishUpgrade();
       await fundingQueue.deprecate(true);
       await fundingQueue.uninstall();
+
+      const code = await web3GetCode(fundingQueue.address);
+      expect(code).to.equal("0x");
     });
 
     it("can install the extension with the extension manager", async () => {

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -65,6 +65,11 @@ contract("One transaction payments", (accounts) => {
 
       await checkErrorRevert(oneTxPayment.install(colony.address), "extension-already-installed");
 
+      const identifier = await oneTxPayment.identifier();
+      const version = await oneTxPayment.version();
+      expect(identifier).to.equal(ONE_TX_PAYMENT);
+      expect(version).to.eq.BN(1);
+
       await oneTxPayment.finishUpgrade();
       await oneTxPayment.deprecate(true);
       await oneTxPayment.uninstall();

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -8,8 +8,10 @@ import { ethers } from "ethers";
 import { soliditySha3 } from "web3-utils";
 
 import { UINT256_MAX, WAD, MINING_CYCLE_DURATION, SECONDS_PER_DAY, DEFAULT_STAKE, SUBMITTER_ONLY_WINDOW } from "../../helpers/constants";
+
 import {
   checkErrorRevert,
+  web3GetCode,
   makeReputationKey,
   makeReputationValue,
   getActiveRepCycle,
@@ -245,9 +247,17 @@ contract("Voting Reputation", (accounts) => {
 
       await checkErrorRevert(voting.install(colony.address), "extension-already-installed");
 
+      const identifier = await voting.identifier();
+      const version = await voting.version();
+      expect(identifier).to.equal(VOTING_REPUTATION);
+      expect(version).to.eq.BN(1);
+
       await voting.finishUpgrade();
       await voting.deprecate(true);
       await voting.uninstall();
+
+      const code = await web3GetCode(voting.address);
+      expect(code).to.equal("0x");
     });
 
     it("can install the extension with the extension manager", async () => {


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #808

~Depends on #881~
~Depends on #870~

<!--- Summary of changes including design decisions -->

Following the discussion in #881 , we will add an `identifier()` function to every extension, which returns its `bytes32` identifier. This can be used to verify that an address is a network-managed extension, allowing us to prevent colonies making arbitrary transactions to these extensions.

