### PR TITLE
Missing ABIEncoderV2 pragma in ColonyStorage

### DIFF
--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -16,6 +16,7 @@
 */
 
 pragma solidity 0.5.8;
+pragma experimental ABIEncoderV2;
 
 import "./../../lib/dappsys/math.sol";
 import "./../common/CommonStorage.sol";


### PR DESCRIPTION
This PR fixes `validGlobalSkill()` modifier which is defined in a file that does not use the `ABIEncoderV2` pragma but calls a function that returns a struct, which is a V2 feature. This should not even compile.

It happens to work only by accident - the compiler is missing a check against it and it happens to be a special case that hits the path in the code where nothing explicitly fails. Specifically, all the files where the modifier is used do use `ABIEncoderV2` and the compiler (erroneously) assumes that the user wanted it enabled for the modifier definition too. In many other cases this just causes Internal Compiler Error instead. See https://github.com/ethereum/solidity/issues/8379 for details.

I'm currently working on adding the missing check (https://github.com/ethereum/solidity/pull/9835) and when it's merged, the compiler will start reporting it as an error in the contract.

Colony currently requires Solidity 0.5.8 where this bug does not cause any breakage but it's still there. It should also be ported to the `maint/solidity-0.7.0` branch where it's more relevant (#870).

### Details
This is the piece of code that will start causing a compilation error:
https://github.com/JoinColony/colonyNetwork/blob/af87f374a321b7a52ae38e987523e8a54e796632/contracts/colony/ColonyStorage.sol#L159-L165

Also, here's a smaller piece of Solidity code distilled out of Colony contract that illustrates the problem: https://github.com/ethereum/solidity/issues/8379#issuecomment-700899618