### PR TITLE
Add reverse mapping for extension installations

### DIFF
--- a/contracts/colonyNetwork/ColonyNetworkStorage.sol
+++ b/contracts/colonyNetwork/ColonyNetworkStorage.sol
@@ -92,10 +92,12 @@ contract ColonyNetworkStorage is CommonStorage, ColonyNetworkDataTypes, DSMath {
   uint256 annualMetaColonyStipend; // Storage slot 36
   uint256 lastMetaColonyStipendIssued; // Storage slot 37
 
-  // [_extensionId][version] => resolver
-  mapping(bytes32 => mapping(uint256 => address)) resolvers; // Storage slot 38
-  // [_extensionId][colony] => address
-  mapping(bytes32 => mapping(address => address payable)) installations; // Storage slot 39
+  // [extensionId][version] => resolver
+  mapping(bytes32 => mapping(uint256 => address)) extensionResolvers; // Storage slot 38
+  // [extensionId][colony] => address
+  mapping(bytes32 => mapping(address => address payable)) extensionInstallations; // Storage slot 39
+  // [address][colony] => extensionId
+  mapping(address => mapping(address => bytes32)) extensionIdentifiers; // Storage slot 40
 
   modifier calledByColony() {
     require(_isColony[msg.sender], "colony-caller-must-be-colony");

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -333,6 +333,12 @@ contract IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @return installation The address of the installed extension
   function getExtensionInstallation(bytes32 extensionId, address colony) public view returns (address installation);
 
+  /// @notice Get an extension's identifier (if installed).
+  /// @param extension Address of the extension
+  /// @param colony Address of the colony the extension is installed in
+  /// @return extensionId The identifier of the extension
+  function getExtensionIdentifier(address extension, address colony) public view returns (bytes32 extensionId);
+
   /// @notice Return 1 / the fee to pay to the network. e.g. if the fee is 1% (or 0.01), return 100.
   /// @return _feeInverse The inverse of the network fee
   function getFeeInverse() public view returns (uint256 _feeInverse);

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -153,11 +153,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("db135eb0f95ae2cc2ae50c14a5f66ee497646024feedcd1f87cc013068989d4a");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("d03908010dec47dd2a1b8e6101e30d3c3546130905e0bdff4b39a0597d0f7980");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("f54806d4c084ce6051d732e2a853f87da96e5d747f3ed9c0daf6024194df6f51");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("6e06f76ad3caff1649fad8e2ae3f42eef7bb9c55dab13e6514d45ec65864993f");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("27ec15478ee91943b5d98205085f20fa7255f4b77747931fbf488c5d0d0bfbaa");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("b50ee15b75b3e92f2b4287897ae01956e34791ab76cf91a5079bdbe249a77cfc");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("406c0de45e3132ef57bfa934ba4e8b6786a5f9eb98de6c761d55dc6dc97a07df");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("b69235d3cbc5cb756021ac0bd8985148e72bb36f9b62bfcf7cf54483e4c3753f");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("5a5d76a9bb4a761f4cbd0da4b729bd8143efd7ffe0f42daff9ac5381cb5e9524");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("ed2f5717a69310d3cb20cfdcbcf44ed53111731fa783752e492d949bbc92fe9b");
     });
   });
 });

--- a/test/contracts-network/colony-network-extensions.js
+++ b/test/contracts-network/colony-network-extensions.js
@@ -154,6 +154,9 @@ contract("Colony Network Extensions", (accounts) => {
       const owner = await extension.owner();
       expect(owner).to.equal(colonyNetwork.address);
 
+      const extensionId = await colonyNetwork.getExtensionIdentifier(extension.address, colony.address);
+      expect(extensionId).to.equal(TEST_EXTENSION);
+
       // Only colonyNetwork can install the extension
       await checkErrorRevert(extension.install(colony.address), "ds-auth-unauthorized");
     });
@@ -252,6 +255,9 @@ contract("Colony Network Extensions", (accounts) => {
 
       const colonyBalance = await web3GetBalance(colony.address);
       expect(new BN(colonyBalance)).to.eq.BN(100);
+
+      const extensionId = await colonyNetwork.getExtensionIdentifier(extension.address, colony.address);
+      expect(extensionId).to.equal(ethers.constants.HashZero);
     });
 
     it("does not allow non-root users to uninstall an extension", async () => {


### PR DESCRIPTION
Add a reverse-mapping allowing the lookup of the `extensionId` for an address, allowing for verification of the identity of an address.

This type of reverse-lookup allows for a wide range of functionality, including:

- ~Letting extensions verify that calls are coming from specific extensions (such as reputation voting vs. hybrid voting), see #875~
- Preventing extensions from making arbitrary transactions, see #876 

In gas terms, this is one additional storage slot per installation, not a big deal.