### PR TITLE
Add support for Annotations

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -72,6 +72,10 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     return executeCall(_to, 0, _action);
   }
 
+  function annotateTransaction(bytes32 _txHash, string memory _metadata) public stoppable {
+    emit Annotation(_txHash, msg.sender, _metadata);
+  }
+
   function emitDomainReputationPenalty(
     uint256 _permissionDomainId,
     uint256 _childSkillIndex,

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -73,7 +73,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   }
 
   function annotateTransaction(bytes32 _txHash, string memory _metadata) public stoppable {
-    emit Annotation(_txHash, msg.sender, _metadata);
+    emit Annotation(msg.sender, _txHash, _metadata);
   }
 
   function emitDomainReputationPenalty(

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -198,6 +198,12 @@ interface ColonyDataTypes {
   /// @param fundingPotId Id of the newly-created FundingPot
   event FundingPotAdded(uint256 fundingPotId);
 
+  /// @notice Emit a metadata string for a transaction
+  /// @param txHash Hash of transaction being annotated (0x0 for current tx)
+  /// @param user User emitting the annotation
+  /// @param metadata String of metadata for tx
+  event Annotation(bytes32 indexed txHash, address indexed user, string metadata);
+
   struct RewardPayoutCycle {
     // Reputation root hash at the time of reward payout creation
     bytes32 reputationState;

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -199,10 +199,10 @@ interface ColonyDataTypes {
   event FundingPotAdded(uint256 fundingPotId);
 
   /// @notice Emit a metadata string for a transaction
+  /// @param agent Agent emitting the annotation
   /// @param txHash Hash of transaction being annotated (0x0 for current tx)
-  /// @param user User emitting the annotation
   /// @param metadata String of metadata for tx
-  event Annotation(bytes32 indexed txHash, address indexed user, string metadata);
+  event Annotation(address indexed agent, bytes32 indexed txHash, string metadata);
 
   struct RewardPayoutCycle {
     // Reputation root hash at the time of reward payout creation

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -66,6 +66,11 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @return success Boolean indicating whether the transaction succeeded
   function makeArbitraryTransaction(address _to, bytes memory _action) external returns (bool success);
 
+  /// @notice Emit a metadata string for a transaction
+  /// @param _txHash Hash of transaction being annotated (0x0 for current tx)
+  /// @param _metadata String of metadata for tx
+  function annotateTransaction(bytes32 _txHash, string memory _metadata) external;
+
   /// @notice Set new colony root role.
   /// Can be called by root role only.
   /// @param _user User we want to give an root role to

--- a/contracts/extensions/VotingReputation.sol
+++ b/contracts/extensions/VotingReputation.sol
@@ -922,8 +922,6 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs {
               // call(g,   a,  v, in,                insize,        out, outsize)
       success := call(gas(), to, 0, add(action, 0x20), mload(action), 0, 0)
     }
-
-    return success;
   }
 
   function getSig(bytes memory action) internal returns (bytes4 sig) {

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -61,6 +61,19 @@ Add a new payment in the colony. Secured function to authorised members.
 |---|---|---|
 |paymentId|uint256|Identifier of the newly created payment
 
+### `annotateTransaction`
+
+Emit a metadata string for a transaction
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_txHash|bytes32|Hash of transaction being annotated (0x0 for current tx)
+|_metadata|string|String of metadata for tx
+
+
 ### `approveStake`
 
 Allow the _approvee to obligate some amount of tokens as a stake.

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -153,11 +153,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("85e5a1d7c935fe6853cf86740e5fb8c505aea869e8578f577967be1f1f17707a");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("50e4612eab433ec09443ebb13329c143e8d82be1014901c879fe47e016a59209");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("c8499c8232a66015f8cc80d4c722c346cd8c696818e4ab5e75f6be0fd7cc5c9f");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("c50ad617df6bfe48b6e5fddaa230f0b3f8a22e8e223222aedf6c1e46dc5a7432");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("4362c73092b019330797d71923ab0f176453ee7487c158c28d8c98d217104874");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("66b392106f1f4728ade0838b90841d6d4e8bb9147e0837b2d0e57fa3a2742ddf");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("cdd57f6ce7854b30e2171e9e220ad88575cd0cfa500127bdf76cc688a67f7178");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("21541f59b876767da6e0fac459688cfbe312dc77b3bafdcf83c3b05f072cfbda");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("b595491a8eaa6c954387d49840a54f2ab4a532c7c60fe589e330ff75c594ea03");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("7ed473bc856b04ff76f51f244381f5313ed4da7828ead2591ad51db3f84e3c2d");
     });
   });
 });

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -349,4 +349,12 @@ contract("Colony", (accounts) => {
       await checkErrorRevert(colony.setRewardInverse(0), "colony-reward-inverse-cannot-be-zero");
     });
   });
+
+  describe("when annotating transactions", () => {
+    it("should be able to emit transaction annotations", async () => {
+      const tx1 = await colony.addDomain(1, UINT256_MAX, 1);
+      const tx2 = await colony.annotateTransaction(tx1.tx, "annotation");
+      await expectEvent(tx2, "Annotation", [tx1.tx, USER0, "annotation"]);
+    });
+  });
 });

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -354,7 +354,7 @@ contract("Colony", (accounts) => {
     it("should be able to emit transaction annotations", async () => {
       const tx1 = await colony.addDomain(1, UINT256_MAX, 1);
       const tx2 = await colony.annotateTransaction(tx1.tx, "annotation");
-      await expectEvent(tx2, "Annotation", [tx1.tx, USER0, "annotation"]);
+      await expectEvent(tx2, "Annotation", [USER0, tx1.tx, "annotation"]);
     });
   });
 });


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #877

<!--- Summary of changes including design decisions -->

### Design

This PR adds support for transaction annotations -- arbitrary strings which provide additional metadata about a transaction. These annotations can be plaintext, or some other structure (such as JSON).

Annotations are emitted via the `annotateTransaction` function, which is public:

```
  function annotateTransaction(bytes32 _txHash, string memory _metadata) public stoppable {
    emit Annotation(_txHash, msg.sender, _metadata);
  }
```

In principle, anyone can add an annotation to any transaction, via an additional transaction.

## Open Question

Currently, the ability to emit annotations doesn't distinguish between any sort of type. Specifically, if annotations can be used to emit descriptions of transactions, as well as _comments_ on transactions, how can we distinguish a comment from the initial `msg.sender` and an updating of the description?