### PR TITLE
Make extension manager development easier for app

### DIFF
--- a/contracts/extensions/ColonyExtension.sol
+++ b/contracts/extensions/ColonyExtension.sol
@@ -37,4 +37,9 @@ abstract contract ColonyExtension is DSAuth {
   function finishUpgrade() public virtual;
   function deprecate(bool _deprecated) public virtual;
   function uninstall() public virtual;
+
+  function getDeprecated() public returns (bool deprecated) {
+    return deprecated;
+  }
+
 }

--- a/migrations/9_setup_extensions.js
+++ b/migrations/9_setup_extensions.js
@@ -1,0 +1,55 @@
+/* globals artifacts */
+
+const { soliditySha3 } = require("web3-utils");
+
+const { setupEtherRouter } = require("../helpers/upgradable-contracts");
+
+const CoinMachine = artifacts.require("./CoinMachine");
+const FundingQueue = artifacts.require("./FundingQueue");
+const OneTxPayment = artifacts.require("./OneTxPayment");
+const VotingReputation = artifacts.require("./VotingReputation");
+
+const Resolver = artifacts.require("./Resolver");
+const EtherRouter = artifacts.require("./EtherRouter");
+const IColonyNetwork = artifacts.require("./IColonyNetwork");
+const IMetaColony = artifacts.require("./IMetaColony");
+
+// eslint-disable-next-line no-unused-vars
+module.exports = async function (deployer, network, accounts) {
+  const etherRouterDeployed = await EtherRouter.deployed();
+  const colonyNetwork = await IColonyNetwork.at(etherRouterDeployed.address);
+  const metaColonyAddress = await colonyNetwork.getMetaColony();
+  const metaColony = await IMetaColony.at(metaColonyAddress);
+
+  const COIN_MACHINE = soliditySha3("CoinMachine");
+  const coinMachineImplementation = await CoinMachine.new();
+  const coinmachineResolver = await Resolver.new();
+  await setupEtherRouter("CoinMachine", { CoinMachine: coinMachineImplementation.address }, coinmachineResolver);
+  await metaColony.addExtensionToNetwork(COIN_MACHINE, coinmachineResolver.address);
+
+  console.log("### CoinMachine extension installed");
+
+  const FUNDING_QUEUE = soliditySha3("FundingQueue");
+  const fundingQueueImplementation = await FundingQueue.new();
+  const fundingQueueResolver = await Resolver.new();
+  await setupEtherRouter("FundingQueue", { FundingQueue: fundingQueueImplementation.address }, fundingQueueResolver);
+  await metaColony.addExtensionToNetwork(FUNDING_QUEUE, fundingQueueResolver.address);
+
+  console.log("### FundingQueue extension installed");
+
+  const ONE_TX_PAYMENT = soliditySha3("OneTxPayment");
+  const oneTxPaymentImplementation = await OneTxPayment.new();
+  const oneTxPaymentResolver = await Resolver.new();
+  await setupEtherRouter("OneTxPayment", { OneTxPayment: oneTxPaymentImplementation.address }, oneTxPaymentResolver);
+  await metaColony.addExtensionToNetwork(ONE_TX_PAYMENT, oneTxPaymentResolver.address);
+
+  console.log("### OneTxPayment extension installed");
+
+  const VOTING_REPUTATION = soliditySha3("VotingReputation");
+  const votingReputationImplementation = await VotingReputation.new();
+  const votingReputationResolver = await Resolver.new();
+  await setupEtherRouter("VotingReputation", { VotingReputation: votingReputationImplementation.address }, votingReputationResolver);
+  await metaColony.addExtensionToNetwork(VOTING_REPUTATION, votingReputationResolver.address);
+
+  console.log("### VotingReputation extension installed");
+};

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -153,8 +153,8 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("db135eb0f95ae2cc2ae50c14a5f66ee497646024feedcd1f87cc013068989d4a");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("d03908010dec47dd2a1b8e6101e30d3c3546130905e0bdff4b39a0597d0f7980");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("d74a226d8ca1bd524548860759ed53c3ada38aba89fe2e9f33e9cbc65146585f");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("344ecc02bf9adc343db72750d1aa1957b70eba28aa16b7feb22555ec4d26030c");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("f54806d4c084ce6051d732e2a853f87da96e5d747f3ed9c0daf6024194df6f51");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("6e06f76ad3caff1649fad8e2ae3f42eef7bb9c55dab13e6514d45ec65864993f");
       expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("27ec15478ee91943b5d98205085f20fa7255f4b77747931fbf488c5d0d0bfbaa");


### PR DESCRIPTION
After a call with Chris about developing the extension manager, a couple of minor things came up that will help him. One is to install the extensions when the migrations are run, and the other is a minor functional change, making the `deprecated` boolean available via `getDeprecated`.
