### PR TITLE
Add maxTotal to cap total tokens available

### DIFF
--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -153,8 +153,8 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("6c35ebbf3db3b97c9a2f58058894161bae322f5f2c5c4504782031e153404225");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("3183c6269d0f20f9e9d19f28332674ca929b19121a8504c19d4fb0a392950d1c");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("155af9df86571a3f3d77663d177fe08a12843e1dfb90d9fc90bd3a19097c3ab3");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("f8c3923760ef108c0ba09339448f88117e334220837c645e0954d1b5ed25df6f");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("dde1dd7452e9f4037ab8eb491a9e95e6a81a8e0a17c1a8e59b40c1b67086fe43");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("5a5d76a9bb4a761f4cbd0da4b729bd8143efd7ffe0f42daff9ac5381cb5e9524");
       expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("ed2f5717a69310d3cb20cfdcbcf44ed53111731fa783752e492d949bbc92fe9b");

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -168,7 +168,7 @@ contract("Colony", (accounts) => {
 
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       const coinMachine = await CoinMachine.at(coinMachineAddress);
-      await coinMachine.initialise(ethers.constants.AddressZero, 60 * 60, 10, WAD.muln(100), WAD.muln(200), WAD);
+      await coinMachine.initialise(ethers.constants.AddressZero, 60 * 60, 10, WAD.muln(100), WAD.muln(200), UINT256_MAX, WAD);
 
       const action = await encodeTxData(coinMachine, "buyTokens", [WAD]);
 

--- a/test/extensions/coin-machine.js
+++ b/test/extensions/coin-machine.js
@@ -166,7 +166,7 @@ contract("Coin Machine", (accounts) => {
       await checkErrorRevert(coinMachine.buyTokens(WAD, { from: USER0 }), "ds-token-insufficient-balance");
     });
 
-    it("cannot buy more than totalMax tokens", async () => {
+    it("cannot buy more than tokensToSell tokens", async () => {
       ({ colony, token } = await setupRandomColony(colonyNetwork));
 
       await colony.installExtension(COIN_MACHINE, 1);
@@ -183,6 +183,9 @@ contract("Coin Machine", (accounts) => {
       await purchaseToken.approve(coinMachine.address, WAD.muln(2), { from: USER0 });
 
       await coinMachine.buyTokens(WAD, { from: USER0 });
+
+      const tokensToSell = await coinMachine.getTokensToSell();
+      expect(tokensToSell).to.be.zero;
 
       await forwardTime(periodLength.toNumber(), this);
 


### PR DESCRIPTION
Includes the ability to cap the total number of tokens sold by a CoinMachine instance, as an initialisation argument.