### PR TITLE
Only emit necessary events from setUserRoles

### DIFF
--- a/contracts/colony/ColonyRoles.sol
+++ b/contracts/colony/ColonyRoles.sol
@@ -92,17 +92,23 @@ contract ColonyRoles is ColonyStorage {
     // This is not strictly necessary, since these roles are never used in subdomains
     require(_roles & ROOT_ROLES == 0 || _domainId == 1, "colony-bad-domain-for-role");
 
-    bytes32 roles = _roles;
     bool setTo;
+    bytes32 existingRoles = ColonyAuthority(address(authority)).getUserRoles(_user, _domainId);
+    bytes32 rolesChanged = _roles ^ existingRoles;
+    bytes32 roles = _roles;
 
     for (uint8 roleId; roleId < uint8(ColonyRole.NUMBER_OF_ROLES); roleId += 1) {
-      setTo = uint256(roles) % 2 == 1;
+      bool changed = uint256(rolesChanged) % 2 == 1;
+      if (changed) {
+        setTo = uint256(roles) % 2 == 1;
 
-      ColonyAuthority(address(authority)).setUserRole(_user, _domainId, roleId, setTo);
+        ColonyAuthority(address(authority)).setUserRole(_user, _domainId, roleId, setTo);
 
-      emit ColonyRoleSet(_user, _domainId, roleId, setTo);
+        emit ColonyRoleSet(_user, _domainId, roleId, setTo);
 
+      }
       roles >>= 1;
+      rolesChanged >>= 1;
     }
   }
 

--- a/test/contracts-network/colony-permissions.js
+++ b/test/contracts-network/colony-permissions.js
@@ -394,8 +394,25 @@ contract("ColonyPermissions", (accounts) => {
       userRoles = await colony.getUserRoles(USER2, 3);
       expect(userRoles).to.equal(rolesArch);
 
+      // Events are only emitted for roles that change...
+      let tx = await colony.setUserRoles(1, 1, USER2, 3, rolesArch, { from: USER1 });
+      expect(tx.logs.length).to.equal(0);
+
       // Can also remove roles
-      await colony.setUserRoles(1, 1, USER2, 3, "0x0", { from: USER1 });
+      tx = await colony.setUserRoles(1, 1, USER2, 3, "0x0", { from: USER1 });
+
+      expect(tx.logs.length).to.equal(2);
+
+      expect(tx.logs[0].event).to.equal("ColonyRoleSet");
+      expect(tx.logs[0].args.setTo).to.equal(false);
+      expect(tx.logs[0].args.role.toNumber()).to.equal(ARBITRATION_ROLE);
+      expect(tx.logs[0].args.user).to.equal(USER2);
+
+      expect(tx.logs[1].event).to.equal("ColonyRoleSet");
+      expect(tx.logs[1].args.setTo).to.equal(false);
+      expect(tx.logs[1].args.role.toNumber()).to.equal(FUNDING_ROLE);
+      expect(tx.logs[1].args.user).to.equal(USER2);
+
       userRoles = await colony.getUserRoles(USER2, 3);
       expect(userRoles).to.equal(ethers.constants.HashZero);
     });


### PR DESCRIPTION
`setUserRoles` emitted an event for every role, even if it didn't change. This change only emits the events necessary and as a bonus, saves us gas (as `setRole` is also only called when necessary) if fewer than all-but-one roles are being set.