### PR TITLE
Add needed events to recovery mode; Improve event tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,10 +21,14 @@
     "no-await-in-loop": "off",
     "no-trailing-spaces": "error",
     "no-multi-spaces": ["error", {"ignoreEOLComments": true}],
+    "no-only-tests/no-only-tests": ["error", {"block": ["contract", "it"], "focus": ["only"]}],
     "eslint-comments/disable-enable-pair": ["error", {"allowWholeFile": true}],
     "space-infix-ops": ["error"]
   },
   "parserOptions": {
     "ecmaVersion": 2018
-  }
+  },
+  "plugins": [
+    "no-only-tests"
+  ]
 }

--- a/contracts/common/ContractRecovery.sol
+++ b/contracts/common/ContractRecovery.sol
@@ -90,6 +90,7 @@ contract ContractRecovery is ContractRecoveryDataTypes, CommonStorage { // ignor
     uint numRequired = totalAuthorized / 2 + 1;
     require(recoveryApprovalCount >= numRequired, "colony-recovery-exit-insufficient-approvals");
     recoveryMode = false;
+
     emit RecoveryModeExited(msg.sender);
   }
 

--- a/contracts/common/ContractRecovery.sol
+++ b/contracts/common/ContractRecovery.sol
@@ -44,7 +44,9 @@ contract ContractRecovery is ContractRecoveryDataTypes, CommonStorage { // ignor
     // Make recovery edit
     uint x = _slot;
     bytes32 y = _value;
+    bytes32 oldValue;
     assembly {
+      oldValue := sload(x)
       sstore(x, y) // ignore-swc-124
     }
 
@@ -56,7 +58,7 @@ contract ContractRecovery is ContractRecoveryDataTypes, CommonStorage { // ignor
     recoveryApprovalCount = 0;
     recoveryEditedTimestamp = block.timestamp;
 
-    emit RecoveryStorageSlotSet(_slot, _value);
+    emit RecoveryStorageSlotSet(_slot, oldValue, _value);
   }
 
   function isInRecoveryMode() public view returns (bool) {
@@ -68,7 +70,7 @@ contract ContractRecovery is ContractRecoveryDataTypes, CommonStorage { // ignor
     recoveryApprovalCount = 0;
     recoveryEditedTimestamp = block.timestamp;
 
-    emit RecoveryModeEntered();
+    emit RecoveryModeEntered(msg.sender);
   }
 
   function approveExitRecovery() public recovery auth {
@@ -88,7 +90,7 @@ contract ContractRecovery is ContractRecoveryDataTypes, CommonStorage { // ignor
     uint numRequired = totalAuthorized / 2 + 1;
     require(recoveryApprovalCount >= numRequired, "colony-recovery-exit-insufficient-approvals");
     recoveryMode = false;
-    emit RecoveryModeExited();
+    emit RecoveryModeExited(msg.sender);
   }
 
   // Can only be called by the root role.

--- a/contracts/common/ContractRecovery.sol
+++ b/contracts/common/ContractRecovery.sol
@@ -55,6 +55,8 @@ contract ContractRecovery is ContractRecoveryDataTypes, CommonStorage { // ignor
     recoveryMode = true;
     recoveryApprovalCount = 0;
     recoveryEditedTimestamp = block.timestamp;
+
+    emit RecoveryStorageSlotSet(_slot, _value);
   }
 
   function isInRecoveryMode() public view returns (bool) {
@@ -65,12 +67,16 @@ contract ContractRecovery is ContractRecoveryDataTypes, CommonStorage { // ignor
     recoveryMode = true;
     recoveryApprovalCount = 0;
     recoveryEditedTimestamp = block.timestamp;
+
+    emit RecoveryModeEntered();
   }
 
   function approveExitRecovery() public recovery auth {
     require(recoveryApprovalTimestamps[msg.sender] < recoveryEditedTimestamp, "colony-recovery-approval-already-given");  // ignore-swc-116
     recoveryApprovalTimestamps[msg.sender] = block.timestamp;
     recoveryApprovalCount++;
+
+    emit RecoveryModeExitApproved(msg.sender);
   }
 
   function exitRecoveryMode() public recovery auth {
@@ -82,6 +88,7 @@ contract ContractRecovery is ContractRecoveryDataTypes, CommonStorage { // ignor
     uint numRequired = totalAuthorized / 2 + 1;
     require(recoveryApprovalCount >= numRequired, "colony-recovery-exit-insufficient-approvals");
     recoveryMode = false;
+    emit RecoveryModeExited();
   }
 
   // Can only be called by the root role.

--- a/contracts/common/ContractRecoveryDataTypes.sol
+++ b/contracts/common/ContractRecoveryDataTypes.sol
@@ -24,9 +24,23 @@ interface ContractRecoveryDataTypes {
   /// @param setTo The boolean indicating whether the role is being granted or revoked
   event RecoveryRoleSet(address indexed user, bool setTo);
 
-  event RecoveryModeEntered();
-  event RecoveryModeExited();
-  event RecoveryStorageSlotSet(uint256 slot, bytes32 value);
+  /// @notice Event logged when recovery mode is triggered.
+  /// @param user The address that triggered recovery mode
+  event RecoveryModeEntered(address user);
+
+  /// @notice Event logged when recovery mode is left
+  /// @param user The address that left recovery mode
+  event RecoveryModeExited(address user);
+
+  /// @notice Event logged when in recovery mode a storage slot is set
+  /// @param slot The storage slot being modified
+  /// @param fromValue The value the storage slot had before this transaction
+  /// @param toValue The value the storage slot has after this transaction
+  event RecoveryStorageSlotSet(uint256 slot, bytes32 fromValue, bytes32 toValue);
+
+  /// @notice Event logged when someone with recovery mode signals they are happy with the state
+  /// and wish to leave recovery mode
+  /// @param user The address signalling they are happy with the state
   event RecoveryModeExitApproved(address user);
 
 }

--- a/contracts/common/ContractRecoveryDataTypes.sol
+++ b/contracts/common/ContractRecoveryDataTypes.sol
@@ -23,4 +23,10 @@ interface ContractRecoveryDataTypes {
   /// @param user The address being modified
   /// @param setTo The boolean indicating whether the role is being granted or revoked
   event RecoveryRoleSet(address indexed user, bool setTo);
+
+  event RecoveryModeEntered();
+  event RecoveryModeExited();
+  event RecoveryStorageSlotSet(uint256 slot, bytes32 value);
+  event RecoveryModeExitApproved(address user);
+
 }

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -251,9 +251,21 @@ export async function getBlockTime(blockNumber) {
   return p;
 }
 
-export async function expectEvent(tx, eventName) {
+function hexlifyAndPad(input) {
+  let i = input;
+  if (i.toString) {
+    i = i.toString();
+  }
+  i = ethers.BigNumber.from(i);
+  return ethers.utils.hexZeroPad(ethers.utils.hexlify(i), 32);
+}
+
+export async function expectEvent(tx, eventName, args) {
   const { logs } = await tx;
   const event = logs.find((e) => e.event === eventName);
+  for (let i = 0; i < args.length; i += 1) {
+    expect(hexlifyAndPad(args[i])).to.equal(hexlifyAndPad(event.args[i]));
+  }
   return expect(event).to.exist;
 }
 

--- a/package.json
+++ b/package.json
@@ -119,5 +119,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "dependencies": {}
+  "dependencies": {
+    "eslint-plugin-no-only-tests": "^2.4.0"
+  }
 }

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -291,7 +291,10 @@ contract("Colony Network", (accounts) => {
 
     it("should log a ColonyAdded event", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await expectEvent(colonyNetwork.createColony(token.address, 0, ""), "ColonyAdded");
+      const tx = await colonyNetwork.createColony(token.address, 0, "");
+      const colonyCount = await colonyNetwork.getColonyCount();
+      const colonyAddress = await colonyNetwork.getColony(colonyCount);
+      await expectEvent(tx, "ColonyAdded", [colonyCount, colonyAddress, token.address]);
     });
   });
 

--- a/test/contracts-network/colony-recovery.js
+++ b/test/contracts-network/colony-recovery.js
@@ -70,6 +70,13 @@ contract("Colony Recovery", (accounts) => {
       await expectEvent(colony.removeRecoveryRole(accounts[1]), "RecoveryRoleSet");
     });
 
+    it("should emit events when moving through the recovery procress", async () => {
+      await expectEvent(colony.enterRecoveryMode(), "RecoveryModeEntered");
+      await expectEvent(colony.setStorageSlotRecovery("0xdeadbeef", "0xdeadbeef"), "RecoveryStorageSlotSet");
+      await expectEvent(colony.approveExitRecovery(), "RecoveryModeExitApproved");
+      await expectEvent(colony.exitRecoveryMode(), "RecoveryModeExited");
+    });
+
     it("should not error when adding recovery roles for existing recovery users", async () => {
       let numRecoveryRoles;
 

--- a/test/contracts-network/colony-recovery.js
+++ b/test/contracts-network/colony-recovery.js
@@ -66,15 +66,28 @@ contract("Colony Recovery", (accounts) => {
     });
 
     it("should emit events when changing recovery roles", async () => {
-      await expectEvent(colony.setRecoveryRole(accounts[1]), "RecoveryRoleSet");
-      await expectEvent(colony.removeRecoveryRole(accounts[1]), "RecoveryRoleSet");
+      await expectEvent(colony.setRecoveryRole(accounts[1]), "RecoveryRoleSet", [accounts[1]]);
+      await expectEvent(colony.removeRecoveryRole(accounts[1]), "RecoveryRoleSet", [accounts[1]]);
     });
 
     it("should emit events when moving through the recovery procress", async () => {
-      await expectEvent(colony.enterRecoveryMode(), "RecoveryModeEntered");
-      await expectEvent(colony.setStorageSlotRecovery("0xdeadbeef", "0xdeadbeef"), "RecoveryStorageSlotSet");
-      await expectEvent(colony.approveExitRecovery(), "RecoveryModeExitApproved");
-      await expectEvent(colony.exitRecoveryMode(), "RecoveryModeExited");
+      await expectEvent(colony.enterRecoveryMode(), "RecoveryModeEntered", [accounts[0]]);
+      await expectEvent(
+        colony.setStorageSlotRecovery("0xdead", "0xbeef00000000000000000000000000000000000000000000000000000000beef"),
+        "RecoveryStorageSlotSet",
+        ["0xdead", "0x00", "0xbeef00000000000000000000000000000000000000000000000000000000beef"]
+      );
+      await expectEvent(
+        colony.setStorageSlotRecovery("0xdead", "0xbadbeef00000000000000000000000000000000000000000000000000badbeef"),
+        "RecoveryStorageSlotSet",
+        [
+          "0xdead",
+          "0xbeef00000000000000000000000000000000000000000000000000000000beef",
+          "0xbadbeef00000000000000000000000000000000000000000000000000badbeef",
+        ]
+      );
+      await expectEvent(colony.approveExitRecovery(), "RecoveryModeExitApproved", [accounts[0]]);
+      await expectEvent(colony.exitRecoveryMode(), "RecoveryModeExited", [accounts[0]]);
     });
 
     it("should not error when adding recovery roles for existing recovery users", async () => {

--- a/test/contracts-network/colony-task-work-rating.js
+++ b/test/contracts-network/colony-task-work-rating.js
@@ -354,7 +354,7 @@ contract("Colony Task Work Rating", (accounts) => {
       );
     });
 
-    it.only("should log a TaskWorkRatingRevealed event", async () => {
+    it("should log a TaskWorkRatingRevealed event", async () => {
       let dueDate = await currentBlockTime();
       dueDate += SECONDS_PER_DAY * 8;
 

--- a/test/contracts-network/colony-task-work-rating.js
+++ b/test/contracts-network/colony-task-work-rating.js
@@ -354,7 +354,7 @@ contract("Colony Task Work Rating", (accounts) => {
       );
     });
 
-    it("should log a TaskWorkRatingRevealed event", async () => {
+    it.only("should log a TaskWorkRatingRevealed event", async () => {
       let dueDate = await currentBlockTime();
       dueDate += SECONDS_PER_DAY * 8;
 
@@ -365,7 +365,8 @@ contract("Colony Task Work Rating", (accounts) => {
 
       await expectEvent(
         colony.revealTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR }),
-        "TaskWorkRatingRevealed"
+        "TaskWorkRatingRevealed",
+        [taskId, WORKER_ROLE, WORKER_RATING]
       );
     });
   });

--- a/test/contracts-network/colony-task.js
+++ b/test/contracts-network/colony-task.js
@@ -1098,7 +1098,8 @@ contract("ColonyTask", (accounts) => {
           sigTypes: [0],
           args: [taskId, SPECIFICATION_HASH_UPDATED],
         }),
-        "TaskBriefSet"
+        "TaskBriefSet",
+        [taskId, SPECIFICATION_HASH_UPDATED]
       );
     });
 
@@ -1115,7 +1116,8 @@ contract("ColonyTask", (accounts) => {
           sigTypes: [0],
           args: [taskId, dueDate],
         }),
-        "TaskDueDateSet"
+        "TaskDueDateSet",
+        [taskId, dueDate]
       );
     });
 
@@ -1134,7 +1136,8 @@ contract("ColonyTask", (accounts) => {
           sigTypes: [0],
           args: [taskId, skillCount],
         }),
-        "TaskSkillSet"
+        "TaskSkillSet",
+        [taskId, skillCount]
       );
     });
 
@@ -1151,7 +1154,8 @@ contract("ColonyTask", (accounts) => {
           sigTypes: [0, 0],
           args: [taskId, WORKER],
         }),
-        "TaskRoleUserSet"
+        "TaskRoleUserSet",
+        [taskId, WORKER_ROLE, WORKER]
       );
     });
 
@@ -1271,7 +1275,10 @@ contract("ColonyTask", (accounts) => {
       dueDate += SECONDS_PER_DAY * 4;
       const taskId = await setupAssignedTask({ colonyNetwork, colony, dueDate });
 
-      await expectEvent(colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH, { from: WORKER }), "TaskDeliverableSubmitted");
+      await expectEvent(colony.submitTaskDeliverable(taskId, DELIVERABLE_HASH, { from: WORKER }), "TaskDeliverableSubmitted", [
+        taskId,
+        DELIVERABLE_HASH,
+      ]);
     });
   });
 
@@ -1320,7 +1327,7 @@ contract("ColonyTask", (accounts) => {
     it("should log a TaskFinalized event", async () => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupRatedTask({ colonyNetwork, colony, token });
-      await expectEvent(colony.finalizeTask(taskId), "TaskFinalized");
+      await expectEvent(colony.finalizeTask(taskId), "TaskFinalized", [taskId]);
     });
   });
 
@@ -1454,7 +1461,8 @@ contract("ColonyTask", (accounts) => {
           sigTypes: [0, 0],
           args: [taskId],
         }),
-        "TaskCanceled"
+        "TaskCanceled",
+        [taskId]
       );
     });
   });
@@ -1641,7 +1649,8 @@ contract("ColonyTask", (accounts) => {
           sigTypes: [0, 0],
           args: [taskId, ethers.constants.AddressZero, 98000],
         }),
-        "TaskPayoutSet"
+        "TaskPayoutSet",
+        [taskId, WORKER_ROLE, ethers.constants.AddressZero, 98000]
       );
     });
 
@@ -1905,7 +1914,7 @@ contract("ColonyTask", (accounts) => {
       for (let i = 0; i < 42; i += 1) {
         await taskSkillEditingColony.addTaskSkill(taskId, GLOBAL_SKILL_ID);
       }
-      await expectEvent(colony.finalizeTask(taskId), "TaskFinalized");
+      await expectEvent(colony.finalizeTask(taskId), "TaskFinalized", [taskId]);
     });
 
     it("an empty element shouldn't affect finalization of the task", async () => {
@@ -1916,7 +1925,7 @@ contract("ColonyTask", (accounts) => {
       await taskSkillEditingColony.addTaskSkill(taskId, 3);
       await taskSkillEditingColony.addTaskSkill(taskId, 3);
       await taskSkillEditingColony.removeTaskSkill(taskId, 2);
-      await expectEvent(colony.finalizeTask(taskId), "TaskFinalized");
+      await expectEvent(colony.finalizeTask(taskId), "TaskFinalized", [taskId]);
     });
   });
 });

--- a/test/extensions/coin-machine.js
+++ b/test/extensions/coin-machine.js
@@ -106,7 +106,7 @@ contract("Coin Machine", (accounts) => {
     });
 
     it("can initialise", async () => {
-      await expectEvent(coinMachine.initialise(purchaseToken.address, 60, 511, 10, 10, 0), "ExtensionInitialised");
+      await expectEvent(coinMachine.initialise(purchaseToken.address, 60, 511, 10, 10, 0), "ExtensionInitialised", []);
     });
 
     it("can handle a large windowSize", async () => {

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -312,7 +312,7 @@ contract("Voting Reputation", (accounts) => {
       voting = await VotingReputation.new();
       await voting.install(colony.address);
 
-      await expectEvent(voting.initialise(HALF, HALF, WAD, WAD, YEAR, YEAR, YEAR, YEAR), "ExtensionInitialised");
+      await expectEvent(voting.initialise(HALF, HALF, WAD, WAD, YEAR, YEAR, YEAR, YEAR), "ExtensionInitialised", []);
     });
 
     it("can query for initialisation values", async () => {


### PR DESCRIPTION
Based on the designs for the recovery mode screens, we need these events, so I've added them.

While writing the tests it also became apparent that we were not rigorously testing our events. So I've improved `expectEvent` to check the parameters passed by the event as well, and updated all relevant tests (we probably need more, but not in this PR).