### PR TITLE
Add payoutWhitelist to ColonyNetwork

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -182,48 +182,49 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   auth
   returns (uint256)
   {
-    IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
-    return colonyNetwork.addSkill(0); // ignore-swc-107
+    return IColonyNetwork(colonyNetworkAddress).addSkill(0); // ignore-swc-107
   }
 
   function deprecateGlobalSkill(uint256 _skillId) public
   stoppable
   auth
   {
-    IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
-    return colonyNetwork.deprecateSkill(_skillId);
+    IColonyNetwork(colonyNetworkAddress).deprecateSkill(_skillId);
   }
 
   function setNetworkFeeInverse(uint256 _feeInverse) public
   stoppable
   auth
   {
-    IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
-    return colonyNetwork.setFeeInverse(_feeInverse); // ignore-swc-107
+    IColonyNetwork(colonyNetworkAddress).setFeeInverse(_feeInverse); // ignore-swc-107
+  }
+
+  function setPayoutWhitelist(address _token, bool _status) public
+  stoppable
+  auth
+  {
+    IColonyNetwork(colonyNetworkAddress).setPayoutWhitelist(_token, _status); // ignore-swc-107
   }
 
   function setAnnualMetaColonyStipend(uint256 _amount) public
   stoppable
   auth
   {
-    IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
-    return colonyNetwork.setAnnualMetaColonyStipend(_amount); // ignore-swc-107
+    IColonyNetwork(colonyNetworkAddress).setAnnualMetaColonyStipend(_amount); // ignore-swc-107
   }
 
   function setReputationMiningCycleReward(uint256 _amount) public
   stoppable
   auth
   {
-    IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
-    return colonyNetwork.setReputationMiningCycleReward(_amount); // ignore-swc-107
+    IColonyNetwork(colonyNetworkAddress).setReputationMiningCycleReward(_amount);
   }
 
   function addNetworkColonyVersion(uint256 _version, address _resolver) public
   stoppable
   auth
   {
-    IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
-    return colonyNetwork.addColonyVersion(_version, _resolver);
+    IColonyNetwork(colonyNetworkAddress).addColonyVersion(_version, _resolver);
   }
 
   function addExtensionToNetwork(bytes32 _extensionId, address _resolver)
@@ -375,6 +376,10 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
     // Add arbitrary tx functionality
     sig = bytes4(keccak256("makeArbitraryTransaction(address,bytes)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
+
+    // Add payout whitelist functionality
+    sig = bytes4(keccak256("setPayoutWhitelist(address,bool)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
   }
 

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -86,6 +86,7 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ARBITRATION_ROLE, "setExpenditureClaimDelay(uint256,uint256,uint256,uint256,uint256)");
 
     // Added in colony v5 (cerulean-lwss)
+    addRoleCapability(ROOT_ROLE, "setPayoutWhitelist(address,bool)");
     addRoleCapability(ROOT_ROLE, "mintTokensFor(address,uint256)");
     addRoleCapability(ROOT_ROLE, "setAnnualMetaColonyStipend(uint256)");
     addRoleCapability(ROOT_ROLE, "setReputationMiningCycleReward(uint256)");

--- a/contracts/colony/IMetaColony.sol
+++ b/contracts/colony/IMetaColony.sol
@@ -44,6 +44,11 @@ interface IMetaColony is IColony {
   /// @param _feeInverse Nonzero amount for the fee inverse
   function setNetworkFeeInverse(uint256 _feeInverse) external;
 
+  /// @notice Set a token's status in the payout whitelist on the Colony Network
+  /// @param _token The token being set
+  /// @param _status The whitelist status
+  function setPayoutWhitelist(address _token, bool _status) external;
+
   /// @notice Adds a new Colony contract version and the address of associated `_resolver` contract. Secured function to authorised members.
   /// @dev Calls `IColonyNetwork.addColonyVersion`.
   /// @param _version The new Colony contract version

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -307,6 +307,18 @@ contract ColonyNetwork is ColonyNetworkStorage {
     emit NetworkFeeInverseSet(_feeInverse);
   }
 
+  function getPayoutWhitelist(address _token) public view returns (bool) {
+    return payoutWhitelist[_token];
+  }
+
+  function setPayoutWhitelist(address _token, bool _status) public stoppable
+  calledByMetaColony
+  {
+    payoutWhitelist[_token] = _status;
+
+    emit TokenWhitelisted(_token, _status);
+  }
+
   function issueMetaColonyStipend() public stoppable {
     // Can be called by anyone
     require(lastMetaColonyStipendIssued > 0, "colony-network-metacolony-stipend-not-set");

--- a/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
+++ b/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
@@ -35,6 +35,11 @@ interface ColonyNetworkDataTypes {
   /// @param feeInverse The network fee inverse value
   event NetworkFeeInverseSet(uint256 feeInverse);
 
+  /// @notice Event logged when the payout whitelist is updated
+  /// @param token The token being set
+  /// @param status The whitelist status
+  event TokenWhitelisted(address token, bool status);
+
   /// @notice Event logged when a new colony contract version is set
   /// @param version The new int colony version, e.g. 2, 3, 4, etc
   /// @param resolver The new colony contract resolver contract instance

--- a/contracts/colonyNetwork/ColonyNetworkStorage.sol
+++ b/contracts/colonyNetwork/ColonyNetworkStorage.sol
@@ -97,6 +97,9 @@ contract ColonyNetworkStorage is CommonStorage, ColonyNetworkDataTypes, DSMath {
   // [_extensionId][colony] => address
   mapping(bytes32 => mapping(address => address payable)) installations; // Storage slot 39
 
+  // Used for whitelisting payout tokens
+  mapping (address => bool) payoutWhitelist; // Storage slot 40
+
   modifier calledByColony() {
     require(_isColony[msg.sender], "colony-caller-must-be-colony");
     _;

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -341,6 +341,15 @@ interface IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @param _feeInverse The inverse of the network fee to set
   function setFeeInverse(uint256 _feeInverse) external;
 
+  /// @notice Get a token's status in the payout whitelist
+  /// @param _token The token being queried
+  function getPayoutWhitelist(address _token) external view returns (bool status);
+
+  /// @notice Set a token's status in the payout whitelist
+  /// @param _token The token being set
+  /// @param _status The whitelist status
+  function setPayoutWhitelist(address _token, bool _status) external;
+
   /// @notice Function called to punish people who staked against a new reputation root hash that turned out to be incorrect.
   /// @dev While external, it can only be called successfully by the current ReputationMiningCycle.
   /// @param _stakers Array of the addresses of stakers to punish

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -432,6 +432,23 @@ Get the id of the parent skill at index `_parentSkillIndex` for skill with Id `_
 |---|---|---|
 |skillId|uint256|Skill Id of the requested parent skill
 
+### `getPayoutWhitelist`
+
+Get a token's status in the payout whitelist
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_token|address|The token being queried
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|status|bool|
+
 ### `getProfileDBAddress`
 
 Retrieve the orbitdb address corresponding to a registered account.
@@ -768,6 +785,19 @@ Set the resolver to be used by new instances of ReputationMiningCycle.
 |Name|Type|Description|
 |---|---|---|
 |miningResolverAddress|address|The address of the Resolver contract with the functions correctly wired.
+
+
+### `setPayoutWhitelist`
+
+Set a token's status in the payout whitelist
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_token|address|The token being set
+|_status|bool|The whitelist status
 
 
 ### `setReplacementReputationUpdateLogEntry`

--- a/docs/_Interface_IMetaColony.md
+++ b/docs/_Interface_IMetaColony.md
@@ -99,6 +99,19 @@ Set the Colony Network fee inverse amount.
 |_feeInverse|uint256|Nonzero amount for the fee inverse
 
 
+### `setPayoutWhitelist`
+
+Set a token's status in the payout whitelist on the Colony Network
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_token|address|The token being set
+|_status|bool|The whitelist status
+
+
 ### `setReputationMiningCycleReward`
 
 Called to set the total per-cycle reputation reward, which will be split between all miners.

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -153,11 +153,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("155af9df86571a3f3d77663d177fe08a12843e1dfb90d9fc90bd3a19097c3ab3");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("f8c3923760ef108c0ba09339448f88117e334220837c645e0954d1b5ed25df6f");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("dde1dd7452e9f4037ab8eb491a9e95e6a81a8e0a17c1a8e59b40c1b67086fe43");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("5a5d76a9bb4a761f4cbd0da4b729bd8143efd7ffe0f42daff9ac5381cb5e9524");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("ed2f5717a69310d3cb20cfdcbcf44ed53111731fa783752e492d949bbc92fe9b");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("51c3d93fb3b226482eb9ff2186dbb0ed7b676f825e60ffaaad95e4c3138f18e4");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("0d382067c08abd8a971cd7c0c2ba0c4e2d813034545b56a37060c1f933fc2b38");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("8080a650e4da5e587816c3086ebdc16e95f7850ebbdef2d6de2326e4d001b1f7");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("a8406a6d420aa9a725d28457d0af71c8bfcda4d323005670050000b01300eee9");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("00e56845847cdbb7b531eb5dd95dbd0e0f8110fd37b0cd7e77a40d583e03585f");
     });
   });
 });

--- a/test/contracts-network/meta-colony.js
+++ b/test/contracts-network/meta-colony.js
@@ -539,6 +539,26 @@ contract("Meta Colony", (accounts) => {
     });
   });
 
+  describe("when managing the payout whitelist", () => {
+    it("should allow a meta colony root user to update the whitelist", async () => {
+      let status = await colonyNetwork.getPayoutWhitelist(clnyToken.address);
+      expect(status).to.be.false;
+
+      await metaColony.setPayoutWhitelist(clnyToken.address, true);
+
+      status = await colonyNetwork.getPayoutWhitelist(clnyToken.address);
+      expect(status).to.be.true;
+    });
+
+    it("should not allow anyone else but a meta colony root user to update the whitelist", async () => {
+      await checkErrorRevert(metaColony.setPayoutWhitelist(clnyToken.address, true, { from: accounts[1] }), "ds-auth-unauthorized");
+    });
+
+    it("should not allow another account, than the meta colony, to update the whitelist", async () => {
+      await checkErrorRevert(colonyNetwork.setPayoutWhitelist(clnyToken.address, true), "colony-caller-must-be-meta-colony");
+    });
+  });
+
   describe("when minting tokens for the Network", () => {
     it("should NOT allow anyone but the Network to call mintTokensForColonyNetwork", async () => {
       await checkErrorRevert(metaColony.mintTokensForColonyNetwork(100), "colony-access-denied-only-network-allowed");


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #903

<!--- Summary of changes including design decisions -->

Adds a `payoutWhitelist` mapping to the Colony Network, configurable from the Metacolony. Used to determine if a token fee should be sent to auction or directly to the Metacolony.

The intention is to whitelist stablecoins, but who knows!

