### PR TITLE
Add further events and functions required by app

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -297,7 +297,9 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     // Add domain to local mapping
     initialiseDomain(newLocalSkill);
 
-    emit DomainMetadata(domainCount, _metadata);
+    if (keccak256(abi.encodePacked(_metadata)) != keccak256(abi.encodePacked(""))) {
+      emit DomainMetadata(domainCount, _metadata);
+    }
   }
 
   function editDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _domainId, string memory _metadata) public

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -307,7 +307,9 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   stoppable
   authDomain(_permissionDomainId, _childSkillIndex, _domainId)
   {
-    emit DomainMetadata(_domainId, _metadata);
+    if (keccak256(abi.encodePacked(_metadata)) != keccak256(abi.encodePacked(""))) {
+      emit DomainMetadata(_domainId, _metadata);
+    }
   }
 
   function getDomain(uint256 _id) public view returns (Domain memory domain) {

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -128,6 +128,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
   function initialiseColony(address _colonyNetworkAddress, address _token, string memory _metadata) public stoppable {
     initialiseColony(_colonyNetworkAddress, _token);
+
     emit ColonyMetadata(_metadata);
   }
 

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -126,6 +126,17 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     emit ColonyInitialised(_colonyNetworkAddress, _token);
   }
 
+  function initialiseColony(address _colonyNetworkAddress, address _token, string memory _metadata) public stoppable {
+    initialiseColony(_colonyNetworkAddress, _token);
+    emit ColonyMetadata(_metadata);
+  }
+
+  function editColony(string memory _metadata) public
+  stoppable
+  auth {
+    emit ColonyMetadata(_metadata);
+  }
+
   function bootstrapColony(address[] memory _users, int[] memory _amounts) public
   stoppable
   auth
@@ -151,6 +162,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   auth
   {
     ERC20Extended(token).mint(address(this), _wad); // ignore-swc-107
+
+    emit TokensMinted(address(this), _wad);
   }
 
   function mintTokensFor(address _guy, uint _wad) public
@@ -158,6 +171,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   auth
   {
     ERC20Extended(token).mint(_guy, _wad); // ignore-swc-107
+
+    emit TokensMinted(_guy, _wad);
   }
 
   function mintTokensForColonyNetwork(uint _wad) public stoppable {
@@ -167,6 +182,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     require(address(this) == IColonyNetwork(colonyNetworkAddress).getMetaColony(), "colony-access-denied-only-meta-colony-allowed");
     ERC20Extended(token).mint(_wad);
     assert(ERC20Extended(token).transfer(colonyNetworkAddress, _wad));
+
+    emit TokensMinted(colonyNetworkAddress, _wad);
   }
 
   function registerColonyLabel(string memory colonyName, string memory orbitdb) public stoppable auth {
@@ -272,6 +289,21 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
     // Add domain to local mapping
     initialiseDomain(newLocalSkill);
+  }
+
+  function addDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _parentDomainId, string memory _metadata) public
+  stoppable
+  authDomain(_permissionDomainId, _childSkillIndex, _parentDomainId)
+  {
+    addDomain(_permissionDomainId, _childSkillIndex, _parentDomainId);
+    emit DomainMetadata(domainCount, _metadata);
+  }
+
+  function editDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _domainId, string memory _metadata) public
+  stoppable
+  authDomain(_permissionDomainId, _childSkillIndex, _domainId)
+  {
+    emit DomainMetadata(_domainId, _metadata);
   }
 
   function getDomain(uint256 _id) public view returns (Domain memory domain) {
@@ -380,6 +412,14 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
     // Add payout whitelist functionality
     sig = bytes4(keccak256("setPayoutWhitelist(address,bool)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
+
+    // Add metadata functions
+    sig = bytes4(keccak256("addDomain(uint256,uint256,uint256,string)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Architecture), address(this), sig, true);
+    sig = bytes4(keccak256("editDomain(uint256,uint256,uint256,string)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Architecture), address(this), sig, true);
+    sig = bytes4(keccak256("editColony(string)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
   }
 

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -278,6 +278,13 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   stoppable
   authDomain(_permissionDomainId, _childSkillIndex, _parentDomainId)
   {
+    addDomain(_permissionDomainId, _childSkillIndex, _parentDomainId, "");
+  }
+
+  function addDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _parentDomainId, string memory _metadata) public
+  stoppable
+  authDomain(_permissionDomainId, _childSkillIndex, _parentDomainId)
+  {
     // Note: Remove when we want to allow more domain hierarchy levels
     require(_parentDomainId == 1, "colony-parent-domain-not-root");
 
@@ -289,13 +296,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
     // Add domain to local mapping
     initialiseDomain(newLocalSkill);
-  }
 
-  function addDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _parentDomainId, string memory _metadata) public
-  stoppable
-  authDomain(_permissionDomainId, _childSkillIndex, _parentDomainId)
-  {
-    addDomain(_permissionDomainId, _childSkillIndex, _parentDomainId);
     emit DomainMetadata(domainCount, _metadata);
   }
 

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -102,6 +102,9 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ARBITRATION_ROLE, "emitSkillReputationPenalty(uint256,address,int256)");
     addRoleCapability(ARBITRATION_ROLE, "setExpenditureState(uint256,uint256,uint256,uint256,bool[],bytes32[],bytes32)");
     addRoleCapability(ARCHITECTURE_ROLE, "setUserRoles(uint256,uint256,address,uint256,bytes32)");
+    addRoleCapability(ARCHITECTURE_ROLE, "addDomain(uint256,uint256,uint256,string)");
+    addRoleCapability(ARCHITECTURE_ROLE, "editDomain(uint256,uint256,uint256,string)");
+    addRoleCapability(ROOT_ROLE, "editColony(string)");
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -167,6 +167,11 @@ interface ColonyDataTypes {
   /// @param taskId Id of the finalized task
   event TaskFinalized(uint256 indexed taskId);
 
+  /// @notice Event logged when tokens are minted
+  /// @param who The address being awarded the tokens
+  /// @param amount The amount of tokens being awarded
+  event TokensMinted(address who, uint256 amount);
+
   /// @notice Event logged when a payout is claimed, either from a Task or Payment
   /// @param fundingPotId Id of the funding pot where payout comes from
   /// @param token Token of the payout claim
@@ -180,6 +185,14 @@ interface ColonyDataTypes {
   /// @notice Event logged when a new Domain is added
   /// @param domainId Id of the newly-created Domain
   event DomainAdded(uint256 domainId);
+
+  /// @notice Event logged when domain metadata is updated
+  /// @param domainId Id of the newly-created Domain
+  event DomainMetadata(uint256 indexed domainId, string metadata);
+
+  /// @notice Event logged when Colony metadata is updated
+  /// @param metadata IPFS hash of the metadata
+  event ColonyMetadata(string metadata);
 
   /// @notice Event logged when a new FundingPot is added
   /// @param fundingPotId Id of the newly-created FundingPot

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -189,6 +189,11 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _token Address of the colony ERC20 Token
   function initialiseColony(address _colonyNetworkAddress, address _token) external;
 
+  /// @notice Called to change the metadat associated with a colony. Expected to be a IPFS hash of a
+  /// JSON blob, but not enforced to any degree by the contracts
+  /// @param _metadata IPFS hash of the metadata
+  function editColony(string memory _metadata) external;
+
   /// @notice Allows the colony to bootstrap itself by having initial reputation and token `_amount` assigned to `_users`.
   /// This reputation is assigned in the colony-wide domain. Secured function to authorised members.
   /// @dev Only allowed to be called when `taskCount` is `0` by authorized addresses.
@@ -241,7 +246,25 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`
   /// @param _parentDomainId Id of the domain under which the new one will be added
   /// @dev Adding new domains is currently retricted to one level only, i.e. `_parentDomainId` has to be the root domain id: `1`.
+  /// @dev This signature is now deprecated and will be removed at a later date.
   function addDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _parentDomainId) external;
+
+  /// @notice Add a colony domain, and its respective local skill under skill with id `_parentSkillId`.
+  /// New funding pot is created and associated with the domain here.
+  /// @param _permissionDomainId The domainId in which I have the permission to take this action
+  /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`
+  /// @param _parentDomainId Id of the domain under which the new one will be added
+  /// @param _metadata Metadata relating to the domain. Expected to be the IPFS hash of a JSON blob, but not enforced by the contracts.
+  /// @dev Adding new domains is currently retricted to one level only, i.e. `_parentDomainId` has to be the root domain id: `1`.
+  function addDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _parentDomainId, string memory _metadata) external;
+
+  /// @notice Add a colony domain, and its respective local skill under skill with id `_parentSkillId`.
+  /// New funding pot is created and associated with the domain here.
+  /// @param _permissionDomainId The domainId in which I have the permission to take this action
+  /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`
+  /// @param _domainId Id of the domain being edited
+  /// @param _metadata Metadata relating to the domain. Expected to be the IPFS hash of a JSON blob, but not enforced by the contracts.
+  function editDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _domainId, string memory _metadata) external;
 
   /// @notice Get a domain by id.
   /// @param _id Id of the domain which details to get

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -189,7 +189,7 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _token Address of the colony ERC20 Token
   function initialiseColony(address _colonyNetworkAddress, address _token) external;
 
-  /// @notice Called to change the metadat associated with a colony. Expected to be a IPFS hash of a
+  /// @notice Called to change the metadata associated with a colony. Expected to be a IPFS hash of a
   /// JSON blob, but not enforced to any degree by the contracts
   /// @param _metadata IPFS hash of the metadata
   function editColony(string memory _metadata) external;

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -246,7 +246,6 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`
   /// @param _parentDomainId Id of the domain under which the new one will be added
   /// @dev Adding new domains is currently retricted to one level only, i.e. `_parentDomainId` has to be the root domain id: `1`.
-  /// @dev This signature is now deprecated and will be removed at a later date.
   function addDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _parentDomainId) external;
 
   /// @notice Add a colony domain, and its respective local skill under skill with id `_parentSkillId`.
@@ -256,6 +255,7 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _parentDomainId Id of the domain under which the new one will be added
   /// @param _metadata Metadata relating to the domain. Expected to be the IPFS hash of a JSON blob, but not enforced by the contracts.
   /// @dev Adding new domains is currently retricted to one level only, i.e. `_parentDomainId` has to be the root domain id: `1`.
+  /// @dev We expect this function to only be used by the dapp
   function addDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _parentDomainId, string memory _metadata) external;
 
   /// @notice Add a colony domain, and its respective local skill under skill with id `_parentSkillId`.

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -122,7 +122,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
   {
     require(metaColony == address(0x0), "colony-meta-colony-exists-already");
 
-    metaColony = createColony(_tokenAddress, currentColonyVersion, "");
+    metaColony = createColony(_tokenAddress, currentColonyVersion, "", "");
 
     // Add the special mining skill
     reputationMiningSkillId = this.addSkill(skillCount);
@@ -135,7 +135,7 @@ contract ColonyNetwork is ColonyNetworkStorage {
   stoppable
   returns (address)
   {
-    return createColony(_tokenAddress, 3, "");
+    return createColony(_tokenAddress, 3, "", "");
   }
 
   // DEPRECATED, only deploys version 4 colonies.
@@ -147,13 +147,14 @@ contract ColonyNetwork is ColonyNetworkStorage {
     bool _useExtensionManager // solhint-disable-line no-unused-vars
   ) public stoppable returns (address)
   {
-    return createColony(_tokenAddress, 4, _colonyName);
+    return createColony(_tokenAddress, 4, _colonyName, "");
   }
 
   function createColony(
     address _tokenAddress,
     uint256 _version,
-    string memory _colonyName
+    string memory _colonyName,
+    string memory _metadata
   ) public stoppable returns (address)
   {
     uint256 version = (_version == 0) ? currentColonyVersion : _version;
@@ -163,7 +164,10 @@ contract ColonyNetwork is ColonyNetworkStorage {
       IColony(colonyAddress).registerColonyLabel(_colonyName, "");
     }
 
+    IColony(colonyAddress).editColony(_metadata);
+
     setFounderPermissions(colonyAddress);
+
     return colonyAddress;
   }
 

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -153,6 +153,15 @@ contract ColonyNetwork is ColonyNetworkStorage {
   function createColony(
     address _tokenAddress,
     uint256 _version,
+    string memory _colonyName
+  ) public stoppable returns (address)
+  {
+    return createColony(_tokenAddress, _version, _colonyName, "");
+  }
+
+  function createColony(
+    address _tokenAddress,
+    uint256 _version,
     string memory _colonyName,
     string memory _metadata
   ) public stoppable returns (address)
@@ -164,7 +173,9 @@ contract ColonyNetwork is ColonyNetworkStorage {
       IColony(colonyAddress).registerColonyLabel(_colonyName, "");
     }
 
-    IColony(colonyAddress).editColony(_metadata);
+    if (keccak256(abi.encodePacked(_metadata)) != keccak256(abi.encodePacked(""))) {
+      IColony(colonyAddress).editColony(_metadata);
+    }
 
     setFounderPermissions(colonyAddress);
 

--- a/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
+++ b/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
@@ -17,8 +17,9 @@
 
 pragma solidity 0.7.3;
 
+import "./../colony/ColonyDataTypes.sol"; // TODO: Is there a better solution to this?
 
-interface ColonyNetworkDataTypes {
+interface ColonyNetworkDataTypes is ColonyDataTypes {
   /// @notice Event logged when the colony network is intialised. This is only ever emitted once in a network's lifetime
   /// @param resolver The Resolver contract address used by the Colony version 1
   event ColonyNetworkInitialised(address resolver);

--- a/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
+++ b/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
@@ -17,9 +17,7 @@
 
 pragma solidity 0.7.3;
 
-import "./../colony/ColonyDataTypes.sol"; // TODO: Is there a better solution to this?
-
-interface ColonyNetworkDataTypes is ColonyDataTypes {
+interface ColonyNetworkDataTypes {
   /// @notice Event logged when the colony network is intialised. This is only ever emitted once in a network's lifetime
   /// @param resolver The Resolver contract address used by the Colony version 1
   event ColonyNetworkInitialised(address resolver);

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -151,7 +151,7 @@ interface IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @param _version The version of colony to deploy (pass 0 for the current version)
   /// @param _colonyName The label to register (if null, no label is registered)
   /// @return colonyAddress Address of the newly created colony
-  function createColony(address _tokenAddress, uint256 _version, string memory _colonyName)
+  function createColony(address _tokenAddress, uint256 _version, string memory _colonyName, string memory _metadata)
     external returns (address colonyAddress);
 
   /// @notice Adds a new Colony contract version and the address of associated `_resolver` contract. Secured function to authorised members.

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -150,6 +150,7 @@ interface IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @param _tokenAddress Address of an ERC20 token to serve as the colony token
   /// @param _version The version of colony to deploy (pass 0 for the current version)
   /// @param _colonyName The label to register (if null, no label is registered)
+  /// @param _metadata The metadata associated with the new colony
   /// @return colonyAddress Address of the newly created colony
   function createColony(address _tokenAddress, uint256 _version, string memory _colonyName, string memory _metadata)
     external returns (address colonyAddress);

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -150,8 +150,18 @@ interface IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @param _tokenAddress Address of an ERC20 token to serve as the colony token
   /// @param _version The version of colony to deploy (pass 0 for the current version)
   /// @param _colonyName The label to register (if null, no label is registered)
+  /// @return colonyAddress Address of the newly created colony
+  function createColony(address _tokenAddress, uint256 _version, string memory _colonyName)
+    external returns (address colonyAddress);
+
+  /// @notice Creates a new colony in the network, with an optional ENS name
+  /// @dev For the colony to mint tokens, token ownership must be transferred to the new colony
+  /// @param _tokenAddress Address of an ERC20 token to serve as the colony token
+  /// @param _version The version of colony to deploy (pass 0 for the current version)
+  /// @param _colonyName The label to register (if null, no label is registered)
   /// @param _metadata The metadata associated with the new colony
   /// @return colonyAddress Address of the newly created colony
+  /// @dev We expect this function to only be used by the dapp
   function createColony(address _tokenAddress, uint256 _version, string memory _colonyName, string memory _metadata)
     external returns (address colonyAddress);
 

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -24,6 +24,8 @@ import "./ColonyExtension.sol";
 
 
 contract OneTxPayment is ColonyExtension {
+  event OneTxPaymentMade();
+  
   uint256 constant UINT256_MAX = 2**256 - 1;
   ColonyDataTypes.ColonyRole constant ADMINISTRATION = ColonyDataTypes.ColonyRole.Administration;
   ColonyDataTypes.ColonyRole constant FUNDING = ColonyDataTypes.ColonyRole.Funding;
@@ -131,6 +133,8 @@ contract OneTxPayment is ColonyExtension {
       finalizeAndClaim(expenditureId, _workers, _tokens);
 
     }
+
+    emit OneTxPaymentMade();
   }
 
   /// @notice Completes a colony payment in a single transaction
@@ -212,6 +216,8 @@ contract OneTxPayment is ColonyExtension {
       finalizeAndClaim(expenditureId, _workers, _tokens);
 
     }
+
+    emit OneTxPaymentMade();
   }
 
   function calculateUniqueAmounts(

--- a/contracts/extensions/TokenSupplier.sol
+++ b/contracts/extensions/TokenSupplier.sol
@@ -105,6 +105,8 @@ contract TokenSupplier is ColonyExtension {
     tokenIssuanceRate = _tokenIssuanceRate;
     lastIssue = block.timestamp;
     lastRateUpdate = block.timestamp;
+
+    emit ExtensionInitialised();
   }
 
   /// @notice Update the tokenSupplyCeiling, cannot set below current tokenSupply

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -237,7 +237,7 @@ Set the deprecation of an extension in a colony. Secured function to authorised 
 
 ### `editColony`
 
-Called to change the metadat associated with a colony. Expected to be a IPFS hash of a JSON blob, but not enforced to any degree by the contracts
+Called to change the metadata associated with a colony. Expected to be a IPFS hash of a JSON blob, but not enforced to any degree by the contracts
 
 
 **Parameters**

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -22,6 +22,22 @@ Add a colony domain, and its respective local skill under skill with id `_parent
 |_parentDomainId|uint256|Id of the domain under which the new one will be added
 
 
+### `addDomain`
+
+Add a colony domain, and its respective local skill under skill with id `_parentSkillId`. New funding pot is created and associated with the domain here.
+
+*Note: Adding new domains is currently retricted to one level only, i.e. `_parentDomainId` has to be the root domain id: `1`.*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_permissionDomainId|uint256|The domainId in which I have the permission to take this action
+|_childSkillIndex|uint256|The index that the `_domainId` is relative to `_permissionDomainId`
+|_parentDomainId|uint256|Id of the domain under which the new one will be added
+|_metadata|string|Metadata relating to the domain. Expected to be the IPFS hash of a JSON blob, but not enforced by the contracts.
+
+
 ### `addPayment`
 
 Add a new payment in the colony. Secured function to authorised members.
@@ -217,6 +233,33 @@ Set the deprecation of an extension in a colony. Secured function to authorised 
 |---|---|---|
 |extensionId|bytes32|keccak256 hash of the extension name, used as an indentifier
 |deprecated|bool|Whether to deprecate the extension or not
+
+
+### `editColony`
+
+Called to change the metadat associated with a colony. Expected to be a IPFS hash of a JSON blob, but not enforced to any degree by the contracts
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_metadata|string|IPFS hash of the metadata
+
+
+### `editDomain`
+
+Add a colony domain, and its respective local skill under skill with id `_parentSkillId`. New funding pot is created and associated with the domain here.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_permissionDomainId|uint256|The domainId in which I have the permission to take this action
+|_childSkillIndex|uint256|The index that the `_domainId` is relative to `_permissionDomainId`
+|_domainId|uint256|Id of the domain being edited
+|_metadata|string|Metadata relating to the domain. Expected to be the IPFS hash of a JSON blob, but not enforced by the contracts.
 
 
 ### `emitDomainReputationPenalty`

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -159,6 +159,26 @@ Creates a new colony in the network, with an optional ENS name
 |_tokenAddress|address|Address of an ERC20 token to serve as the colony token
 |_version|uint256|The version of colony to deploy (pass 0 for the current version)
 |_colonyName|string|The label to register (if null, no label is registered)
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|colonyAddress|address|Address of the newly created colony
+
+### `createColony`
+
+Creates a new colony in the network, with an optional ENS name
+
+*Note: For the colony to mint tokens, token ownership must be transferred to the new colony*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_tokenAddress|address|Address of an ERC20 token to serve as the colony token
+|_version|uint256|The version of colony to deploy (pass 0 for the current version)
+|_colonyName|string|The label to register (if null, no label is registered)
 |_metadata|string|The metadata associated with the new colony
 
 **Return Parameters**

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -159,6 +159,7 @@ Creates a new colony in the network, with an optional ENS name
 |_tokenAddress|address|Address of an ERC20 token to serve as the colony token
 |_version|uint256|The version of colony to deploy (pass 0 for the current version)
 |_colonyName|string|The label to register (if null, no label is registered)
+|_metadata|string|
 
 **Return Parameters**
 

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -159,7 +159,7 @@ Creates a new colony in the network, with an optional ENS name
 |_tokenAddress|address|Address of an ERC20 token to serve as the colony token
 |_version|uint256|The version of colony to deploy (pass 0 for the current version)
 |_colonyName|string|The label to register (if null, no label is registered)
-|_metadata|string|
+|_metadata|string|The metadata associated with the new colony
 
 **Return Parameters**
 

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -29,6 +29,8 @@ const SPECIFICATION_HASH_UPDATED = "0x017dfd85d4f6cb4dcd715a88101f7b1f06cd1e009b
 // The base58 decoded, bytes32 converted hex value of a test task ipfsHash "qmv8ndh7ageh9b24zngaextmuhj7aiuw3scc8hkczvjkww"
 const DELIVERABLE_HASH = "0xfb027a4d64f29d83e27769cb05d945e67ef7396fa1bd73ef53f065311fd3313e";
 
+const IPFS_HASH = "QmTfCejgo2wTwqnDJs8Lu1pCNeCrCDuE4GAwkna93zdd7d";
+
 const WAD = new BN(10).pow(new BN(18));
 const MIN_STAKE = WAD.muln(2000);
 const DEFAULT_STAKE = MIN_STAKE.muln(1000);
@@ -108,4 +110,5 @@ module.exports = {
   MINING_CYCLE_TIMEOUT,
   DECAY_RATE,
   GLOBAL_SKILL_ID,
+  IPFS_HASH,
 };

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -385,7 +385,7 @@ export async function setupRandomColony(colonyNetwork) {
 
 export async function setupColony(colonyNetwork, tokenAddress) {
   const { logs } = await colonyNetwork.createColony(tokenAddress, 0, "", "");
-  const { colonyAddress } = logs[0].args;
+  const { colonyAddress } = logs.filter((x) => x.event === "ColonyAdded")[0].args;
   const colony = await IColony.at(colonyAddress);
   return colony;
 }

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -384,7 +384,7 @@ export async function setupRandomColony(colonyNetwork) {
 }
 
 export async function setupColony(colonyNetwork, tokenAddress) {
-  const { logs } = await colonyNetwork.createColony(tokenAddress, 0, "");
+  const { logs } = await colonyNetwork.createColony(tokenAddress, 0, "", "");
   const { colonyAddress } = logs[0].args;
   const colony = await IColony.at(colonyAddress);
   return colony;

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -265,7 +265,7 @@ export async function expectEvent(tx, eventName, args) {
   const event = logs.find((e) => e.event === eventName);
   expect(event).to.exist;
   for (let i = 0; i < args.length; i += 1) {
-    if (typeof event.args[i] === "string") {
+    if (typeof event.args[i] === "string" && !ethers.utils.isHexString(event.args[i])) {
       expect(args[i]).to.equal(event.args[i]);
     } else {
       expect(hexlifyAndPad(args[i])).to.equal(hexlifyAndPad(event.args[i]));

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -265,10 +265,10 @@ export async function expectEvent(tx, eventName, args) {
   const event = logs.find((e) => e.event === eventName);
   expect(event).to.exist;
   for (let i = 0; i < args.length; i += 1) {
-    if (ethers.utils.isHexString(event.args[i])) {
-      expect(hexlifyAndPad(args[i])).to.equal(hexlifyAndPad(event.args[i]));
-    } else {
+    if (typeof event.args[i] === "string") {
       expect(args[i]).to.equal(event.args[i]);
+    } else {
+      expect(hexlifyAndPad(args[i])).to.equal(hexlifyAndPad(event.args[i]));
     }
   }
   return expect(event).to.exist;

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -263,8 +263,13 @@ function hexlifyAndPad(input) {
 export async function expectEvent(tx, eventName, args) {
   const { logs } = await tx;
   const event = logs.find((e) => e.event === eventName);
+  expect(event).to.exist;
   for (let i = 0; i < args.length; i += 1) {
-    expect(hexlifyAndPad(args[i])).to.equal(hexlifyAndPad(event.args[i]));
+    if (ethers.utils.isHexString(event.args[i])) {
+      expect(hexlifyAndPad(args[i])).to.equal(hexlifyAndPad(event.args[i]));
+    } else {
+      expect(args[i]).to.equal(event.args[i]);
+    }
   }
   return expect(event).to.exist;
 }

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -285,6 +285,23 @@ export async function expectEvent(tx, nameOrSig, args) {
   }
 }
 
+export async function expectNoEvent(tx, nameOrSig) {
+  const re = /\((.*)\)/;
+  let event;
+
+  if (nameOrSig.match(re)) {
+    // i.e. if the passed nameOrSig has () in it, we assume it's a signature
+    const { rawLogs } = await tx.receipt;
+    const topic = web3.utils.soliditySha3(nameOrSig);
+    event = rawLogs.find((e) => e.topics[0] === topic);
+    expect(event).to.not.exist;
+  } else {
+    const { logs } = await tx;
+    event = logs.find((e) => e.event === nameOrSig);
+    expect(event).to.not.exist;
+  }
+}
+
 export async function expectAllEvents(tx, eventNames) {
   const { logs } = await tx;
   const events = eventNames.every((eventName) => logs.find((e) => e.event === eventName));

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -96,7 +96,7 @@ contract("All", function (accounts) {
       const tokenArgs = getTokenArgs();
       const colonyToken = await Token.new(...tokenArgs);
       await colonyToken.unlock();
-      await colonyNetwork.createColony(colonyToken.address, CURR_VERSION, "");
+      await colonyNetwork.createColony(colonyToken.address, CURR_VERSION, "", "");
     });
 
     it("when working with the Meta Colony", async function () {

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -153,11 +153,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("51c3d93fb3b226482eb9ff2186dbb0ed7b676f825e60ffaaad95e4c3138f18e4");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("0d382067c08abd8a971cd7c0c2ba0c4e2d813034545b56a37060c1f933fc2b38");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("8080a650e4da5e587816c3086ebdc16e95f7850ebbdef2d6de2326e4d001b1f7");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("a8406a6d420aa9a725d28457d0af71c8bfcda4d323005670050000b01300eee9");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("00e56845847cdbb7b531eb5dd95dbd0e0f8110fd37b0cd7e77a40d583e03585f");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("4c07d8d06f0c49e60f8a869c745c75a41b41e20e2cf76c19c2f1ec23c45f9098");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("84bf5434ea31cbf8973da6eb9fd83909cdf1a96593228aa3cffe322e3c9fbf61");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("e2eb0c7a3bc79651468c45e16f737d997e9db219964493043ecd99f7be57ad07");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("80f93c4efedbbe276aa35376ea88e3ab9f0f8a9e7d6143cbf91b73be376652c6");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("dbbb3f76eb1ef02e27e6da38b2a9729c25258b7092377f1719aaa8efe0e68d8a");
     });
   });
 });

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -153,11 +153,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("4c07d8d06f0c49e60f8a869c745c75a41b41e20e2cf76c19c2f1ec23c45f9098");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("84bf5434ea31cbf8973da6eb9fd83909cdf1a96593228aa3cffe322e3c9fbf61");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("e2eb0c7a3bc79651468c45e16f737d997e9db219964493043ecd99f7be57ad07");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("80f93c4efedbbe276aa35376ea88e3ab9f0f8a9e7d6143cbf91b73be376652c6");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("dbbb3f76eb1ef02e27e6da38b2a9729c25258b7092377f1719aaa8efe0e68d8a");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("85e5a1d7c935fe6853cf86740e5fb8c505aea869e8578f577967be1f1f17707a");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("50e4612eab433ec09443ebb13329c143e8d82be1014901c879fe47e016a59209");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("c8499c8232a66015f8cc80d4c722c346cd8c696818e4ab5e75f6be0fd7cc5c9f");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("c50ad617df6bfe48b6e5fddaa230f0b3f8a22e8e223222aedf6c1e46dc5a7432");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("4362c73092b019330797d71923ab0f176453ee7487c158c28d8c98d217104874");
     });
   });
 });

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -196,7 +196,7 @@ contract("Colony Network", (accounts) => {
       const nonexistentVersion = currentColonyVersion.addn(1);
       const token = await Token.new(...getTokenArgs());
 
-      await checkErrorRevert(colonyNetwork.createColony(token.address, nonexistentVersion, ""), "colony-network-invalid-version");
+      await checkErrorRevert(colonyNetwork.createColony(token.address, nonexistentVersion, "", ""), "colony-network-invalid-version");
     });
 
     it("should allow use of the deprecated one-parameter createColony", async () => {
@@ -231,13 +231,13 @@ contract("Colony Network", (accounts) => {
     it("should maintain correct count of colonies", async () => {
       const token = await Token.new(...getTokenArgs());
       await token.unlock();
-      await colonyNetwork.createColony(token.address, 0, "");
-      await colonyNetwork.createColony(token.address, 0, "");
-      await colonyNetwork.createColony(token.address, 0, "");
-      await colonyNetwork.createColony(token.address, 0, "");
-      await colonyNetwork.createColony(token.address, 0, "");
-      await colonyNetwork.createColony(token.address, 0, "");
-      await colonyNetwork.createColony(token.address, 0, "");
+      await colonyNetwork.createColony(token.address, 0, "", "");
+      await colonyNetwork.createColony(token.address, 0, "", "");
+      await colonyNetwork.createColony(token.address, 0, "", "");
+      await colonyNetwork.createColony(token.address, 0, "", "");
+      await colonyNetwork.createColony(token.address, 0, "", "");
+      await colonyNetwork.createColony(token.address, 0, "", "");
+      await colonyNetwork.createColony(token.address, 0, "", "");
       const colonyCount = await colonyNetwork.getColonyCount();
       expect(colonyCount).to.eq.BN(8);
     });
@@ -266,7 +266,7 @@ contract("Colony Network", (accounts) => {
     });
 
     it("should not allow users to create a colony with empty token", async () => {
-      await checkErrorRevert(colonyNetwork.createColony(ethers.constants.AddressZero, 0, ""), "colony-token-invalid-address");
+      await checkErrorRevert(colonyNetwork.createColony(ethers.constants.AddressZero, 0, "", ""), "colony-token-invalid-address");
     });
 
     it("when any colony is created, should have the root local skill initialised", async () => {
@@ -290,8 +290,8 @@ contract("Colony Network", (accounts) => {
 
     it("should fail if ETH is sent", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      const sig = "createColony(address,uint256,string)";
-      await checkErrorRevert(colonyNetwork.methods[sig](token.address, 0, "", { value: 1, gas: createColonyGas }));
+      const sig = "createColony(address,uint256,string,string)";
+      await checkErrorRevert(colonyNetwork.methods[sig](token.address, 0, "", "", { value: 1, gas: createColonyGas }));
 
       const colonyNetworkBalance = await web3GetBalance(colonyNetwork.address);
       expect(colonyNetworkBalance).to.be.zero;
@@ -299,7 +299,7 @@ contract("Colony Network", (accounts) => {
 
     it("should log a ColonyAdded event", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      const tx = await colonyNetwork.createColony(token.address, 0, "");
+      const tx = await colonyNetwork.createColony(token.address, 0, "", "");
       const colonyCount = await colonyNetwork.getColonyCount();
       const colonyAddress = await colonyNetwork.getColony(colonyCount);
       await expectEvent(tx, "ColonyAdded", [colonyCount, colonyAddress, token.address]);
@@ -309,9 +309,9 @@ contract("Colony Network", (accounts) => {
   describe("when getting existing colonies", () => {
     it("should allow users to get the address of a colony by its index", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      await colonyNetwork.createColony(token.address, 0, "");
-      await colonyNetwork.createColony(token.address, 0, "");
-      await colonyNetwork.createColony(token.address, 0, "");
+      await colonyNetwork.createColony(token.address, 0, "", "");
+      await colonyNetwork.createColony(token.address, 0, "", "");
+      await colonyNetwork.createColony(token.address, 0, "", "");
       const colonyAddress = await colonyNetwork.getColony(3);
       expect(colonyAddress).to.not.equal(ethers.constants.AddressZero);
     });
@@ -415,8 +415,8 @@ contract("Colony Network", (accounts) => {
 
     it("should be able to create a colony with label in one tx", async () => {
       const token = await Token.new(...TOKEN_ARGS);
-      const { logs } = await colonyNetwork.createColony(token.address, 0, "test");
-      const { colonyAddress } = logs[0].args;
+      const { logs } = await colonyNetwork.createColony(token.address, 0, "test", "");
+      const { colonyAddress } = logs.filter((x) => x.event === "ColonyAdded")[0].args;
 
       const name = await colonyNetwork.lookupRegisteredENSDomain(colonyAddress);
       expect(name).to.equal("test.colony.joincolony.eth");

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -225,7 +225,7 @@ contract("Colony Network", (accounts) => {
       const token = await Token.new(...getTokenArgs());
       await token.unlock();
       const tx = await colonyNetwork.createColony(token.address, 0, "", IPFS_HASH);
-      expectEvent(tx, "ColonyMetadata", [IPFS_HASH]);
+      await expectEvent(tx, "ColonyMetadata(string)", [IPFS_HASH]);
     });
 
     it("should maintain correct count of colonies", async () => {

--- a/test/contracts-network/colony-reward-payouts.js
+++ b/test/contracts-network/colony-reward-payouts.js
@@ -636,11 +636,11 @@ contract("Colony Reward Payouts", (accounts) => {
       const newToken = await Token.new(...tokenArgs);
       await newToken.unlock();
 
-      let { logs } = await colonyNetwork.createColony(newToken.address, 0, "");
+      let { logs } = await colonyNetwork.createColony(newToken.address, 0, "", "");
       let { colonyAddress } = logs[0].args;
       const colony1 = await IColony.at(colonyAddress);
 
-      ({ logs } = await colonyNetwork.createColony(newToken.address, 0, ""));
+      ({ logs } = await colonyNetwork.createColony(newToken.address, 0, "", ""));
       ({ colonyAddress } = logs[0].args);
       const colony2 = await IColony.at(colonyAddress);
 
@@ -735,11 +735,11 @@ contract("Colony Reward Payouts", (accounts) => {
       const newToken = await Token.new(...tokenArgs);
       await newToken.unlock();
 
-      let { logs } = await colonyNetwork.createColony(newToken.address, 0, "");
+      let { logs } = await colonyNetwork.createColony(newToken.address, 0, "", "");
       let { colonyAddress } = logs[0].args;
       const colony1 = await IColony.at(colonyAddress);
 
-      ({ logs } = await colonyNetwork.createColony(newToken.address, 0, ""));
+      ({ logs } = await colonyNetwork.createColony(newToken.address, 0, "", ""));
       ({ colonyAddress } = logs[0].args);
       const colony2 = await IColony.at(colonyAddress);
 

--- a/test/contracts-network/colony-reward-payouts.js
+++ b/test/contracts-network/colony-reward-payouts.js
@@ -637,11 +637,11 @@ contract("Colony Reward Payouts", (accounts) => {
       await newToken.unlock();
 
       let { logs } = await colonyNetwork.createColony(newToken.address, 0, "", "");
-      let { colonyAddress } = logs[0].args;
+      let { colonyAddress } = logs.filter((x) => x.event === "ColonyAdded")[0].args;
       const colony1 = await IColony.at(colonyAddress);
 
       ({ logs } = await colonyNetwork.createColony(newToken.address, 0, "", ""));
-      ({ colonyAddress } = logs[0].args);
+      ({ colonyAddress } = logs.filter((x) => x.event === "ColonyAdded")[0].args);
       const colony2 = await IColony.at(colonyAddress);
 
       // Giving both colonies the capability to call `mint` function
@@ -736,11 +736,11 @@ contract("Colony Reward Payouts", (accounts) => {
       await newToken.unlock();
 
       let { logs } = await colonyNetwork.createColony(newToken.address, 0, "", "");
-      let { colonyAddress } = logs[0].args;
+      let { colonyAddress } = logs.filter((x) => x.event === "ColonyAdded")[0].args;
       const colony1 = await IColony.at(colonyAddress);
 
       ({ logs } = await colonyNetwork.createColony(newToken.address, 0, "", ""));
-      ({ colonyAddress } = logs[0].args);
+      ({ colonyAddress } = logs.filter((x) => x.event === "ColonyAdded")[0].args);
       const colony2 = await IColony.at(colonyAddress);
 
       // Giving both colonies the capability to call `mint` function

--- a/test/contracts-network/colony-token-integrations.js
+++ b/test/contracts-network/colony-token-integrations.js
@@ -24,7 +24,7 @@ contract("Colony Token Integration", (addresses) => {
     // Instantiate an openzeppelin ERC20Mintable token instance
     erc20Mintable = await ERC20PresetMinterPauser.new("Test", "TEST");
     const { logs } = await colonyNetwork.createColony(erc20Mintable.address, 0, "", "");
-    const { colonyAddress } = logs[0].args;
+    const { colonyAddress } = logs.filter((x) => x.event === "ColonyAdded")[0].args;
     colony = await IColony.at(colonyAddress);
     await colony.setRewardInverse(100);
   });

--- a/test/contracts-network/colony-token-integrations.js
+++ b/test/contracts-network/colony-token-integrations.js
@@ -23,7 +23,7 @@ contract("Colony Token Integration", (addresses) => {
   beforeEach(async () => {
     // Instantiate an openzeppelin ERC20Mintable token instance
     erc20Mintable = await ERC20PresetMinterPauser.new("Test", "TEST");
-    const { logs } = await colonyNetwork.createColony(erc20Mintable.address, 0, "");
+    const { logs } = await colonyNetwork.createColony(erc20Mintable.address, 0, "", "");
     const { colonyAddress } = logs[0].args;
     colony = await IColony.at(colonyAddress);
     await colony.setRewardInverse(100);

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -236,6 +236,11 @@ contract("Colony", (accounts) => {
       const domainCount = await colony.getDomainCount();
       await expectEvent(colony.editDomain(1, 0, 2, IPFS_HASH), "DomainMetadata", [domainCount, IPFS_HASH]);
     });
+
+    it("should not log the DomainMetadata event if empty string passed", async () => {
+      await colony.addDomain(1, UINT256_MAX, 1);
+      await expectNoEvent(colony.editDomain(1, 0, 2, ""), "DomainMetadata");
+    });
   });
 
   describe("when bootstrapping the colony", () => {

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -16,7 +16,7 @@ import {
   RATING_2_SECRET,
   WAD,
 } from "../../helpers/constants";
-import { getTokenArgs, web3GetBalance, checkErrorRevert, encodeTxData, expectAllEvents, expectEvent } from "../../helpers/test-helper";
+import { getTokenArgs, web3GetBalance, checkErrorRevert, encodeTxData, expectNoEvent, expectAllEvents, expectEvent } from "../../helpers/test-helper";
 import { makeTask, setupRandomColony } from "../../helpers/test-data-generator";
 
 const { expect } = chai;
@@ -219,7 +219,7 @@ contract("Colony", (accounts) => {
       await expectEvent(tx, "DomainAdded", [domainCount]);
       let fundingPotCount = await colony.getFundingPotCount();
       await expectEvent(tx, "FundingPotAdded", [fundingPotCount]);
-      await expectEvent(tx, "DomainMetadata", [domainCount, ""]);
+      await expectNoEvent(tx, "DomainMetadata");
 
       tx = await colony.addDomain(1, UINT256_MAX, 1, IPFS_HASH);
       domainCount = await colony.getDomainCount();

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -15,7 +15,7 @@ import {
   RATING_2_SECRET,
   WAD,
 } from "../../helpers/constants";
-import { getTokenArgs, web3GetBalance, checkErrorRevert, encodeTxData, expectAllEvents } from "../../helpers/test-helper";
+import { getTokenArgs, web3GetBalance, checkErrorRevert, encodeTxData, expectAllEvents, expectEvent } from "../../helpers/test-helper";
 import { makeTask, setupRandomColony } from "../../helpers/test-data-generator";
 
 const { expect } = chai;
@@ -88,6 +88,15 @@ contract("Colony", (accounts) => {
       await otherToken.unlock();
 
       await expectAllEvents(otherToken.methods["mint(uint256)"](100), ["Mint"]);
+    });
+
+    it("should emit correct Mint event when minting tokens through the colony", async () => {
+      const tokenArgs = getTokenArgs();
+      const otherToken = await Token.new(...tokenArgs);
+      await otherToken.unlock();
+
+      await expectEvent(colony.mintTokens(100), "TokensMinted", [colony.address, 100]);
+      await expectEvent(colony.mintTokensFor(accounts[0], 100), "TokensMinted", [accounts[0], 100]);
     });
 
     it("should fail if a non-admin tries to mint tokens", async () => {

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -6,6 +6,7 @@ import { ethers } from "ethers";
 import { soliditySha3 } from "web3-utils";
 
 import {
+  IPFS_HASH,
   UINT256_MAX,
   MANAGER_RATING,
   WORKER_RATING,
@@ -212,8 +213,28 @@ contract("Colony", (accounts) => {
   });
 
   describe("when adding domains", () => {
-    it("should log DomainAdded and FundingPotAdded events", async () => {
-      await expectAllEvents(colony.addDomain(1, UINT256_MAX, 1), ["DomainAdded", "FundingPotAdded"]);
+    it("should log DomainAdded and FundingPotAdded and DomainMetadata events", async () => {
+      let tx = await colony.addDomain(1, UINT256_MAX, 1);
+      let domainCount = await colony.getDomainCount();
+      await expectEvent(tx, "DomainAdded", [domainCount]);
+      let fundingPotCount = await colony.getFundingPotCount();
+      await expectEvent(tx, "FundingPotAdded", [fundingPotCount]);
+      await expectEvent(tx, "DomainMetadata", [domainCount, ""]);
+
+      tx = await colony.addDomain(1, UINT256_MAX, 1, IPFS_HASH);
+      domainCount = await colony.getDomainCount();
+      await expectEvent(tx, "DomainAdded", [domainCount]);
+      fundingPotCount = await colony.getFundingPotCount();
+      await expectEvent(tx, "FundingPotAdded", [fundingPotCount]);
+      await expectEvent(tx, "DomainMetadata", [domainCount, IPFS_HASH]);
+    });
+  });
+
+  describe("when editing domains", () => {
+    it("should log the DomainMetadata event", async () => {
+      await colony.addDomain(1, UINT256_MAX, 1);
+      const domainCount = await colony.getDomainCount();
+      await expectEvent(colony.editDomain(1, 0, 2, IPFS_HASH), "DomainMetadata", [domainCount, IPFS_HASH]);
     });
   });
 

--- a/test/contracts-network/router-resolver.js
+++ b/test/contracts-network/router-resolver.js
@@ -70,7 +70,7 @@ contract("EtherRouter / Resolver", (accounts) => {
     it("should return correct destination for given function, including overloads", async () => {
       const deployedColonyNetwork = await ColonyNetwork.deployed();
       const signature = await resolver.stringToSig("createColony(address)");
-      const overloadedSignature = await resolver.stringToSig("createColony(address,uint256,string)");
+      const overloadedSignature = await resolver.stringToSig("createColony(address,uint256,string,string)");
       const destination = await resolver.lookup(signature);
       const overloadedDestination = await resolver.lookup(overloadedSignature);
       expect(destination).to.equal(deployedColonyNetwork.address);

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -6,7 +6,7 @@ import { ethers } from "ethers";
 import { soliditySha3 } from "web3-utils";
 
 import { UINT256_MAX, WAD, INITIAL_FUNDING, GLOBAL_SKILL_ID, FUNDING_ROLE, ADMINISTRATION_ROLE } from "../../helpers/constants";
-import { checkErrorRevert, web3GetCode, rolesToBytes32 } from "../../helpers/test-helper";
+import { checkErrorRevert, web3GetCode, rolesToBytes32, expectEvent } from "../../helpers/test-helper";
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony, fundColonyWithTokens } from "../../helpers/test-data-generator";
 import { setupEtherRouter } from "../../helpers/upgradable-contracts";
 
@@ -94,10 +94,12 @@ contract("One transaction payments", (accounts) => {
       const balanceBefore = await token.balanceOf(USER1);
       expect(balanceBefore).to.be.zero;
 
-      await oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, GLOBAL_SKILL_ID);
+      const tx = await oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, GLOBAL_SKILL_ID);
 
       const balanceAfter = await token.balanceOf(USER1);
       expect(balanceAfter).to.eq.BN(9);
+
+      await expectEvent(tx, "OneTxPaymentMade", []);
     });
 
     it("should allow a single-transaction payment of ETH to occur", async () => {


### PR DESCRIPTION
Work on the Universal Action Creator is to begin soon, so Raul and I had a call to figure out what the contracts have to change or add in order for that to work. Some of that work is taking place in #882, and this PR is intended to contain the remainder. The resulting additional work can broadly be split in to two categories.

## Allowing the app to identify actions

The type of screens we're thinking of look like this (once an action has been created):

![screenshot-2020-11-26_15-39-41](https://user-images.githubusercontent.com/311812/100370164-c8fa2480-2ffd-11eb-8a1f-de57ce7ae721.png)

The example here is moving funds, but in principle this applies to all actions in the UAC. This type of screen will be navigated to via a path that involves the transaction id. The app will get the transaction in question, and attempt to work out what is going on in it. There are four possibilities 

1. The transaction doesn't exist
2. The transaction exists, but isn't mined yet
3. The transaction is mined, but doesn't do anything the app recognises
4. The transaction is mined, and does something we recognise

We're are purely talking about possibility 4 here, and how the app 'recognises' what is going on.

The natural starting point is looking at the `data` field of the transaction and examine the function being called (the first four bytes of the `data` field). If the function signature is one we recognise, great! Otherwise we fall in the category 3 above. Unfortunately, this is quite a fragile approach. It would require a much more detailed examination of the transaction data if it were performed through the annotation extension in one transaction (see #882), and would also be unable to recognise things done through other multisigs unless they were explicitly added. This is because in both of these cases, the function being called would not be `moveFundsBetweenPots`, but `executeMultisigTransaction` or similar, requiring a much more involved examination of the transaction. Not wishing to put that burden on the app team, we discounted this approach unless it turns out absolutely necessary.

A more robust approach is to use events, which the app team are already fairly comfortable with querying and interpreting. If that transaction contains an event that corresponds to an action we recognise, the app can display the relevant screen and interpret any other events that are present appropriately. This means that every one-transaction action has to have a unique event, and every multi-transaction action down the line (such as the full task flow) will have to have a unique event in the first transaction that starts that flow. Subsequent transactions that interact with that flow will have to be able to be identified via events as well, but we have no such examples in the UAC work for now.

To this end, I add the events 

* `OneTxPaymentMade` 
* `TokensMinted`

And for any future functionality / extensions, we should keep this 'first transaction must contain a unique event' requirement in mind.

~~_I have not yet checked other existing extensions, but I would probably do so in this PR down the line if/when we've settled on this approach_~~ Now done

_A different approach to identifying proposals of actions will be required, despite the very similar interface. I have a plan for that though, and does not need to be worried about here. Essentially, we will emit the function signature of whatever is being proposed as an event in the motions and disputes contract._

## Allowing the app to rely less on a backend

The UAC also contains some new actions that require new functions. These are based around 'metadata' being added to colonies and domains (containing names, colours, a list of 'active' tokens, and so on), stored on-chain in events in order to remove some reliance on the backend. We propose that the contracts are as agnostic as possible, and just accept IPFS hashes of whatever the app team deems needed to be in them (likely JSON blobs), and validating and consuming them falls on the app team, as does handling failure cases where the corresponding data cannot be retrieved from IPFS. Daniel and I loosely agreed to adding relevant permissioned functions last time we discussed it in #882, though not their contents.

To this end, I have added extra `metadata` parameters to `createColony` and `createDomain` with corresponding events, and the new functions `editColony` and `editDomain` that only emit the same events, used to update the details.

We currently propose that the list of tokens relevant to the colony is stored in this metadata along with the colony name etc, with root permission allowed to edit both the list of tokens and the colony description etc. If that separation of permissions is incorrect, now is the time to let us know! Similarly, I have assumed that the permissions required to edit the domain information are the same permissions required to create the domain in the first place. If that is incorrect, similarly, this is the time to let us know!

No tests yet, pending agreement between all parties on the above, but they will exist eventually, whatever we decide.

Finally, the app team is starting the UAC work in around a week, so we should try and have this hashed out by then otherwise we risk blocking them.