### PR TITLE
Make sure SoliditySHA3 knows shortIDs are strings

### DIFF
--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -44,8 +44,8 @@ const MANAGER_RATING = 2;
 const WORKER_RATING = 2;
 const RATING_MULTIPLIER = { 1: -1, 2: 1, 3: 1.5 };
 
-const RATING_1_SALT = soliditySha3(shortid.generate());
-const RATING_2_SALT = soliditySha3(shortid.generate());
+const RATING_1_SALT = soliditySha3({ type: "string", value: shortid.generate() });
+const RATING_2_SALT = soliditySha3({ type: "string", value: shortid.generate() });
 const RATING_1_SECRET = soliditySha3(RATING_1_SALT, MANAGER_RATING);
 const RATING_2_SECRET = soliditySha3(RATING_2_SALT, WORKER_RATING);
 

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -87,8 +87,8 @@ contract("Voting Reputation", (accounts) => {
   const USER2 = accounts[2];
   const MINER = accounts[5];
 
-  const SALT = soliditySha3(shortid.generate());
-  const FAKE = soliditySha3(shortid.generate());
+  const SALT = soliditySha3({ type: "string", value: shortid.generate() });
+  const FAKE = soliditySha3({ type: "string", value: shortid.generate() });
 
   const NAY = 0;
   const YAY = 1;


### PR DESCRIPTION
Occasionally, [such as in the last merge](https://app.circleci.com/pipelines/github/JoinColony/colonyNetwork/2894/workflows/c99d5d45-b49a-4b33-bf9a-04eb512d4a5b/jobs/14718), `web3.utils.soliditySha3` throws a bit of a wobbly. What happens is that `shortId.generate()` generates a string that starts `0x` and `web3.utils.soliditySha3` tries to interpret this as a `bytes`, but the subsequent characters are taken from the whole alphabet, and at least one is therefore almost certainly invalid, causing a test failure.

By using the optional, explicit, syntax for `soliditySha3`, in this scenario, even when the string starts `0x`, it is interpreted as a string.