### PR TITLE
Events for the event god

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -133,19 +133,19 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     // Set initial colony reward inverse amount to the max indicating a zero rewards to start with
     rewardInverse = 2**256 - 1;
 
-    emit ColonyInitialised(_colonyNetworkAddress, _token);
+    emit ColonyInitialised(msg.sender, _colonyNetworkAddress, _token);
   }
 
   function initialiseColony(address _colonyNetworkAddress, address _token, string memory _metadata) public stoppable {
     initialiseColony(_colonyNetworkAddress, _token);
 
-    emit ColonyMetadata(_metadata);
+    emit ColonyMetadata(msg.sender, _metadata);
   }
 
   function editColony(string memory _metadata) public
   stoppable
   auth {
-    emit ColonyMetadata(_metadata);
+    emit ColonyMetadata(msg.sender, _metadata);
   }
 
   function bootstrapColony(address[] memory _users, int[] memory _amounts) public
@@ -165,7 +165,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
       IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_users[i], _amounts[i], domains[1].skillId);
     }
 
-    emit ColonyBootstrapped(_users, _amounts);
+    emit ColonyBootstrapped(msg.sender, _users, _amounts);
   }
 
   function mintTokens(uint _wad) public
@@ -174,7 +174,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   {
     ERC20Extended(token).mint(address(this), _wad); // ignore-swc-107
 
-    emit TokensMinted(address(this), _wad);
+    emit TokensMinted(msg.sender, address(this), _wad);
   }
 
   function mintTokensFor(address _guy, uint _wad) public
@@ -183,7 +183,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   {
     ERC20Extended(token).mint(_guy, _wad); // ignore-swc-107
 
-    emit TokensMinted(_guy, _wad);
+    emit TokensMinted(msg.sender, _guy, _wad);
   }
 
   function mintTokensForColonyNetwork(uint _wad) public stoppable {
@@ -194,7 +194,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     ERC20Extended(token).mint(_wad);
     assert(ERC20Extended(token).transfer(colonyNetworkAddress, _wad));
 
-    emit TokensMinted(colonyNetworkAddress, _wad);
+    emit TokensMinted(msg.sender, colonyNetworkAddress, _wad);
   }
 
   function registerColonyLabel(string memory colonyName, string memory orbitdb) public stoppable auth {
@@ -309,7 +309,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     initialiseDomain(newLocalSkill);
 
     if (keccak256(abi.encodePacked(_metadata)) != keccak256(abi.encodePacked(""))) {
-      emit DomainMetadata(domainCount, _metadata);
+      emit DomainMetadata(msg.sender, domainCount, _metadata);
     }
   }
 
@@ -318,7 +318,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   authDomain(_permissionDomainId, _childSkillIndex, _domainId)
   {
     if (keccak256(abi.encodePacked(_metadata)) != keccak256(abi.encodePacked(""))) {
-      emit DomainMetadata(_domainId, _metadata);
+      emit DomainMetadata(msg.sender, _domainId, _metadata);
     }
   }
 
@@ -374,7 +374,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     // Because it's called after setResolver, it'll do the new finishUpgrade, which will be populated with what we know
     // we need to do once we know what's in it!
     this.finishUpgrade();
-    emit ColonyUpgraded(currentVersion, _newVersion);
+    emit ColonyUpgraded(msg.sender, currentVersion, _newVersion);
   }
 
   // v4 to v5
@@ -509,7 +509,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
       fundingPotId: fundingPotCount
     });
 
-    emit DomainAdded(domainCount);
+    emit DomainAdded(msg.sender, domainCount);
     emit FundingPotAdded(fundingPotCount);
   }
 

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -485,7 +485,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     require(fundingPots[1].balance[_token] >= _amount, "colony-not-enough-tokens");
     ERC20Extended(_token).burn(_amount);
     fundingPots[1].balance[_token] -= _amount;
-    emit TokensBurned(_token, _amount);
+    emit TokensBurned(msg.sender, _token, _amount);
   }
 
   function getApproval(address _user, address _obligator, uint256 _domainId) public view returns (uint256) {

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -22,21 +22,25 @@ interface ColonyDataTypes {
   // Events
 
   /// @notice Event logged when Colony is initialised
+  /// @param agent The address that is responsible for triggering this event
   /// @param colonyNetwork The Colony Network address
   /// @param token The Colony Token address
   event ColonyInitialised(address agent, address colonyNetwork, address token);
 
   /// @notice Event logged when Colony is initially bootstrapped
+  /// @param agent The address that is responsible for triggering this event
   /// @param users Array of address bootstraped with reputation
   /// @param amounts Amounts of reputation/tokens for every address
   event ColonyBootstrapped(address agent, address[] users, int[] amounts);
 
   /// @notice Event logged when colony is upgraded
+  /// @param agent The address that is responsible for triggering this event
   /// @param oldVersion The previous colony version
   /// @param newVersion The new colony version upgraded to
   event ColonyUpgraded(address agent, uint256 oldVersion, uint256 newVersion);
 
   /// @notice Event logged when a user/domain/role is granted or revoked
+  /// @param agent The address that is responsible for triggering this event
   /// @param user The address of the user being affected
   /// @param domainId The domainId of the role
   /// @param role The role being granted/revoked
@@ -44,6 +48,7 @@ interface ColonyDataTypes {
   event ColonyRoleSet(address agent, address indexed user, uint256 indexed domainId, uint8 indexed role, bool setTo);
 
   /// @notice Event logged when colony funds, either tokens or ether, has been moved between funding pots
+  /// @param agent The address that is responsible for triggering this event
   /// @param fromPot The source funding pot
   /// @param toPot The targer funding pot
   /// @param amount The amount that was transferred
@@ -51,16 +56,19 @@ interface ColonyDataTypes {
   event ColonyFundsMovedBetweenFundingPots(address agent, uint256 indexed fromPot, uint256 indexed toPot, uint256 amount, address token);
 
   /// @notice Event logged when colony funds are moved to the top-level domain pot
+  /// @param agent The address that is responsible for triggering this event
   /// @param token The token address
   /// @param fee The fee deducted for rewards
   /// @param payoutRemainder The remaining funds moved to the top-level domain pot
   event ColonyFundsClaimed(address agent, address token, uint256 fee, uint256 payoutRemainder);
 
   /// @notice Event logged when a new reward payout cycle has started
+  /// @param agent The address that is responsible for triggering this event
   /// @param rewardPayoutId The reward payout cycle id
   event RewardPayoutCycleStarted(address agent, uint256 rewardPayoutId);
 
   /// @notice Event logged when the reward payout cycle has ended
+  /// @param agent The address that is responsible for triggering this event
   /// @param rewardPayoutId The reward payout cycle id
   event RewardPayoutCycleEnded(address agent, uint256 rewardPayoutId);
 
@@ -72,39 +80,47 @@ interface ColonyDataTypes {
   event RewardPayoutClaimed(uint256 rewardPayoutId, address user, uint256 fee, uint256 rewardRemainder);
 
   /// @notice Event logged when the colony reward inverse is set
+  /// @param agent The address that is responsible for triggering this event
   /// @param rewardInverse The reward inverse value
   event ColonyRewardInverseSet(address agent, uint256 rewardInverse);
 
   /// @notice Event logged when a new expenditure is added
+  /// @param agent The address that is responsible for triggering this event
   /// @param expenditureId The newly added expenditure id
   event ExpenditureAdded(address agent, uint256 expenditureId);
 
   /// @notice Event logged when a new expenditure is transferred
+  /// @param agent The address that is responsible for triggering this event
   /// @param expenditureId The expenditure id
   /// @param owner The new owner of the expenditure
   event ExpenditureTransferred(address agent, uint256 indexed expenditureId, address indexed owner);
 
   /// @notice Event logged when a expenditure has been cancelled
+  /// @param agent The address that is responsible for triggering this event
   /// @param expenditureId Id of the cancelled expenditure
   event ExpenditureCancelled(address agent, uint256 indexed expenditureId);
 
   /// @notice Event logged when a expenditure has been finalized
+  /// @param agent The address that is responsible for triggering this event
   /// @param expenditureId Id of the finalized expenditure
   event ExpenditureFinalized(address agent, uint256 indexed expenditureId);
 
   /// @notice Event logged when an expenditure's recipient is set
+  /// @param agent The address that is responsible for triggering this event
   /// @param expenditureId Id of the expenditure
   /// @param slot Expenditure slot of the recipient
   /// @param recipient Address of the recipient
   event ExpenditureRecipientSet(address agent, uint256 indexed expenditureId, uint256 indexed slot, address indexed recipient);
 
   /// @notice Event logged when a expenditure's skill changes
+  /// @param agent The address that is responsible for triggering this event
   /// @param expenditureId Id of the expenditure
   /// @param slot Slot receiving the skill
   /// @param skillId Id of the set skill
   event ExpenditureSkillSet(address agent, uint256 indexed expenditureId, uint256 indexed slot, uint256 indexed skillId);
 
   /// @notice Event logged when a expenditure payout changes
+  /// @param agent The address that is responsible for triggering this event
   /// @param expenditureId Id of the expenditure
   /// @param slot Expenditure slot of the payout being changed
   /// @param token Token of the payout funding
@@ -112,10 +128,12 @@ interface ColonyDataTypes {
   event ExpenditurePayoutSet(address agent, uint256 indexed expenditureId, uint256 indexed slot, address indexed token, uint256 amount);
 
   /// @notice Event logged when a new payment is added
+  /// @param agent The address that is responsible for triggering this event
   /// @param paymentId The newly added payment id
   event PaymentAdded(address agent, uint256 paymentId);
 
   /// @notice Event logged when a new task is added
+  /// @param agent The address that is responsible for triggering this event
   /// @param taskId The newly added task id
   event TaskAdded(address agent, uint256 taskId);
 
@@ -152,6 +170,7 @@ interface ColonyDataTypes {
   event TaskChangedViaSignatures(address[] reviewerAddresses);
 
   /// @notice Event logged when a deliverable has been submitted for a task
+  /// @param agent The address that is responsible for triggering this event
   /// @param taskId Id of the task
   /// @param deliverableHash Hash of the work performed
   event TaskDeliverableSubmitted(address agent, uint256 indexed taskId, bytes32 deliverableHash);
@@ -159,24 +178,30 @@ interface ColonyDataTypes {
   /// @notice Event logged when a task has been completed. This is either because the dueDate has passed
   /// and the manager closed the task, or the worker has submitted the deliverable. In the
   /// latter case, TaskDeliverableSubmitted will also be emitted.
+  /// @param agent The address that is responsible for triggering this event
+  /// @param taskId The id of the task being completed
   event TaskCompleted(address agent, uint256 indexed taskId);
 
   /// @notice Event logged when the rating of a role was revealed
+  /// @param agent The address that is responsible for triggering this event
   /// @param taskId Id of the task
   /// @param role Role that got rated
   /// @param rating Rating the role received
   event TaskWorkRatingRevealed(address agent, uint256 indexed taskId, TaskRole role, uint8 rating);
 
   /// @notice Event logged when a task has been finalized
+  /// @param agent The address that is responsible for triggering this event
   /// @param taskId Id of the finalized task
   event TaskFinalized(address agent, uint256 indexed taskId);
 
   /// @notice Event logged when tokens are minted
+  /// @param agent The address that is responsible for triggering this event
   /// @param who The address being awarded the tokens
   /// @param amount The amount of tokens being awarded
   event TokensMinted(address agent, address who, uint256 amount);
 
   /// @notice Event logged when a payout is claimed, either from a Task or Payment
+  /// @param agent The address that is responsible for triggering this event
   /// @param fundingPotId Id of the funding pot where payout comes from
   /// @param token Token of the payout claim
   /// @param amount Amount of the payout claimed, after network fee was deducted
@@ -187,14 +212,17 @@ interface ColonyDataTypes {
   event TaskCanceled(uint256 indexed taskId);
 
   /// @notice Event logged when a new Domain is added
+  /// @param agent The address that is responsible for triggering this event
   /// @param domainId Id of the newly-created Domain
   event DomainAdded(address agent, uint256 domainId);
 
   /// @notice Event logged when domain metadata is updated
+  /// @param agent The address that is responsible for triggering this event
   /// @param domainId Id of the newly-created Domain
   event DomainMetadata(address agent, uint256 indexed domainId, string metadata);
 
   /// @notice Event logged when Colony metadata is updated
+  /// @param agent The address that is responsible for triggering this event
   /// @param metadata IPFS hash of the metadata
   event ColonyMetadata(address agent, string metadata);
 
@@ -209,29 +237,34 @@ interface ColonyDataTypes {
   event Annotation(address indexed agent, bytes32 indexed txHash, string metadata);
 
   /// @notice Event logged when a payment has its payout set
+  /// @param agent The address that is responsible for triggering this event
   /// @param paymentId Id of the payment
   /// @param token Token of the payout
   /// @param amount Amount of token to be paid out
   event PaymentPayoutSet(address agent, uint256 indexed paymentId, address token, uint256 amount);
 
   /// @notice Event logged when a payment has its skill set
+  /// @param agent The address that is responsible for triggering this event
   /// @param paymentId Id of the payment
   /// @param skillId Token of the payout
   event PaymentSkillSet(address agent, uint256 indexed paymentId, uint256 skillId);
 
   /// @notice Event logged when a payment has its recipient set
+  /// @param agent The address that is responsible for triggering this event
   /// @param paymentId Id of the payment
   /// @param recipient Address to receive the payout
   event PaymentRecipientSet(address agent, uint256 indexed paymentId, address recipient);
 
   /// @notice Event logged when a payment is finalised
+  /// @param agent The address that is responsible for triggering this event
   /// @param paymentId Id of the payment
   event PaymentFinalized(address agent, uint256 indexed paymentId);
 
   /// @notice Event logged when the colony burns tokens
+  /// @param agent The address that is responsible for triggering this event
   /// @param token the address of the token being burned
   /// @param token the amount of the token being burned
-  event TokensBurned(address token, uint256 amount);
+  event TokensBurned(address agent, address token, uint256 amount);
 
   struct RewardPayoutCycle {
     // Reputation root hash at the time of reward payout creation

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -24,45 +24,45 @@ interface ColonyDataTypes {
   /// @notice Event logged when Colony is initialised
   /// @param colonyNetwork The Colony Network address
   /// @param token The Colony Token address
-  event ColonyInitialised(address colonyNetwork, address token);
+  event ColonyInitialised(address agent, address colonyNetwork, address token);
 
   /// @notice Event logged when Colony is initially bootstrapped
   /// @param users Array of address bootstraped with reputation
   /// @param amounts Amounts of reputation/tokens for every address
-  event ColonyBootstrapped(address[] users, int[] amounts);
+  event ColonyBootstrapped(address agent, address[] users, int[] amounts);
 
   /// @notice Event logged when colony is upgraded
   /// @param oldVersion The previous colony version
   /// @param newVersion The new colony version upgraded to
-  event ColonyUpgraded(uint256 oldVersion, uint256 newVersion);
+  event ColonyUpgraded(address agent, uint256 oldVersion, uint256 newVersion);
 
   /// @notice Event logged when a user/domain/role is granted or revoked
   /// @param user The address of the user being affected
   /// @param domainId The domainId of the role
   /// @param role The role being granted/revoked
   /// @param setTo A boolean representing the action -- granted (`true`) or revoked (`false`)
-  event ColonyRoleSet(address indexed user, uint256 indexed domainId, uint8 indexed role, bool setTo);
+  event ColonyRoleSet(address agent, address indexed user, uint256 indexed domainId, uint8 indexed role, bool setTo);
 
   /// @notice Event logged when colony funds, either tokens or ether, has been moved between funding pots
   /// @param fromPot The source funding pot
   /// @param toPot The targer funding pot
   /// @param amount The amount that was transferred
   /// @param token The token address being transferred
-  event ColonyFundsMovedBetweenFundingPots(uint256 indexed fromPot, uint256 indexed toPot, uint256 amount, address token);
+  event ColonyFundsMovedBetweenFundingPots(address agent, uint256 indexed fromPot, uint256 indexed toPot, uint256 amount, address token);
 
   /// @notice Event logged when colony funds are moved to the top-level domain pot
   /// @param token The token address
   /// @param fee The fee deducted for rewards
   /// @param payoutRemainder The remaining funds moved to the top-level domain pot
-  event ColonyFundsClaimed(address token, uint256 fee, uint256 payoutRemainder);
+  event ColonyFundsClaimed(address agent, address token, uint256 fee, uint256 payoutRemainder);
 
   /// @notice Event logged when a new reward payout cycle has started
   /// @param rewardPayoutId The reward payout cycle id
-  event RewardPayoutCycleStarted(uint256 rewardPayoutId);
+  event RewardPayoutCycleStarted(address agent, uint256 rewardPayoutId);
 
   /// @notice Event logged when the reward payout cycle has ended
   /// @param rewardPayoutId The reward payout cycle id
-  event RewardPayoutCycleEnded(uint256 rewardPayoutId);
+  event RewardPayoutCycleEnded(address agent, uint256 rewardPayoutId);
 
   /// @notice Event logged when reward payout is claimed
   /// @param rewardPayoutId The reward payout cycle id
@@ -73,51 +73,51 @@ interface ColonyDataTypes {
 
   /// @notice Event logged when the colony reward inverse is set
   /// @param rewardInverse The reward inverse value
-  event ColonyRewardInverseSet(uint256 rewardInverse);
+  event ColonyRewardInverseSet(address agent, uint256 rewardInverse);
 
   /// @notice Event logged when a new expenditure is added
   /// @param expenditureId The newly added expenditure id
-  event ExpenditureAdded(uint256 expenditureId);
+  event ExpenditureAdded(address agent, uint256 expenditureId);
 
   /// @notice Event logged when a new expenditure is transferred
   /// @param expenditureId The expenditure id
   /// @param owner The new owner of the expenditure
-  event ExpenditureTransferred(uint256 indexed expenditureId, address indexed owner);
+  event ExpenditureTransferred(address agent, uint256 indexed expenditureId, address indexed owner);
 
   /// @notice Event logged when a expenditure has been cancelled
   /// @param expenditureId Id of the cancelled expenditure
-  event ExpenditureCancelled(uint256 indexed expenditureId);
+  event ExpenditureCancelled(address agent, uint256 indexed expenditureId);
 
   /// @notice Event logged when a expenditure has been finalized
   /// @param expenditureId Id of the finalized expenditure
-  event ExpenditureFinalized(uint256 indexed expenditureId);
+  event ExpenditureFinalized(address agent, uint256 indexed expenditureId);
 
   /// @notice Event logged when an expenditure's recipient is set
   /// @param expenditureId Id of the expenditure
   /// @param slot Expenditure slot of the recipient
   /// @param recipient Address of the recipient
-  event ExpenditureRecipientSet(uint256 indexed expenditureId, uint256 indexed slot, address indexed recipient);
+  event ExpenditureRecipientSet(address agent, uint256 indexed expenditureId, uint256 indexed slot, address indexed recipient);
 
   /// @notice Event logged when a expenditure's skill changes
   /// @param expenditureId Id of the expenditure
   /// @param slot Slot receiving the skill
   /// @param skillId Id of the set skill
-  event ExpenditureSkillSet(uint256 indexed expenditureId, uint256 indexed slot, uint256 indexed skillId);
+  event ExpenditureSkillSet(address agent, uint256 indexed expenditureId, uint256 indexed slot, uint256 indexed skillId);
 
   /// @notice Event logged when a expenditure payout changes
   /// @param expenditureId Id of the expenditure
   /// @param slot Expenditure slot of the payout being changed
   /// @param token Token of the payout funding
   /// @param amount Amount of the payout funding
-  event ExpenditurePayoutSet(uint256 indexed expenditureId, uint256 indexed slot, address indexed token, uint256 amount);
+  event ExpenditurePayoutSet(address agent, uint256 indexed expenditureId, uint256 indexed slot, address indexed token, uint256 amount);
 
   /// @notice Event logged when a new payment is added
   /// @param paymentId The newly added payment id
-  event PaymentAdded(uint256 paymentId);
+  event PaymentAdded(address agent, uint256 paymentId);
 
   /// @notice Event logged when a new task is added
   /// @param taskId The newly added task id
-  event TaskAdded(uint256 taskId);
+  event TaskAdded(address agent, uint256 taskId);
 
   /// @notice Event logged when a task's specification hash changes
   /// @param taskId Id of the task
@@ -147,36 +147,40 @@ interface ColonyDataTypes {
   /// @param amount Amount of the payout funding
   event TaskPayoutSet(uint256 indexed taskId, TaskRole role, address token, uint256 amount);
 
+  /// @notice Event logged when task data is changed via signed messages by those involved
+  /// @param reviewerAddresses Array of addresses that signed off this change.
+  event TaskChangedViaSignatures(address[] reviewerAddresses);
+
   /// @notice Event logged when a deliverable has been submitted for a task
   /// @param taskId Id of the task
   /// @param deliverableHash Hash of the work performed
-  event TaskDeliverableSubmitted(uint256 indexed taskId, bytes32 deliverableHash);
+  event TaskDeliverableSubmitted(address agent, uint256 indexed taskId, bytes32 deliverableHash);
 
   /// @notice Event logged when a task has been completed. This is either because the dueDate has passed
   /// and the manager closed the task, or the worker has submitted the deliverable. In the
   /// latter case, TaskDeliverableSubmitted will also be emitted.
-  event TaskCompleted(uint256 indexed taskId);
+  event TaskCompleted(address agent, uint256 indexed taskId);
 
   /// @notice Event logged when the rating of a role was revealed
   /// @param taskId Id of the task
   /// @param role Role that got rated
   /// @param rating Rating the role received
-  event TaskWorkRatingRevealed(uint256 indexed taskId, TaskRole role, uint8 rating);
+  event TaskWorkRatingRevealed(address agent, uint256 indexed taskId, TaskRole role, uint8 rating);
 
   /// @notice Event logged when a task has been finalized
   /// @param taskId Id of the finalized task
-  event TaskFinalized(uint256 indexed taskId);
+  event TaskFinalized(address agent, uint256 indexed taskId);
 
   /// @notice Event logged when tokens are minted
   /// @param who The address being awarded the tokens
   /// @param amount The amount of tokens being awarded
-  event TokensMinted(address who, uint256 amount);
+  event TokensMinted(address agent, address who, uint256 amount);
 
   /// @notice Event logged when a payout is claimed, either from a Task or Payment
   /// @param fundingPotId Id of the funding pot where payout comes from
   /// @param token Token of the payout claim
   /// @param amount Amount of the payout claimed, after network fee was deducted
-  event PayoutClaimed(uint256 indexed fundingPotId, address token, uint256 amount);
+  event PayoutClaimed(address agent, uint256 indexed fundingPotId, address token, uint256 amount);
 
   /// @notice Event logged when a task has been canceled
   /// @param taskId Id of the canceled task
@@ -184,15 +188,15 @@ interface ColonyDataTypes {
 
   /// @notice Event logged when a new Domain is added
   /// @param domainId Id of the newly-created Domain
-  event DomainAdded(uint256 domainId);
+  event DomainAdded(address agent, uint256 domainId);
 
   /// @notice Event logged when domain metadata is updated
   /// @param domainId Id of the newly-created Domain
-  event DomainMetadata(uint256 indexed domainId, string metadata);
+  event DomainMetadata(address agent, uint256 indexed domainId, string metadata);
 
   /// @notice Event logged when Colony metadata is updated
   /// @param metadata IPFS hash of the metadata
-  event ColonyMetadata(string metadata);
+  event ColonyMetadata(address agent, string metadata);
 
   /// @notice Event logged when a new FundingPot is added
   /// @param fundingPotId Id of the newly-created FundingPot
@@ -208,21 +212,21 @@ interface ColonyDataTypes {
   /// @param paymentId Id of the payment
   /// @param token Token of the payout
   /// @param amount Amount of token to be paid out
-  event PaymentPayoutSet(uint256 indexed paymentId, address token, uint256 amount);
+  event PaymentPayoutSet(address agent, uint256 indexed paymentId, address token, uint256 amount);
 
   /// @notice Event logged when a payment has its skill set
   /// @param paymentId Id of the payment
   /// @param skillId Token of the payout
-  event PaymentSkillSet(uint256 indexed paymentId, uint256 skillId);
+  event PaymentSkillSet(address agent, uint256 indexed paymentId, uint256 skillId);
 
   /// @notice Event logged when a payment has its recipient set
   /// @param paymentId Id of the payment
   /// @param recipient Address to receive the payout
-  event PaymentRecipientSet(uint256 indexed paymentId, address recipient);
+  event PaymentRecipientSet(address agent, uint256 indexed paymentId, address recipient);
 
   /// @notice Event logged when a payment is finalised
   /// @param paymentId Id of the payment
-  event PaymentFinalized(uint256 indexed paymentId);
+  event PaymentFinalized(address agent, uint256 indexed paymentId);
 
   /// @notice Event logged when the colony burns tokens
   /// @param token the address of the token being burned

--- a/contracts/colony/ColonyExpenditure.sol
+++ b/contracts/colony/ColonyExpenditure.sol
@@ -49,7 +49,7 @@ contract ColonyExpenditure is ColonyStorage {
     });
 
     emit FundingPotAdded(fundingPotCount);
-    emit ExpenditureAdded(expenditureCount);
+    emit ExpenditureAdded(msg.sender, expenditureCount);
 
     return expenditureCount;
   }
@@ -63,7 +63,7 @@ contract ColonyExpenditure is ColonyStorage {
   {
     expenditures[_id].owner = _newOwner;
 
-    emit ExpenditureTransferred(_id, _newOwner);
+    emit ExpenditureTransferred(msg.sender, _id, _newOwner);
   }
 
   // Deprecated
@@ -81,7 +81,7 @@ contract ColonyExpenditure is ColonyStorage {
   {
     expenditures[_id].owner = _newOwner;
 
-    emit ExpenditureTransferred(_id, _newOwner);
+    emit ExpenditureTransferred(msg.sender, _id, _newOwner);
   }
 
   function cancelExpenditure(uint256 _id)
@@ -93,7 +93,7 @@ contract ColonyExpenditure is ColonyStorage {
   {
     expenditures[_id].status = ExpenditureStatus.Cancelled;
 
-    emit ExpenditureCancelled(_id);
+    emit ExpenditureCancelled(msg.sender, _id);
   }
 
   function finalizeExpenditure(uint256 _id)
@@ -109,7 +109,7 @@ contract ColonyExpenditure is ColonyStorage {
     expenditures[_id].status = ExpenditureStatus.Finalized;
     expenditures[_id].finalizedTimestamp = block.timestamp;
 
-    emit ExpenditureFinalized(_id);
+    emit ExpenditureFinalized(msg.sender, _id);
   }
 
   function setExpenditureRecipient(uint256 _id, uint256 _slot, address payable _recipient)
@@ -121,7 +121,7 @@ contract ColonyExpenditure is ColonyStorage {
   {
     expenditureSlots[_id][_slot].recipient = _recipient;
 
-    emit ExpenditureRecipientSet(_id, _slot, _recipient);
+    emit ExpenditureRecipientSet(msg.sender, _id, _slot, _recipient);
   }
 
   function setExpenditureSkill(uint256 _id, uint256 _slot, uint256 _skillId)
@@ -139,7 +139,7 @@ contract ColonyExpenditure is ColonyStorage {
     expenditureSlots[_id][_slot].skills = new uint256[](1);
     expenditureSlots[_id][_slot].skills[0] = _skillId;
 
-    emit ExpenditureSkillSet(_id, _slot, _skillId);
+    emit ExpenditureSkillSet(msg.sender, _id, _slot, _skillId);
   }
 
   // Deprecated

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -172,7 +172,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
 
     updatePayoutsWeCannotMakeAfterBudgetChange(payment.fundingPotId, _token, currentTotalAmount);
 
-    emit PaymentPayoutSet(_id, _token, _amount);
+    emit PaymentPayoutSet(msg.sender, _id, _token, _amount);
   }
 
   function getFundingPotCount() public view returns (uint256 count) {
@@ -255,7 +255,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
       nonRewardPotsTotal[_token] = sub(nonRewardPotsTotal[_token], _amount);
     }
 
-    emit ColonyFundsMovedBetweenFundingPots(_fromPot, _toPot, _amount, _token);
+    emit ColonyFundsMovedBetweenFundingPots(msg.sender, _fromPot, _toPot, _amount, _token);
   }
 
   function claimColonyFunds(address _token) public stoppable {
@@ -280,7 +280,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     fundingPots[1].balance[_token] = add(fundingPots[1].balance[_token], remainder);
     fundingPots[0].balance[_token] = add(fundingPots[0].balance[_token], feeToPay);
 
-    emit ColonyFundsClaimed(_token, feeToPay, remainder);
+    emit ColonyFundsClaimed(msg.sender, _token, feeToPay, remainder);
   }
 
   function getNonRewardPotsTotal(address _token) public view returns (uint256) {
@@ -322,7 +322,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
       false
     );
 
-    emit RewardPayoutCycleStarted(totalLockCount);
+    emit RewardPayoutCycleStarted(msg.sender, totalLockCount);
   }
 
   function claimRewardPayout(
@@ -373,7 +373,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     rewardPayoutCycles[_payoutId].finalized = true;
     pendingRewardPayments[payout.tokenAddress] = sub(pendingRewardPayments[payout.tokenAddress], payout.amountRemaining);
 
-    emit RewardPayoutCycleEnded(_payoutId);
+    emit RewardPayoutCycleEnded(msg.sender, _payoutId);
   }
 
   function getRewardPayoutInfo(uint256 _payoutId) public view returns (RewardPayoutCycle memory rewardPayoutCycle) {
@@ -387,7 +387,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     require(_rewardInverse > 0, "colony-reward-inverse-cannot-be-zero");
     rewardInverse = _rewardInverse;
 
-    emit ColonyRewardInverseSet(_rewardInverse);
+    emit ColonyRewardInverseSet(msg.sender, _rewardInverse);
   }
 
   function getRewardInverse() public view returns (uint256) {
@@ -530,7 +530,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
 
     updatePayoutsWeCannotMakeAfterBudgetChange(expenditures[_id].fundingPotId, _token, currentTotal);
 
-    emit ExpenditurePayoutSet(_id, _slot, _token, _amount);
+    emit ExpenditurePayoutSet(msg.sender, _id, _slot, _token, _amount);
   }
 
   function setTaskPayout(uint256 _id, TaskRole _role, address _token, uint256 _amount) private
@@ -580,7 +580,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
       }
     }
 
-    emit PayoutClaimed(_fundingPotId, _token, remainder);
+    emit PayoutClaimed(msg.sender, _fundingPotId, _token, remainder);
   }
 
   function calculateNetworkFeeForPayout(uint256 _payout) private view returns (uint256 fee) {

--- a/contracts/colony/ColonyPayment.sol
+++ b/contracts/colony/ColonyPayment.sol
@@ -56,16 +56,16 @@ contract ColonyPayment is ColonyStorage {
     payments[paymentCount] = payment;
 
     emit FundingPotAdded(fundingPotCount);
-    emit PaymentAdded(paymentCount);
+    emit PaymentAdded(msg.sender, paymentCount);
 
     if (_skillId > 0) {
       setPaymentSkill(_permissionDomainId, _childSkillIndex, paymentCount, _skillId);
 
-      emit PaymentSkillSet(paymentCount, _skillId);
+      emit PaymentSkillSet(msg.sender, paymentCount, _skillId);
     }
 
-    emit PaymentRecipientSet(paymentCount, _recipient);
-    emit PaymentPayoutSet(paymentCount, _token, _amount);
+    emit PaymentRecipientSet(msg.sender, paymentCount, _recipient);
+    emit PaymentPayoutSet(msg.sender, paymentCount, _token, _amount);
 
     return paymentCount;
   }
@@ -90,7 +90,7 @@ contract ColonyPayment is ColonyStorage {
       colonyNetworkContract.appendReputationUpdateLog(payment.recipient, int(fundingPot.payouts[token]), payment.skills[0]);
     }
 
-    emit PaymentFinalized(_id);
+    emit PaymentFinalized(msg.sender, _id);
   }
 
   function setPaymentRecipient(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, address payable _recipient) public
@@ -101,7 +101,7 @@ contract ColonyPayment is ColonyStorage {
     require(_recipient != address(0x0), "colony-payment-invalid-recipient");
     payments[_id].recipient = _recipient;
 
-    emit PaymentRecipientSet(_id, _recipient);
+    emit PaymentRecipientSet(msg.sender, _id, _recipient);
   }
 
   function setPaymentSkill(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, uint256 _skillId) public
@@ -113,7 +113,7 @@ contract ColonyPayment is ColonyStorage {
   {
     payments[_id].skills[0] = _skillId;
 
-    emit PaymentSkillSet(_id, _skillId);
+    emit PaymentSkillSet(msg.sender, _id, _skillId);
   }
 
   function getPayment(uint256 _id) public view returns (Payment memory) {

--- a/contracts/colony/ColonyPayment.sol
+++ b/contracts/colony/ColonyPayment.sol
@@ -60,7 +60,7 @@ contract ColonyPayment is ColonyStorage {
 
     if (_skillId > 0) {
       setPaymentSkill(_permissionDomainId, _childSkillIndex, paymentCount, _skillId);
-      
+
       emit PaymentSkillSet(paymentCount, _skillId);
     }
 

--- a/contracts/colony/ColonyRoles.sol
+++ b/contracts/colony/ColonyRoles.sol
@@ -26,7 +26,7 @@ contract ColonyRoles is ColonyStorage {
   function setRootRole(address _user, bool _setTo) public stoppable auth {
     ColonyAuthority(address(authority)).setUserRole(_user, uint8(ColonyRole.Root), _setTo);
 
-    emit ColonyRoleSet(_user, 1, uint8(ColonyRole.Root), _setTo);
+    emit ColonyRoleSet(msg.sender, _user, 1, uint8(ColonyRole.Root), _setTo);
   }
 
   function setArbitrationRole(
@@ -39,7 +39,7 @@ contract ColonyRoles is ColonyStorage {
   {
     ColonyAuthority(address(authority)).setUserRole(_user, _domainId, uint8(ColonyRole.Arbitration), _setTo);
 
-    emit ColonyRoleSet(_user, _domainId, uint8(ColonyRole.Arbitration), _setTo);
+    emit ColonyRoleSet(msg.sender, _user, _domainId, uint8(ColonyRole.Arbitration), _setTo);
   }
 
   function setArchitectureRole(
@@ -52,7 +52,7 @@ contract ColonyRoles is ColonyStorage {
   {
     ColonyAuthority(address(authority)).setUserRole(_user, _domainId, uint8(ColonyRole.Architecture), _setTo);
 
-    emit ColonyRoleSet(_user, _domainId, uint8(ColonyRole.Architecture), _setTo);
+    emit ColonyRoleSet(msg.sender, _user, _domainId, uint8(ColonyRole.Architecture), _setTo);
   }
 
   function setFundingRole(
@@ -65,7 +65,7 @@ contract ColonyRoles is ColonyStorage {
   {
     ColonyAuthority(address(authority)).setUserRole(_user, _domainId, uint8(ColonyRole.Funding), _setTo);
 
-    emit ColonyRoleSet(_user, _domainId, uint8(ColonyRole.Funding), _setTo);
+    emit ColonyRoleSet(msg.sender, _user, _domainId, uint8(ColonyRole.Funding), _setTo);
   }
 
   function setAdministrationRole(
@@ -78,7 +78,7 @@ contract ColonyRoles is ColonyStorage {
   {
     ColonyAuthority(address(authority)).setUserRole(_user, _domainId, uint8(ColonyRole.Administration), _setTo);
 
-    emit ColonyRoleSet(_user, _domainId, uint8(ColonyRole.Administration), _setTo);
+    emit ColonyRoleSet(msg.sender, _user, _domainId, uint8(ColonyRole.Administration), _setTo);
   }
 
   function setUserRoles(
@@ -104,7 +104,7 @@ contract ColonyRoles is ColonyStorage {
 
         ColonyAuthority(address(authority)).setUserRole(_user, _domainId, roleId, setTo);
 
-        emit ColonyRoleSet(_user, _domainId, roleId, setTo);
+        emit ColonyRoleSet(msg.sender, _user, _domainId, roleId, setTo);
 
       }
       roles >>= 1;

--- a/contracts/colony/ColonyTask.sol
+++ b/contracts/colony/ColonyTask.sol
@@ -126,7 +126,7 @@ contract ColonyTask is ColonyStorage {
     this.setTaskDueDate(taskCount, dueDate);
 
     emit FundingPotAdded(fundingPotCount);
-    emit TaskAdded(taskCount);
+    emit TaskAdded(msg.sender, taskCount);
   }
 
   function getTaskCount() public view returns (uint256) {
@@ -196,6 +196,8 @@ contract ColonyTask is ColonyStorage {
 
     taskChangeNonces[taskId]++;
     require(executeCall(address(this), _value, _data), "colony-task-change-execution-failed");
+
+    emit TaskChangedViaSignatures(reviewerAddresses);
   }
 
   function executeTaskRoleAssignment(
@@ -256,6 +258,8 @@ contract ColonyTask is ColonyStorage {
 
     taskChangeNonces[taskId]++;
     require(executeCall(address(this), _value, _data), "colony-task-role-assignment-execution-failed");
+
+    emit TaskChangedViaSignatures(reviewerAddresses);
   }
 
   function submitTaskWorkRating(uint256 _id, TaskRole _role, bytes32 _ratingSecret) public
@@ -284,7 +288,7 @@ contract ColonyTask is ColonyStorage {
     require(rating != TaskRatings.None, "colony-task-rating-missing");
     tasks[_id].roles[uint8(_role)].rating = rating;
 
-    emit TaskWorkRatingRevealed(_id, _role, _rating);
+    emit TaskWorkRatingRevealed(msg.sender, _id, _role, _rating);
   }
 
   function generateSecret(bytes32 _salt, uint256 _value) public pure returns (bytes32) {
@@ -375,7 +379,7 @@ contract ColonyTask is ColonyStorage {
   {
     tasks[_id].deliverableHash = _deliverableHash;
     markTaskCompleted(_id);
-    emit TaskDeliverableSubmitted(_id, _deliverableHash);
+    emit TaskDeliverableSubmitted(msg.sender, _id, _deliverableHash);
   }
 
   function submitTaskDeliverableAndRating(uint256 _id, bytes32 _deliverableHash, bytes32 _ratingSecret) public
@@ -417,7 +421,7 @@ contract ColonyTask is ColonyStorage {
       updateReputation(TaskRole(roleId), task);
     }
 
-    emit TaskFinalized(_id);
+    emit TaskFinalized(msg.sender, _id);
   }
 
   function cancelTask(uint256 _id) public
@@ -460,7 +464,7 @@ contract ColonyTask is ColonyStorage {
 
   function markTaskCompleted(uint256 _id) internal {
     tasks[_id].completionTimestamp = block.timestamp;
-    emit TaskCompleted(_id);
+    emit TaskCompleted(msg.sender, _id);
   }
 
   function updateReputation(TaskRole taskRole, Task storage task) internal {

--- a/contracts/common/ContractRecovery.sol
+++ b/contracts/common/ContractRecovery.sol
@@ -58,7 +58,7 @@ contract ContractRecovery is ContractRecoveryDataTypes, CommonStorage { // ignor
     recoveryApprovalCount = 0;
     recoveryEditedTimestamp = block.timestamp;
 
-    emit RecoveryStorageSlotSet(_slot, oldValue, _value);
+    emit RecoveryStorageSlotSet(msg.sender, _slot, oldValue, _value);
   }
 
   function isInRecoveryMode() public view returns (bool) {

--- a/contracts/common/ContractRecoveryDataTypes.sol
+++ b/contracts/common/ContractRecoveryDataTypes.sol
@@ -33,10 +33,11 @@ interface ContractRecoveryDataTypes {
   event RecoveryModeExited(address user);
 
   /// @notice Event logged when in recovery mode a storage slot is set
+  /// @param user The address that set the storage slot
   /// @param slot The storage slot being modified
   /// @param fromValue The value the storage slot had before this transaction
   /// @param toValue The value the storage slot has after this transaction
-  event RecoveryStorageSlotSet(uint256 slot, bytes32 fromValue, bytes32 toValue);
+  event RecoveryStorageSlotSet(address user, uint256 slot, bytes32 fromValue, bytes32 toValue);
 
   /// @notice Event logged when someone with recovery mode signals they are happy with the state
   /// and wish to leave recovery mode

--- a/contracts/testHelpers/NoLimitSubdomains.sol
+++ b/contracts/testHelpers/NoLimitSubdomains.sol
@@ -49,7 +49,7 @@ contract NoLimitSubdomains is ColonyStorage {
       fundingPotId: fundingPotCount
     });
 
-    emit DomainAdded(domainCount);
+    emit DomainAdded(msg.sender, domainCount);
     emit FundingPotAdded(fundingPotCount);
   }
 

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -277,7 +277,9 @@ export async function expectEvent(tx, nameOrSig, args) {
     expect(event).to.exist;
   }
   for (let i = 0; i < args.length; i += 1) {
-    if (typeof event.args[i] === "string" && !ethers.utils.isHexString(event.args[i])) {
+    if (typeof args[i] === "object") {
+      expect(args[i]).to.deep.equal(event.args[i]);
+    } else if (typeof args[i] === "string" && !ethers.utils.isHexString(event.args[i])) {
       expect(args[i]).to.equal(event.args[i]);
     } else {
       expect(hexlifyAndPad(args[i])).to.equal(hexlifyAndPad(event.args[i]));

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -277,12 +277,18 @@ export async function expectEvent(tx, nameOrSig, args) {
     expect(event).to.exist;
   }
   for (let i = 0; i < args.length; i += 1) {
-    if (typeof args[i] === "object") {
-      expect(args[i]).to.deep.equal(event.args[i]);
-    } else if (typeof args[i] === "string" && !ethers.utils.isHexString(event.args[i])) {
-      expect(args[i]).to.equal(event.args[i]);
+    let arg = args[i];
+    if (arg.constructor.name === "BN" || event.args[i].constructor.name === "BN") {
+      if (ethers.utils.isHexString(arg)) {
+        arg = ethers.BigNumber.from(arg).toString();
+      }
+      expect(arg.toString()).to.equal(event.args[i].toString());
+    } else if (typeof arg === "object") {
+      expect(arg).to.deep.equal(event.args[i]);
+    } else if (typeof arg === "string" && !ethers.utils.isHexString(event.args[i])) {
+      expect(arg).to.equal(event.args[i]);
     } else {
-      expect(hexlifyAndPad(args[i])).to.equal(hexlifyAndPad(event.args[i]));
+      expect(hexlifyAndPad(arg)).to.equal(hexlifyAndPad(event.args[i]));
     }
   }
 }

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -239,7 +239,7 @@ contract("Colony Network", (accounts) => {
       const token = await Token.new(...getTokenArgs());
       await token.unlock();
       const tx = await colonyNetwork.createColony(token.address, 0, "", IPFS_HASH);
-      await expectEvent(tx, "ColonyMetadata(string)", [IPFS_HASH]);
+      await expectEvent(tx, "ColonyMetadata(address,string)", [colonyNetwork.address, IPFS_HASH]);
     });
 
     it("metadata should not be emitted on colony creation if not supplied", async () => {

--- a/test/contracts-network/colony-payment.js
+++ b/test/contracts-network/colony-payment.js
@@ -48,9 +48,10 @@ contract("Colony Payment", (accounts) => {
       const tx = await colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, WAD, 1, 0, { from: COLONY_ADMIN });
 
       const paymentsCountAfter = await colony.getPaymentCount();
-      await expectEvent(tx, "PaymentAdded", [paymentsCountAfter]);
-      await expectEvent(tx, "PaymentRecipientSet", [paymentsCountAfter, RECIPIENT]);
-      await expectEvent(tx, "PaymentPayoutSet", [paymentsCountAfter, token.address, WAD]);
+      await expectEvent(tx, "PaymentAdded", [COLONY_ADMIN, paymentsCountAfter]);
+      await expectEvent(tx, "PaymentRecipientSet", [COLONY_ADMIN, paymentsCountAfter, RECIPIENT]);
+      // console.log(JSON.stringify(tx))
+      await expectEvent(tx, "PaymentPayoutSet", [COLONY_ADMIN, paymentsCountAfter, token.address, WAD]);
       expect(paymentsCountAfter.sub(paymentsCountBefore)).to.eq.BN(1);
 
       const fundingPotId = await colony.getFundingPotCount();
@@ -143,7 +144,7 @@ contract("Colony Payment", (accounts) => {
       const tx = await colony.setPaymentSkill(1, UINT256_MAX, paymentId, 3, { from: COLONY_ADMIN });
       payment = await colony.getPayment(paymentId);
       expect(payment.skills[0]).to.eq.BN(3);
-      await expectEvent(tx, "PaymentSkillSet", [paymentId, 3]);
+      await expectEvent(tx, "PaymentSkillSet", [COLONY_ADMIN, paymentId, 3]);
     });
 
     it("should not allow admins to update payment with deprecated global skill", async () => {
@@ -174,7 +175,7 @@ contract("Colony Payment", (accounts) => {
       const fundingPotPayoutForOtherToken = await colony.getFundingPotPayout(payment.fundingPotId, otherToken.address);
       expect(fundingPotPayoutForToken).to.eq.BN(WAD);
       expect(fundingPotPayoutForOtherToken).to.eq.BN(100);
-      await expectEvent(tx, "PaymentPayoutSet", [paymentId, otherToken.address, 100]);
+      await expectEvent(tx, "PaymentPayoutSet", [accounts[0], paymentId, otherToken.address, 100]);
     });
 
     it("should allow admins to fund a payment", async () => {
@@ -223,7 +224,7 @@ contract("Colony Payment", (accounts) => {
 
       payment = await colony.getPayment(paymentId);
       expect(payment.finalized).to.be.true;
-      await expectEvent(tx, "PaymentFinalized", [paymentId]);
+      await expectEvent(tx, "PaymentFinalized", [accounts[0], paymentId]);
     });
 
     it("cannnot finalize payment if it is NOT fully funded", async () => {

--- a/test/contracts-network/colony-recovery.js
+++ b/test/contracts-network/colony-recovery.js
@@ -75,12 +75,13 @@ contract("Colony Recovery", (accounts) => {
       await expectEvent(
         colony.setStorageSlotRecovery("0xdead", "0xbeef00000000000000000000000000000000000000000000000000000000beef"),
         "RecoveryStorageSlotSet",
-        ["0xdead", "0x00", "0xbeef00000000000000000000000000000000000000000000000000000000beef"]
+        [accounts[0], "0xdead", "0x00", "0xbeef00000000000000000000000000000000000000000000000000000000beef"]
       );
       await expectEvent(
         colony.setStorageSlotRecovery("0xdead", "0xbadbeef00000000000000000000000000000000000000000000000000badbeef"),
         "RecoveryStorageSlotSet",
         [
+          accounts[0],
           "0xdead",
           "0xbeef00000000000000000000000000000000000000000000000000000000beef",
           "0xbadbeef00000000000000000000000000000000000000000000000000badbeef",

--- a/test/contracts-network/colony-task-work-rating.js
+++ b/test/contracts-network/colony-task-work-rating.js
@@ -366,7 +366,7 @@ contract("Colony Task Work Rating", (accounts) => {
       await expectEvent(
         colony.revealTaskWorkRating(taskId, WORKER_ROLE, WORKER_RATING, RATING_2_SALT, { from: EVALUATOR }),
         "TaskWorkRatingRevealed",
-        [taskId, WORKER_ROLE, WORKER_RATING]
+        [EVALUATOR, taskId, WORKER_ROLE, WORKER_RATING]
       );
     });
   });

--- a/test/contracts-network/colony-task.js
+++ b/test/contracts-network/colony-task.js
@@ -1906,7 +1906,7 @@ contract("ColonyTask", (accounts) => {
       for (let i = 0; i < 42; i += 1) {
         await taskSkillEditingColony.addTaskSkill(taskId, GLOBAL_SKILL_ID);
       }
-      await expectEvent(colony.finalizeTask(taskId), "TaskFinalized", [taskId]);
+      await expectEvent(colony.finalizeTask(taskId), "TaskFinalized", [MANAGER, taskId]);
     });
 
     it("an empty element shouldn't affect finalization of the task", async () => {

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -373,7 +373,7 @@ contract("Colony", (accounts) => {
     it("should allow root user to burn", async () => {
       const amount = await colony.getFundingPotBalance(1, token.address);
       const tx = await colony.burnTokens(token.address, amount);
-      await expectEvent(tx, "TokensBurned", [token.address, amount]);
+      await expectEvent(tx, "TokensBurned", [accounts[0], token.address, amount]);
     });
 
     it("should not allow anyone else but a root user to burn", async () => {

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -96,8 +96,8 @@ contract("Colony", (accounts) => {
       const otherToken = await Token.new(...tokenArgs);
       await otherToken.unlock();
 
-      await expectEvent(colony.mintTokens(100), "TokensMinted", [colony.address, 100]);
-      await expectEvent(colony.mintTokensFor(accounts[0], 100), "TokensMinted", [accounts[0], 100]);
+      await expectEvent(colony.mintTokens(100), "TokensMinted", [accounts[0], colony.address, 100]);
+      await expectEvent(colony.mintTokensFor(accounts[1], 100), "TokensMinted", [accounts[0], accounts[1], 100]);
     });
 
     it("should fail if a non-admin tries to mint tokens", async () => {
@@ -222,17 +222,17 @@ contract("Colony", (accounts) => {
     it("should log DomainAdded and FundingPotAdded and DomainMetadata events", async () => {
       let tx = await colony.addDomain(1, UINT256_MAX, 1);
       let domainCount = await colony.getDomainCount();
-      await expectEvent(tx, "DomainAdded", [domainCount]);
+      await expectEvent(tx, "DomainAdded", [accounts[0], domainCount]);
       let fundingPotCount = await colony.getFundingPotCount();
       await expectEvent(tx, "FundingPotAdded", [fundingPotCount]);
       await expectNoEvent(tx, "DomainMetadata");
 
       tx = await colony.addDomain(1, UINT256_MAX, 1, IPFS_HASH);
       domainCount = await colony.getDomainCount();
-      await expectEvent(tx, "DomainAdded", [domainCount]);
+      await expectEvent(tx, "DomainAdded", [accounts[0], domainCount]);
       fundingPotCount = await colony.getFundingPotCount();
       await expectEvent(tx, "FundingPotAdded", [fundingPotCount]);
-      await expectEvent(tx, "DomainMetadata", [domainCount, IPFS_HASH]);
+      await expectEvent(tx, "DomainMetadata", [accounts[0], domainCount, IPFS_HASH]);
     });
   });
 
@@ -240,7 +240,7 @@ contract("Colony", (accounts) => {
     it("should log the DomainMetadata event", async () => {
       await colony.addDomain(1, UINT256_MAX, 1);
       const domainCount = await colony.getDomainCount();
-      await expectEvent(colony.editDomain(1, 0, 2, IPFS_HASH), "DomainMetadata", [domainCount, IPFS_HASH]);
+      await expectEvent(colony.editDomain(1, 0, 2, IPFS_HASH), "DomainMetadata", [accounts[0], domainCount, IPFS_HASH]);
     });
 
     it("should not log the DomainMetadata event if empty string passed", async () => {


### PR DESCRIPTION
Explanation / reasoning for events here can be split up:

## New events for payment lifecycle

We just didn't have events you would ordinarily expect. `PaymentFinalized` and things. So I've added them.

## New arguments for existing events

Mostly `agent` i.e. `msg.sender` for the event. There's no other clean way to get this as far as I can see if we're restricting ourselves to events. We _might_ be able to get clever here with TheGraph's call handlers, and not need these in most cases. Note that `FundingPotAdded` doesn't get one, because there is always another event emitted with it, and similarly the events related to signed changes to tasks don't get them, because those are triggered by the contract making an external call to itself, so would always give the colony address. To work around that, I've added `TaskChangedViaSignatures` emitting the addresses that agreed to change the property. Making that work with `expectEvent` is why the helper has changed.