### PR TITLE
OneTxPayment event changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ reputations.json
 reputationStates.sqlite
 truffle-security-output.json
 .coverage_contracts
+etherrouter-address.json

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -204,6 +204,26 @@ interface ColonyDataTypes {
   /// @param metadata String of metadata for tx
   event Annotation(address indexed agent, bytes32 indexed txHash, string metadata);
 
+  /// @notice Event logged when a payment has its payout set
+  /// @param paymentId Id of the payment
+  /// @param token Token of the payout
+  /// @param amount Amount of token to be paid out
+  event PaymentPayoutSet(uint256 indexed paymentId, address token, uint256 amount);
+
+  /// @notice Event logged when a payment has its skill set
+  /// @param paymentId Id of the payment
+  /// @param skillId Token of the payout
+  event PaymentSkillSet(uint256 indexed paymentId, uint256 skillId);
+
+  /// @notice Event logged when a payment has its recipient set
+  /// @param paymentId Id of the payment
+  /// @param recipient Address to receive the payout
+  event PaymentRecipientSet(uint256 indexed paymentId, address recipient);
+
+  /// @notice Event logged when a payment is finalised
+  /// @param paymentId Id of the payment
+  event PaymentFinalized(uint256 indexed paymentId);
+
   struct RewardPayoutCycle {
     // Reputation root hash at the time of reward payout creation
     bytes32 reputationState;

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -171,6 +171,8 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     fundingPot.payouts[_token] = _amount;
 
     updatePayoutsWeCannotMakeAfterBudgetChange(payment.fundingPotId, _token, currentTotalAmount);
+
+    emit PaymentPayoutSet(_id, _token, _amount);
   }
 
   function getFundingPotCount() public view returns (uint256 count) {

--- a/contracts/colony/ColonyPayment.sol
+++ b/contracts/colony/ColonyPayment.sol
@@ -55,12 +55,16 @@ contract ColonyPayment is ColonyStorage {
 
     payments[paymentCount] = payment;
 
-    if (_skillId > 0) {
-      setPaymentSkill(_permissionDomainId, _childSkillIndex, paymentCount, _skillId);
-    }
-
     emit FundingPotAdded(fundingPotCount);
     emit PaymentAdded(paymentCount);
+
+    if (_skillId > 0) {
+      setPaymentSkill(_permissionDomainId, _childSkillIndex, paymentCount, _skillId);
+      emit PaymentSkillSet(paymentCount, _skillId);
+    }
+
+    emit PaymentRecipientSet(paymentCount, _recipient);
+    emit PaymentPayoutSet(paymentCount, _token, _amount);
 
     return paymentCount;
   }
@@ -84,6 +88,8 @@ contract ColonyPayment is ColonyStorage {
       // This may change in future to allow multiple skills to be set on both Tasks and Payments
       colonyNetworkContract.appendReputationUpdateLog(payment.recipient, int(fundingPot.payouts[token]), payment.skills[0]);
     }
+
+    emit PaymentFinalized(_id);
   }
 
   function setPaymentRecipient(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, address payable _recipient) public
@@ -93,6 +99,8 @@ contract ColonyPayment is ColonyStorage {
   {
     require(_recipient != address(0x0), "colony-payment-invalid-recipient");
     payments[_id].recipient = _recipient;
+
+    emit PaymentRecipientSet(_id, _recipient);
   }
 
   function setPaymentSkill(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, uint256 _skillId) public
@@ -103,6 +111,8 @@ contract ColonyPayment is ColonyStorage {
   validGlobalSkill(_skillId)
   {
     payments[_id].skills[0] = _skillId;
+
+    emit PaymentSkillSet(_id, _skillId);
   }
 
   function getPayment(uint256 _id) public view returns (Payment memory) {

--- a/contracts/colony/ColonyPayment.sol
+++ b/contracts/colony/ColonyPayment.sol
@@ -60,6 +60,7 @@ contract ColonyPayment is ColonyStorage {
 
     if (_skillId > 0) {
       setPaymentSkill(_permissionDomainId, _childSkillIndex, paymentCount, _skillId);
+      
       emit PaymentSkillSet(paymentCount, _skillId);
     }
 

--- a/contracts/extensions/ColonyExtension.sol
+++ b/contracts/extensions/ColonyExtension.sol
@@ -49,4 +49,8 @@ abstract contract ColonyExtension is DSAuth, DSMath {
     return deprecated;
   }
 
+  function getColony() public view returns(address) {
+    return address(colony);
+  }
+
 }

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -24,8 +24,8 @@ import "./ColonyExtension.sol";
 
 
 contract OneTxPayment is ColonyExtension {
-  event OneTxPaymentMade();
-  
+  event OneTxPaymentMade(address agent, uint256 paymentId, uint256 nTransactions);
+
   uint256 constant UINT256_MAX = 2**256 - 1;
   ColonyDataTypes.ColonyRole constant ADMINISTRATION = ColonyDataTypes.ColonyRole.Administration;
   ColonyDataTypes.ColonyRole constant FUNDING = ColonyDataTypes.ColonyRole.Funding;
@@ -91,6 +91,7 @@ contract OneTxPayment is ColonyExtension {
       "one-tx-payment-not-authorized"
     );
 
+
     if (_workers.length == 1) {
 
       uint256 paymentId = colony.addPayment(1, _childSkillIndex, _workers[0], _tokens[0], _amounts[0], _domainId, _skillId);
@@ -101,6 +102,7 @@ contract OneTxPayment is ColonyExtension {
       colony.finalizePayment(1, _childSkillIndex, paymentId);
       colony.claimPayment(paymentId, _tokens[0]);
 
+      emit OneTxPaymentMade(msg.sender, paymentId, _workers.length);
     } else {
 
       uint256 expenditureId = colony.makeExpenditure(1, _childSkillIndex, _domainId);
@@ -132,9 +134,8 @@ contract OneTxPayment is ColonyExtension {
 
       finalizeAndClaim(expenditureId, _workers, _tokens);
 
+      emit OneTxPaymentMade(msg.sender, expenditureId, _workers.length);
     }
-
-    emit OneTxPaymentMade();
   }
 
   /// @notice Completes a colony payment in a single transaction
@@ -183,6 +184,7 @@ contract OneTxPayment is ColonyExtension {
       colony.finalizePayment(_permissionDomainId, _childSkillIndex, paymentId);
       colony.claimPayment(paymentId, _tokens[0]);
 
+      emit OneTxPaymentMade(msg.sender, paymentId, _workers.length);
     } else {
 
       uint256 expenditureId = colony.makeExpenditure(_permissionDomainId, _childSkillIndex, _domainId);
@@ -215,9 +217,8 @@ contract OneTxPayment is ColonyExtension {
 
       finalizeAndClaim(expenditureId, _workers, _tokens);
 
+      emit OneTxPaymentMade(msg.sender, expenditureId, _workers.length);
     }
-
-    emit OneTxPaymentMade();
   }
 
   function calculateUniqueAmounts(

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -24,7 +24,7 @@ import "./ColonyExtension.sol";
 
 
 contract OneTxPayment is ColonyExtension {
-  event OneTxPaymentMade(address agent, uint256 paymentId, uint256 nTransactions);
+  event OneTxPaymentMade(address agent, uint256 fundamentalId, uint256 nPayouts);
 
   uint256 constant UINT256_MAX = 2**256 - 1;
   ColonyDataTypes.ColonyRole constant ADMINISTRATION = ColonyDataTypes.ColonyRole.Administration;

--- a/migrations/3_setup_colony_network.js
+++ b/migrations/3_setup_colony_network.js
@@ -1,4 +1,6 @@
 /* globals artifacts */
+const { writeFileSync } = require("fs");
+const path = require("path");
 const { setupUpgradableColonyNetwork } = require("../helpers/upgradable-contracts");
 
 const ColonyNetworkAuthority = artifacts.require("./ColonyNetworkAuthority");
@@ -36,6 +38,10 @@ module.exports = async function (deployer) {
   const authorityNetwork = await ColonyNetworkAuthority.new(etherRouter.address);
   await authorityNetwork.setOwner(etherRouter.address);
   await etherRouter.setAuthority(authorityNetwork.address);
+
+  writeFileSync(path.resolve(__dirname, "..", "etherrouter-address.json"), JSON.stringify({ etherRouterAddress: etherRouter.address }), {
+    encoding: "utf8",
+  });
 
   console.log(
     "### Colony Network setup with Resolver",

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -153,8 +153,8 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("66b392106f1f4728ade0838b90841d6d4e8bb9147e0837b2d0e57fa3a2742ddf");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("cdd57f6ce7854b30e2171e9e220ad88575cd0cfa500127bdf76cc688a67f7178");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("a7fc16974873ea8a267d51925c3958a22346ed6c68f74ef2ac1a4d822aaa1879");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("9b4bbdd5feb5206b00184d6e7bf976439aa259da2ec38470a290647e98384592");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("21541f59b876767da6e0fac459688cfbe312dc77b3bafdcf83c3b05f072cfbda");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("b595491a8eaa6c954387d49840a54f2ab4a532c7c60fe589e330ff75c594ea03");
       expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("7ed473bc856b04ff76f51f244381f5313ed4da7828ead2591ad51db3f84e3c2d");

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -99,7 +99,7 @@ contract("One transaction payments", (accounts) => {
       const balanceAfter = await token.balanceOf(USER1);
       expect(balanceAfter).to.eq.BN(9);
 
-      await expectEvent(tx, "OneTxPaymentMade", []);
+      await expectEvent(tx, "OneTxPaymentMade", [accounts[0], 1, 1]);
     });
 
     it("should allow a single-transaction payment of ETH to occur", async () => {


### PR DESCRIPTION
This branch is the one Raul and I were using to get The Graph working with the contracts / the dev environment, so merging this is sort of obligatory. There's a cherry-picked commit from #911 and some other changes.

`OneTxPaymentMade` event gets `agent` (like many things are going to), I add some events to the payment lifecycle. I added a getter to extensions so that we can work out what colony they're from. Raul added functionality to a migration that writes out the colonynetwork address to a file, which gets used by the graph dev environment to set itself up programmatically.