### PR TITLE
Prevent burning of tokens by colony without appropriate bookkeeping

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -18,11 +18,11 @@
 pragma solidity 0.7.3;
 pragma experimental ABIEncoderV2;
 
+import "./../common/ERC20Extended.sol";
 import "./../common/IEtherRouter.sol";
 import "./../extensions/ColonyExtension.sol";
 import "./../tokenLocking/ITokenLocking.sol";
 import "./ColonyStorage.sol";
-
 
 contract Colony is ColonyStorage, PatriciaTreeProofs {
 
@@ -475,6 +475,17 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     obligations[_user][_obligator][_domainId] = sub(obligations[_user][_obligator][_domainId], _amount);
 
     ITokenLocking(tokenLockingAddress).transferStake(_user, _amount, token, _beneficiary);
+  }
+
+  function burnTokens(
+    address _token,
+    uint256 _amount
+  ) public stoppable auth {
+    // Check the root funding pot has enought
+    require(fundingPots[1].balance[_token] >= _amount, "colony-not-enough-tokens");
+    ERC20Extended(_token).burn(_amount);
+    fundingPots[1].balance[_token] -= _amount;
+    emit TokensBurned(_token, _amount);
   }
 
   function getApproval(address _user, address _obligator, uint256 _domainId) public view returns (uint256) {

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -437,6 +437,9 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Architecture), address(this), sig, true);
     sig = bytes4(keccak256("editColony(string)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
+
+    sig = bytes4(keccak256("burnTokens(address,uint256)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
   }
 
   function checkNotAdditionalProtectedVariable(uint256 _slot) public view recovery {

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -40,6 +40,9 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
   bytes4 constant APPROVE_SIG = bytes4(keccak256("approve(address,uint256)"));
   bytes4 constant TRANSFER_SIG = bytes4(keccak256("transfer(address,uint256)"));
+  bytes4 constant TRANSFER_FROM_SIG = bytes4(keccak256("transferFrom(address,address,uint256)"));
+  bytes4 constant BURN_SIG = bytes4(keccak256("burn(uint256)"));
+  bytes4 constant BURN_GUY_SIG = bytes4(keccak256("burn(address,uint256)"));
 
   function makeArbitraryTransaction(address _to, bytes memory _action)
   public stoppable auth
@@ -60,6 +63,9 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
     require(sig != APPROVE_SIG, "colony-cannot-call-erc20-approve");
     require(sig != TRANSFER_SIG, "colony-cannot-call-erc20-transfer");
+    require(sig != TRANSFER_FROM_SIG, "colony-cannot-call-erc20-transfer-from");
+    require(sig != BURN_SIG, "colony-cannot-call-burn");
+    require(sig != BURN_GUY_SIG, "colony-cannot-call-burn-guy");
 
     // Prevent transactions to network-managed extensions installed in this colony
     try ColonyExtension(_to).identifier() returns (bytes32 extensionId) {

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -480,10 +480,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     ITokenLocking(tokenLockingAddress).transferStake(_user, _amount, token, _beneficiary);
   }
 
-  function burnTokens(
-    address _token,
-    uint256 _amount
-  ) public stoppable auth {
+  function burnTokens(address _token, uint256 _amount) public stoppable auth {
     // Check the root funding pot has enought
     require(fundingPots[1].balance[_token] >= _amount, "colony-not-enough-tokens");
     ERC20Extended(_token).burn(_amount);

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -105,6 +105,7 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ARCHITECTURE_ROLE, "addDomain(uint256,uint256,uint256,string)");
     addRoleCapability(ARCHITECTURE_ROLE, "editDomain(uint256,uint256,uint256,string)");
     addRoleCapability(ROOT_ROLE, "editColony(string)");
+    addRoleCapability(ROOT_ROLE, "burnTokens(address,uint256)");
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -224,6 +224,11 @@ interface ColonyDataTypes {
   /// @param paymentId Id of the payment
   event PaymentFinalized(uint256 indexed paymentId);
 
+  /// @notice Event logged when the colony burns tokens
+  /// @param token the address of the token being burned
+  /// @param token the amount of the token being burned
+  event TokensBurned(address token, uint256 amount);
+
   struct RewardPayoutCycle {
     // Reputation root hash at the time of reward payout creation
     bytes32 reputationState;

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -918,4 +918,6 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _fundingPotId Id of the funding pot
   /// @return domainId Id of the corresponding domain
   function getDomainFromFundingPot(uint256 _fundingPotId) external view returns (uint256 domainId);
+
+  function burnTokens(address token, uint256 amount) external;
 }

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -919,5 +919,8 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @return domainId Id of the corresponding domain
   function getDomainFromFundingPot(uint256 _fundingPotId) external view returns (uint256 domainId);
 
+  /// @notice Burn tokens held by the colony. Can only burn tokens held in the root funding pot.
+  /// @param token The address of the token to burn
+  /// @return amount The amount of tokens to burn
   function burnTokens(address token, uint256 amount) external;
 }

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -921,6 +921,6 @@ interface IColony is ColonyDataTypes, IRecovery {
 
   /// @notice Burn tokens held by the colony. Can only burn tokens held in the root funding pot.
   /// @param token The address of the token to burn
-  /// @return amount The amount of tokens to burn
+  /// @param amount The amount of tokens to burn
   function burnTokens(address token, uint256 amount) external;
 }

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -124,7 +124,7 @@ Burn tokens held by the colony. Can only burn tokens held in the root funding po
 |Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token to burn
-|amount|uint256|
+|amount|uint256|The amount of tokens to burn
 
 
 ### `cancelExpenditure`

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -114,6 +114,19 @@ Allows the colony to bootstrap itself by having initial reputation and token `_a
 |_amount|int[]|Amount of reputation/tokens for every address
 
 
+### `burnTokens`
+
+
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|token|address|
+|amount|uint256|
+
+
 ### `cancelExpenditure`
 
 Cancels the expenditure and prevents further editing. Can only be called by expenditure owner.

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -116,14 +116,14 @@ Allows the colony to bootstrap itself by having initial reputation and token `_a
 
 ### `burnTokens`
 
-
+Burn tokens held by the colony. Can only burn tokens held in the root funding pot.
 
 
 **Parameters**
 
 |Name|Type|Description|
 |---|---|---|
-|token|address|
+|token|address|The address of the token to burn
 |amount|uint256|
 
 

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -153,11 +153,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("a7fc16974873ea8a267d51925c3958a22346ed6c68f74ef2ac1a4d822aaa1879");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("9b4bbdd5feb5206b00184d6e7bf976439aa259da2ec38470a290647e98384592");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("21541f59b876767da6e0fac459688cfbe312dc77b3bafdcf83c3b05f072cfbda");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("b595491a8eaa6c954387d49840a54f2ab4a532c7c60fe589e330ff75c594ea03");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("7ed473bc856b04ff76f51f244381f5313ed4da7828ead2591ad51db3f84e3c2d");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("475c26514483d1e326e8ce55428a3452e9861e07f6610dd49f319528ad417fac");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("ea56020b077d5768d370a4e5a1b0dd771c77a974949536434e7959c158d17fbf");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("bbb3a6b35dbe471a14184a26de6a00f0aa63228795f4b749c593e133db6f8f32");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("977cc07c68504e153585526f96b13d11e8970cd2c9d139c15a72d18fde555098");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("2e65b5e05d527ff5167244eb2e15231ec0be15fabb42ee5073544d73ae21df26");
     });
   });
 });

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -167,9 +167,15 @@ contract("Colony", (accounts) => {
     it("should not be able to make arbitrary transactions to transfer tokens", async () => {
       const action1 = await encodeTxData(token, "approve", [USER0, WAD]);
       const action2 = await encodeTxData(token, "transfer", [USER0, WAD]);
+      const action3 = await encodeTxData(token, "transferFrom", [USER0, USER0, WAD]);
+      const action4 = await encodeTxData(token, "burn", [WAD]);
+      const action5 = await encodeTxData(token, "burn(address,uint256)", [USER0, WAD]);
 
       await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action1), "colony-cannot-call-erc20-approve");
       await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action2), "colony-cannot-call-erc20-transfer");
+      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action3), "colony-cannot-call-erc20-transfer-from");
+      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action4), "colony-cannot-call-burn");
+      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action5), "colony-cannot-call-burn-guy");
     });
 
     it("should not be able to make arbitrary transactions to the colony's own extensions", async () => {


### PR DESCRIPTION
Closes #910.

I've added the two burn transaction function signatures we have on the token we provide to the 'forbidden' list of transactions, though I'm wondering if we need to take a different approach to this. Maybe preventing arbitrary transactions to a contract that (appears to be) an ERC20 that the colony has a balance in, or something? I've had to add `transferFrom` too despite arguing against that last time we looked at this, because in some ERC20 implementations (including the one the token we provide uses) you don't have to give yourself permission to `transferFrom` from yourself. That's pretty annoying, because there is a legitimate reason for a colony to want to be able to call `transferFrom`. Are we going to have to inspect a 'transferFrom` transaction further? This is probably involved enough to warrant 

It's also possible there's a more gas-efficient way to do this check (bloom-filter-esqe?), but I haven't worked out what that is or whether it's worthwhile.

I've then added the `burnTokens` functionality to provide a mechanism to burn tokens owned by the colony. You have to burn tokens out of the root funding pot. While this is arguably tokens leaving the colony, I've opted to not put in a network tax.