### PR TITLE
Have previous version resolvers respond accurately

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -18,7 +18,8 @@ module.exports = {
       'patriciaTree',
       'testHelpers/ContractEditing.sol', // only used in setting up colony-network-recovery.js tests, never in production
       'testHelpers/NoLimitSubdomains.sol',
-      'testHelpers/TaskSkillEditing.sol'
+      'testHelpers/TaskSkillEditing.sol',
+      'testHelpers/PreviousVersion.sol'
     ],
     providerOptions: {
       port: 8555,

--- a/.solcover.reputation.js
+++ b/.solcover.reputation.js
@@ -18,7 +18,8 @@ module.exports = {
       'patriciaTree',
       'testHelpers/ContractEditing.sol', // only used in setting up colony-network-recovery.js tests, never in production
       'testHelpers/NoLimitSubdomains.sol',
-      'testHelpers/TaskSkillEditing.sol'
+      'testHelpers/TaskSkillEditing.sol',
+      'testHelpers/PreviousVersion.sol'
     ],
     providerOptions: {
       port: 8555,

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -363,7 +363,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
   function upgrade(uint256 _newVersion) public always auth {
     // Upgrades can only go up in version, one at a time
-    uint256 currentVersion = version();
+    uint256 currentVersion = this.version();
     require(_newVersion == currentVersion + 1, "colony-version-must-be-one-newer");
     // Requested version has to be registered
     address newResolver = IColonyNetwork(colonyNetworkAddress).getColonyVersionResolver(_newVersion);

--- a/contracts/testHelpers/PreviousVersion.sol
+++ b/contracts/testHelpers/PreviousVersion.sol
@@ -1,0 +1,13 @@
+pragma solidity 0.7.3;
+
+contract Version3 {
+  function version() pure external returns (uint256) {
+  	return 3;
+  }
+}
+
+contract Version4 {
+  function version() pure external returns (uint256) {
+  	return 4;
+  }
+}

--- a/migrations/8_setup_meta_colony.js
+++ b/migrations/8_setup_meta_colony.js
@@ -78,10 +78,10 @@ module.exports = async function (deployer, network, accounts) {
   await metaColony.addNetworkColonyVersion(3, resolver3.address);
 
   const resolver4 = await Resolver.new();
-  await setupColonyVersionResolver(colony, colonyExpenditure, colonyTask, colonyPayment, colonyFunding, colonyRoles, contractRecovery, resolver3);
+  await setupColonyVersionResolver(colony, colonyExpenditure, colonyTask, colonyPayment, colonyFunding, colonyRoles, contractRecovery, resolver4);
   const v4responder = await Version4.new();
   await resolver4.register("version()", v4responder.address);
-  await metaColony.addNetworkColonyVersion(4, resolver3.address);
+  await metaColony.addNetworkColonyVersion(4, resolver4.address);
 
   await colonyNetwork.initialiseReputationMining();
   await colonyNetwork.startNextCycle();

--- a/migrations/8_setup_meta_colony.js
+++ b/migrations/8_setup_meta_colony.js
@@ -6,8 +6,14 @@ const Token = artifacts.require("./Token");
 const IColonyNetwork = artifacts.require("./IColonyNetwork");
 const IMetaColony = artifacts.require("./IMetaColony");
 const ITokenLocking = artifacts.require("./ITokenLocking");
-const EtherRouter = artifacts.require("./EtherRouter");
 const TokenAuthority = artifacts.require("./TokenAuthority");
+
+const Resolver = artifacts.require("./Resolver");
+const EtherRouter = artifacts.require("./EtherRouter");
+
+const Version3 = artifacts.require("./Version3");
+const Version4 = artifacts.require("./Version4");
+const { setupColonyVersionResolver } = require("../helpers/upgradable-contracts");
 
 const DEFAULT_STAKE = "2000000000000000000000000"; // 1000 * MIN_STAKE
 
@@ -48,10 +54,34 @@ module.exports = async function (deployer, network, accounts) {
   await colonyNetwork.stakeForMining(DEFAULT_STAKE, { from: MAIN_ACCOUNT });
   await metaColony.addGlobalSkill();
 
-  // Also set up the pinned version (3)... TODO: remove along with the deprecated `createColony`
-  const version = await metaColony.version();
-  const resolverAddress = await colonyNetwork.getColonyVersionResolver(version);
-  await metaColony.addNetworkColonyVersion(3, resolverAddress);
+  // Set up functional resolvers that identify correctly as previous versions.
+  const Colony = artifacts.require("./Colony");
+  const ColonyFunding = artifacts.require("./ColonyFunding");
+  const ColonyExpenditure = artifacts.require("./ColonyExpenditure");
+  const ColonyRoles = artifacts.require("./ColonyRoles");
+  const ColonyTask = artifacts.require("./ColonyTask");
+  const ColonyPayment = artifacts.require("./ColonyPayment");
+  const ContractRecovery = artifacts.require("./ContractRecovery");
+
+  const colony = await Colony.new();
+  const colonyFunding = await ColonyFunding.new();
+  const colonyExpenditure = await ColonyExpenditure.new();
+  const colonyRoles = await ColonyRoles.new();
+  const colonyTask = await ColonyTask.new();
+  const colonyPayment = await ColonyPayment.new();
+  const contractRecovery = await ContractRecovery.deployed();
+
+  const resolver3 = await Resolver.new();
+  await setupColonyVersionResolver(colony, colonyExpenditure, colonyTask, colonyPayment, colonyFunding, colonyRoles, contractRecovery, resolver3);
+  const v3responder = await Version3.new();
+  await resolver3.register("version()", v3responder.address);
+  await metaColony.addNetworkColonyVersion(3, resolver3.address);
+
+  const resolver4 = await Resolver.new();
+  await setupColonyVersionResolver(colony, colonyExpenditure, colonyTask, colonyPayment, colonyFunding, colonyRoles, contractRecovery, resolver3);
+  const v4responder = await Version4.new();
+  await resolver4.register("version()", v4responder.address);
+  await metaColony.addNetworkColonyVersion(4, resolver3.address);
 
   await colonyNetwork.initialiseReputationMining();
   await colonyNetwork.startNextCycle();

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -153,7 +153,7 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("8cd671792635c6edb9ce06cf71282897048f8a05463fdfd11d55805300f42601");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("1c716a8d208a809b82d4f1f98e10931a93c70358eebbbba72677ec21a045a7c6");
       expect(colonyAccount.stateRoot.toString("hex")).to.equal("e8c01c2cfc7f58dd1c2e2d39f9e0c8652980885f9d17cb69dc61cd650361b9bd");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("bbb3a6b35dbe471a14184a26de6a00f0aa63228795f4b749c593e133db6f8f32");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("977cc07c68504e153585526f96b13d11e8970cd2c9d139c15a72d18fde555098");

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -153,8 +153,8 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("475c26514483d1e326e8ce55428a3452e9861e07f6610dd49f319528ad417fac");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("ea56020b077d5768d370a4e5a1b0dd771c77a974949536434e7959c158d17fbf");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("8cd671792635c6edb9ce06cf71282897048f8a05463fdfd11d55805300f42601");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("e8c01c2cfc7f58dd1c2e2d39f9e0c8652980885f9d17cb69dc61cd650361b9bd");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("bbb3a6b35dbe471a14184a26de6a00f0aa63228795f4b749c593e133db6f8f32");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("977cc07c68504e153585526f96b13d11e8970cd2c9d139c15a72d18fde555098");
       expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("2e65b5e05d527ff5167244eb2e15231ec0be15fabb42ee5073544d73ae21df26");


### PR DESCRIPTION
Previously, resolvers were registered as previous versions, but `.version()` was still the current version number.  This makes them respond accurately to `version`, at least, which means that relevant UI development is possible.