### PR TITLE
Add script to deploy 'true' old versions of the contracts

### DIFF
--- a/scripts/deployUnmockedColonyVersions.js
+++ b/scripts/deployUnmockedColonyVersions.js
@@ -40,7 +40,7 @@ module.exports = async () => {
       res = res.stdout;
     }
     let index = res.indexOf("Colony version 3 set to Resolver");
-    v3ResolverAddress = res.substring(index + 33, index + 33 + 42);
+    v3ResolverAddress = res.substring(index + RESOLVER_LOG_OFFSET, index + RESOLVER_LOG_OFFSET + ADDRESS_LENGTH);
     console.log("v3 address:", v3ResolverAddress);
     await metaColony.addNetworkColonyVersion(3, v3ResolverAddress);
 

--- a/scripts/deployUnmockedColonyVersions.js
+++ b/scripts/deployUnmockedColonyVersions.js
@@ -44,7 +44,7 @@ module.exports = async () => {
     res = await exec("yarn run truffle migrate --reset");
     index = res.indexOf("Colony version 4 set to Resolver");
     v4ResolverAddress = res.substring(index + 33, index + 33 + 42);
-    await metaColony.addNetworkColonyVersion(3, v4ResolverAddress);
+    await metaColony.addNetworkColonyVersion(4, v4ResolverAddress);
   } catch (err) {
     console.log(err);
   }

--- a/scripts/deployUnmockedColonyVersions.js
+++ b/scripts/deployUnmockedColonyVersions.js
@@ -26,6 +26,7 @@ module.exports = async () => {
   const metaColonyAddress = await colonyNetwork.getMetaColony();
   const metaColony = await IMetaColony.at(metaColonyAddress);
   try {
+    await exec("mv ./build ./buildBackup");
     await exec("git checkout ad5569de24567517aa12624e29600c9136fb594d && git submodule update");
 
     // Comment out uneeded parts of file
@@ -66,5 +67,5 @@ module.exports = async () => {
   // put things back how they were.
   await exec(`git checkout -f ${currentHash}`);
   await exec("git submodule update");
-  await exec("yarn run truffle compile");
+  await exec("mv ./buildBackup ./build");
 };

--- a/scripts/deployUnmockedColonyVersions.js
+++ b/scripts/deployUnmockedColonyVersions.js
@@ -17,7 +17,7 @@ const IMetaColony = artifacts.require("./IMetaColony");
 
 module.exports = async () => {
   // While debugging, always checkout currenthash
-  await exec("git checkout 2690fba3d3002fd72912cd74f1fbf4932c734e94 && git submodule update");
+  // await exec("git checkout 2690fba3d3002fd72912cd74f1fbf4932c734e94 && git submodule update");
   let res = await exec("git log -1 --format='%H'");
   const currentHash = res.stdout.trim();
   let v3ResolverAddress;
@@ -42,15 +42,13 @@ module.exports = async () => {
     index = res.stdout.indexOf("Colony version 4 set to Resolver");
     v4ResolverAddress = res.stdout.substring(index + 33, index + 33 + 42);
     await metaColony.addNetworkColonyVersion(3, v4ResolverAddress);
-
-    // put things back how they were.
-    await exec(`git checkout ${currentHash}`);
-    await exec("git submodule update");
-    await exec("yarn run truffle compile");
   } catch (err) {
     console.log(err);
   }
   console.log(v3ResolverAddress);
   console.log(v4ResolverAddress);
-  // await exec("git checkout " + currentHash)
+  // put things back how they were.
+  await exec(`git checkout ${currentHash}`);
+  await exec("git submodule update");
+  await exec("yarn run truffle compile");
 };

--- a/scripts/deployUnmockedColonyVersions.js
+++ b/scripts/deployUnmockedColonyVersions.js
@@ -31,6 +31,8 @@ module.exports = async () => {
     // Comment out uneeded parts of file
     await exec("sed -i'' '26,27 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
     await exec("sed -i'' '31 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
+    await exec("sed -i'' 's|await ContractRecovery.deployed()|await ContractRecovery.new()");
+    await exec("rm -r ./build");
     let res = await exec("yarn run truffle migrate --reset -f 4 --to 4");
     if (res.stdout) {
       // How this response looks changes node 10->12
@@ -46,6 +48,8 @@ module.exports = async () => {
     // Comment out uneeded parts of file
     await exec("sed -i'' '27,28 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
     await exec("sed -i'' '32 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
+    await exec("sed -i'' 's|await ContractRecovery.deployed()|await ContractRecovery.new()");
+    await exec("rm -r ./build");
     res = await exec("yarn run truffle migrate --reset -f 4 --to 4");
     if (res.stdout) {
       // How this response looks changes node 10->12

--- a/scripts/deployUnmockedColonyVersions.js
+++ b/scripts/deployUnmockedColonyVersions.js
@@ -18,29 +18,34 @@ const IMetaColony = artifacts.require("./IMetaColony");
 module.exports = async () => {
   // While debugging, always checkout currenthash
   // await exec("git checkout 2690fba3d3002fd72912cd74f1fbf4932c734e94 && git submodule update");
-  let res = await exec("git log -1 --format='%H'");
-  const currentHash = res.stdout.trim();
+  console.log('last chance')
+  let currentHash = await exec("git log -1 --format='%H'");
+  // const currentHash = res.stdout.trim();
+  console.log(currentHash, 'hash')
   let v3ResolverAddress;
   let v4ResolverAddress;
+  console.log('maybe here?')
   const colonyNetwork = await IColonyNetwork.at(cnAddress);
   const metaColonyAddress = await colonyNetwork.getMetaColony();
   const metaColony = await IMetaColony.at(metaColonyAddress);
-
+  console.log('here')
   try {
-    res = await exec("yarn run truffle migrate --reset");
+    console.log('in try')
+    let res = await exec("yarn run truffle migrate --reset");
+    console.log('truffle migrate')
     await exec("git checkout ad5569de24567517aa12624e29600c9136fb594d && git submodule update");
 
     res = await exec("yarn run truffle migrate --reset");
-    let index = res.stdout.indexOf("Colony version 3 set to Resolver");
-    v3ResolverAddress = res.stdout.substring(index + 33, index + 33 + 42);
+    let index = res.indexOf("Colony version 3 set to Resolver");
+    v3ResolverAddress = res.substring(index + 33, index + 33 + 42);
     console.log("v3 address:", v3ResolverAddress);
     await exec("git checkout burgundy-glider && git submodule update");
 
     await metaColony.addNetworkColonyVersion(3, v3ResolverAddress);
 
     res = await exec("yarn run truffle migrate --reset");
-    index = res.stdout.indexOf("Colony version 4 set to Resolver");
-    v4ResolverAddress = res.stdout.substring(index + 33, index + 33 + 42);
+    index = res.indexOf("Colony version 4 set to Resolver");
+    v4ResolverAddress = res.substring(index + 33, index + 33 + 42);
     await metaColony.addNetworkColonyVersion(3, v4ResolverAddress);
   } catch (err) {
     console.log(err);

--- a/scripts/deployUnmockedColonyVersions.js
+++ b/scripts/deployUnmockedColonyVersions.js
@@ -67,5 +67,6 @@ module.exports = async () => {
   // put things back how they were.
   await exec(`git checkout -f ${currentHash}`);
   await exec("git submodule update");
+  await exec("rm -rf ./build");
   await exec("mv ./buildBackup ./build");
 };

--- a/scripts/deployUnmockedColonyVersions.js
+++ b/scripts/deployUnmockedColonyVersions.js
@@ -18,30 +18,39 @@ const IMetaColony = artifacts.require("./IMetaColony");
 module.exports = async () => {
   // While debugging, always checkout currenthash
   // await exec("git checkout 2690fba3d3002fd72912cd74f1fbf4932c734e94 && git submodule update");
-  console.log('last chance')
-  let currentHash = await exec("git log -1 --format='%H'");
+  const currentHash = await exec("git log -1 --format='%H'");
   // const currentHash = res.stdout.trim();
-  console.log(currentHash, 'hash')
   let v3ResolverAddress;
   let v4ResolverAddress;
-  console.log('maybe here?')
   const colonyNetwork = await IColonyNetwork.at(cnAddress);
-  console.log(cnAddress, 'cnAddress');
   const metaColonyAddress = await colonyNetwork.getMetaColony();
   const metaColony = await IMetaColony.at(metaColonyAddress);
-  console.log('here')
   try {
     await exec("git checkout ad5569de24567517aa12624e29600c9136fb594d && git submodule update");
 
-    let res = await exec("yarn run truffle migrate --reset");
+    // Comment out uneeded parts of file
+    await exec("sed -i'' '26,27 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
+    await exec("sed -i'' '31 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
+    let res = await exec("yarn run truffle migrate --reset -f 4 --to 4");
+    if (res.stdout) {
+      // How this response looks changes node 10->12
+      res = res.stdout;
+    }
     let index = res.indexOf("Colony version 3 set to Resolver");
     v3ResolverAddress = res.substring(index + 33, index + 33 + 42);
     console.log("v3 address:", v3ResolverAddress);
-    await exec("git checkout burgundy-glider && git submodule update");
-
     await metaColony.addNetworkColonyVersion(3, v3ResolverAddress);
 
-    res = await exec("yarn run truffle migrate --reset");
+    await exec("git checkout -f burgundy-glider && git submodule update");
+
+    // Comment out uneeded parts of file
+    await exec("sed -i'' '27,28 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
+    await exec("sed -i'' '32 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
+    res = await exec("yarn run truffle migrate --reset -f 4 --to 4");
+    if (res.stdout) {
+      // How this response looks changes node 10->12
+      res = res.stdout;
+    }
     index = res.indexOf("Colony version 4 set to Resolver");
     v4ResolverAddress = res.substring(index + 33, index + 33 + 42);
     await metaColony.addNetworkColonyVersion(4, v4ResolverAddress);
@@ -51,7 +60,7 @@ module.exports = async () => {
   console.log(v3ResolverAddress);
   console.log(v4ResolverAddress);
   // put things back how they were.
-  await exec(`git checkout ${currentHash}`);
+  await exec(`git checkout -f ${currentHash}`);
   await exec("git submodule update");
   await exec("yarn run truffle compile");
 };

--- a/scripts/deployUnmockedColonyVersions.js
+++ b/scripts/deployUnmockedColonyVersions.js
@@ -32,7 +32,7 @@ module.exports = async () => {
     await exec("sed -i'' '26,27 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
     await exec("sed -i'' '31 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
     await exec("sed -i'' 's|await ContractRecovery.deployed()|await ContractRecovery.new()|' ./migrations/4_setup_colony_version_resolver.js");
-    await exec("rm -r ./build");
+    await exec("rm -rf ./build");
     let res = await exec("yarn run truffle migrate --reset -f 4 --to 4");
     if (res.stdout) {
       // How this response looks changes node 10->12
@@ -49,7 +49,7 @@ module.exports = async () => {
     await exec("sed -i'' '27,28 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
     await exec("sed -i'' '32 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
     await exec("sed -i'' 's|await ContractRecovery.deployed()|await ContractRecovery.new()|' ./migrations/4_setup_colony_version_resolver.js");
-    await exec("rm -r ./build");
+    await exec("rm -rf ./build");
     res = await exec("yarn run truffle migrate --reset -f 4 --to 4");
     if (res.stdout) {
       // How this response looks changes node 10->12

--- a/scripts/deployUnmockedColonyVersions.js
+++ b/scripts/deployUnmockedColonyVersions.js
@@ -26,16 +26,14 @@ module.exports = async () => {
   let v4ResolverAddress;
   console.log('maybe here?')
   const colonyNetwork = await IColonyNetwork.at(cnAddress);
+  console.log(cnAddress, 'cnAddress');
   const metaColonyAddress = await colonyNetwork.getMetaColony();
   const metaColony = await IMetaColony.at(metaColonyAddress);
   console.log('here')
   try {
-    console.log('in try')
-    let res = await exec("yarn run truffle migrate --reset");
-    console.log('truffle migrate')
     await exec("git checkout ad5569de24567517aa12624e29600c9136fb594d && git submodule update");
 
-    res = await exec("yarn run truffle migrate --reset");
+    let res = await exec("yarn run truffle migrate --reset");
     let index = res.indexOf("Colony version 3 set to Resolver");
     v3ResolverAddress = res.substring(index + 33, index + 33 + 42);
     console.log("v3 address:", v3ResolverAddress);

--- a/scripts/deployUnmockedColonyVersions.js
+++ b/scripts/deployUnmockedColonyVersions.js
@@ -31,7 +31,7 @@ module.exports = async () => {
     // Comment out uneeded parts of file
     await exec("sed -i'' '26,27 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
     await exec("sed -i'' '31 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
-    await exec("sed -i'' 's|await ContractRecovery.deployed()|await ContractRecovery.new()");
+    await exec("sed -i'' 's|await ContractRecovery.deployed()|await ContractRecovery.new()|' ./migrations/4_setup_colony_version_resolver.js");
     await exec("rm -r ./build");
     let res = await exec("yarn run truffle migrate --reset -f 4 --to 4");
     if (res.stdout) {
@@ -48,7 +48,7 @@ module.exports = async () => {
     // Comment out uneeded parts of file
     await exec("sed -i'' '27,28 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
     await exec("sed -i'' '32 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
-    await exec("sed -i'' 's|await ContractRecovery.deployed()|await ContractRecovery.new()");
+    await exec("sed -i'' 's|await ContractRecovery.deployed()|await ContractRecovery.new()|' ./migrations/4_setup_colony_version_resolver.js");
     await exec("rm -r ./build");
     res = await exec("yarn run truffle migrate --reset -f 4 --to 4");
     if (res.stdout) {

--- a/scripts/deployUnmockedColonyVersions.js
+++ b/scripts/deployUnmockedColonyVersions.js
@@ -1,0 +1,56 @@
+// Input:
+/* globals artifacts */
+
+// Check out v3
+// Deploy v3 resolver
+// Point v3 on network to that resolver
+
+// Checkout out v4
+// Deploy v4 resolver
+// Point v4 on network to that resolver
+const util = require("util");
+const exec = util.promisify(require("child_process").exec);
+const cnAddress = require("../etherrouter-address.json").etherRouterAddress;
+
+const IColonyNetwork = artifacts.require("./IColonyNetwork");
+const IMetaColony = artifacts.require("./IMetaColony");
+
+module.exports = async () => {
+  // While debugging, always checkout currenthash
+  await exec("git checkout 2690fba3d3002fd72912cd74f1fbf4932c734e94 && git submodule update");
+  let res = await exec("git log -1 --format='%H'");
+  const currentHash = res.stdout.trim();
+  let v3ResolverAddress;
+  let v4ResolverAddress;
+  const colonyNetwork = await IColonyNetwork.at(cnAddress);
+  const metaColonyAddress = await colonyNetwork.getMetaColony();
+  const metaColony = await IMetaColony.at(metaColonyAddress);
+
+  try {
+    res = await exec("yarn run truffle migrate --reset");
+    await exec("git checkout ad5569de24567517aa12624e29600c9136fb594d && git submodule update");
+
+    res = await exec("yarn run truffle migrate --reset");
+    let index = res.stdout.indexOf("Colony version 3 set to Resolver");
+    v3ResolverAddress = res.stdout.substring(index + 33, index + 33 + 42);
+    console.log("v3 address:", v3ResolverAddress);
+    await exec("git checkout burgundy-glider && git submodule update");
+
+    await metaColony.addNetworkColonyVersion(3, v3ResolverAddress);
+
+    res = await exec("yarn run truffle migrate --reset");
+    index = res.stdout.indexOf("Colony version 4 set to Resolver");
+    v4ResolverAddress = res.stdout.substring(index + 33, index + 33 + 42);
+    await metaColony.addNetworkColonyVersion(3, v4ResolverAddress);
+
+    // put things back how they were.
+    await exec(`git checkout ${currentHash}`);
+    await exec("git submodule update");
+    await exec("yarn run truffle compile");
+  } catch (err) {
+    console.log(err);
+  }
+  console.log(v3ResolverAddress);
+  console.log(v4ResolverAddress);
+  // await exec("git checkout " + currentHash)
+};

--- a/scripts/deployUnmockedColonyVersions.js
+++ b/scripts/deployUnmockedColonyVersions.js
@@ -29,9 +29,9 @@ module.exports = async () => {
     await exec("git checkout ad5569de24567517aa12624e29600c9136fb594d && git submodule update");
 
     // Comment out uneeded parts of file
-    await exec("sed -i'' '26,27 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
-    await exec("sed -i'' '31 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
-    await exec("sed -i'' 's|await ContractRecovery.deployed()|await ContractRecovery.new()|' ./migrations/4_setup_colony_version_resolver.js");
+    await exec("sed -i'' -e '26,27 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
+    await exec("sed -i'' -e '31 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
+    await exec("sed -i'' -e 's|await ContractRecovery.deployed()|await ContractRecovery.new()|' ./migrations/4_setup_colony_version_resolver.js");
     await exec("rm -rf ./build");
     let res = await exec("yarn run truffle migrate --reset -f 4 --to 4");
     if (res.stdout) {
@@ -46,9 +46,9 @@ module.exports = async () => {
     await exec("git checkout -f burgundy-glider && git submodule update");
 
     // Comment out uneeded parts of file
-    await exec("sed -i'' '27,28 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
-    await exec("sed -i'' '32 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
-    await exec("sed -i'' 's|await ContractRecovery.deployed()|await ContractRecovery.new()|' ./migrations/4_setup_colony_version_resolver.js");
+    await exec("sed -i'' -e '27,28 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
+    await exec("sed -i'' -e '32 s|^|//|' ./migrations/4_setup_colony_version_resolver.js");
+    await exec("sed -i'' -e 's|await ContractRecovery.deployed()|await ContractRecovery.new()|' ./migrations/4_setup_colony_version_resolver.js");
     await exec("rm -rf ./build");
     res = await exec("yarn run truffle migrate --reset -f 4 --to 4");
     if (res.stdout) {

--- a/scripts/deployUnmockedColonyVersions.js
+++ b/scripts/deployUnmockedColonyVersions.js
@@ -10,7 +10,7 @@
 // Point v4 on network to that resolver
 const util = require("util");
 const exec = util.promisify(require("child_process").exec);
-const cnAddress = require("../etherrouter-address.json").etherRouterAddress;
+const cnAddress = require("../etherrouter-address.json").etherRouterAddress; // eslint-disable-line import/no-unresolved
 
 const IColonyNetwork = artifacts.require("./IColonyNetwork");
 const IMetaColony = artifacts.require("./IMetaColony");


### PR DESCRIPTION
For some of the work @alicjakujawa has been doing, she needed to be able to easily deploy old versions of the contracts. The kludge that we have in the migrations was inadequate (see #916) because while those versions claimed to be old versions, they were actually version 5 contracts. That meant that events and so forth had an unexpected number of arguments (especially after #911) and so colonyJS would error out, making the development of the frontend impossible in this scenario.

This script checks out old versions as appropriate and deploys them to the existing network deployment found at the address in `etherrouter-address.json` (introduced in [this commit](https://github.com/JoinColony/colonyNetwork/commit/adf8b3e995cb3cbba4631cf09086d49a5cfdb8a8) with little fanfare at the time)).