### PR TITLE
Extension token locking

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -19,7 +19,8 @@ module.exports = {
       'testHelpers/ContractEditing.sol', // only used in setting up colony-network-recovery.js tests, never in production
       'testHelpers/NoLimitSubdomains.sol',
       'testHelpers/TaskSkillEditing.sol',
-      'testHelpers/PreviousVersion.sol'
+      'testHelpers/PreviousVersion.sol',
+      'testHelpers/RequireExecuteCall.sol',
     ],
     providerOptions: {
       port: 8555,

--- a/.solcover.reputation.js
+++ b/.solcover.reputation.js
@@ -19,7 +19,8 @@ module.exports = {
       'testHelpers/ContractEditing.sol', // only used in setting up colony-network-recovery.js tests, never in production
       'testHelpers/NoLimitSubdomains.sol',
       'testHelpers/TaskSkillEditing.sol',
-      'testHelpers/PreviousVersion.sol'
+      'testHelpers/PreviousVersion.sol',
+      'testHelpers/RequireExecuteCall.sol',
     ],
     providerOptions: {
       port: 8555,

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -47,12 +47,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
   public stoppable auth
   returns (bool)
   {
-    // Ensure _to is a contract
-    uint256 size;
-    assembly { size := extcodesize(_to) }
-    require(size > 0, "colony-to-must-be-contract");
-
     // Prevent transactions to network contracts
+    require(_to != address(this), "colony-cannot-target-self");
     require(_to != colonyNetworkAddress, "colony-cannot-target-network");
     require(_to != tokenLockingAddress, "colony-cannot-target-token-locking");
 
@@ -67,6 +63,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     require(sig != BURN_GUY_SIG, "colony-cannot-call-burn-guy");
 
     // Prevent transactions to network-managed extensions installed in this colony
+    require(isContract(_to), "colony-to-must-be-contract");
     try ColonyExtension(_to).identifier() returns (bytes32 extensionId) {
       require(
         IColonyNetwork(colonyNetworkAddress).getExtensionInstallation(extensionId, address(this)) != _to,

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -20,7 +20,6 @@ pragma experimental ABIEncoderV2;
 
 import "./../common/ERC20Extended.sol";
 import "./../common/IEtherRouter.sol";
-import "./../extensions/ColonyExtension.sol";
 import "./../tokenLocking/ITokenLocking.sol";
 import "./ColonyStorage.sol";
 

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -24,10 +24,13 @@ import "./ColonyStorage.sol";
 
 contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
   function lockToken() public stoppable onlyExtension returns (uint256) {
-    return ITokenLocking(tokenLockingAddress).lockToken(token);
+    uint256 lockId = ITokenLocking(tokenLockingAddress).lockToken(token);
+    tokenLocks[msg.sender][lockId] = true;
+    return lockId;
   }
 
   function unlockTokenForUser(address _user, uint256 _lockId) public stoppable onlyExtension {
+    require(tokenLocks[msg.sender][_lockId], "colony-bad-lock-id");
     ITokenLocking(tokenLockingAddress).unlockTokenForUser(token, _user, _lockId);
   }
 

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -23,6 +23,14 @@ import "./ColonyStorage.sol";
 
 
 contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
+  function lockToken() public stoppable extension returns (uint256) {
+    return ITokenLocking(tokenLockingAddress).lockToken(token);
+  }
+
+  function unlockTokenForUser(address _user, uint256 _lockId) public stoppable extension {
+    ITokenLocking(tokenLockingAddress).unlockTokenForUser(token, _user, _lockId);
+  }
+
   function setTaskManagerPayout(uint256 _id, address _token, uint256 _amount) public stoppable self {
     setTaskPayout(_id, TaskRole.Manager, _token, _amount);
     emit TaskPayoutSet(_id, TaskRole.Manager, _token, _amount);

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -23,11 +23,11 @@ import "./ColonyStorage.sol";
 
 
 contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
-  function lockToken() public stoppable extension returns (uint256) {
+  function lockToken() public stoppable onlyExtension returns (uint256) {
     return ITokenLocking(tokenLockingAddress).lockToken(token);
   }
 
-  function unlockTokenForUser(address _user, uint256 _lockId) public stoppable extension {
+  function unlockTokenForUser(address _user, uint256 _lockId) public stoppable onlyExtension {
     ITokenLocking(tokenLockingAddress).unlockTokenForUser(token, _user, _lockId);
   }
 

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -212,12 +212,9 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, ColonyNetworkDataTypes
     _;
   }
 
-  modifier extension() {
+  modifier onlyExtension() {
     // Ensure msg.sender is a contract
-    uint256 size;
-    address msgSender = msg.sender;
-    assembly { size := extcodesize(msgSender) }
-    require(size > 0, "colony-must-be-extension");
+    require(isContract(msg.sender), "colony-sender-must-be-contract");
 
     // Ensure msg.sender is an extension
     try ColonyExtension(msg.sender).identifier() returns (bytes32 extensionId) {
@@ -268,6 +265,12 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, ColonyNetworkDataTypes
 
   function isAuthorized(address src, uint256 domainId, bytes4 sig) internal view returns (bool) {
     return (src == owner) || DomainRoles(address(authority)).canCall(src, domainId, address(this), sig);
+  }
+
+  function isContract(address addr) internal returns (bool) {
+    uint256 size;
+    assembly { size := extcodesize(addr) }
+    return size > 0;
   }
 
   function domainExists(uint256 domainId) internal view returns (bool) {

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -94,6 +94,8 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, ColonyNetworkDataTypes
 
   address tokenLockingAddress; // Storage slot 30
 
+  mapping (address => mapping (uint256 => bool)) tokenLocks; // Storage slot 31
+
   // Constants
   uint256 constant MAX_PAYOUT = 2**128 - 1; // 340,282,366,920,938,463,463 WADs
   bytes32 constant ROOT_ROLES = bytes32(uint256(1)) << uint8(ColonyRole.Recovery) | bytes32(uint256(1)) << uint8(ColonyRole.Root);

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -227,6 +227,14 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _wad Amount to mint
   function mintTokensFor(address _guy, uint256 _wad) external;
 
+  /// @notice Lock the colony's token. Can only be called by a network-managed extension.
+  function lockToken() external returns (uint256);
+
+  /// @notice Unlock the colony's token for a user. Can only be called by a network-managed extension.
+  /// @param user The user to unlock
+  /// @param lockId The specific lock to unlock
+  function unlockTokenForUser(address user, uint256 lockId) external;
+
   /// @notice Register colony's ENS label.
   /// @param colonyName The label to register.
   /// @param orbitdb The path of the orbitDB database associated with the colony name

--- a/contracts/testHelpers/RequireExecuteCall.sol
+++ b/contracts/testHelpers/RequireExecuteCall.sol
@@ -22,7 +22,19 @@ pragma experimental ABIEncoderV2;
 contract RequireExecuteCall {
   function executeCall(address target, bytes memory action) public {
     bool success;
-    assembly { success := call(gas(), target, 0, add(action, 0x20), mload(action), 0, 0) }
-    require(success, "transaction-failed");
+    bytes memory returndata;
+    (success, returndata) = target.call(action);
+    if (!success){
+      // Stolen shamelessly from
+      // https://ethereum.stackexchange.com/questions/83528/how-can-i-get-the-revert-reason-of-a-call-in-solidity-so-that-i-can-use-it-in-th
+      // If the _res length is less than 68, then the transaction failed silently (without a revert message)
+      if (returndata.length >= 68) {
+        assembly {
+          // Slice the sighash.
+          returndata := add(returndata, 0x04)
+        }
+      require(false, abi.decode(returndata, (string))); // All that remains is the revert string
+      }
+    }
   }
 }

--- a/contracts/testHelpers/RequireExecuteCall.sol
+++ b/contracts/testHelpers/RequireExecuteCall.sol
@@ -33,8 +33,9 @@ contract RequireExecuteCall {
           // Slice the sighash.
           returndata := add(returndata, 0x04)
         }
-      require(false, abi.decode(returndata, (string))); // All that remains is the revert string
+        require(false, abi.decode(returndata, (string))); // All that remains is the revert string
       }
+      require(false, "require-execute-call-reverted-with-no-error");
     }
   }
 }

--- a/contracts/testHelpers/TestExtensions.sol
+++ b/contracts/testHelpers/TestExtensions.sol
@@ -75,6 +75,17 @@ contract TestVotingReputation is TestExtension {
   }
 }
 
+contract TestVotingToken is TestExtension {
+  function identifier() public pure override returns (bytes32) { return keccak256("VotingToken"); }
+  function version() public pure override returns (uint256) { return 1; }
+  function lockToken() public returns (uint256) {
+    return colony.lockToken();
+  }
+  function unlockTokenForUser(address _user, uint256 _lockId) public {
+    colony.unlockTokenForUser(_user, _lockId);
+  }
+}
+
 contract TestVotingHybrid is TestExtension {
   function identifier() public pure override returns (bytes32) { return keccak256("VotingHybrid"); }
   function version() public pure override returns (uint256) { return 1; }

--- a/contracts/testHelpers/TestExtensions.sol
+++ b/contracts/testHelpers/TestExtensions.sol
@@ -19,6 +19,7 @@ pragma solidity 0.7.3;
 pragma experimental ABIEncoderV2;
 
 import "../extensions/ColonyExtension.sol";
+import "./RequireExecuteCall.sol";
 
 
 abstract contract TestExtension is ColonyExtension {
@@ -65,18 +66,13 @@ contract TestExtension3 is TestExtension {
   function version() public pure override returns (uint256) { return 3; }
 }
 
-contract TestVotingReputation is TestExtension {
+contract TestVotingReputation is TestExtension, RequireExecuteCall {
   function identifier() public pure override returns (bytes32) { return keccak256("VotingReputation"); }
   function version() public pure override returns (uint256) { return 1; }
-  function executeCall(address target, bytes memory action) public {
-    bool success;
-    assembly { success := call(gas(), target, 0, add(action, 0x20), mload(action), 0, 0) }
-    require(success, "transaction-failed");
-  }
 }
 
 contract TestVotingToken is TestExtension {
-  function identifier() public pure override returns (bytes32) { return keccak256("TestVotingToken"); }
+  function identifier() public pure override returns (bytes32) { return keccak256("VotingToken"); }
   function version() public pure override returns (uint256) { return 1; }
   function lockToken() public returns (uint256) {
     return colony.lockToken();
@@ -86,12 +82,9 @@ contract TestVotingToken is TestExtension {
   }
 }
 
-contract TestVotingHybrid is TestExtension {
-  function identifier() public pure override returns (bytes32) { return keccak256("TestVotingHybrid"); }
+contract TestVotingHybrid is TestExtension, RequireExecuteCall {
+  function identifier() public pure override returns (bytes32) { return keccak256("VotingHybrid"); }
   function version() public pure override returns (uint256) { return 1; }
-  function executeCall(address target, bytes memory action) public {
-    bool success;
-    assembly { success := call(gas(), target, 0, add(action, 0x20), mload(action), 0, 0) }
-    require(success, "transaction-failed");
-  }
 }
+
+

--- a/contracts/testHelpers/TestExtensions.sol
+++ b/contracts/testHelpers/TestExtensions.sol
@@ -76,7 +76,7 @@ contract TestVotingReputation is TestExtension {
 }
 
 contract TestVotingToken is TestExtension {
-  function identifier() public pure override returns (bytes32) { return keccak256("VotingToken"); }
+  function identifier() public pure override returns (bytes32) { return keccak256("TestVotingToken"); }
   function version() public pure override returns (uint256) { return 1; }
   function lockToken() public returns (uint256) {
     return colony.lockToken();
@@ -87,7 +87,7 @@ contract TestVotingToken is TestExtension {
 }
 
 contract TestVotingHybrid is TestExtension {
-  function identifier() public pure override returns (bytes32) { return keccak256("VotingHybrid"); }
+  function identifier() public pure override returns (bytes32) { return keccak256("TestVotingHybrid"); }
   function version() public pure override returns (uint256) { return 1; }
   function executeCall(address target, bytes memory action) public {
     bool success;

--- a/contracts/tokenLocking/TokenLocking.sol
+++ b/contracts/tokenLocking/TokenLocking.sol
@@ -79,7 +79,7 @@ contract TokenLocking is TokenLockingStorage, DSMath { // ignore-swc-123
 
     // These checks should happen in this order, as the second is stricter than the first
     uint256 lockCountDelta = sub(_lockId, userLocks[_token][_user].lockCount);
-    require(lockCountDelta != 0, "colony-token-already-unlocked");
+    require(lockCountDelta != 0, "colony-token-locking-already-unlocked");
     require(lockCountDelta == 1, "colony-token-locking-has-previous-active-locks");
 
     userLocks[_token][_user].lockCount = _lockId; // Basically just a ++

--- a/contracts/tokenLocking/TokenLocking.sol
+++ b/contracts/tokenLocking/TokenLocking.sol
@@ -67,7 +67,7 @@ contract TokenLocking is TokenLockingStorage, DSMath { // ignore-swc-123
     totalLockCount[_token] += 1;
     lockers[_token][totalLockCount[_token]] = msg.sender;
 
-    emit TokenLocked(_token, totalLockCount[_token]);
+    emit TokenLocked(_token, msg.sender, totalLockCount[_token]);
 
     return totalLockCount[_token];
   }

--- a/contracts/tokenLocking/TokenLocking.sol
+++ b/contracts/tokenLocking/TokenLocking.sol
@@ -65,6 +65,7 @@ contract TokenLocking is TokenLockingStorage, DSMath { // ignore-swc-123
 
   function lockToken(address _token) public calledByColonyOrNetwork returns (uint256) {
     totalLockCount[_token] += 1;
+    lockers[_token][totalLockCount[_token]] = msg.sender;
 
     emit TokenLocked(_token, totalLockCount[_token]);
 
@@ -74,6 +75,8 @@ contract TokenLocking is TokenLockingStorage, DSMath { // ignore-swc-123
   function unlockTokenForUser(address _token, address _user, uint256 _lockId) public
   calledByColonyOrNetwork
   {
+    require(lockers[_token][_lockId] == msg.sender, "colony-token-locking-not-locker");
+
     // If we want to unlock tokens at id greater than total lock count, we are doing something wrong
     require(_lockId <= totalLockCount[_token], "colony-token-invalid-lockid");
 

--- a/contracts/tokenLocking/TokenLockingDataTypes.sol
+++ b/contracts/tokenLocking/TokenLockingDataTypes.sol
@@ -21,7 +21,7 @@ pragma solidity 0.7.3;
 interface TokenLockingDataTypes {
 
   event ColonyNetworkSet(address colonyNetwork);
-  event TokenLocked(address token, uint256 lockCount);
+  event TokenLocked(address indexed token, address indexed lockedBy, uint256 lockCount);
   event UserTokenUnlocked(address token, address user, uint256 lockId);
   event UserTokenDeposited(address token, address user, uint256 amount);
   event UserTokenClaimed(address token, address user, uint256 amount);

--- a/contracts/tokenLocking/TokenLockingStorage.sol
+++ b/contracts/tokenLocking/TokenLockingStorage.sol
@@ -43,4 +43,7 @@ contract TokenLockingStorage is TokenLockingDataTypes, DSAuth {
   mapping (address => mapping (address => mapping (address => uint256))) approvals;
   mapping (address => mapping (address => mapping (address => uint256))) obligations;
   mapping (address => mapping (address => uint256)) totalObligations;
+
+  // Keep track of which colony is placing which lock ([token][lockId] => colony)
+  mapping (address => mapping (uint256 => address)) lockers;
 }

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -1004,6 +1004,18 @@ Install an extension to the colony. Secured function to authorised members.
 |version|uint256|The new extension version to install
 
 
+### `lockToken`
+
+Lock the colony's token. Can only be called by a network-managed extension.
+
+
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|uint256|uint256|
+
 ### `makeArbitraryTransaction`
 
 Execute arbitrary transaction on behalf of the Colony
@@ -1687,6 +1699,19 @@ Uninstall an extension from a colony. Secured function to authorised members.
 |Name|Type|Description|
 |---|---|---|
 |extensionId|bytes32|keccak256 hash of the extension name, used as an indentifier
+
+
+### `unlockTokenForUser`
+
+Unlock the colony's token for a user. Can only be called by a network-managed extension.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|user|address|The user to unlock
+|lockId|uint256|The specific lock to unlock
 
 
 ### `updateColonyOrbitDB`

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -1701,6 +1701,13 @@ Uninstall an extension from a colony. Secured function to authorised members.
 |extensionId|bytes32|keccak256 hash of the extension name, used as an indentifier
 
 
+### `unlockToken`
+
+unlock the native colony token, if possible
+
+
+
+
 ### `unlockTokenForUser`
 
 Unlock the colony's token for a user. Can only be called by a network-managed extension.

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -153,11 +153,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("97e1c6d4d66e2d25f9383c8b1b70bb7680f09746871a589c70453b8348bd12f8");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("13eb14d2eecef97fc149f34d4395a2740ff73e648ba628c96bca47cc7a1fe5fc");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("732c7f5e08625dd988817c08cab50f790e936be6631d6977ae4759c8eace4501");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("0d53ccdb3a8572d8dbce13d4c44c764d936dd33c1f16602ccb4cf5b749255935");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("2ad6ae85a6fca70dd65e94acca366d699b5fb558b4017ea790f1c8371c9e0aca");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("0389ad89b0b6e33f0c61344a3e0a9046c9e77e0783279852f4f5dd796835e2cc");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("a855bdceb16d16c2b84557d8836b2af9ed80f2ee61b026d33444c9b73b45343f");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("87cb26976b719dc15b579dbbde4d517dd6109e57453e6aff855b2293842091cf");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("b5ed349fbd30f4c326e9b781cfa4f74341615f3ec7d5d0e326b2d30ef64dbcbc");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("8f63b2041527c2c8bacea1ee895300c92d3f918f992ef1e2756745300b4c873f");
     });
   });
 });

--- a/test/contracts-network/colony-network-extensions.js
+++ b/test/contracts-network/colony-network-extensions.js
@@ -309,6 +309,9 @@ contract("Colony Network Extensions", (accounts) => {
       const lockCountPost = await tokenLocking.getTotalLockCount(token.address);
       expect(lockCountPost.sub(lockCountPre)).to.eq.BN(1);
 
+      // Check that you can't unlock a lock you haven't set
+      await checkErrorRevert(extension.unlockTokenForUser(ROOT, lockCountPost.addn(1)), "colony-bad-lock-id");
+
       // Check that you can't unlock too far ahead
       await extension.lockToken();
       await checkErrorRevert(extension.unlockTokenForUser(ROOT, lockCountPost.addn(1)), "colony-token-locking-has-previous-active-locks");

--- a/test/contracts-network/colony-network-extensions.js
+++ b/test/contracts-network/colony-network-extensions.js
@@ -43,7 +43,7 @@ contract("Colony Network Extensions", (accounts) => {
   const USER = accounts[2];
 
   const TEST_EXTENSION = soliditySha3("TestExtension");
-  const TEST_VOTING_TOKEN = soliditySha3("TestVotingToken");
+  const TEST_VOTING_TOKEN = soliditySha3("VotingToken");
 
   before(async () => {
     testExtension0Resolver = await Resolver.new();
@@ -367,7 +367,7 @@ contract("Colony Network Extensions", (accounts) => {
       const otherColonyExecuteCall = await RequireExecuteCall.at(otherColony.address);
 
       const action = await encodeTxData(tokenLocking, "unlockTokenForUser", [token.address, USER, lockId]);
-      await checkErrorRevert(otherColonyExecuteCall.executeCall(tokenLocking.address, action), "transaction-failed");
+      await checkErrorRevert(otherColonyExecuteCall.executeCall(tokenLocking.address, action), "colony-token-locking-not-locker");
     });
   });
 });

--- a/test/contracts-network/colony-reward-payouts.js
+++ b/test/contracts-network/colony-reward-payouts.js
@@ -514,7 +514,7 @@ contract("Colony Reward Payouts", (accounts) => {
 
       await checkErrorRevert(
         colony.claimRewardPayout(payoutId, initialSquareRoots, ...userReputationProof1, { from: userAddress1 }),
-        "colony-token-already-unlocked"
+        "colony-token-locking-already-unlocked"
       );
     });
 
@@ -610,7 +610,7 @@ contract("Colony Reward Payouts", (accounts) => {
 
       await checkErrorRevert(
         colony.claimRewardPayout(payoutId, initialSquareRoots, ...userReputationProof1, { from: userAddress1 }),
-        "colony-token-already-unlocked"
+        "colony-token-locking-already-unlocked"
       );
     });
 
@@ -626,7 +626,7 @@ contract("Colony Reward Payouts", (accounts) => {
 
       await checkErrorRevert(
         colony.claimRewardPayout(payoutId, initialSquareRoots, ...userReputationProof1, { from: userAddress1 }),
-        "colony-token-already-unlocked"
+        "colony-token-locking-already-unlocked"
       );
     });
 

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -150,6 +150,10 @@ contract("Colony", (accounts) => {
       await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action, { from: USER1 }), "ds-auth-unauthorized");
     });
 
+    it("should not be able to make arbitrary transactions to a colony itself", async () => {
+      await checkErrorRevert(colony.makeArbitraryTransaction(colony.address, "0x0"), "colony-cannot-target-self");
+    });
+
     it("should not be able to make arbitrary transactions to a user address", async () => {
       await checkErrorRevert(colony.makeArbitraryTransaction(accounts[0], "0x0"), "colony-to-must-be-contract");
     });

--- a/test/extensions/token-supplier.js
+++ b/test/extensions/token-supplier.js
@@ -125,19 +125,19 @@ contract("Token Supplier", (accounts) => {
       // Cannot set if not a network-managed extension
       const unofficialVotingHybrid = await VotingHybrid.new(colony.address);
       await colony.setRootRole(unofficialVotingHybrid.address, true);
-      await checkErrorRevert(unofficialVotingHybrid.executeCall(tokenSupplier.address, action), "transaction-failed");
+      await checkErrorRevert(unofficialVotingHybrid.executeCall(tokenSupplier.address, action), "token-supplier-not-managed-extension");
 
       // Cannot set if the caller does not implement `identifier()`
       const requireExecuteCall = await RequireExecuteCall.new();
       await colony.setRootRole(requireExecuteCall.address, true);
-      await checkErrorRevert(requireExecuteCall.executeCall(tokenSupplier.address, action), "transaction-failed");
+      await checkErrorRevert(requireExecuteCall.executeCall(tokenSupplier.address, action), "token-supplier-no-identifier");
 
       // Cannot set if not VotingHybrid
       await colony.installExtension(VOTING_REPUTATION, 1);
       const votingReputationAddress = await colonyNetwork.getExtensionInstallation(VOTING_REPUTATION, colony.address);
       const votingReputation = await VotingHybrid.at(votingReputationAddress);
       await colony.setRootRole(votingReputation.address, true);
-      await checkErrorRevert(votingReputation.executeCall(tokenSupplier.address, action), "transaction-failed");
+      await checkErrorRevert(votingReputation.executeCall(tokenSupplier.address, action), "token-supplier-cannot-set-value");
     });
 
     it("can update the tokenIssuanceRate via a hybrid vote", async () => {
@@ -160,12 +160,12 @@ contract("Token Supplier", (accounts) => {
       // Cannot set if not a network-managed extension
       const unofficialVotingHybrid = await VotingHybrid.new(colony.address);
       await colony.setRootRole(unofficialVotingHybrid.address, true);
-      await checkErrorRevert(unofficialVotingHybrid.executeCall(tokenSupplier.address, action), "transaction-failed");
+      await checkErrorRevert(unofficialVotingHybrid.executeCall(tokenSupplier.address, action), "token-supplier-not-managed-extension");
 
       // Cannot set if the caller does not implement `identifier()`
       const requireExecuteCall = await RequireExecuteCall.new();
       await colony.setRootRole(requireExecuteCall.address, true);
-      await checkErrorRevert(requireExecuteCall.executeCall(tokenSupplier.address, action), "transaction-failed");
+      await checkErrorRevert(requireExecuteCall.executeCall(tokenSupplier.address, action), "token-supplier-no-identifier");
     });
 
     it("can update the tokenIssuanceRate via a reputation vote, by <=10% once every 4 weeks", async () => {
@@ -182,12 +182,12 @@ contract("Token Supplier", (accounts) => {
       const action2 = await encodeTxData(tokenSupplier, "setTokenIssuanceRate", [WAD.add(WAD.divn(9))]);
 
       // Cannot change more than once in 4 weeks
-      await checkErrorRevert(votingReputation.executeCall(tokenSupplier.address, action1), "transaction-failed");
+      await checkErrorRevert(votingReputation.executeCall(tokenSupplier.address, action1), "token-supplier-cannot-set-value");
 
       await forwardTime(SECONDS_PER_DAY * 28, this);
 
       // Cannot change more than 10%
-      await checkErrorRevert(votingReputation.executeCall(tokenSupplier.address, action2), "transaction-failed");
+      await checkErrorRevert(votingReputation.executeCall(tokenSupplier.address, action2), "token-supplier-cannot-set-value");
 
       await votingReputation.executeCall(tokenSupplier.address, action1);
 
@@ -195,7 +195,7 @@ contract("Token Supplier", (accounts) => {
       expect(tokenIssuanceRate).to.eq.BN(WAD.add(WAD.divn(10)));
 
       // Cannot change more than once in 4 weeks
-      await checkErrorRevert(votingReputation.executeCall(tokenSupplier.address, action2), "transaction-failed");
+      await checkErrorRevert(votingReputation.executeCall(tokenSupplier.address, action2), "token-supplier-cannot-set-value");
 
       await forwardTime(SECONDS_PER_DAY * 28, this);
 


### PR DESCRIPTION
Closes #921 

Supports #915, allowing extensions (here, `VotingToken`) to lock & unlock user's tokens.

