### PR TITLE
Add reputation rewards

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -489,30 +489,6 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     ITokenLocking(tokenLockingAddress).deobligateStake(_user, _amount, token);
   }
 
-  function transferStake(
-    uint256 _permissionDomainId,
-    uint256 _childSkillIndex,
-    address _obligator,
-    address _user,
-    uint256 _domainId,
-    uint256 _amount,
-    address _beneficiary
-  ) public stoppable authDomain(_permissionDomainId, _childSkillIndex, _domainId)
-  {
-    obligations[_user][_obligator][_domainId] = sub(obligations[_user][_obligator][_domainId], _amount);
-
-    ITokenLocking(tokenLockingAddress).transferStake(_user, _amount, token, _beneficiary);
-  }
-
-  function burnTokens(address _token, uint256 _amount) public stoppable auth {
-    // Check the root funding pot has enought
-    require(fundingPots[1].balance[_token] >= _amount, "colony-not-enough-tokens");
-    ERC20Extended(_token).burn(_amount);
-    fundingPots[1].balance[_token] -= _amount;
-
-    emit TokensBurned(msg.sender, _token, _amount);
-  }
-
   function getApproval(address _user, address _obligator, uint256 _domainId) public view returns (uint256) {
     return approvals[_user][_obligator][_domainId];
   }

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -459,6 +459,11 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
     sig = bytes4(keccak256("unlockToken()"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
+
+    sig = bytes4(keccak256("emitDomainReputationReward(uint256,address,int256)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
+    sig = bytes4(keccak256("emitSkillReputationReward(uint256,address,int256)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
   }
 
   function checkNotAdditionalProtectedVariable(uint256 _slot) public view recovery {

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -489,6 +489,21 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     ITokenLocking(tokenLockingAddress).deobligateStake(_user, _amount, token);
   }
 
+  function transferStake(
+    uint256 _permissionDomainId,
+    uint256 _childSkillIndex,
+    address _obligator,
+    address _user,
+    uint256 _domainId,
+    uint256 _amount,
+    address _beneficiary
+  ) public stoppable authDomain(_permissionDomainId, _childSkillIndex, _domainId)
+  {
+    obligations[_user][_obligator][_domainId] = sub(obligations[_user][_obligator][_domainId], _amount);
+
+    ITokenLocking(tokenLockingAddress).transferStake(_user, _amount, token, _beneficiary);
+  }
+
   function getApproval(address _user, address _obligator, uint256 _domainId) public view returns (uint256) {
     return approvals[_user][_obligator][_domainId];
   }

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -82,6 +82,21 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     emit Annotation(msg.sender, _txHash, _metadata);
   }
 
+  function emitDomainReputationReward(uint256 _domainId, address _user, int256 _amount)
+  public stoppable auth
+  {
+    require(_amount > 0, "colony-reward-must-be-positive");
+    require(domainExists(_domainId), "colony-domain-does-not-exist");
+    IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, domains[_domainId].skillId);
+  }
+
+  function emitSkillReputationReward(uint256 _skillId, address _user, int256 _amount)
+  public stoppable auth validGlobalSkill(_skillId)
+  {
+    require(_amount > 0, "colony-reward-must-be-positive");
+    IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, _skillId);
+  }
+
   function emitDomainReputationPenalty(
     uint256 _permissionDomainId,
     uint256 _childSkillIndex,

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -97,6 +97,8 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ROOT_ROLE, "deprecateExtension(bytes32,bool)");
     addRoleCapability(ROOT_ROLE, "uninstallExtension(bytes32)");
     addRoleCapability(ROOT_ROLE, "makeArbitraryTransaction(address,bytes)");
+    addRoleCapability(ROOT_ROLE, "emitDomainReputationReward(uint256,address,int256)");
+    addRoleCapability(ROOT_ROLE, "emitSkillReputationReward(uint256,address,int256)");
     addRoleCapability(ARBITRATION_ROLE, "transferStake(uint256,uint256,address,address,uint256,uint256,address)");
     addRoleCapability(ARBITRATION_ROLE, "emitDomainReputationPenalty(uint256,uint256,uint256,address,int256)");
     addRoleCapability(ARBITRATION_ROLE, "emitSkillReputationPenalty(uint256,address,int256)");

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -594,21 +594,6 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     }
   }
 
-  function transferStake(
-    uint256 _permissionDomainId,
-    uint256 _childSkillIndex,
-    address _obligator,
-    address _user,
-    uint256 _domainId,
-    uint256 _amount,
-    address _beneficiary
-  ) public stoppable authDomain(_permissionDomainId, _childSkillIndex, _domainId)
-  {
-    obligations[_user][_obligator][_domainId] = sub(obligations[_user][_obligator][_domainId], _amount);
-
-    ITokenLocking(tokenLockingAddress).transferStake(_user, _amount, token, _beneficiary);
-  }
-
   function burnTokens(address _token, uint256 _amount) public stoppable auth {
     // Check the root funding pot has enought
     require(fundingPots[1].balance[_token] >= _amount, "colony-not-enough-tokens");

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -593,4 +593,29 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
       fee = _payout/feeInverse + 1;
     }
   }
+
+  function transferStake(
+    uint256 _permissionDomainId,
+    uint256 _childSkillIndex,
+    address _obligator,
+    address _user,
+    uint256 _domainId,
+    uint256 _amount,
+    address _beneficiary
+  ) public stoppable authDomain(_permissionDomainId, _childSkillIndex, _domainId)
+  {
+    obligations[_user][_obligator][_domainId] = sub(obligations[_user][_obligator][_domainId], _amount);
+
+    ITokenLocking(tokenLockingAddress).transferStake(_user, _amount, token, _beneficiary);
+  }
+
+  function burnTokens(address _token, uint256 _amount) public stoppable auth {
+    // Check the root funding pot has enought
+    require(fundingPots[1].balance[_token] >= _amount, "colony-not-enough-tokens");
+    ERC20Extended(_token).burn(_amount);
+    fundingPots[1].balance[_token] -= _amount;
+
+    emit TokensBurned(msg.sender, _token, _amount);
+  }
+
 }

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -168,6 +168,18 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @return roles bytes32 representation of the authorized roles
   function getCapabilityRoles(bytes4 _sig) external view returns (bytes32 roles);
 
+  /// @notice Emit a positive domain reputation update. Available only to Root role holders
+  /// @param _domainId The domain where the user will gain reputation
+  /// @param _user The user who will gain reputation
+  /// @param _amount The (positive) amount of reputation to gain
+  function emitDomainReputationReward(uint256 _domainId, address _user, int256 _amount) external;
+
+  /// @notice Emit a positive skill reputation update. Available only to Root role holders
+  /// @param _skillId The skill where the user will gain reputation
+  /// @param _user The user who will gain reputation
+  /// @param _amount The (positive) amount of reputation to gain
+  function emitSkillReputationReward(uint256 _skillId, address _user, int256 _amount) external;
+
   /// @notice Emit a negative domain reputation update. Available only to Arbitration role holders
   /// @param _permissionDomainId The domainId in which I hold the Arbitration role
   /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -304,6 +304,20 @@ Emit a negative domain reputation update. Available only to Arbitration role hol
 |_amount|int256|The (negative) amount of reputation to lose
 
 
+### `emitDomainReputationReward`
+
+Emit a positive domain reputation update. Available only to Root role holders
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_domainId|uint256|The domain where the user will gain reputation
+|_user|address|The user who will gain reputation
+|_amount|int256|The (positive) amount of reputation to gain
+
+
 ### `emitSkillReputationPenalty`
 
 Emit a negative skill reputation update. Available only to Arbitration role holders in the root domain
@@ -316,6 +330,20 @@ Emit a negative skill reputation update. Available only to Arbitration role hold
 |_skillId|uint256|The skill where the user will lose reputation
 |_user|address|The user who will lose reputation
 |_amount|int256|The (negative) amount of reputation to lose
+
+
+### `emitSkillReputationReward`
+
+Emit a positive skill reputation update. Available only to Root role holders
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_skillId|uint256|The skill where the user will gain reputation
+|_user|address|The user who will gain reputation
+|_amount|int256|The (positive) amount of reputation to gain
 
 
 ### `executeTaskChange`

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -5,6 +5,7 @@ import shortid from "shortid";
 const UINT256_MAX = new BN(0).notn(256);
 const UINT128_MAX = new BN(0).notn(128);
 const INT256_MAX = new BN(0).notn(255);
+const INT256_MIN = new BN(2).pow(new BN(255)).mul(new BN(-1));
 const INT128_MAX = new BN(2).pow(new BN(127)).sub(new BN(1));
 const INT128_MIN = new BN(2).pow(new BN(127)).mul(new BN(-1));
 
@@ -69,6 +70,7 @@ const GLOBAL_SKILL_ID = new BN("3"); // Not a root global skill ID or anything, 
 
 module.exports = {
   UINT256_MAX,
+  INT256_MIN,
   INT256_MAX,
   INT128_MAX,
   INT128_MIN,

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -153,11 +153,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("0a90160b8b2075d551d0db53fd84304e204fdccff6aa1420f6f4e97bfb8459a3");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("a9ca046d8a243432bed17849c35da5b19378f24f93d582cbfa8e9601782d1a07");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("832f6ca9325702200888f6dc1eecf88bcd4d547fa22a72d83f3a64e226219e54");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("4f22f8595eba3ac10b82c870598fbc830480765e39b586e4a224a8da88a6a43e");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("71b80b77b39ef14d51f09cfa2382447d62954c6b3aa4b72eee953c65d01dd8f6");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("97e1c6d4d66e2d25f9383c8b1b70bb7680f09746871a589c70453b8348bd12f8");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("13eb14d2eecef97fc149f34d4395a2740ff73e648ba628c96bca47cc7a1fe5fc");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("732c7f5e08625dd988817c08cab50f790e936be6631d6977ae4759c8eace4501");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("0d53ccdb3a8572d8dbce13d4c44c764d936dd33c1f16602ccb4cf5b749255935");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("2ad6ae85a6fca70dd65e94acca366d699b5fb558b4017ea790f1c8371c9e0aca");
     });
   });
 });


### PR DESCRIPTION
Closes #920 

This PR adds two new root-level functions: `emitDomainReputationReward` and `emitSkillReputationReward`, which do what they say on the tin.