### PR TITLE
Add function for a colony to unlock its own token, if owner

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -440,6 +440,9 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
     sig = bytes4(keccak256("burnTokens(address,uint256)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
+
+    sig = bytes4(keccak256("unlockToken()"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
   }
 
   function checkNotAdditionalProtectedVariable(uint256 _slot) public view recovery {
@@ -494,6 +497,11 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
   function getObligation(address _user, address _obligator, uint256 _domainId) public view returns (uint256) {
     return obligations[_user][_obligator][_domainId];
+  }
+
+  function unlockToken() public stoppable auth {
+    ERC20Extended(token).unlock();
+    emit TokenUnlocked();
   }
 
   function initialiseDomain(uint256 _skillId) internal skillExists(_skillId) {

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -374,6 +374,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     // Because it's called after setResolver, it'll do the new finishUpgrade, which will be populated with what we know
     // we need to do once we know what's in it!
     this.finishUpgrade();
+
     emit ColonyUpgraded(msg.sender, currentVersion, _newVersion);
   }
 
@@ -488,6 +489,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
     require(fundingPots[1].balance[_token] >= _amount, "colony-not-enough-tokens");
     ERC20Extended(_token).burn(_amount);
     fundingPots[1].balance[_token] -= _amount;
+
     emit TokensBurned(msg.sender, _token, _amount);
   }
 
@@ -501,6 +503,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs {
 
   function unlockToken() public stoppable auth {
     ERC20Extended(token).unlock();
+
     emit TokenUnlocked();
   }
 

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -106,6 +106,7 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ARCHITECTURE_ROLE, "editDomain(uint256,uint256,uint256,string)");
     addRoleCapability(ROOT_ROLE, "editColony(string)");
     addRoleCapability(ROOT_ROLE, "burnTokens(address,uint256)");
+    addRoleCapability(ROOT_ROLE, "unlockToken()");
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -266,6 +266,10 @@ interface ColonyDataTypes {
   /// @param token the amount of the token being burned
   event TokensBurned(address agent, address token, uint256 amount);
 
+  /// @notice Event emitted when the colony unlocks its native token through the
+  /// provided function
+  event TokenUnlocked();
+
   struct RewardPayoutCycle {
     // Reputation root hash at the time of reward payout creation
     bytes32 reputationState;

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -923,4 +923,7 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param token The address of the token to burn
   /// @param amount The amount of tokens to burn
   function burnTokens(address token, uint256 amount) external;
+
+  /// @notice unlock the native colony token, if possible
+  function unlockToken() external;
 }

--- a/contracts/common/ERC20Extended.sol
+++ b/contracts/common/ERC20Extended.sol
@@ -31,4 +31,6 @@ abstract contract ERC20Extended is ERC20 {
   function burn(uint wad) public virtual;
 
   function burn(address guy, uint wad) public virtual;
+
+  function unlock() public virtual;
 }

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -364,15 +364,17 @@ export async function setupColonyNetwork() {
   return colonyNetwork;
 }
 
-export async function setupRandomToken() {
+export async function setupRandomToken(lockedToken) {
   const tokenArgs = getTokenArgs();
   const token = await Token.new(...tokenArgs);
-  await token.unlock();
+  if (!lockedToken) {
+    await token.unlock();
+  }
   return token;
 }
 
-export async function setupRandomColony(colonyNetwork) {
-  const token = await setupRandomToken();
+export async function setupRandomColony(colonyNetwork, lockedToken = false) {
+  const token = await setupRandomToken(lockedToken);
 
   const colony = await setupColony(colonyNetwork, token.address);
 

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -153,11 +153,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("1c716a8d208a809b82d4f1f98e10931a93c70358eebbbba72677ec21a045a7c6");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("e8c01c2cfc7f58dd1c2e2d39f9e0c8652980885f9d17cb69dc61cd650361b9bd");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("bbb3a6b35dbe471a14184a26de6a00f0aa63228795f4b749c593e133db6f8f32");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("977cc07c68504e153585526f96b13d11e8970cd2c9d139c15a72d18fde555098");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("2e65b5e05d527ff5167244eb2e15231ec0be15fabb42ee5073544d73ae21df26");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("0a90160b8b2075d551d0db53fd84304e204fdccff6aa1420f6f4e97bfb8459a3");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("a9ca046d8a243432bed17849c35da5b19378f24f93d582cbfa8e9601782d1a07");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("832f6ca9325702200888f6dc1eecf88bcd4d547fa22a72d83f3a64e226219e54");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("4f22f8595eba3ac10b82c870598fbc830480765e39b586e4a224a8da88a6a43e");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("71b80b77b39ef14d51f09cfa2382447d62954c6b3aa4b72eee953c65d01dd8f6");
     });
   });
 });

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -216,6 +216,19 @@ contract("Colony", (accounts) => {
       expect(rewardPotInfo.associatedTypeId).to.be.zero;
       expect(rewardPotInfo.payoutsWeCannotMake).to.be.zero;
     });
+
+    it("should allow the token to be unlocked by a root user only", async () => {
+      ({ colony, token } = await setupRandomColony(colonyNetwork, true));
+      await token.setOwner(colony.address);
+      let locked = await token.locked();
+      expect(locked).to.be.equal(true);
+
+      await checkErrorRevert(colony.unlockToken({ from: accounts[1] }), "ds-auth-unauthorized");
+
+      await expectEvent(colony.unlockToken({ from: accounts[0] }), "TokenUnlocked", []);
+      locked = await token.locked();
+      expect(locked).to.be.equal(false);
+    });
   });
 
   describe("when adding domains", () => {

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -36,7 +36,7 @@ contract("Colony", (accounts) => {
   let colonyNetwork;
 
   const USER0 = accounts[0];
-  const USER1 = USER1;
+  const USER1 = accounts[1];
 
   before(async () => {
     const etherRouter = await EtherRouter.deployed();

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -36,6 +36,7 @@ contract("Colony", (accounts) => {
   let colonyNetwork;
 
   const USER0 = accounts[0];
+  const USER1 = USER1;
 
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
@@ -97,7 +98,7 @@ contract("Colony", (accounts) => {
       await otherToken.unlock();
 
       await expectEvent(colony.mintTokens(100), "TokensMinted", [accounts[0], colony.address, 100]);
-      await expectEvent(colony.mintTokensFor(accounts[1], 100), "TokensMinted", [accounts[0], accounts[1], 100]);
+      await expectEvent(colony.mintTokensFor(USER1, 100), "TokensMinted", [accounts[0], USER1, 100]);
     });
 
     it("should fail if a non-admin tries to mint tokens", async () => {
@@ -146,7 +147,7 @@ contract("Colony", (accounts) => {
     it("should not be able to make arbitrary transactions if not root", async () => {
       const action = await encodeTxData(token, "mint", [WAD]);
 
-      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action, { from: accounts[1] }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action, { from: USER1 }), "ds-auth-unauthorized");
     });
 
     it("should not be able to make arbitrary transactions to a user address", async () => {
@@ -223,7 +224,7 @@ contract("Colony", (accounts) => {
       let locked = await token.locked();
       expect(locked).to.be.equal(true);
 
-      await checkErrorRevert(colony.unlockToken({ from: accounts[1] }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.unlockToken({ from: USER1 }), "ds-auth-unauthorized");
 
       await expectEvent(colony.unlockToken({ from: accounts[0] }), "TokenUnlocked", []);
       locked = await token.locked();
@@ -332,7 +333,7 @@ contract("Colony", (accounts) => {
       await colony.mintTokens(WAD.muln(14));
       await checkErrorRevert(
         colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS, {
-          from: accounts[1],
+          from: USER1,
         }),
         "ds-auth-unauthorized"
       );
@@ -359,7 +360,7 @@ contract("Colony", (accounts) => {
 
     it("should not allow anyone else but a root user to set it", async () => {
       await colony.setRewardInverse(100);
-      await checkErrorRevert(colony.setRewardInverse(234, { from: accounts[1] }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.setRewardInverse(234, { from: USER1 }), "ds-auth-unauthorized");
       const defaultRewardInverse = await colony.getRewardInverse();
       expect(defaultRewardInverse).to.eq.BN(100);
     });
@@ -391,7 +392,7 @@ contract("Colony", (accounts) => {
 
     it("should not allow anyone else but a root user to burn", async () => {
       const amount = await colony.getFundingPotBalance(1, token.address);
-      await checkErrorRevert(colony.burnTokens(token.address, amount, { from: accounts[1] }), "ds-auth-unauthorized");
+      await checkErrorRevert(colony.burnTokens(token.address, amount, { from: USER1 }), "ds-auth-unauthorized");
     });
 
     it("cannot burn more tokens than it has", async () => {


### PR DESCRIPTION
In order for 'unlock token' to appear as an action in the frontend, there needs to be an event for it to key off of. The token is already deployed, so we can't alter is there, so I've added a function to the colony that calls `unlock` on the token. To work on the frontend we'll have to give the colony `owner`ship of the token, but arguably we should have been doing that anyway.

I had to steal my changes in `test-data-generator` from #907 to write the test, so they're here too.