### PR TITLE
Do not burn CLNY on Xdai during mining

### DIFF
--- a/contracts/colonyNetwork/ColonyNetworkMining.sol
+++ b/contracts/colonyNetwork/ColonyNetworkMining.sol
@@ -248,7 +248,13 @@ contract ColonyNetworkMining is ColonyNetworkStorage, MultiChain {
   function burnUnneededRewards(uint256 _amount) public stoppable onlyReputationMiningCycle() {
     address clnyToken = IMetaColony(metaColony).getToken();
     ITokenLocking(tokenLocking).withdraw(clnyToken, _amount, true);
-    ERC20Extended(clnyToken).burn(_amount);
+    if (isXdai()){
+      // On Xdai, I'm burning bridged tokens is certainly not what we want. So let's
+      // send them to the metacolony for now.
+      ERC20Extended(clnyToken).transfer(metaColony, _amount);
+    } else {
+      ERC20Extended(clnyToken).burn(_amount);
+    }
   }
 
   function setReputationMiningCycleReward(uint256 _amount) public stoppable

--- a/test-chainid/chainid-dependent-behaviour.js
+++ b/test-chainid/chainid-dependent-behaviour.js
@@ -4,7 +4,14 @@ import bnChai from "bn-chai";
 
 import { setupENSRegistrar } from "../helpers/upgradable-contracts";
 import { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, giveUserCLNYTokensAndStake } from "../helpers/test-data-generator";
-import { forwardTime, getActiveRepCycle, advanceMiningCycleNoContest, getValidEntryNumber, checkErrorRevert, expectEvent } from "../helpers/test-helper";
+import {
+  forwardTime,
+  getActiveRepCycle,
+  advanceMiningCycleNoContest,
+  getValidEntryNumber,
+  checkErrorRevert,
+  expectEvent,
+} from "../helpers/test-helper";
 
 import { MINING_CYCLE_DURATION, DEFAULT_STAKE, SUBMITTER_ONLY_WINDOW } from "../helpers/constants";
 


### PR DESCRIPTION
If we've bridged CLNY, burning the bridged token does nothing to the supply on mainnet, and the bridge will just hold the tokens for eternity (I think?). For now, send the CLNY to the metacolony. We can decide to unbridge and 'truly' burn down the line, if we like.