### PR TITLE
Fix first issues arising from actual use

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -26,6 +26,7 @@ import "./ColonyStorage.sol";
 
 contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
 
+  // V6: Cerulean Lightweight Spaceship
   // This function, exactly as defined, is used in build scripts. Take care when updating.
   // Version number should be upped with every change in Colony or its dependency contracts or libraries.
   function version() public pure returns (uint256 colonyVersion) { return 6; }

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -386,74 +386,9 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     emit ColonyUpgraded(msg.sender, currentVersion, _newVersion);
   }
 
-  // v4 to v5
+  // v5 to v6
   function finishUpgrade() public always {
-    tokenLockingAddress = IColonyNetwork(colonyNetworkAddress).getTokenLocking();
-
-    ColonyAuthority colonyAuthority = ColonyAuthority(address(authority));
-    bytes4 sig;
-
-    // Add stake management functionality (colonyNetwork#757)
-    sig = bytes4(keccak256("transferStake(uint256,uint256,address,address,uint256,uint256,address)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Arbitration), address(this), sig, true);
-
-    // Add reputation penalty functionality (colonyNetwork#845)
-    sig = bytes4(keccak256("emitDomainReputationPenalty(uint256,uint256,uint256,address,int256)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Arbitration), address(this), sig, true);
-    sig = bytes4(keccak256("emitSkillReputationPenalty(uint256,address,int256)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Arbitration), address(this), sig, true);
-
-    // Add CLNY issuance functionality
-    sig = bytes4(keccak256("setReputationMiningCycleReward(uint256)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
-
-    // Add expenditure state change support
-    sig = bytes4(keccak256("setExpenditureState(uint256,uint256,uint256,uint256,bool[],bytes32[],bytes32)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Arbitration), address(this), sig, true);
-
-    // Add coin machine support
-    sig = bytes4(keccak256("mintTokensFor(address,uint256)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
-
-    // Add extension manager functionality
-    sig = bytes4(keccak256("addExtensionToNetwork(bytes32,address)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
-    sig = bytes4(keccak256("installExtension(bytes32,uint256)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
-    sig = bytes4(keccak256("upgradeExtension(bytes32,uint256)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
-    sig = bytes4(keccak256("deprecateExtension(bytes32,bool)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
-    sig = bytes4(keccak256("uninstallExtension(bytes32)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
     sig = bytes4(keccak256("setUserRoles(uint256,uint256,address,uint256,bytes32)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Architecture), address(this), sig, true);
-
-    // Add arbitrary tx functionality
-    sig = bytes4(keccak256("makeArbitraryTransaction(address,bytes)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
-
-    // Add payout whitelist functionality
-    sig = bytes4(keccak256("setPayoutWhitelist(address,bool)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
-
-    // Add metadata functions
-    sig = bytes4(keccak256("addDomain(uint256,uint256,uint256,string)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Architecture), address(this), sig, true);
-    sig = bytes4(keccak256("editDomain(uint256,uint256,uint256,string)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Architecture), address(this), sig, true);
-    sig = bytes4(keccak256("editColony(string)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
-
-    sig = bytes4(keccak256("burnTokens(address,uint256)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
-
-    sig = bytes4(keccak256("unlockToken()"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
-
-    sig = bytes4(keccak256("emitDomainReputationReward(uint256,address,int256)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
-    sig = bytes4(keccak256("emitSkillReputationReward(uint256,address,int256)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
   }
 

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -75,7 +75,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     return executeCall(_to, 0, _action);
   }
 
-  function annotateTransaction(bytes32 _txHash, string memory _metadata) public stoppable {
+  function annotateTransaction(bytes32 _txHash, string memory _metadata) public always {
     emit Annotation(msg.sender, _txHash, _metadata);
   }
 

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -28,7 +28,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
 
   // This function, exactly as defined, is used in build scripts. Take care when updating.
   // Version number should be upped with every change in Colony or its dependency contracts or libraries.
-  function version() public pure returns (uint256 colonyVersion) { return 5; }
+  function version() public pure returns (uint256 colonyVersion) { return 6; }
 
   function getColonyNetwork() public view returns (address) {
     return colonyNetworkAddress;
@@ -388,6 +388,9 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
 
   // v5 to v6
   function finishUpgrade() public always {
+    ColonyAuthority colonyAuthority = ColonyAuthority(address(authority));
+    bytes4 sig;
+
     sig = bytes4(keccak256("setUserRoles(uint256,uint256,address,uint256,bytes32)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
   }

--- a/contracts/colony/ColonyRoles.sol
+++ b/contracts/colony/ColonyRoles.sol
@@ -104,7 +104,7 @@ contract ColonyRoles is ColonyStorage, ContractRecoveryDataTypes {
         setTo = uint256(roles) % 2 == 1;
 
         ColonyAuthority(address(authority)).setUserRole(_user, _domainId, roleId, setTo);
-        if (roleId == 0){
+        if (roleId == uint8(ColonyRole.Recovery)) {
           if (setTo){
             recoveryRolesCount++;
           } else {

--- a/contracts/colony/ColonyRoles.sol
+++ b/contracts/colony/ColonyRoles.sol
@@ -19,9 +19,10 @@ pragma solidity 0.7.3;
 pragma experimental ABIEncoderV2;
 
 import "./ColonyStorage.sol";
+import "./../common/ContractRecoveryDataTypes.sol";
 
 
-contract ColonyRoles is ColonyStorage {
+contract ColonyRoles is ColonyStorage, ContractRecoveryDataTypes {
 
   function setRootRole(address _user, bool _setTo) public stoppable auth {
     ColonyAuthority(address(authority)).setUserRole(_user, uint8(ColonyRole.Root), _setTo);
@@ -103,7 +104,14 @@ contract ColonyRoles is ColonyStorage {
         setTo = uint256(roles) % 2 == 1;
 
         ColonyAuthority(address(authority)).setUserRole(_user, _domainId, roleId, setTo);
-
+        if (roleId == 0){
+          if (setTo){
+            recoveryRolesCount++;
+          } else {
+            recoveryRolesCount--;
+          }
+          emit RecoveryRoleSet(_user, setTo);
+        }
         emit ColonyRoleSet(msg.sender, _user, _domainId, roleId, setTo);
 
       }

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -9,7 +9,7 @@ const INT256_MIN = new BN(2).pow(new BN(255)).mul(new BN(-1));
 const INT128_MAX = new BN(2).pow(new BN(127)).sub(new BN(1));
 const INT128_MIN = new BN(2).pow(new BN(127)).mul(new BN(-1));
 
-const CURR_VERSION = 5;
+const CURR_VERSION = 6;
 
 const RECOVERY_ROLE = 0;
 const ROOT_ROLE = 1;

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -120,6 +120,9 @@ contract("Contract Storage", (accounts) => {
 
       await editableNetwork.setStorageSlot(slot, "0x0000000000000000000000000000000000000000000000000000000000000000");
 
+      // Also zero out the slot containing the current colony version
+      await editableNetwork.setStorageSlot(7, "0x0000000000000000000000000000000000000000000000000000000000000000");
+
       const colonyNetworkStateHash = await getAddressStateHash(colonyNetwork.address);
       const colonyNetworkAccount = new Account(colonyNetworkStateHash);
 
@@ -146,13 +149,12 @@ contract("Contract Storage", (accounts) => {
 
       const tokenLockingStateHash = await getAddressStateHash(tokenLockingAddress);
       const tokenLockingAccount = new Account(tokenLockingStateHash);
-
       console.log("colonyNetworkStateHash:", colonyNetworkAccount.stateRoot.toString("hex"));
       console.log("colonyStateHash:", colonyAccount.stateRoot.toString("hex"));
       console.log("metaColonyStateHash:", metaColonyAccount.stateRoot.toString("hex"));
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("bab7de481917cc3420ec4f596281d62ac340b3fc5c904496a6dbcfc1326d2b3b");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("88075c360145ff7453f5b3dab1ef62acebdbfc31f234b0a016e6392ec97b16d2");
       expect(colonyAccount.stateRoot.toString("hex")).to.equal("f33c405a1e7064905b600a6a87dc20de3dbac37be6935588bb57ea62ee6c7539");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("ce60ed2e314b5ae83e9d78f4518330496cdf8a2dab275798822bb7277cc304c2");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("1cbcf4998ef6be25f00b4a704ddfccc162c2395396f055f3660f099deb20c11f");

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -182,6 +182,9 @@ contract("Colony Network", (accounts) => {
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       const oldVersion = currentColonyVersion.subn(1);
       await metaColony.addNetworkColonyVersion(oldVersion, newResolverAddress);
+
+      // v4 specifically is needed for the deprecated five-parameter test
+      await metaColony.addNetworkColonyVersion(4, newResolverAddress);
     });
 
     it("should allow users to create a new colony at a specific older version", async () => {
@@ -223,7 +226,7 @@ contract("Colony Network", (accounts) => {
     it("should allow use of the deprecated five-parameter createColony", async () => {
       const token = await Token.new(...getTokenArgs());
 
-      await colonyNetwork.createColony(token.address, 4, "", "", "");
+      await colonyNetwork.createColony(token.address, 5, "", "", "");
     });
   });
 

--- a/test/contracts-network/colony-permissions.js
+++ b/test/contracts-network/colony-permissions.js
@@ -420,6 +420,11 @@ contract("ColonyPermissions", (accounts) => {
       recoveryRolesCount = await colony.numRecoveryRoles();
       expect(recoveryRolesCount).to.eq.BN(2);
 
+      // Setting the roles again doesn't increment the count of recovery roles
+      await colony.setUserRoles(1, UINT256_MAX, USER2, 1, rolesRoot, { from: FOUNDER });
+      recoveryRolesCount = await colony.numRecoveryRoles();
+      expect(recoveryRolesCount).to.eq.BN(2);
+
       // But not in subdomains!
       await checkErrorRevert(colony.setUserRoles(1, 0, USER2, 2, rolesRoot, { from: FOUNDER }), "colony-bad-domain-for-role");
 
@@ -459,6 +464,12 @@ contract("ColonyPermissions", (accounts) => {
       expect(userRoles).to.equal(ethers.constants.HashZero);
 
       // And the recovery roles count is updated when recovery is removed
+      await colony.setUserRoles(1, UINT256_MAX, USER2, 1, "0x0", { from: FOUNDER });
+
+      recoveryRolesCount = await colony.numRecoveryRoles();
+      expect(recoveryRolesCount).to.eq.BN(1);
+
+      // But not when they're 'removed' again
       await colony.setUserRoles(1, UINT256_MAX, USER2, 1, "0x0", { from: FOUNDER });
 
       recoveryRolesCount = await colony.numRecoveryRoles();


### PR DESCRIPTION
Could be a worse crop, all things considered...

1. We were not correctly tracking the recovery role count when using `setUserRoles`. This fixes that. The consequences of this are frustrating, and are going to be dealt with on the frontend to a limited extent. Basically, the frontend will prevent people upgrading unless there is exactly one person with the recovery role. It can tell this from events, and not from `numRecoveryRoles`, which isn't incremented when using `setUserRoles`, which is all the frontend uses. `numRecoveryRoles` will then be correct, and the users can upgrade and re-award the recovery roles as they see fit.
If someone upgrades without doing that, by interacting directly with the contracts, then not even recovery mode can save them, as `numRecoveryRoles` is protected, which is a little awkward. I don't really think there's much to be done there, though.
Only two colonies have been affected by this so far, and this was discovered internally, so hopefully won't affect anyone meaningfully once we're deployed.

2. Upgraded colonies missed a permission being given to them in `finishUpgrade`, just like we'd always feared. This one was tricky to spot, as the function can be called by two different permissions. I discovered this through using the Metacolony. It only affects colonies that have upgraded 4->5, so shouldn't be too big a deal as very few fall in to that category.

3. The designed frontend for recovery mode requires annotations to be allowed in recovery mode. I can't see an issue with this, so I've enabled it there.

I've also bumped the colony version to six.