### PR TITLE
Minor real-world based changed to reputation miner

### DIFF
--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -105,10 +105,6 @@ class ReputationMiner {
     this.reputations = {};
     this.gasPrice = ethers.utils.hexlify(20000000000);
 
-    // Are we using ganache? If so, note this so we add safety margin to gas estimates because ganache sucks at that
-    // See if we're talking to Ganache to fix a ganache crash (which, while fun to say, is not fun to see)
-    const clientString = await this.realProvider.send("web3_clientVersion");
-    this.isGanacheClient = clientString.indexOf('TestRPC') !== -1;
   }
 
   /**
@@ -647,7 +643,6 @@ class ReputationMiner {
     } catch (err) { // eslint-disable-line no-empty
 
     }
-    gasEstimate = this.padGasEstimateIfGanache(gasEstimate);
 
     // Submit that entry
     return repCycle.submitRootHash(hash, nLeaves, jrh, entryIndex, { gasLimit: gasEstimate, gasPrice: this.gasPrice });
@@ -835,7 +830,6 @@ class ReputationMiner {
     } catch (err) { // eslint-disable-line no-empty
 
     }
-    gasEstimate = this.padGasEstimateIfGanache(gasEstimate);
 
     return repCycle.confirmJustificationRootHash(
       round,
@@ -923,7 +917,6 @@ class ReputationMiner {
     } catch (err) { // eslint-disable-line no-empty
 
     }
-    gasEstimate = this.padGasEstimateIfGanache(gasEstimate);
     return repCycle.respondToBinarySearchForChallenge(
       round,
       index,
@@ -958,7 +951,6 @@ class ReputationMiner {
     } catch (err){ // eslint-disable-line no-empty
 
     }
-    gasEstimate = this.padGasEstimateIfGanache(gasEstimate);
 
     return repCycle.confirmBinarySearchResult(round, index, intermediateReputationHash, siblings, {
       gasLimit: gasEstimate,
@@ -1062,7 +1054,6 @@ class ReputationMiner {
     } catch (err){ // eslint-disable-line no-empty
 
     }
-    gasEstimate = this.padGasEstimateIfGanache(gasEstimate);
 
     return repCycle.respondToChallenge(...functionArgs,
       { gasLimit: gasEstimate, gasPrice: this.gasPrice }
@@ -1195,13 +1186,6 @@ class ReputationMiner {
       console.log("value", decimalValue.toString());
       console.log("---------");
     }
-  }
-
-  padGasEstimateIfGanache(gasEstimate){
-    if (this.isGanacheClient) {
-      return `0x${new BN(gasEstimate.toString()).mul(new BN("11")).div(new BN("10")).toString(16)}`;
-    }
-    return gasEstimate;
   }
 
   async saveCurrentState() {

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -225,10 +225,18 @@ class ReputationMinerClient {
     // Set up the listener to take actions on each block
     this.lockedForBlockProcessing = false;
     this._miner.realProvider.on('block', this.doBlockChecks.bind(this));
+
+    const network = await this._miner.realProvider.getNetwork();
+    this.chainId = network.chainId;
+
     this._adapter.log("🏁 Initialised");
   }
 
   async updateGasEstimate(type) {
+    if (this.chainId === 100){
+      this._miner.gasPrice = ethers.utils.hexlify(1000000000);
+      return;
+    }
     // Get latest from ethGasStation
     const options = {
       uri: 'https://ethgasstation.info/json/ethgasAPI.json',

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -591,13 +591,7 @@ class ReputationMinerClient {
     // Confirm hash
     const [round] = await this._miner.getMySubmissionRoundAndIndex();
     if (round && round.gte(0)) {
-      let gasEstimate;
-      if (this._miner.isGanacheClient) {
-        gasEstimate = ethers.BigNumber.from(2500000);
-      } else {
-        gasEstimate = await repCycle.estimate.confirmNewHash(round);
-      }
-      gasEstimate = this._miner.padGasEstimateIfGanache(gasEstimate);
+      const gasEstimate = await repCycle.estimateGas.confirmNewHash(round);
 
       const confirmNewHashTx = await repCycle.confirmNewHash(round, { gasLimit: gasEstimate, gasPrice: this._miner.gasPrice });
       this._adapter.log(`⛏️ Transaction waiting to be mined ${confirmNewHashTx.hash}`);


### PR DESCRIPTION
Doing two things here:

1. Remove all ganache-specific functionality from the miner. Ganache seem to have finally got their gas estimation up to snuff (or rather, I finally noticed that they did [nearly two years ago](https://github.com/trufflesuite/ganache-cli/releases/tag/v6.4.2-beta.0)), so can rip this out. This was why the miner was having grief in the real world - [this line](https://github.com/JoinColony/colonyNetwork/compare/develop...maint/miner-gas-price#diff-0a992c98d4c940fcc61183e5a53e2df4edbaa11fdab2eb89f3621ee7a8622ec2L590) needed changing going from [Ethers v4 to v5](https://docs.ethers.io/v5/migration/ethers-v4/) but wasn't tested, because all of our tests run against Ganache.
2. If connected to Xdai, only use a gas price of 1Gwei rather than the mainnet gas prices.