### PR TITLE
First pass at allowing arbitrary approve transactions

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -91,7 +91,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     return res;
   }
 
-  function updateApprovalAmount(address _token, address _spender) public {
+  function updateApprovalAmount(address _token, address _spender) stoppable public {
     updateApprovalAmountInternal(_token, _spender, false);
   }
 
@@ -491,11 +491,11 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     emit TokenUnlocked();
   }
 
-  function getTokenApproval(address _token, address _spender) public returns (uint256 amount) {
+  function getTokenApproval(address _token, address _spender) public view returns (uint256 amount) {
     return tokenApprovals[_token][_spender];
   }
 
-  function getTotalTokenApproval(address _token) public returns (uint256 amount) {
+  function getTotalTokenApproval(address _token) public view returns (uint256 amount) {
     return tokenApprovalTotals[_token];
   }
 

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -58,10 +58,10 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     bytes4 sig;
     assembly { sig := mload(add(_action, 0x20)) }
 
-    if (sig == APPROVE_SIG){ approveTransactionPreparation(_to, _action); } 
-    else if (sig == BURN_SIG ) { burnTransactionPreparation(_to, _action); }
-    else if (sig == TRANSFER_SIG ) { transferTransactionPreparation(_to, _action); }
-    else if (sig == BURN_GUY_SIG || sig == TRANSFER_FROM_SIG){ burnFromOrTransferFromTransactionPreparation(_to, _action); }
+    if (sig == APPROVE_SIG) { approveTransactionPreparation(_to, _action); }
+    else if (sig == BURN_SIG) { burnTransactionPreparation(_to, _action); }
+    else if (sig == TRANSFER_SIG) { transferTransactionPreparation(_to, _action); }
+    else if (sig == BURN_GUY_SIG || sig == TRANSFER_FROM_SIG) { burnGuyOrTransferFromTransactionPreparation(_action); }
 
     // Prevent transactions to network-managed extensions installed in this colony
     require(isContract(_to), "colony-to-must-be-contract");
@@ -74,7 +74,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     } catch {}
 
     bool res = executeCall(_to, 0, _action);
-    if (sig == APPROVE_SIG){ approveTransactionCleanup(_to, _action); }
+
+    if (sig == APPROVE_SIG) { approveTransactionCleanup(_to, _action); }
 
     return res;
   }
@@ -106,7 +107,6 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
 
   function transferTransactionPreparation(address _to, bytes memory _action) internal {
     uint256 amount;
-    address recipient;
     assembly {
       amount := mload(add(_action, 0x44))
     }
@@ -114,7 +114,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     require(fundingPots[1].balance[_to] >= tokenApprovalTotals[_to], "colony-not-enough-tokens");
   }
 
-  function burnFromOrTransferFromTransactionPreparation(address _to, bytes memory _action) internal {
+  function burnGuyOrTransferFromTransactionPreparation(bytes memory _action) internal {
     address spender;
     assembly {
       spender := mload(add(_action, 0x24))
@@ -143,7 +143,6 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     require(fundingPots[1].balance[_token] >= tokenApprovalTotals[_token], "colony-approval-exceeds-balance");
 
     tokenApprovals[_token][_spender] = actualApproval;
-
   }
 
   function annotateTransaction(bytes32 _txHash, string memory _metadata) public always {
@@ -522,11 +521,11 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     emit TokenUnlocked();
   }
 
-  function getTokenApproval(address _token, address _spender) public view returns (uint256 amount) {
+  function getTokenApproval(address _token, address _spender) public view returns (uint256) {
     return tokenApprovals[_token][_spender];
   }
 
-  function getTotalTokenApproval(address _token) public view returns (uint256 amount) {
+  function getTotalTokenApproval(address _token) public view returns (uint256) {
     return tokenApprovalTotals[_token];
   }
 

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -226,6 +226,12 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     fromPot.balance[_token] = sub(fromPot.balance[_token], _amount);
     toPot.balance[_token] = add(toPot.balance[_token], _amount);
 
+    if (_fromPot == 1){
+      // If we're moving from the root pot, then check we haven't dropped below what we need
+      // to cover any approvals that we've made.
+      require(fromPot.balance[_token] >= tokenApprovalTotals[_token], "colony-funding-too-many-approvals");
+    }
+
     // If this pot is associated with a Task or Expenditure, prevent money
     // being taken from the pot if the remaining balance is less than
     // the amount needed for payouts, unless the task was cancelled.

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -96,6 +96,12 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, ColonyNetworkDataTypes
 
   mapping (address => mapping (uint256 => bool)) tokenLocks; // Storage slot 31
 
+  // Mapping of token address -> address approved -> amount approved
+  mapping (address => mapping (address => uint256 )) tokenApprovals; // Storage slot 32
+
+  // Mapping of token address -> total amount approved
+  mapping (address => uint256 ) tokenApprovalTotals; // Storage slot 33
+
   // Constants
   uint256 constant MAX_PAYOUT = 2**128 - 1; // 340,282,366,920,938,463,463 WADs
   bytes32 constant ROOT_ROLES = bytes32(uint256(1)) << uint8(ColonyRole.Recovery) | bytes32(uint256(1)) << uint8(ColonyRole.Root);

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -946,4 +946,10 @@ interface IColony is ColonyDataTypes, IRecovery {
 
   /// @notice unlock the native colony token, if possible
   function unlockToken() external;
+
+  function updateApprovalAmount(address _token, address _spender) external;
+  function getTokenApproval(address _token, address _spender) external view returns (uint256 amount);
+
+  function getTotalTokenApproval(address _token) external view returns (uint256 amount);
+
 }

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -947,9 +947,17 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @notice unlock the native colony token, if possible
   function unlockToken() external;
 
-  function updateApprovalAmount(address _token, address _spender) external;
-  function getTokenApproval(address _token, address _spender) external view returns (uint256 amount);
+  /// @notice Update the internal bookkeeping around external ERC20 approvals
+  /// @param token The address of the token which was approved
+  /// @param spender The account we have approved
+  function updateApprovalAmount(address token, address spender) external;
 
-  function getTotalTokenApproval(address _token) external view returns (uint256 amount);
+  /// @notice Get the current approval amount
+  /// @param token The address of the token which was approved
+  /// @param spender The account we have approved
+  function getTokenApproval(address token, address spender) external view returns (uint256 amount);
 
+  /// @notice Get the current total approval amount across all spenders
+  /// @param token The address of the token which was approved
+  function getTotalTokenApproval(address token) external view returns (uint256 amount);
 }

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -919,6 +919,41 @@ Get the colony token.
 |---|---|---|
 |tokenAddress|address|Address of the token contract
 
+### `getTokenApproval`
+
+
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_token|address|
+|_spender|address|
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|amount|uint256|
+
+### `getTotalTokenApproval`
+
+
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_token|address|
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|amount|uint256|
+
 ### `getUserRoles`
 
 Gets the bytes32 representation of the roles for a user in a given domain
@@ -1719,6 +1754,19 @@ Unlock the colony's token for a user. Can only be called by a network-managed ex
 |---|---|---|
 |user|address|The user to unlock
 |lockId|uint256|The specific lock to unlock
+
+
+### `updateApprovalAmount`
+
+
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_token|address|
+|_spender|address|
 
 
 ### `updateColonyOrbitDB`

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "find-in-files": "^0.5.0",
     "ganache-cli": "^6.10.1",
     "ganache-core": "^2.11.2",
-    "husky": "^4.2.5",
+    "husky": "^4.3.8",
     "istanbul": "^0.4.5",
     "istanbul-combine": "^0.3.0",
     "mocha": "^8.0.0",

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -143,22 +143,22 @@ contract("Contract Storage", (accounts) => {
 
       const colonyStateHash = await getAddressStateHash(colony.address);
       const colonyAccount = new Account(colonyStateHash);
-
       const metaColonyStateHash = await getAddressStateHash(metaColony.address);
       const metaColonyAccount = new Account(metaColonyStateHash);
-
       const tokenLockingStateHash = await getAddressStateHash(tokenLockingAddress);
       const tokenLockingAccount = new Account(tokenLockingStateHash);
+
       console.log("colonyNetworkStateHash:", colonyNetworkAccount.stateRoot.toString("hex"));
       console.log("colonyStateHash:", colonyAccount.stateRoot.toString("hex"));
       console.log("metaColonyStateHash:", metaColonyAccount.stateRoot.toString("hex"));
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("72951bdaf341c997f2c1b6421eae532ca09082258c276f59565b09d1a5b74aeb");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("f33c405a1e7064905b600a6a87dc20de3dbac37be6935588bb57ea62ee6c7539");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("ce60ed2e314b5ae83e9d78f4518330496cdf8a2dab275798822bb7277cc304c2");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("1cbcf4998ef6be25f00b4a704ddfccc162c2395396f055f3660f099deb20c11f");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("569eb40a55836a9bf2b8c89084a0addf9b653694bfe55e968e94b56dbe4f4c8d");
+
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("a42ed7b73309b2e081a096ebe46a475329ae2e228e93629b0d3c63ff0410f0ae");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("9aa1a2e003bb54c12e4861d00bb90239e8dd8e11eeb7733884285ae60d035307");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("4eac8ccffe8b2eebb1da321e5544c8334005fe0e9afbaa1a4d654abf14515ede");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("f7ce25312c171119867cd296607295d7a781cfb87fc6088c09787919b3ff3b25");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("b23982e9f9e790251021a0b5a81fe4e8c38b9799e9291f258368014259106c71");
     });
   });
 });

--- a/test/contracts-network/colony-arbitrary-transactions.js
+++ b/test/contracts-network/colony-arbitrary-transactions.js
@@ -70,13 +70,11 @@ contract("Colony Arbitrary Transactions", (accounts) => {
   });
 
   it("should not be able to make arbitrary transactions to transfer tokens", async () => {
-    const action1 = await encodeTxData(token, "approve", [USER0, WAD]);
     const action2 = await encodeTxData(token, "transfer", [USER0, WAD]);
     const action3 = await encodeTxData(token, "transferFrom", [USER0, USER0, WAD]);
     const action4 = await encodeTxData(token, "burn", [WAD]);
     const action5 = await encodeTxData(token, "burn(address,uint256)", [USER0, WAD]);
 
-    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action1), "colony-cannot-call-erc20-approve");
     await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action2), "colony-cannot-call-erc20-transfer");
     await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action3), "colony-cannot-call-erc20-transfer-from");
     await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action4), "colony-cannot-call-burn");

--- a/test/contracts-network/colony-arbitrary-transactions.js
+++ b/test/contracts-network/colony-arbitrary-transactions.js
@@ -1,0 +1,183 @@
+/* globals artifacts */
+
+import chai from "chai";
+import bnChai from "bn-chai";
+import { ethers } from "ethers";
+import { soliditySha3 } from "web3-utils";
+
+import { UINT256_MAX, WAD } from "../../helpers/constants";
+import { checkErrorRevert, encodeTxData } from "../../helpers/test-helper";
+import { setupRandomColony, fundColonyWithTokens } from "../../helpers/test-data-generator";
+
+const { expect } = chai;
+chai.use(bnChai(web3.utils.BN));
+
+const CoinMachine = artifacts.require("CoinMachine");
+const EtherRouter = artifacts.require("EtherRouter");
+const IColonyNetwork = artifacts.require("IColonyNetwork");
+const ITokenLocking = artifacts.require("ITokenLocking");
+
+contract("Colony Arbitrary Transactions", (accounts) => {
+  let colony;
+  let token;
+  let colonyNetwork;
+
+  const USER0 = accounts[0];
+  const USER1 = accounts[1];
+
+  before(async () => {
+    const etherRouter = await EtherRouter.deployed();
+    colonyNetwork = await IColonyNetwork.at(etherRouter.address);
+  });
+
+  beforeEach(async () => {
+    ({ colony, token } = await setupRandomColony(colonyNetwork));
+  });
+
+  it("should be able to make arbitrary transactions", async () => {
+    const action = await encodeTxData(token, "mint", [WAD]);
+    const balancePre = await token.balanceOf(colony.address);
+
+    await colony.makeArbitraryTransaction(token.address, action);
+
+    const balancePost = await token.balanceOf(colony.address);
+    expect(balancePost.sub(balancePre)).to.eq.BN(WAD);
+  });
+
+  it("should not be able to make arbitrary transactions if not root", async () => {
+    const action = await encodeTxData(token, "mint", [WAD]);
+
+    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action, { from: USER1 }), "ds-auth-unauthorized");
+  });
+
+  it("should not be able to make arbitrary transactions to a colony itself", async () => {
+    await checkErrorRevert(colony.makeArbitraryTransaction(colony.address, "0x0"), "colony-cannot-target-self");
+  });
+
+  it("should not be able to make arbitrary transactions to a user address", async () => {
+    await checkErrorRevert(colony.makeArbitraryTransaction(accounts[0], "0x0"), "colony-to-must-be-contract");
+  });
+
+  it("should not be able to make arbitrary transactions to network or token locking", async () => {
+    const tokenLockingAddress = await colonyNetwork.getTokenLocking();
+    const tokenLocking = await ITokenLocking.at(tokenLockingAddress);
+
+    const action1 = await encodeTxData(colonyNetwork, "addSkill", [0]);
+    const action2 = await encodeTxData(tokenLocking, "lockToken", [token.address]);
+
+    await checkErrorRevert(colony.makeArbitraryTransaction(colonyNetwork.address, action1), "colony-cannot-target-network");
+    await checkErrorRevert(colony.makeArbitraryTransaction(tokenLocking.address, action2), "colony-cannot-target-token-locking");
+  });
+
+  it("should not be able to make arbitrary transactions to transfer tokens", async () => {
+    const action1 = await encodeTxData(token, "approve", [USER0, WAD]);
+    const action2 = await encodeTxData(token, "transfer", [USER0, WAD]);
+    const action3 = await encodeTxData(token, "transferFrom", [USER0, USER0, WAD]);
+    const action4 = await encodeTxData(token, "burn", [WAD]);
+    const action5 = await encodeTxData(token, "burn(address,uint256)", [USER0, WAD]);
+
+    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action1), "colony-cannot-call-erc20-approve");
+    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action2), "colony-cannot-call-erc20-transfer");
+    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action3), "colony-cannot-call-erc20-transfer-from");
+    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action4), "colony-cannot-call-burn");
+    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action5), "colony-cannot-call-burn-guy");
+  });
+
+  it("if an arbitrary transaction is made to approve tokens, then tokens needed for approval cannot be moved out of the main pot", async () => {
+    await fundColonyWithTokens(colony, token, 100);
+    const action1 = await encodeTxData(token, "approve", [USER0, 50]);
+    await colony.makeArbitraryTransaction(token.address, action1);
+    await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 50, token.address);
+    await checkErrorRevert(colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 50, token.address), "colony-funding-too-many-approvals");
+    const approval = await colony.getTokenApproval(token.address, USER0);
+    expect(approval).to.be.eq.BN(50);
+    const allApprovals = await colony.getTotalTokenApproval(token.address);
+    expect(allApprovals).to.be.eq.BN(50);
+  });
+
+  it(`if an allowance is used against a colony, then if moving tokens from the main pot,
+   tokens can only be moved from main pot that weren't part of the allowance`, async () => {
+    await fundColonyWithTokens(colony, token, 100);
+    const action1 = await encodeTxData(token, "approve", [USER0, 20]);
+    await colony.makeArbitraryTransaction(token.address, action1);
+    // Use allowance
+    await token.transferFrom(colony.address, USER0, 20, { from: USER0 });
+    // Approval tracking still thinks it has to reserve 20
+    let approval = await colony.getTokenApproval(token.address, USER0);
+    expect(approval).to.eq.BN(20);
+    let allApprovals = await colony.getTotalTokenApproval(token.address);
+    expect(allApprovals).to.eq.BN(20);
+    await checkErrorRevert(colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 81, token.address), "colony-funding-too-many-approvals");
+    await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 80, token.address);
+    // Pot still thinks it has 20 tokens in it
+    let potBalance = await colony.getFundingPotBalance(1, token.address);
+    expect(potBalance).to.eq.BN(20);
+    // Tell it to check
+    await colony.updateApprovalAmount(token.address, USER0);
+    // Pot now knows its empty
+    potBalance = await colony.getFundingPotBalance(1, token.address);
+    expect(potBalance).to.be.zero;
+    // And approvals are now 0
+    approval = await colony.getTokenApproval(token.address, USER0);
+    expect(approval).to.be.zero;
+    allApprovals = await colony.getTotalTokenApproval(token.address);
+    expect(allApprovals).to.be.zero;
+  });
+
+  it("an approval cannot be given via arbitrary transaction if it cannot be covered exclusively from unreserved tokens in root pot", async () => {
+    await fundColonyWithTokens(colony, token, 100);
+    const action1 = await encodeTxData(token, "approve", [USER0, 300]);
+    // Not enough tokens at all
+    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action1), "colony-too-many-approvals");
+    await fundColonyWithTokens(colony, token, 1000);
+    await colony.makeArbitraryTransaction(token.address, action1);
+    // They are now approved for 300.
+    let approval = await colony.getTokenApproval(token.address, USER0);
+    expect(approval).to.be.eq.BN(300);
+    let allApprovals = await colony.getTotalTokenApproval(token.address);
+    expect(allApprovals).to.be.eq.BN(300);
+
+    const action2 = await encodeTxData(token, "approve", [USER0, 900]);
+    // User was approved for 300, we now approve them for 900. There are enough tokens to cover this, even though 900 + 300 > 1100, the balance of the pot
+    await colony.makeArbitraryTransaction(token.address, action2);
+    approval = await colony.getTokenApproval(token.address, USER0);
+    expect(approval).to.be.eq.BN(900);
+    allApprovals = await colony.getTotalTokenApproval(token.address);
+    expect(allApprovals).to.be.eq.BN(900);
+
+    // Set them back to 300
+    await colony.makeArbitraryTransaction(token.address, action1);
+    approval = await colony.getTokenApproval(token.address, USER0);
+    expect(approval).to.be.eq.BN(300);
+    allApprovals = await colony.getTotalTokenApproval(token.address);
+    expect(allApprovals).to.be.eq.BN(300);
+
+    // Cannot approve someone else for 900
+    const action3 = await encodeTxData(token, "approve", [USER1, 900]);
+    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action3), "colony-too-many-approvals");
+    // But can for 800
+    const action4 = await encodeTxData(token, "approve", [USER1, 800]);
+    await colony.makeArbitraryTransaction(token.address, action4);
+    approval = await colony.getTokenApproval(token.address, USER1);
+    expect(approval).to.be.eq.BN(800);
+    allApprovals = await colony.getTotalTokenApproval(token.address);
+    expect(allApprovals).to.be.eq.BN(1100);
+  });
+
+  it("should not be able to make arbitrary transactions to the colony's own extensions", async () => {
+    const COIN_MACHINE = soliditySha3("CoinMachine");
+    await colony.installExtension(COIN_MACHINE, 1);
+
+    const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
+    const coinMachine = await CoinMachine.at(coinMachineAddress);
+    await coinMachine.initialise(ethers.constants.AddressZero, 60 * 60, 10, WAD.muln(100), WAD.muln(200), UINT256_MAX, WAD);
+
+    const action = await encodeTxData(coinMachine, "buyTokens", [WAD]);
+
+    await checkErrorRevert(colony.makeArbitraryTransaction(coinMachine.address, action), "colony-cannot-target-extensions");
+
+    // But other colonies can
+    const { colony: otherColony } = await setupRandomColony(colonyNetwork);
+    await otherColony.makeArbitraryTransaction(coinMachine.address, action);
+  });
+});

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -3,7 +3,6 @@
 import chai from "chai";
 import bnChai from "bn-chai";
 import { ethers } from "ethers";
-import { soliditySha3 } from "web3-utils";
 
 import {
   IPFS_HASH,
@@ -16,17 +15,15 @@ import {
   RATING_2_SECRET,
   WAD,
 } from "../../helpers/constants";
-import { getTokenArgs, web3GetBalance, checkErrorRevert, encodeTxData, expectNoEvent, expectAllEvents, expectEvent } from "../../helpers/test-helper";
+import { getTokenArgs, web3GetBalance, checkErrorRevert, expectNoEvent, expectAllEvents, expectEvent } from "../../helpers/test-helper";
 import { makeTask, setupRandomColony } from "../../helpers/test-data-generator";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
 
-const CoinMachine = artifacts.require("CoinMachine");
 const EtherRouter = artifacts.require("EtherRouter");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const IReputationMiningCycle = artifacts.require("IReputationMiningCycle");
-const ITokenLocking = artifacts.require("ITokenLocking");
 const TransferTest = artifacts.require("TransferTest");
 const Token = artifacts.require("Token");
 
@@ -134,72 +131,6 @@ contract("Colony", (accounts) => {
       // A root skill should have been created for the Colony
       const rootLocalSkillId = await colonyNetwork.getSkillCount();
       expect(domain.skillId).to.eq.BN(rootLocalSkillId);
-    });
-
-    it("should be able to make arbitrary transactions", async () => {
-      const action = await encodeTxData(token, "mint", [WAD]);
-      const balancePre = await token.balanceOf(colony.address);
-
-      await colony.makeArbitraryTransaction(token.address, action);
-
-      const balancePost = await token.balanceOf(colony.address);
-      expect(balancePost.sub(balancePre)).to.eq.BN(WAD);
-    });
-
-    it("should not be able to make arbitrary transactions if not root", async () => {
-      const action = await encodeTxData(token, "mint", [WAD]);
-
-      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action, { from: USER1 }), "ds-auth-unauthorized");
-    });
-
-    it("should not be able to make arbitrary transactions to a colony itself", async () => {
-      await checkErrorRevert(colony.makeArbitraryTransaction(colony.address, "0x0"), "colony-cannot-target-self");
-    });
-
-    it("should not be able to make arbitrary transactions to a user address", async () => {
-      await checkErrorRevert(colony.makeArbitraryTransaction(accounts[0], "0x0"), "colony-to-must-be-contract");
-    });
-
-    it("should not be able to make arbitrary transactions to network or token locking", async () => {
-      const tokenLockingAddress = await colonyNetwork.getTokenLocking();
-      const tokenLocking = await ITokenLocking.at(tokenLockingAddress);
-
-      const action1 = await encodeTxData(colonyNetwork, "addSkill", [0]);
-      const action2 = await encodeTxData(tokenLocking, "lockToken", [token.address]);
-
-      await checkErrorRevert(colony.makeArbitraryTransaction(colonyNetwork.address, action1), "colony-cannot-target-network");
-      await checkErrorRevert(colony.makeArbitraryTransaction(tokenLocking.address, action2), "colony-cannot-target-token-locking");
-    });
-
-    it("should not be able to make arbitrary transactions to transfer tokens", async () => {
-      const action1 = await encodeTxData(token, "approve", [USER0, WAD]);
-      const action2 = await encodeTxData(token, "transfer", [USER0, WAD]);
-      const action3 = await encodeTxData(token, "transferFrom", [USER0, USER0, WAD]);
-      const action4 = await encodeTxData(token, "burn", [WAD]);
-      const action5 = await encodeTxData(token, "burn(address,uint256)", [USER0, WAD]);
-
-      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action1), "colony-cannot-call-erc20-approve");
-      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action2), "colony-cannot-call-erc20-transfer");
-      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action3), "colony-cannot-call-erc20-transfer-from");
-      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action4), "colony-cannot-call-burn");
-      await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action5), "colony-cannot-call-burn-guy");
-    });
-
-    it("should not be able to make arbitrary transactions to the colony's own extensions", async () => {
-      const COIN_MACHINE = soliditySha3("CoinMachine");
-      await colony.installExtension(COIN_MACHINE, 1);
-
-      const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
-      const coinMachine = await CoinMachine.at(coinMachineAddress);
-      await coinMachine.initialise(ethers.constants.AddressZero, 60 * 60, 10, WAD.muln(100), WAD.muln(200), UINT256_MAX, WAD);
-
-      const action = await encodeTxData(coinMachine, "buyTokens", [WAD]);
-
-      await checkErrorRevert(colony.makeArbitraryTransaction(coinMachine.address, action), "colony-cannot-target-extensions");
-
-      // But other colonies can
-      const { colony: otherColony } = await setupRandomColony(colonyNetwork);
-      await otherColony.makeArbitraryTransaction(coinMachine.address, action);
     });
 
     it("should let funding pot information be read", async () => {


### PR DESCRIPTION
Okay, this is a first pass at this ready for feedback. I'm not completely happy with merging this yet (might be able to extend this idea to other 'forbidden' transactions), but happy enough for it to start being reviewed. 

Basically, this introduces some more internal accounting so that when a colony `approve`s another contract to take its tokens via the very common ERC20 interface, we only allow tokens to be removed from the root ~~address~~ domain. Tokens may be taken, but the internal bookkeeping won't update until another approve transaction to the same address is made, or any user calls the `updateApprovalAmount` function.