### PR TITLE
Fix bug in reputation mining around the zero address

### DIFF
--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -296,7 +296,11 @@ contract ColonyNetwork is ColonyNetworkStorage, MultiChain {
   calledByColony
   skillExists(_skillId)
   {
-    if (_amount == 0) {
+    if (_amount == 0 || _user == 0x0000000000000000000000000000000000000000) {
+      // We short-circut amount=0 as it has no effect to save gas, and we ignore Address Zero because it will
+      // mess up the tracking of the total amount of reputation in a colony, as that's the key that it's
+      // stored under in the patricia/merkle tree. Colonies can still pay tokens out to it if they want,
+      // it just won't earn reputation.
       return;
     }
 

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -296,7 +296,7 @@ contract ColonyNetwork is ColonyNetworkStorage, MultiChain {
   calledByColony
   skillExists(_skillId)
   {
-    if (_amount == 0 || _user == 0x0000000000000000000000000000000000000000) {
+    if (_amount == 0 || _user == address(0x0)) {
       // We short-circut amount=0 as it has no effect to save gas, and we ignore Address Zero because it will
       // mess up the tracking of the total amount of reputation in a colony, as that's the key that it's
       // stored under in the patricia/merkle tree. Colonies can still pay tokens out to it if they want,


### PR DESCRIPTION
In the reputation tree, reputation for an address in a skill is stored at the key generated from the concatenation of the colony address, the skill id, and the address that holds the reputation. We also need to store the total reputation in a skill in a colony. This is stored in the same tree, but at a key generated from the concatenation of the colony address, the skill id, and the zero address.

With the introduction of expenditures, and more obviously the ability to award and slash reputation owned by arbitrary addresses, we accidentally added the ability for colonies to mess around with the zero-address reputation, which will cause votes and rewards to behave in unexpected ways. I believe a colony can only mess things up for themselves (at least while we're the only miners... I haven't dug in to what would happen with such an entry in the log in the event of a disputes) but still something we shouldn't allow.

This PR causes such a reputation being added to the log to be a no-op, which I think is the least obstructive way to go about this, and means that we don't have to make sure that any future ways to append to the reputation log also behave properly.