### PR TITLE
Add new convenience functionality to the miner

### DIFF
--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -1140,6 +1140,19 @@ class ReputationMiner {
     for (let i = 0; i < events.length; i += 1) {
       console.log(`Syncing mining cycle ${i + 1} of ${events.length}...`)
       const event = events[i];
+      if (i === 0) {
+        // If we are syncing from the very start of the reputation history, the block
+        // before the very first 'ReputationMiningCycleComplete' does not have an
+        // active reputation cycle. So we skip it if 'fromBlock' has not been judiciously
+        // chosen here. This is fine, as with no reputation cycle, there was no reputation,
+        // so nothing needs to be processed.
+        try {
+          await this.getActiveRepCycle(event.blockNumber - 1);
+        } catch(err){
+          // Honestly, this seems the cleanest way to implement this. Open to alternatives that ESLint likes though!
+          continue; // eslint-disable-line no-continue
+        }
+      }
       const hash = event.data.slice(0, 66);
       if (applyLogs) {
         const nLeaves = ethers.BigNumber.from(`0x${event.data.slice(66, 130)}`);

--- a/packages/reputation-miner/adapters/console.js
+++ b/packages/reputation-miner/adapters/console.js
@@ -1,4 +1,4 @@
- const ConsoleAdapter = {
+const ConsoleAdapter = {
   async log(output) {
     console.log(output);
   },

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -27,7 +27,8 @@ const {
   oracle,
   exitOnError,
   adapter,
-  oraclePort
+  oraclePort,
+  processingDelay
 } = argv;
 
 if ((!minerAddress && !privateKey) || !colonyNetworkAddress || !syncFrom) {
@@ -60,7 +61,18 @@ if (adapter === 'slack') {
   adapterObject = require('../adapters/console').default; // eslint-disable-line global-require
 }
 
-const client = new ReputationMinerClient(
-  { loader, minerAddress, privateKey, provider, useJsTree: true, dbPath, auto, oracle, exitOnError, adapter:adapterObject, oraclePort }
-);
+const client = new ReputationMinerClient({
+  loader,
+  minerAddress,
+  privateKey,
+  provider,
+  useJsTree: true,
+  dbPath,
+  auto,
+  oracle,
+  exitOnError,
+  adapter: adapterObject,
+  oraclePort,
+  processingDelay
+});
 client.initialise(colonyNetworkAddress, syncFrom);

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -4,7 +4,10 @@ require("@babel/register")({
 require("@babel/polyfill");
 
 const path = require("path");
-const { argv } = require("yargs").option('privateKey', {string:true}).option('colonyNetworkAddress', {string:true});
+const { argv } = require("yargs")
+  .option('privateKey', {string:true})
+  .option('colonyNetworkAddress', {string:true})
+  .option('minerAddress', {string:true});
 const ethers = require("ethers");
 
 const ReputationMinerClient = require("../ReputationMinerClient");
@@ -32,7 +35,7 @@ if ((!minerAddress && !privateKey) || !colonyNetworkAddress || !syncFrom) {
 }
 
 const loader = new TruffleLoader({
-  contractDir: path.resolve(process.cwd(), "build", "contracts")
+  contractDir: path.resolve(__dirname, "..", "..", "..", "build", "contracts")
 });
 
 let provider;

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -26,7 +26,8 @@ const {
   auto,
   oracle,
   exitOnError,
-  adapter
+  adapter,
+  oraclePort
 } = argv;
 
 if ((!minerAddress && !privateKey) || !colonyNetworkAddress || !syncFrom) {
@@ -60,6 +61,6 @@ if (adapter === 'slack') {
 }
 
 const client = new ReputationMinerClient(
-  { loader, minerAddress, privateKey, provider, useJsTree: true, dbPath, auto, oracle, exitOnError, adapter:adapterObject }
+  { loader, minerAddress, privateKey, provider, useJsTree: true, dbPath, auto, oracle, exitOnError, adapter:adapterObject, oraclePort }
 );
 client.initialise(colonyNetworkAddress, syncFrom);


### PR DESCRIPTION
While helping Olga with motions and disputes, which requires running the miner locally in a dev context, we ran across several things that needed to be configurable to make life as easy as possible. The app is using `feat/miner-fixes-backported` for now, as we've bumped the version number on the contracts but no corresponding colonyJS release exists, but we should have these fixes in the `develop` branch for when there is.

* Make the port the oracle responds on configurable.
* Add an option for the number of blocks to wait before ingesting a new reputation state. 
* Make `fromBlock=1` work for syncing, rather than having to judiciously choose the first block where there were two reputation mining contracts.
* Make `minerAddress` on the command line explicitly a string to avoid it being converted to a number and all heck breaking loose.
* Make the miner able to find the built contracts no matter what directory it has been started from.