### PR TITLE
Slight mining improvement and bootstrap correction

### DIFF
--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -198,7 +198,7 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, ColonyNetworkDataTypes
   }
 
   modifier isInBootstrapPhase() {
-    require(taskCount == 0, "colony-not-in-bootstrap-mode");
+    require(taskCount == 0 && expenditureCount == 0 && paymentCount == 0, "colony-not-in-bootstrap-mode");
     _;
   }
 

--- a/contracts/colonyNetwork/ColonyNetworkMining.sol
+++ b/contracts/colonyNetwork/ColonyNetworkMining.sol
@@ -249,6 +249,9 @@ contract ColonyNetworkMining is ColonyNetworkStorage, MultiChain {
   }
 
   function burnUnneededRewards(uint256 _amount) public stoppable onlyReputationMiningCycle() {
+    // If there are no rewards to burn, no need to do anything
+    if (_amount == 0){ return; }
+
     address clnyToken = IMetaColony(metaColony).getToken();
     ITokenLocking(tokenLocking).withdraw(clnyToken, _amount, true);
     if (isXdai()){

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -321,6 +321,9 @@ async function eventMatches(tx, nameOrSig, args) {
 async function eventMatchArgs(event, args) {
   for (let i = 0; i < args.length; i += 1) {
     let arg = args[i];
+    if (arg === null) {
+      continue; // eslint-disable-line no-continue
+    }
     if (arg.constructor.name === "BN" || event.args[i].constructor.name === "BN") {
       if (ethers.utils.isHexString(arg)) {
         arg = ethers.BigNumber.from(arg).toString();

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -277,6 +277,20 @@ function hexlifyAndPad(input) {
 }
 
 export async function expectEvent(tx, nameOrSig, args) {
+  const matches = await eventMatches(tx, nameOrSig, args);
+  if (matches.indexOf(true) === -1) {
+    throw Error(`No matching event was found for ${nameOrSig} with args ${args}`);
+  }
+}
+
+export async function expectNoEvent(tx, nameOrSig, args) {
+  const matches = await eventMatches(tx, nameOrSig, args);
+  if (matches.indexOf(true) !== -1) {
+    throw Error(`A matching event was found for ${nameOrSig} with args ${args}`);
+  }
+}
+
+async function eventMatches(tx, nameOrSig, args) {
   const re = /\((.*)\)/;
   let eventMatch;
   if (nameOrSig.match(re)) {
@@ -303,9 +317,7 @@ export async function expectEvent(tx, nameOrSig, args) {
     expect(events.length).to.be.at.least(1);
     eventMatch = await Promise.all(events.map((e) => eventMatchArgs(e, args)));
   }
-  if (eventMatch.indexOf(true) === -1) {
-    throw Error(`No matching event was found for ${nameOrSig} with args ${args}`);
-  }
+  return eventMatch;
 }
 
 async function eventMatchArgs(event, args) {
@@ -331,23 +343,6 @@ async function eventMatchArgs(event, args) {
     }
   }
   return true;
-}
-
-export async function expectNoEvent(tx, nameOrSig) {
-  const re = /\((.*)\)/;
-  let event;
-
-  if (nameOrSig.match(re)) {
-    // i.e. if the passed nameOrSig has () in it, we assume it's a signature
-    const { rawLogs } = await tx.receipt;
-    const topic = web3.utils.soliditySha3(nameOrSig);
-    event = rawLogs.find((e) => e.topics[0] === topic);
-    expect(event).to.not.exist;
-  } else {
-    const { logs } = await tx;
-    event = logs.find((e) => e.event === nameOrSig);
-    expect(event).to.not.exist;
-  }
 }
 
 export async function expectAllEvents(tx, eventNames) {

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -299,7 +299,6 @@ async function eventMatches(tx, nameOrSig, args) {
     const canonicalSig = nameOrSig.replace(/ indexed/g, "");
     const topic = web3.utils.soliditySha3(canonicalSig);
     const events = rawLogs.filter((e) => e.topics[0] === topic);
-    expect(events.length).to.be.at.least(1);
     eventMatch = await Promise.all(
       events.map((e) => {
         // Set up an abi so we decode correctly, including indexed topics
@@ -314,7 +313,6 @@ async function eventMatches(tx, nameOrSig, args) {
   } else {
     const { logs } = await tx;
     const events = logs.filter((e) => e.event === nameOrSig);
-    expect(events.length).to.be.at.least(1);
     eventMatch = await Promise.all(events.map((e) => eventMatchArgs(e, args)));
   }
   return eventMatch;

--- a/test-chainid/chainid-dependent-behaviour.js
+++ b/test-chainid/chainid-dependent-behaviour.js
@@ -106,11 +106,11 @@ contract("Contract Storage", (accounts) => {
       // Unneeded rewards should be dealt with differently as well.
 
       if (chainId === XDAI || chainId === FORKED_XDAI) {
-        // tokens should be transferred to metacolony
-        await expectEvent(tx, "Transfer(address indexed,address indexed,uint256)", [colonyNetwork.address, metaColony.address, 0]);
+        // tokens should be transferred to metacolony (but not this time because value == 0)
+        await expectNoEvent(tx, "Transfer(address indexed,address indexed,uint256)", [colonyNetwork.address, metaColony.address, 0]);
       } else {
-        // tokens should be burned.
-        await expectEvent(tx, "Burn(address indexed,uint256)", [colonyNetwork.address, 0]);
+        // tokens should be burned (but not this time because value == 0)
+        await expectNoEvent(tx, "Burn(address indexed,uint256)", [colonyNetwork.address, 0]);
       }
     });
 

--- a/test-chainid/chainid-dependent-behaviour.js
+++ b/test-chainid/chainid-dependent-behaviour.js
@@ -13,8 +13,7 @@ import {
   expectEvent,
   expectNoEvent,
 } from "../helpers/test-helper";
-
-import { MINING_CYCLE_DURATION, DEFAULT_STAKE, SUBMITTER_ONLY_WINDOW, MIN_STAKE } from "../helpers/constants";
+import { MINING_CYCLE_DURATION, DEFAULT_STAKE, SUBMITTER_ONLY_WINDOW, MIN_STAKE, MINING_CYCLE_TIMEOUT } from "../helpers/constants";
 
 const { expect } = chai;
 const ENSRegistry = artifacts.require("ENSRegistry");
@@ -31,6 +30,8 @@ const FORKED_XDAI = 265669100;
 
 contract("Contract Storage", (accounts) => {
   const MINER1 = accounts[5];
+  const MINER2 = accounts[6];
+  const MINER3 = accounts[7];
 
   let metaColony;
   let clnyToken;
@@ -49,6 +50,8 @@ contract("Contract Storage", (accounts) => {
     const ensRegistry = await ENSRegistry.new();
     await setupENSRegistrar(colonyNetwork, ensRegistry, accounts[0]);
     await giveUserCLNYTokensAndStake(colonyNetwork, MINER1, DEFAULT_STAKE);
+    await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
+    await giveUserCLNYTokensAndStake(colonyNetwork, MINER3, DEFAULT_STAKE);
 
     await colonyNetwork.initialiseReputationMining();
     await colonyNetwork.startNextCycle();
@@ -80,18 +83,32 @@ contract("Contract Storage", (accounts) => {
       await metaColony.setReputationMiningCycleReward(100);
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
 
-      const entryNumber = await getValidEntryNumber(colonyNetwork, MINER1, "0x12345678");
+      const MINER1HASH = "0x01";
+      const MINER2HASH = "0x02";
+      const MINER3HASH = "0x03";
+
+      const entryNumber1 = await getValidEntryNumber(colonyNetwork, MINER1, MINER1HASH);
+      const entryNumber2 = await getValidEntryNumber(colonyNetwork, MINER2, MINER2HASH);
+      const entryNumber3 = await getValidEntryNumber(colonyNetwork, MINER3, MINER3HASH);
       const repCycle = await getActiveRepCycle(colonyNetwork);
 
-      await repCycle.submitRootHash("0x12345678", 10, "0x00", entryNumber, { from: MINER1 });
+      await repCycle.submitRootHash(MINER1HASH, 10, "0x00", entryNumber1, { from: MINER1 });
+      await repCycle.submitRootHash(MINER2HASH, 10, "0x00", entryNumber2, { from: MINER2 });
+      await repCycle.submitRootHash(MINER3HASH, 10, "0x00", entryNumber3, { from: MINER3 });
 
       const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
-      expect(nUniqueSubmittedHashes).to.eq.BN(1);
+      expect(nUniqueSubmittedHashes).to.eq.BN(3);
 
-      await forwardTime(MINING_CYCLE_DURATION / 2 + SUBMITTER_ONLY_WINDOW + 1, this);
+      const rewardSize = await repCycle.getDisputeRewardSize();
 
+      await forwardTime(MINING_CYCLE_DURATION / 2 + SUBMITTER_ONLY_WINDOW + MINING_CYCLE_TIMEOUT + 1, this);
+
+      await repCycle.invalidateHash(0, 0);
+      await repCycle.invalidateHash(0, 3);
+
+      await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
       const networkBalanceBefore = await clnyToken.balanceOf(colonyNetwork.address);
-      const tx = await repCycle.confirmNewHash(0);
+      const tx = await repCycle.confirmNewHash(1);
 
       if (chainId === XDAI || chainId === FORKED_XDAI) {
         // tokens should be paid from the network balance
@@ -103,14 +120,17 @@ contract("Contract Storage", (accounts) => {
         expect(networkBalanceBefore).to.eq.BN(networkBalanceAfter);
       }
 
+      // Two people are getting MIN_STAKE slashed, from which two rewards are paid out.
+      // We expect the remaineder to be burned
+      const expectedBurned = MIN_STAKE.muln(2).sub(rewardSize.muln(2));
       // Unneeded rewards should be dealt with differently as well.
 
       if (chainId === XDAI || chainId === FORKED_XDAI) {
-        // tokens should be transferred to metacolony (but not this time because value == 0)
-        await expectNoEvent(tx, "Transfer(address indexed,address indexed,uint256)", [colonyNetwork.address, metaColony.address, 0]);
+        // tokens should be transferred to metacolony
+        await expectEvent(tx, "Transfer(address indexed,address indexed,uint256)", [colonyNetwork.address, metaColony.address, expectedBurned]);
       } else {
-        // tokens should be burned (but not this time because value == 0)
-        await expectNoEvent(tx, "Burn(address indexed,uint256)", [colonyNetwork.address, 0]);
+        // tokens should be burned.
+        await expectEvent(tx, "Burn(address indexed,uint256)", [colonyNetwork.address, expectedBurned]);
       }
     });
 
@@ -127,6 +147,7 @@ contract("Contract Storage", (accounts) => {
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
       const tx = await repCycle.confirmNewHash(0);
       await expectNoEvent(tx, "Transfer(address indexed,address indexed,uint256)", [colonyNetwork.address, metaColony.address, 0]);
+      await expectNoEvent(tx, "Burn(address indexed,uint256)", [colonyNetwork.address, 0]);
     });
   });
 });

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -345,9 +345,21 @@ contract("Colony", (accounts) => {
       );
     });
 
-    it("should not allow bootstrapping if colony is not in bootstrap state", async () => {
+    it("should not allow bootstrapping if tasks have been made", async () => {
       await colony.mintTokens(WAD.muln(14));
       await makeTask({ colony });
+      await checkErrorRevert(colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS), "colony-not-in-bootstrap-mode");
+    });
+
+    it("should not allow bootstrapping if payments have been made", async () => {
+      await colony.mintTokens(WAD.muln(14));
+      await colony.addPayment(1, UINT256_MAX, USER1, token.address, WAD, 1, 0);
+      await checkErrorRevert(colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS), "colony-not-in-bootstrap-mode");
+    });
+
+    it("should not allow bootstrapping if expenditures have been made", async () => {
+      await colony.mintTokens(WAD.muln(14));
+      await colony.makeExpenditure(1, UINT256_MAX, 1);
       await checkErrorRevert(colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS), "colony-not-in-bootstrap-mode");
     });
   });


### PR DESCRIPTION
Two unrelated changes, but both small so I thought I'd bundle them up.

* Jack reported [a large list of incoming transactions](https://www.notion.so/colony/Metacolony-incoming-fees-are-all-denominated-in-CLNY-and-from-the-same-address-8d27401478b6436785852b33812338e2) in the metacolony. These are from the xDai implementation of the `burnUnneededRewards` function, which even if there are no rewards, went ahead and did a 0-value transfer anyway. We shortcircuit the 0 case now, which is good for gas, and good for the app. To test this, I also refactored the helper functions around testing for the presence / lack of presence of an event in a transaction.
* When we added expenditures and payments, bootstrapping got left behind. This PR also prevents bootstrapping if a payment or an expenditure has been created, in the same way bootstrapping is not allowed if a task has been created.