### PR TITLE
Only use required stake in migration

### DIFF
--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -621,7 +621,7 @@ export async function advanceMiningCycleNoContest({ colonyNetwork, client, miner
     const accounts = await web3GetAccounts();
     minerAddress = minerAddress || accounts[5]; // eslint-disable-line no-param-reassign
     try {
-      await repCycle.submitRootHash("0x00", 0, "0x00", 10, { from: minerAddress });
+      await repCycle.submitRootHash("0x00", 0, "0x00", 1, { from: minerAddress });
     } catch (err) {
       console.log("advanceMiningCycleNoContest error thrown by .submitRootHash", err);
     }

--- a/migrations/8_setup_meta_colony.js
+++ b/migrations/8_setup_meta_colony.js
@@ -15,7 +15,7 @@ const Version3 = artifacts.require("./Version3");
 const Version4 = artifacts.require("./Version4");
 const { setupColonyVersionResolver } = require("../helpers/upgradable-contracts");
 
-const DEFAULT_STAKE = "2000000000000000000000000"; // 1000 * MIN_STAKE
+const DEFAULT_STAKE = "2000000000000000000000"; // MIN_STAKE
 
 // eslint-disable-next-line no-unused-vars
 module.exports = async function (deployer, network, accounts) {

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,11 +154,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("a42ed7b73309b2e081a096ebe46a475329ae2e228e93629b0d3c63ff0410f0ae");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("8f4308ab9f0627787f63a405b54bf6b1ae25ae42b18cd4d7fe4b04d2c7e0b8e1");
       expect(colonyAccount.stateRoot.toString("hex")).to.equal("9aa1a2e003bb54c12e4861d00bb90239e8dd8e11eeb7733884285ae60d035307");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("4eac8ccffe8b2eebb1da321e5544c8334005fe0e9afbaa1a4d654abf14515ede");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("f7ce25312c171119867cd296607295d7a781cfb87fc6088c09787919b3ff3b25");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("b23982e9f9e790251021a0b5a81fe4e8c38b9799e9291f258368014259106c71");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("621840deab018bf9f7bb35d60a503c0d2abfb4b0e5bc6ae72a7c4d9a6870e680");
     });
   });
 });

--- a/test/reputation-system/client-sync-functionality.js
+++ b/test/reputation-system/client-sync-functionality.js
@@ -5,7 +5,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 
 import TruffleLoader from "../../packages/reputation-miner/TruffleLoader";
-import { DEFAULT_STAKE, INITIAL_FUNDING } from "../../helpers/constants";
+import { DEFAULT_STAKE, MIN_STAKE, INITIAL_FUNDING } from "../../helpers/constants";
 import { forwardTime, currentBlock, advanceMiningCycleNoContest, getActiveRepCycle } from "../../helpers/test-helper";
 import { giveUserCLNYTokensAndStake, setupFinalizedTask, fundColonyWithTokens } from "../../helpers/test-data-generator";
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
@@ -59,7 +59,7 @@ process.env.SOLIDITY_COVERAGE
         await reputationMiner1.initialise(colonyNetwork.address);
 
         const lock = await tokenLocking.getUserLock(clnyToken.address, MINER1);
-        expect(lock.balance).to.eq.BN(DEFAULT_STAKE);
+        expect(lock.balance).to.eq.BN(MIN_STAKE);
 
         // Advance two cycles to clear active and inactive state.
         await advanceMiningCycleNoContest({ colonyNetwork, test: this });


### PR DESCRIPTION
Staking loads of CLNY in the migration during setup was causing issues with the app dev environment when the miner tried to submit more entries but blocktime was fast-forwarded at the same time. Easiest solution was to stake only the minimum amount of stake.