### PR TITLE
Make getStakerReward behaviour consistent

### DIFF
--- a/contracts/extensions/VotingReputation.sol
+++ b/contracts/extensions/VotingReputation.sol
@@ -750,10 +750,10 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs {
   function getStakerReward(uint256 _motionId, address _staker, uint256 _vote) public view returns (uint256, uint256) {
     Motion storage motion = motions[_motionId];
 
-    uint256 stakeFraction = wdiv(
-      stakes[_motionId][_staker][_vote],
-      add(motion.stakes[_vote], motion.pastVoterComp[_vote])
-    );
+    uint256 totalSideStake = add(motion.stakes[_vote], motion.pastVoterComp[_vote]);
+    if (totalSideStake == 0) { return (0, 0); }
+
+    uint256 stakeFraction = wdiv(stakes[_motionId][_staker][_vote], totalSideStake);
 
     uint256 realStake = wmul(stakeFraction, motion.stakes[_vote]);
     uint256 requiredStake = getRequiredStake(_motionId);

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -1333,6 +1333,16 @@ contract("Voting Reputation", (accounts) => {
       await checkErrorRevert(voting.claimReward(0, 1, UINT256_MAX, USER0, YAY), "voting-rep-motion-not-claimable");
     });
 
+    it("returns 0 for staker rewards if no-one staked on a side of a motion", async () => {
+      await voting.stakeMotion(motionId, 1, UINT256_MAX, YAY, REQUIRED_STAKE, user0Key, user0Value, user0Mask, user0Siblings, { from: USER0 });
+
+      const yayStakerReward = await voting.getStakerReward(motionId, USER0, YAY);
+      const nayStakerReward = await voting.getStakerReward(motionId, USER0, NAY);
+
+      expect(yayStakerReward[0]).to.eq.BN(REQUIRED_STAKE);
+      expect(nayStakerReward[0]).to.eq.BN(new BN(0));
+    });
+
     it("can let stakers claim rewards, based on the stake outcome", async () => {
       const addr = await colonyNetwork.getReputationMiningCycle(false);
       const repCycle = await IReputationMiningCycle.at(addr);


### PR DESCRIPTION
If no-one stakes on a side, and we attempt to query staker rewards on that side, `getStakerReward` errors out. This is because it divides by zero. This doesn't affect anything on the contracts (if no-one staked, then no-one can claim for that side, so the fact that it would divide by zero is irrelevant), but this proved annoying for the frontend team. Dividing by zero is something that we shouldn't do anyway, so let's just return 0 in this scenario (which will always be correct).