### PR TITLE
Relax permission requirement on moveFundingBetweenPots

### DIFF
--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -110,6 +110,9 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ROOT_ROLE, "editColony(string)");
     addRoleCapability(ROOT_ROLE, "burnTokens(address,uint256)");
     addRoleCapability(ROOT_ROLE, "unlockToken()");
+
+    // Added in colony v7 (dusk?-lwss)
+    addRoleCapability(FUNDING_ROLE, "moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,address)");
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -205,6 +205,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     return (fundingPot.associatedType, fundingPot.associatedTypeId, fundingPot.payoutsWeCannotMake);
   }
 
+  // Deprecated
   function moveFundsBetweenPots(
     uint256 _permissionDomainId,
     uint256 _fromChildSkillIndex,
@@ -214,11 +215,25 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     uint256 _amount,
     address _token
   )
+    public
+  {
+    moveFundsBetweenPots(_permissionDomainId, _fromChildSkillIndex, _fromPot, _toPot, _amount, _token);
+  }
+
+  function moveFundsBetweenPots(
+    uint256 _permissionDomainId,
+    uint256 _fromChildSkillIndex,
+    uint256 _fromPot,
+    uint256 _toPot,
+    uint256 _amount,
+    address _token
+  )
   public
   stoppable
-  authDomain(_permissionDomainId, _fromChildSkillIndex, getDomainFromFundingPot(_fromPot))
-  authDomain(_permissionDomainId, _toChildSkillIndex, getDomainFromFundingPot(_toPot))
+  fundingPotExists(_fromPot)
+  fundingPotExists(_toPot)
   validFundingTransfer(_fromPot, _toPot)
+  authDomain(_permissionDomainId, _fromChildSkillIndex, getDomainFromFundingPot(_fromPot))
   {
     FundingPot storage fromPot = fundingPots[_fromPot];
     FundingPot storage toPot = fundingPots[_toPot];
@@ -509,7 +524,6 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
   }
 
   function getDomainFromFundingPot(uint256 _fundingPotId) public view returns (uint256 domainId) {
-    require(_fundingPotId <= fundingPotCount, "colony-funding-nonexistent-pot");
     FundingPot storage fundingPot = fundingPots[_fundingPotId];
 
     if (fundingPot.associatedType == FundingPotAssociatedType.Domain) {

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -108,6 +108,11 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, ColonyNetworkDataTypes
   bytes32 constant BYTES32_1 = bytes32(uint256(1));
 
   // Modifiers
+  modifier fundingPotExists(uint256 _fundingPotId) {
+    require(_fundingPotId <= fundingPotCount, "colony-funding-nonexistent-pot");
+    _;
+  }
+
   modifier validPayoutAmount(uint256 _amount) {
     require(_amount <= MAX_PAYOUT, "colony-payout-too-large");
     _;

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -855,6 +855,7 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @return payout Funding pot payout amount
   function getFundingPotPayout(uint256 _potId, address _token) external view returns (uint256 payout);
 
+  /// DEPRECATED
   /// @notice Move a given amount: `_amount` of `_token` funds from funding pot with id `_fromPot` to one with id `_toPot`.
   /// @param _permissionDomainId The domainId in which I have the permission to take this action
   /// @param _fromChildSkillIndex The child index in `_permissionDomainId` where we can find the domain for `_fromPotId`
@@ -867,6 +868,22 @@ interface IColony is ColonyDataTypes, IRecovery {
     uint256 _permissionDomainId,
     uint256 _fromChildSkillIndex,
     uint256 _toChildSkillIndex,
+    uint256 _fromPot,
+    uint256 _toPot,
+    uint256 _amount,
+    address _token
+    ) external;
+
+  /// @notice Move a given amount: `_amount` of `_token` funds from funding pot with id `_fromPot` to one with id `_toPot`.
+  /// @param _permissionDomainId The domainId in which I have the permission to take this action
+  /// @param _fromChildSkillIndex The child index in `_permissionDomainId` where we can find the domain for `_fromPotId`
+  /// @param _fromPot Funding pot id providing the funds
+  /// @param _toPot Funding pot id receiving the funds
+  /// @param _amount Amount of funds
+  /// @param _token Address of the token, `0x0` value indicates Ether
+  function moveFundsBetweenPots(
+    uint256 _permissionDomainId,
+    uint256 _fromChildSkillIndex,
     uint256 _fromPot,
     uint256 _toPot,
     uint256 _amount,

--- a/contracts/extensions/FundingQueue.sol
+++ b/contracts/extensions/FundingQueue.sol
@@ -59,7 +59,7 @@ contract FundingQueue is ColonyExtension, PatriciaTreeProofs {
     uint256 fromPot;
     uint256 toPot;
     uint256 fromChildSkillIndex;
-    uint256 toChildSkillIndex;
+    uint256 toChildSkillIndex; // Deprecated
     uint256 totalRequested;
     uint256 totalPaid;
     uint256 lastUpdated;
@@ -82,7 +82,7 @@ contract FundingQueue is ColonyExtension, PatriciaTreeProofs {
 
   /// @notice Returns the version of the extension
   function version() public override pure returns (uint256) {
-    return 2;
+    return 3;
   }
 
   /// @notice Configures the extension
@@ -114,7 +114,7 @@ contract FundingQueue is ColonyExtension, PatriciaTreeProofs {
   function createProposal(
     uint256 _domainId,
     uint256 _fromChildSkillIndex,
-    uint256 _toChildSkillIndex,
+    uint256 _toChildSkillIndex, // TODO: Remove
     uint256 _fromPot,
     uint256 _toPot,
     uint256 _totalRequested,
@@ -135,11 +135,6 @@ contract FundingQueue is ColonyExtension, PatriciaTreeProofs {
       fromSkillId == colonyNetwork.getChildSkillId(domainSkillId, _fromChildSkillIndex),
       "funding-queue-bad-inheritence-from"
     );
-    require(
-      (domainSkillId == toSkillId && _toChildSkillIndex == UINT256_MAX) ||
-      toSkillId == colonyNetwork.getChildSkillId(domainSkillId, _toChildSkillIndex),
-      "funding-queue-bad-inheritence-to"
-    );
 
     proposalCount++;
     proposals[proposalCount] = Proposal(
@@ -151,7 +146,7 @@ contract FundingQueue is ColonyExtension, PatriciaTreeProofs {
       _fromPot,
       _toPot,
       _fromChildSkillIndex,
-      _toChildSkillIndex,
+      0, // Deprecated _toChildSkillIndex
       _totalRequested,
       0,
       block.timestamp,
@@ -306,7 +301,6 @@ contract FundingQueue is ColonyExtension, PatriciaTreeProofs {
     colony.moveFundsBetweenPots(
         proposal.domainId,
         proposal.fromChildSkillIndex,
-        proposal.toChildSkillIndex,
         proposal.fromPot,
         proposal.toPot,
         actualFundingToTransfer,

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -37,7 +37,7 @@ contract OneTxPayment is ColonyExtension {
 
   /// @notice Returns the version of the extension
   function version() public override pure returns (uint256) {
-    return 1;
+    return 2;
   }
 
   /// @notice Configures the extension
@@ -97,7 +97,7 @@ contract OneTxPayment is ColonyExtension {
       uint256 paymentId = colony.addPayment(1, _childSkillIndex, _workers[0], _tokens[0], _amounts[0], _domainId, _skillId);
       uint256 fundingPotId = colony.getPayment(paymentId).fundingPotId;
 
-      colony.moveFundsBetweenPots(1, UINT256_MAX, _childSkillIndex, 1, fundingPotId, _amounts[0], _tokens[0]);
+      colony.moveFundsBetweenPots(1, UINT256_MAX, 1, fundingPotId, _amounts[0], _tokens[0]);
 
       colony.finalizePayment(1, _childSkillIndex, paymentId);
       colony.claimPayment(paymentId, _tokens[0]);
@@ -108,7 +108,7 @@ contract OneTxPayment is ColonyExtension {
       uint256 expenditureId = colony.makeExpenditure(1, _childSkillIndex, _domainId);
       uint256 fundingPotId = colony.getExpenditure(expenditureId).fundingPotId;
 
-      prepareFunding(_childSkillIndex, fundingPotId, _tokens, _amounts);
+      prepareFunding(fundingPotId, _tokens, _amounts);
 
       uint256 idx;
       uint256 slot;
@@ -258,11 +258,12 @@ contract OneTxPayment is ColonyExtension {
   }
 
   function prepareFunding(
-    uint256 _childSkillIndex,
     uint256 _fundingPotId,
     address[] memory _tokens,
     uint256[] memory _amounts
-  ) internal {
+  )
+    internal
+  {
     (
       uint256 uniqueTokensIdx,
       address[] memory uniqueTokens,
@@ -273,7 +274,6 @@ contract OneTxPayment is ColonyExtension {
       colony.moveFundsBetweenPots(
         1,
         UINT256_MAX,
-        _childSkillIndex,
         1,
         _fundingPotId,
         uniqueAmounts[i],
@@ -289,7 +289,9 @@ contract OneTxPayment is ColonyExtension {
     uint256 _fundingPotId,
     address[] memory _tokens,
     uint256[] memory _amounts
-  ) internal {
+  )
+    internal
+  {
     (
       uint256 uniqueTokensIdx,
       address[] memory uniqueTokens,
@@ -299,7 +301,6 @@ contract OneTxPayment is ColonyExtension {
     for (uint256 i; i < uniqueTokensIdx; i++) {
       colony.moveFundsBetweenPots(
         _permissionDomainId,
-        _childSkillIndex,
         _childSkillIndex,
         _domainPotId,
         _fundingPotId,
@@ -319,7 +320,7 @@ contract OneTxPayment is ColonyExtension {
   )
     internal
   {
-    colony.moveFundsBetweenPots(_permissionDomainId, _childSkillIndex, _childSkillIndex, _domainPotId, _fundingPotId, _amount, _token);
+    colony.moveFundsBetweenPots(_permissionDomainId, _childSkillIndex, _domainPotId, _fundingPotId, _amount, _token);
   }
 
   function finalizeAndClaim(uint256 _expenditureId, address payable[] memory  _workers, address[] memory _tokens) internal {

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -1141,6 +1141,23 @@ Move a given amount: `_amount` of `_token` funds from funding pot with id `_from
 |---|---|---|
 |_permissionDomainId|uint256|The domainId in which I have the permission to take this action
 |_fromChildSkillIndex|uint256|The child index in `_permissionDomainId` where we can find the domain for `_fromPotId`
+|_fromPot|uint256|
+|_toPot|uint256|
+|_amount|uint256|
+|_token|address|
+
+
+### `moveFundsBetweenPots`
+
+Move a given amount: `_amount` of `_token` funds from funding pot with id `_fromPot` to one with id `_toPot`.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_permissionDomainId|uint256|The domainId in which I have the permission to take this action
+|_fromChildSkillIndex|uint256|The child index in `_permissionDomainId` where we can find the domain for `_fromPotId`
 |_toChildSkillIndex|uint256|The child index in `_permissionDomainId` where we can find the domain for `_toPotId`
 |_fromPot|uint256|Funding pot id providing the funds
 |_toPot|uint256|Funding pot id receiving the funds

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -143,9 +143,9 @@ export async function setupFundedTask({
   const workerPayoutBN = new BN(workerPayout);
   const totalPayouts = managerPayoutBN.add(workerPayoutBN).add(evaluatorPayoutBN);
 
-  const childSkillIndex = await getChildSkillIndex(colonyNetwork, colony, 1, task.domainId);
   await colony.setFundingRole(1, UINT256_MAX, manager, 1, true);
-  await colony.moveFundsBetweenPots(1, UINT256_MAX, childSkillIndex, 1, task.fundingPotId, totalPayouts, tokenAddress, { from: manager });
+  const moveFundsBetweenPots = colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,address)"];
+  await moveFundsBetweenPots(1, UINT256_MAX, 1, task.fundingPotId, totalPayouts, tokenAddress, { from: manager });
   await colony.setAllTaskPayouts(taskId, tokenAddress, managerPayout, evaluatorPayout, workerPayout, { from: manager });
   await assignRoles({ colony, taskId, manager, evaluator, worker });
 

--- a/test/contracts-network/colony-arbitrary-transactions.js
+++ b/test/contracts-network/colony-arbitrary-transactions.js
@@ -74,8 +74,8 @@ contract("Colony Arbitrary Transactions", (accounts) => {
     await fundColonyWithTokens(colony, token, 100);
     const action1 = await encodeTxData(token, "approve", [USER0, 50]);
     await colony.makeArbitraryTransaction(token.address, action1);
-    await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 50, token.address);
-    await checkErrorRevert(colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 50, token.address), "colony-funding-too-many-approvals");
+    await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 50, token.address);
+    await checkErrorRevert(colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 50, token.address), "colony-funding-too-many-approvals");
     const approval = await colony.getTokenApproval(token.address, USER0);
     expect(approval).to.be.eq.BN(50);
     const allApprovals = await colony.getTotalTokenApproval(token.address);
@@ -94,8 +94,8 @@ contract("Colony Arbitrary Transactions", (accounts) => {
     expect(approval).to.eq.BN(20);
     let allApprovals = await colony.getTotalTokenApproval(token.address);
     expect(allApprovals).to.eq.BN(20);
-    await checkErrorRevert(colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 81, token.address), "colony-funding-too-many-approvals");
-    await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 80, token.address);
+    await checkErrorRevert(colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 81, token.address), "colony-funding-too-many-approvals");
+    await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 80, token.address);
     // Pot still thinks it has 20 tokens in it
     let potBalance = await colony.getFundingPotBalance(1, token.address);
     expect(potBalance).to.eq.BN(20);

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -290,7 +290,7 @@ contract("Colony Expenditure", (accounts) => {
       await checkErrorRevert(colony.finalizeExpenditure(expenditureId, { from: ADMIN }), "colony-expenditure-not-funded");
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
 
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
     });
@@ -319,7 +319,7 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -338,8 +338,8 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayout(expenditureId, SLOT0, otherToken.address, WAD, { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, otherToken.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const tokenBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -357,7 +357,7 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
       await colony.claimExpenditurePayout(expenditureId, SLOT0, token.address);
 
@@ -371,7 +371,7 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayoutModifier(1, UINT256_MAX, expenditureId, SLOT0, WAD.neg());
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const balanceBefore = await colony.getFundingPotBalance(domain1.fundingPotId, token.address);
@@ -391,7 +391,7 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayoutModifier(1, UINT256_MAX, expenditureId, SLOT0, WAD.divn(3).neg()); // 2/3 payout
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const balanceBefore = await colony.getFundingPotBalance(domain1.fundingPotId, token.address);
@@ -411,7 +411,7 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditureSkill(expenditureId, SLOT0, GLOBAL_SKILL_ID, { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
       await colony.claimExpenditurePayout(expenditureId, SLOT0, token.address);
 
@@ -438,7 +438,7 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayoutModifier(1, UINT256_MAX, expenditureId, SLOT0, WAD.divn(2).neg());
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -465,7 +465,7 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayoutModifier(1, UINT256_MAX, expenditureId, SLOT0, WAD);
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -490,7 +490,7 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayoutModifier(1, UINT256_MAX, expenditureId, SLOT0, MAX_PAYOUT_MODIFIER);
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, MAX_PAYOUT, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, MAX_PAYOUT, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
       await colony.claimExpenditurePayout(expenditureId, SLOT0, token.address);
 
@@ -511,7 +511,7 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditureState(1, UINT256_MAX, expenditureId, EXPENDITURESLOTS_SLOT, [MAPPING, ARRAY], ["0x0", bn2bytes32(new BN(1))], day32);
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       await checkErrorRevert(colony.claimExpenditurePayout(expenditureId, SLOT0, token.address), "colony-expenditure-cannot-claim");
@@ -543,16 +543,16 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
 
       // Try to move funds back
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, expenditure.fundingPotId, domain1.fundingPotId, WAD, token.address),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, expenditure.fundingPotId, domain1.fundingPotId, WAD, token.address),
         "colony-funding-expenditure-bad-state"
       );
 
       await colony.cancelExpenditure(expenditureId, { from: ADMIN });
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, expenditure.fundingPotId, domain1.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, expenditure.fundingPotId, domain1.fundingPotId, WAD, token.address);
     });
   });
 

--- a/test/contracts-network/colony-funding.js
+++ b/test/contracts-network/colony-funding.js
@@ -86,7 +86,7 @@ contract("Colony Funding", (accounts) => {
       await fundColonyWithTokens(colony, otherToken, 100);
       const taskId = await makeTask({ colony });
       const task = await colony.getTask(taskId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 51, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, task.fundingPotId, 51, otherToken.address);
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
       const pot2Balance = await colony.getFundingPotBalance(2, otherToken.address);
@@ -98,7 +98,7 @@ contract("Colony Funding", (accounts) => {
     it("should not let tokens be moved between the same pot", async () => {
       await fundColonyWithTokens(colony, otherToken, 1);
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 1, 1, otherToken.address),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 1, 1, otherToken.address),
         "colony-funding-cannot-move-funds-between-the-same-pot"
       );
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
@@ -111,7 +111,7 @@ contract("Colony Funding", (accounts) => {
       const task = await colony.getTask(taskId);
 
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 0, task.fundingPotId, 1, otherToken.address),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 0, task.fundingPotId, 1, otherToken.address),
         "colony-funding-cannot-move-funds-from-rewards-pot"
       );
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
@@ -130,7 +130,7 @@ contract("Colony Funding", (accounts) => {
       const task = await colony.getTask(taskId);
 
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 51, otherToken.address, { from: WORKER }),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, task.fundingPotId, 51, otherToken.address, { from: WORKER }),
         "ds-auth-unauthorized"
       );
 
@@ -147,8 +147,8 @@ contract("Colony Funding", (accounts) => {
       await colony.addDomain(1, UINT256_MAX, 1);
       await colony.addDomain(1, UINT256_MAX, 1);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, 1, 2, 40, otherToken.address);
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 1, 2, 3, 50, otherToken.address), "ds-math-sub-underflow");
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 2, 40, otherToken.address);
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 2, 3, 50, otherToken.address), "ds-math-sub-underflow");
 
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
       const pot1Balance = await colony.getFundingPotBalance(1, otherToken.address);
@@ -208,7 +208,7 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 0, Payout 0
       // FundingPot was equal to payout, transition to pot being equal by changing pot (17)
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 0, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, task.fundingPotId, 0, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
@@ -227,13 +227,13 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot Balance: 0, Payout: 40
       // FundingPot was below payout, transition to being equal by increasing pot (1)
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 40, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, task.fundingPotId, 40, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot Balance: 40, Payout 40
       // FundingPot was equal to payout, transition to being above by increasing pot (5)
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 40, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, task.fundingPotId, 40, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
@@ -265,14 +265,14 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 80, Payout 40
       // FundingPot was above payout, transition to being equal by decreasing pot (11)
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 40, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, task.fundingPotId, 1, 40, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 40, Payout 40
       // FundingPot was equal to payout, transition to pot being below payout by changing pot (7)
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 20, otherToken.address),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, task.fundingPotId, 1, 20, otherToken.address),
         "colony-funding-task-bad-state"
       );
 
@@ -285,7 +285,7 @@ contract("Colony Funding", (accounts) => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 20],
       });
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 20, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, task.fundingPotId, 1, 20, otherToken.address);
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -297,14 +297,14 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 20, Payout 40
       // FundingPot was below payout, change to being above by changing pot (3)
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 60, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, task.fundingPotId, 60, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 80, Payout 40
       // FundingPot was above payout, change to being below by changing pot (9)
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 60, otherToken.address),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, task.fundingPotId, 1, 60, otherToken.address),
         "colony-funding-task-bad-state"
       );
 
@@ -317,7 +317,7 @@ contract("Colony Funding", (accounts) => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 20],
       });
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 60, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, task.fundingPotId, 1, 60, otherToken.address);
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -355,7 +355,7 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 20, Payout 5
       // FundingPot was above, change to being above by changing pot (15)
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 10, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, task.fundingPotId, 1, 10, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
@@ -388,7 +388,7 @@ contract("Colony Funding", (accounts) => {
       // FundingPot 10, Payout 30
       // FundingPot was below payout, change to being below by changing pot (13)
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 5, otherToken.address),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, task.fundingPotId, 1, 5, otherToken.address),
         "colony-funding-task-bad-state"
       );
 
@@ -401,7 +401,7 @@ contract("Colony Funding", (accounts) => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 5],
       });
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 5, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, task.fundingPotId, 1, 5, otherToken.address);
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -462,14 +462,14 @@ contract("Colony Funding", (accounts) => {
 
     it("should not allow contributions to nonexistent funding pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, UINT256_MAX, 3, 1, 5, 40, otherToken.address), "colony-funding-nonexistent-pot");
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 5, 40, otherToken.address), "colony-funding-nonexistent-pot");
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       expect(colonyPotBalance).to.eq.BN(99);
     });
 
     it("should not allow attempts to move funds from nonexistent funding pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 3, UINT256_MAX, 5, 1, 40, otherToken.address), "colony-funding-nonexistent-pot");
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, 3, 5, 1, 40, otherToken.address), "colony-funding-nonexistent-pot");
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       expect(colonyPotBalance).to.eq.BN(99);
     });
@@ -480,7 +480,7 @@ contract("Colony Funding", (accounts) => {
       const task = await colony.getTask(taskId);
 
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 40, otherToken.address),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, task.fundingPotId, 1, 40, otherToken.address),
         "colony-funding-task-bad-state"
       );
 
@@ -493,11 +493,11 @@ contract("Colony Funding", (accounts) => {
       const taskId = await setupFinalizedTask({ colonyNetwork, colony, token: otherToken });
 
       const task = await colony.getTask(taskId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 10, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, task.fundingPotId, 10, otherToken.address);
       await colony.claimTaskPayout(taskId, MANAGER_ROLE, otherToken.address);
       await colony.claimTaskPayout(taskId, WORKER_ROLE, otherToken.address);
       await colony.claimTaskPayout(taskId, EVALUATOR_ROLE, otherToken.address);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 10, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, task.fundingPotId, 1, 10, otherToken.address);
 
       const colonyPotBalance = await colony.getFundingPotBalance(2, otherToken.address);
       expect(colonyPotBalance).to.be.zero;
@@ -520,7 +520,7 @@ contract("Colony Funding", (accounts) => {
       const remainingPotBalance = await colony.getFundingPotBalance(task.fundingPotId, token.address);
       expect(remainingPotBalance).to.eq.BN(WORKER_PAYOUT);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, remainingPotBalance, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, task.fundingPotId, 1, remainingPotBalance, token.address);
 
       const potBalance = await colony.getFundingPotBalance(task.fundingPotId, token.address);
       expect(potBalance).to.be.zero;
@@ -570,7 +570,7 @@ contract("Colony Funding", (accounts) => {
       await colony.claimColonyFunds(ethers.constants.AddressZero);
       const taskId = await makeTask({ colony });
       const task = await colony.getTask(taskId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 51, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, task.fundingPotId, 51, ethers.constants.AddressZero);
       const colonyPotBalance = await colony.getFundingPotBalance(1, ethers.constants.AddressZero);
       const colonyEtherBalance = await web3GetBalance(colony.address);
       const pot2Balance = await colony.getFundingPotBalance(2, ethers.constants.AddressZero);
@@ -585,8 +585,8 @@ contract("Colony Funding", (accounts) => {
       await colony.addDomain(1, UINT256_MAX, 1);
       await colony.addDomain(1, UINT256_MAX, 1);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, 1, 2, 40, ethers.constants.AddressZero);
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 1, 2, 3, 50, ethers.constants.AddressZero), "ds-math-sub-underflow");
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 2, 40, ethers.constants.AddressZero);
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 2, 3, 50, ethers.constants.AddressZero), "ds-math-sub-underflow");
 
       const colonyEtherBalance = await web3GetBalance(colony.address);
       const pot1Balance = await colony.getFundingPotBalance(1, ethers.constants.AddressZero);
@@ -627,13 +627,13 @@ contract("Colony Funding", (accounts) => {
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
       // Fund the pot equal to manager payout 40 = 40
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 40, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, task.fundingPotId, 40, ethers.constants.AddressZero);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // Cannot bring pot balance below current payout
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 30, ethers.constants.AddressZero),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, task.fundingPotId, 1, 30, ethers.constants.AddressZero),
         "colony-funding-task-bad-state"
       );
 
@@ -650,18 +650,18 @@ contract("Colony Funding", (accounts) => {
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
       // Fund the pot equal to manager payout, plus 10, 50 < 60
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 20, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, task.fundingPotId, 20, ethers.constants.AddressZero);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // Cannot bring pot balance below current payout
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 30, ethers.constants.AddressZero),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, task.fundingPotId, 1, 30, ethers.constants.AddressZero),
         "colony-funding-task-bad-state"
       );
 
       // Can remove surplus 50 = 50
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 10, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, task.fundingPotId, 1, 10, ethers.constants.AddressZero);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
     });

--- a/test/contracts-network/colony-payment.js
+++ b/test/contracts-network/colony-payment.js
@@ -186,7 +186,7 @@ contract("Colony Payment", (accounts) => {
       expect(fundingPotPayoutForToken).to.eq.BN(WAD);
 
       await fundColonyWithTokens(colony, token, 40);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 40, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, payment.fundingPotId, 40, token.address);
       const fundingPotBalanceForToken = await colony.getFundingPotBalance(payment.fundingPotId, token.address);
       expect(fundingPotBalanceForToken).to.eq.BN(40);
     });
@@ -213,7 +213,7 @@ contract("Colony Payment", (accounts) => {
       paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
       await fundColonyWithTokens(colony, token, 40);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 40, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, payment.fundingPotId, 40, token.address);
     });
 
     it("can finalize payment when it is fully funded", async () => {
@@ -229,7 +229,7 @@ contract("Colony Payment", (accounts) => {
 
     it("cannnot finalize payment if it is NOT fully funded", async () => {
       const payment = await colony.getPayment(paymentId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, payment.fundingPotId, 1, 1, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, payment.fundingPotId, 1, 1, token.address);
       expect(payment.finalized).to.be.false;
 
       await checkErrorRevert(colony.finalizePayment(1, UINT256_MAX, paymentId), "colony-payment-not-funded");
@@ -275,7 +275,7 @@ contract("Colony Payment", (accounts) => {
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
       await colony.finalizePayment(1, UINT256_MAX, paymentId);
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -293,7 +293,7 @@ contract("Colony Payment", (accounts) => {
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
       await colony.finalizePayment(1, UINT256_MAX, paymentId);
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -311,7 +311,7 @@ contract("Colony Payment", (accounts) => {
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
       await colony.finalizePayment(1, UINT256_MAX, paymentId);
       await colony.claimPayment(paymentId, token.address);
 
@@ -324,7 +324,7 @@ contract("Colony Payment", (accounts) => {
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 9999, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, payment.fundingPotId, 9999, token.address);
       await checkErrorRevert(colony.claimPayment(paymentId, token.address), "colony-payment-not-finalized");
     });
 
@@ -338,11 +338,11 @@ contract("Colony Payment", (accounts) => {
       let fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(2);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 199, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, payment.fundingPotId, 199, token.address);
       fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(2);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, payment.fundingPotId, 100, otherToken.address);
       fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 

--- a/test/contracts-network/colony-reward-payouts.js
+++ b/test/contracts-network/colony-reward-payouts.js
@@ -193,7 +193,7 @@ contract("Colony Reward Payouts", (accounts) => {
       await colony.claimColonyFunds(token.address);
       // Move all of them in to the reward pot
       const amount = await colony.getFundingPotBalance(1, token.address);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, amount, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, amount, token.address);
 
       const tx1 = await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
       const payoutId1 = tx1.logs[0].args.rewardPayoutId;
@@ -259,7 +259,7 @@ contract("Colony Reward Payouts", (accounts) => {
       let { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
 
-      await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, newToken.address);
+      await newColony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, newToken.address);
 
       const { logs } = await newColony.startNextRewardPayout(newToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
@@ -294,7 +294,7 @@ contract("Colony Reward Payouts", (accounts) => {
       const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill);
       const { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
-      await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, newToken.address);
+      await newColony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, newToken.address);
 
       await checkErrorRevert(
         newColony.startNextRewardPayout(newToken.address, ...colonyWideReputationProof),
@@ -308,10 +308,10 @@ contract("Colony Reward Payouts", (accounts) => {
     });
 
     it("should be able to create parallel payouts of the same token", async () => {
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
     });
@@ -320,7 +320,7 @@ contract("Colony Reward Payouts", (accounts) => {
       const tx1 = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId1 = tx1.logs[0].args.rewardPayoutId;
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       const tx2 = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId2 = tx2.logs[0].args.rewardPayoutId;
@@ -335,7 +335,7 @@ contract("Colony Reward Payouts", (accounts) => {
       const payoutId1 = tx1.logs[0].args.rewardPayoutId;
       await forwardTime(SECONDS_PER_DAY * 60 + 1, this);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.finalizeRewardPayout(payoutId1);
 
       const tx2 = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
@@ -369,7 +369,7 @@ contract("Colony Reward Payouts", (accounts) => {
 
       await forwardTime(SECONDS_PER_DAY * 60 + 1, this);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.finalizeRewardPayout(payoutId1);
 
       const tx2 = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
@@ -414,7 +414,7 @@ contract("Colony Reward Payouts", (accounts) => {
       const { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
 
-      await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, newToken.address);
+      await newColony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, newToken.address);
 
       await checkErrorRevert(
         newColony.startNextRewardPayout(newToken.address, ...colonyWideReputationProof),
@@ -790,8 +790,8 @@ contract("Colony Reward Payouts", (accounts) => {
       await newToken.approve(tokenLocking.address, userReputation, { from: userAddress1 });
       await tokenLocking.methods["deposit(address,uint256,bool)"](newToken.address, userReputation, true, { from: userAddress1 });
 
-      await colony1.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
-      await colony2.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony1.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony2.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       ({ logs } = await colony1.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof1));
       const payoutId1 = logs[0].args.rewardPayoutId;
@@ -895,7 +895,7 @@ contract("Colony Reward Payouts", (accounts) => {
         await tokenLocking.methods["deposit(address,uint256,bool)"](newToken.address, tokensPerUser, true, { from: userAddress3 });
         await forwardTime(1, this);
 
-        await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, payoutToken.address);
+        await newColony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, payoutToken.address);
 
         const { logs } = await newColony.startNextRewardPayout(payoutToken.address, ...colonyWideReputationProof);
         const payoutId = logs[0].args.rewardPayoutId;

--- a/test/contracts-network/colony-staking.js
+++ b/test/contracts-network/colony-staking.js
@@ -41,7 +41,7 @@ contract("Colony Staking", (accounts) => {
     await colony.setExpenditureRecipient(1, 1, USER1);
 
     await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-    await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 3, WAD.muln(200), token.address);
+    await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 3, WAD.muln(200), token.address);
     await colony.setExpenditurePayout(1, 0, token.address, WAD.muln(100));
     await colony.setExpenditurePayout(1, 1, token.address, WAD.muln(100));
 

--- a/test/contracts-network/colony-task.js
+++ b/test/contracts-network/colony-task.js
@@ -1355,12 +1355,12 @@ contract("ColonyTask", (accounts) => {
       // but we need some Ether, too
       await colony.send(101);
       await colony.claimColonyFunds(ethers.constants.AddressZero);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domainPotId, taskPotId, 100, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, domainPotId, taskPotId, 100, ethers.constants.AddressZero);
 
       // And another token
       await otherToken.mint(colony.address, 101);
       await colony.claimColonyFunds(otherToken.address);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domainPotId, taskPotId, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, domainPotId, taskPotId, 100, otherToken.address);
 
       // Keep track of original Ether balance in funding pots
       const originalDomainEtherBalance = await colony.getFundingPotBalance(domainPotId, ethers.constants.AddressZero);
@@ -1382,9 +1382,9 @@ contract("ColonyTask", (accounts) => {
         args: [taskId],
       });
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, taskPotId, domainPotId, originalTaskEtherBalance, ethers.constants.AddressZero);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, taskPotId, domainPotId, originalTaskTokenBalance, token.address);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, taskPotId, domainPotId, originalTaskOtherTokenBalance, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, taskPotId, domainPotId, originalTaskEtherBalance, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, taskPotId, domainPotId, originalTaskTokenBalance, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, taskPotId, domainPotId, originalTaskOtherTokenBalance, otherToken.address);
 
       const cancelledTaskEtherBalance = await colony.getFundingPotBalance(taskPotId, ethers.constants.AddressZero);
       const cancelledDomainEtherBalance = await colony.getFundingPotBalance(domainPotId, ethers.constants.AddressZero);

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -351,7 +351,7 @@ contract("Colony", (accounts) => {
 
     it("cannot burn more tokens than are in the root funding pot", async () => {
       const amount = await colony.getFundingPotBalance(1, token.address);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, amount.divn(2), token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, amount.divn(2), token.address);
 
       await checkErrorRevert(colony.burnTokens(token.address, amount), "colony-not-enough-tokens");
     });

--- a/test/contracts-network/reputation-update.js
+++ b/test/contracts-network/reputation-update.js
@@ -367,7 +367,7 @@ contract("Reputation Updates", (accounts) => {
       const domain1 = await metaColony.getDomain(1);
 
       const expenditure = await metaColony.getExpenditure(expenditureId);
-      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, clnyToken.address);
+      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, clnyToken.address);
       await metaColony.finalizeExpenditure(expenditureId);
       await metaColony.claimExpenditurePayout(expenditureId, SLOT0, clnyToken.address);
 
@@ -382,7 +382,7 @@ contract("Reputation Updates", (accounts) => {
       const paymentId = await metaColony.getPaymentCount();
 
       const payment = await metaColony.getPayment(paymentId);
-      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), clnyToken.address);
+      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), clnyToken.address);
       await metaColony.finalizePayment(1, UINT256_MAX, paymentId);
       await metaColony.claimPayment(paymentId, clnyToken.address);
 
@@ -412,7 +412,7 @@ contract("Reputation Updates", (accounts) => {
       const paymentId = await metaColony.getPaymentCount();
 
       const payment = await metaColony.getPayment(paymentId);
-      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), otherToken.address);
+      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), otherToken.address);
       await metaColony.finalizePayment(1, UINT256_MAX, paymentId);
       await metaColony.claimPayment(paymentId, otherToken.address);
 

--- a/test/contracts-network/token-locking.js
+++ b/test/contracts-network/token-locking.js
@@ -145,7 +145,7 @@ contract("Token Locking", (addresses) => {
 
     it("should not be able to deposit tokens while they are locked", async () => {
       await fundColonyWithTokens(colony, token);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, token.address);
       await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
 
       await checkErrorRevert(
@@ -164,7 +164,7 @@ contract("Token Locking", (addresses) => {
 
     it("should be able to send tokens directly to the user if they are locked", async () => {
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
 
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
@@ -224,7 +224,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       await checkErrorRevert(
         tokenLocking.methods["withdraw(address,uint256,bool)"](token.address, usersTokens, false, { from: userAddress }),
@@ -236,7 +236,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       await tokenLocking.methods["withdraw(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
     });
@@ -245,7 +245,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
       const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
       await tokenLocking.incrementLockCounterTo(token.address, payoutId, { from: userAddress });
@@ -271,7 +271,7 @@ contract("Token Locking", (addresses) => {
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
 
       await fundColonyWithTokens(colony, token);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, token.address);
       await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
       await tokenLocking.transfer(token.address, usersTokens, otherUserAddress, true, { from: userAddress });
 
@@ -284,7 +284,7 @@ contract("Token Locking", (addresses) => {
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
 
       await fundColonyWithTokens(colony, token);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, token.address);
       await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
 
       await checkErrorRevert(
@@ -298,7 +298,7 @@ contract("Token Locking", (addresses) => {
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
 
       await fundColonyWithTokens(colony, token);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, token.address);
       await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
 
       await tokenLocking.transfer(token.address, usersTokens, otherUserAddress, true, { from: userAddress });
@@ -387,7 +387,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
       const tx = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       await expectEvent(tx, "TokenLocked(address indexed,address indexed,uint256)", [token.address, colony.address, 1]);
     });
@@ -396,7 +396,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const totalLockCount = await tokenLocking.getTotalLockCount(token.address);
       expect(totalLockCount).to.eq.BN(1);
@@ -406,7 +406,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
       const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
 
@@ -417,7 +417,7 @@ contract("Token Locking", (addresses) => {
 
     it("should not be able to waive to id that does not exist", async () => {
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       await checkErrorRevert(tokenLocking.incrementLockCounterTo(token.address, 10, { from: userAddress }), "colony-token-locking-invalid-lock-id");
     });
@@ -432,7 +432,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
       const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
       await checkErrorRevert(
@@ -445,9 +445,9 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
 
       const totalLockCount = await tokenLocking.getTotalLockCount(token.address);

--- a/test/extensions/funding-queue.js
+++ b/test/extensions/funding-queue.js
@@ -241,7 +241,6 @@ contract("Funding Queues", (accounts) => {
 
     it("cannot create a basic proposal with bad inheritence", async () => {
       await checkErrorRevert(fundingQueue.createProposal(1, 0, 1, 1, 3, WAD, token.address, { from: USER0 }), "funding-queue-bad-inheritence-from");
-      await checkErrorRevert(fundingQueue.createProposal(1, 1, 0, 3, 1, WAD, token.address, { from: USER0 }), "funding-queue-bad-inheritence-to");
     });
 
     it("can stake a proposal", async () => {
@@ -851,7 +850,7 @@ contract("Funding Queues", (accounts) => {
       await colony.setFundingRole(1, 0, fundingQueue.address, 2, true);
       await colony.addDomain(1, 0, 2);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, 1, 2, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 2, WAD, token.address);
 
       await fundingQueue.createProposal(2, UINT256_MAX, 0, 2, 4, WAD, token.address, { from: USER0 });
       proposalId = await fundingQueue.getProposalCount();

--- a/test/reputation-system/dispute-resolution-misbehaviour.js
+++ b/test/reputation-system/dispute-resolution-misbehaviour.js
@@ -309,7 +309,7 @@ contract("Reputation Mining - disputes resolution misbehaviour", (accounts) => {
         await metaColony.addPayment(1, UINT256_MAX, accountsForTest[i], clnyToken.address, 40, 1, 0);
         const paymentId = await metaColony.getPaymentCount();
         const payment = await metaColony.getPayment(paymentId);
-        await metaColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, INITIAL_FUNDING, clnyToken.address);
+        await metaColony.moveFundsBetweenPots(1, UINT256_MAX, 1, payment.fundingPotId, INITIAL_FUNDING, clnyToken.address);
         await metaColony.finalizePayment(1, UINT256_MAX, paymentId);
 
         // These have to be done sequentially because this function uses the total number of tasks as a proxy for getting the

--- a/test/reputation-system/root-hash-submissions.js
+++ b/test/reputation-system/root-hash-submissions.js
@@ -771,7 +771,7 @@ contract("Reputation mining - root hash submissions", (accounts) => {
       await metaColony.claimColonyFunds(clnyToken.address);
       // Move all of them in to the reward pot
       const amount = await metaColony.getFundingPotBalance(1, clnyToken.address);
-      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, amount, clnyToken.address);
+      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, amount, clnyToken.address);
 
       const result = await metaColony.getDomain(1);
       const rootDomainSkill = result.skillId;


### PR DESCRIPTION
Reduce the requirement that the `toPot` is in the subtree in which the caller has the `funding` permission. Now, only the source of funds must be in the permitted subtree. In practice, this means that users can now transfer funds "up" the domain tree, all the way up to the root, regardless of the domain in which they hold the permission. This also means that users can now transfer funds to arbitrarily remote domains, even very specific ones, without having the inherited permission in that domain. The main downside (or is it a feature?) here is that now funds may arrive in a domain without anyone in that domain's inheritance path having had anything to do with it.