### PR TITLE
Permission moveFundsBetweenPots properly for voting

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -467,6 +467,10 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
 
     sig = bytes4(keccak256("setUserRoles(uint256,uint256,address,uint256,bytes32)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
+
+    sig = bytes4(keccak256("moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Funding), address(this), sig, true);
+
   }
 
   function checkNotAdditionalProtectedVariable(uint256 _slot) public view recovery {

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -113,7 +113,6 @@ contract ColonyAuthority is CommonAuthority {
 
     // Added in colony v6 (d-lwss)
     addRoleCapability(FUNDING_ROLE, "moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)");
-
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -110,6 +110,10 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ROOT_ROLE, "editColony(string)");
     addRoleCapability(ROOT_ROLE, "burnTokens(address,uint256)");
     addRoleCapability(ROOT_ROLE, "unlockToken()");
+
+    // Added in colony v6 (d-lwss)
+    addRoleCapability(FUNDING_ROLE, "moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)");
+
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -205,6 +205,27 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     return (fundingPot.associatedType, fundingPot.associatedTypeId, fundingPot.payoutsWeCannotMake);
   }
 
+ function moveFundsBetweenPots(
+    uint256 _permissionDomainId,
+    uint256 _childSkillIndex,
+    uint256 _domainId,
+    uint256 _fromChildSkillIndex,
+    uint256 _toChildSkillIndex,
+    uint256 _fromPot,
+    uint256 _toPot,
+    uint256 _amount,
+    address _token
+  )
+  public
+  stoppable
+  authDomain(_permissionDomainId, _childSkillIndex, _domainId)
+  authDomain(_domainId, _fromChildSkillIndex, getDomainFromFundingPot(_fromPot))
+  authDomain(_domainId, _toChildSkillIndex, getDomainFromFundingPot(_toPot))
+  validFundingTransfer(_fromPot, _toPot)
+  {
+    moveFundsBetweenPotsFunctionality(_fromPot, _toPot, _amount, _token);
+  }
+
   function moveFundsBetweenPots(
     uint256 _permissionDomainId,
     uint256 _fromChildSkillIndex,
@@ -220,6 +241,16 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
   authDomain(_permissionDomainId, _toChildSkillIndex, getDomainFromFundingPot(_toPot))
   validFundingTransfer(_fromPot, _toPot)
   {
+    moveFundsBetweenPotsFunctionality(_fromPot, _toPot, _amount, _token);
+  }
+
+  function moveFundsBetweenPotsFunctionality(
+    uint256 _fromPot,
+    uint256 _toPot,
+    uint256 _amount,
+    address _token
+  )
+  internal {
     FundingPot storage fromPot = fundingPots[_fromPot];
     FundingPot storage toPot = fundingPots[_toPot];
 

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -219,10 +219,11 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
   public
   stoppable
   authDomain(_permissionDomainId, _childSkillIndex, _domainId)
-  authDomain(_domainId, _fromChildSkillIndex, getDomainFromFundingPot(_fromPot))
-  authDomain(_domainId, _toChildSkillIndex, getDomainFromFundingPot(_toPot))
   validFundingTransfer(_fromPot, _toPot)
   {
+    require(validateDomainInheritance(_domainId, _fromChildSkillIndex, getDomainFromFundingPot(_fromPot)), "colony-invalid-domain-inheritence");
+    require(validateDomainInheritance(_domainId, _toChildSkillIndex, getDomainFromFundingPot(_toPot)), "colony-invalid-domain-inheritence");
+
     moveFundsBetweenPotsFunctionality(_fromPot, _toPot, _amount, _token);
   }
 

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -857,6 +857,30 @@ interface IColony is ColonyDataTypes, IRecovery {
 
   /// @notice Move a given amount: `_amount` of `_token` funds from funding pot with id `_fromPot` to one with id `_toPot`.
   /// @param _permissionDomainId The domainId in which I have the permission to take this action
+  /// @param _childSkillIndex The child index in _permissionDomainId where I will be taking this action
+  /// @param _domainId The domain where I am taking this action, pointed to by _permissionDomainId and _childSkillIndex
+  /// @param _fromChildSkillIndex In the array of child skills for the skill associated with the domain pointed to by _permissionDomainId + _childSkillIndex,
+  ///         the index of the skill associated with the domain that contains _fromPot
+  /// @param _toChildSkillIndex The same, but for the _toPot which the funds are being moved to
+  /// @param _fromPot Funding pot id providing the funds
+  /// @param _toPot Funding pot id receiving the funds
+  /// @param _amount Amount of funds
+  /// @param _token Address of the token, `0x0` value indicates Ether
+  function moveFundsBetweenPots(
+    uint256 _permissionDomainId,
+    uint256 _childSkillIndex,
+    uint256 _domainId,
+    uint256 _fromChildSkillIndex,
+    uint256 _toChildSkillIndex,
+    uint256 _fromPot,
+    uint256 _toPot,
+    uint256 _amount,
+    address _token
+    ) external;
+
+  /// @notice DEPRECATED
+  /// @notice Move a given amount: `_amount` of `_token` funds from funding pot with id `_fromPot` to one with id `_toPot`.
+  /// @param _permissionDomainId The domainId in which I have the permission to take this action
   /// @param _fromChildSkillIndex The child index in `_permissionDomainId` where we can find the domain for `_fromPotId`
   /// @param _toChildSkillIndex The child index in `_permissionDomainId` where we can find the domain for `_toPotId`
   /// @param _fromPot Funding pot id providing the funds

--- a/contracts/extensions/VotingReputation.sol
+++ b/contracts/extensions/VotingReputation.sol
@@ -975,17 +975,6 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs {
     return colonyNetwork.getChildSkillId(permissionSkillId, childSkillIndex);
   }
 
-  function getActionPermissionSkillId(bytes memory _action) internal view returns (uint256) {
-    uint256 permissionDomainId;
-
-    assembly {
-      permissionDomainId := mload(add(_action, 0x24))
-    }
-
-    uint256 permissionSkillId = colony.getDomain(permissionDomainId).skillId;
-    return permissionSkillId;
-  }
-
   function executeCall(uint256 motionId, bytes memory action) internal returns (bool success) {
     address to = getTarget(motions[motionId].altTarget);
 

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -1140,12 +1140,32 @@ Move a given amount: `_amount` of `_token` funds from funding pot with id `_from
 |Name|Type|Description|
 |---|---|---|
 |_permissionDomainId|uint256|The domainId in which I have the permission to take this action
-|_fromChildSkillIndex|uint256|The child index in `_permissionDomainId` where we can find the domain for `_fromPotId`
-|_toChildSkillIndex|uint256|The child index in `_permissionDomainId` where we can find the domain for `_toPotId`
+|_childSkillIndex|uint256|The child index in _permissionDomainId where I will be taking this action
+|_domainId|uint256|The domain where I am taking this action, pointed to by _permissionDomainId and _childSkillIndex
+|_fromChildSkillIndex|uint256|In the array of child skills for the skill associated with the domain pointed to by _permissionDomainId + _childSkillIndex,         the index of the skill associated with the domain that contains _fromPot
+|_toChildSkillIndex|uint256|The same, but for the _toPot which the funds are being moved to
 |_fromPot|uint256|Funding pot id providing the funds
 |_toPot|uint256|Funding pot id receiving the funds
 |_amount|uint256|Amount of funds
 |_token|address|Address of the token, `0x0` value indicates Ether
+
+
+### `moveFundsBetweenPots`
+
+Move a given amount: `_amount` of `_token` funds from funding pot with id `_fromPot` to one with id `_toPot`.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_permissionDomainId|uint256|The domainId in which I have the permission to take this action
+|_fromChildSkillIndex|uint256|
+|_toChildSkillIndex|uint256|
+|_fromPot|uint256|
+|_toPot|uint256|
+|_amount|uint256|
+|_token|address|
 
 
 ### `obligateStake`

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -144,10 +144,10 @@ export async function setupFundedTask({
   const totalPayouts = managerPayoutBN.add(workerPayoutBN).add(evaluatorPayoutBN);
 
   const childSkillIndex = await getChildSkillIndex(colonyNetwork, colony, 1, task.domainId);
+  const moveFundsBetweenPots = colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)"];
+
   await colony.setFundingRole(1, UINT256_MAX, manager, 1, true);
-  await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, childSkillIndex, 1, task.fundingPotId, totalPayouts, tokenAddress, {
-    from: manager,
-  });
+  await moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, childSkillIndex, 1, task.fundingPotId, totalPayouts, tokenAddress, { from: manager });
   await colony.setAllTaskPayouts(taskId, tokenAddress, managerPayout, evaluatorPayout, workerPayout, { from: manager });
   await assignRoles({ colony, taskId, manager, evaluator, worker });
 

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -145,7 +145,9 @@ export async function setupFundedTask({
 
   const childSkillIndex = await getChildSkillIndex(colonyNetwork, colony, 1, task.domainId);
   await colony.setFundingRole(1, UINT256_MAX, manager, 1, true);
-  await colony.moveFundsBetweenPots(1, UINT256_MAX, childSkillIndex, 1, task.fundingPotId, totalPayouts, tokenAddress, { from: manager });
+  await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, childSkillIndex, 1, task.fundingPotId, totalPayouts, tokenAddress, {
+    from: manager,
+  });
   await colony.setAllTaskPayouts(taskId, tokenAddress, managerPayout, evaluatorPayout, workerPayout, { from: manager });
   await assignRoles({ colony, taskId, manager, evaluator, worker });
 

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,11 +154,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("fba87fb21ad92181a0293eb6ebea6534e3ffdbf4aadeea738760fb4cdd2f4495");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("b72949c9bec989c65b9afed3eaf23706f48e12a01a45d9d0a5a5490180461f81");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("4eac8ccffe8b2eebb1da321e5544c8334005fe0e9afbaa1a4d654abf14515ede");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("f7ce25312c171119867cd296607295d7a781cfb87fc6088c09787919b3ff3b25");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("621840deab018bf9f7bb35d60a503c0d2abfb4b0e5bc6ae72a7c4d9a6870e680");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("aedd2a128409247f2d2a5cfe3140b863fdbf53eb1879936919c0a7be1a4d3c4f");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("76a5c2ea62ee88ed3992e3278cdbb821da482b4d5c3f40ed79ed4f3ee530520f");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("6bee0085d000fc929e06c1281c162eaa7ac22ff9e2dcc520066e5e7720de6394");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("bcfee6939c375d042704e338652a1e2d1e6f7b0e69587b79e72bde08ca777927");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("8b9242eb6e0fd017538f71e90c6ce9793839743e869bed54030861d3594453b1");
     });
   });
 });

--- a/test/contracts-network/colony-arbitrary-transactions.js
+++ b/test/contracts-network/colony-arbitrary-transactions.js
@@ -74,8 +74,11 @@ contract("Colony Arbitrary Transactions", (accounts) => {
     await fundColonyWithTokens(colony, token, 100);
     const action1 = await encodeTxData(token, "approve", [USER0, 50]);
     await colony.makeArbitraryTransaction(token.address, action1);
-    await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 50, token.address);
-    await checkErrorRevert(colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 50, token.address), "colony-funding-too-many-approvals");
+    await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 50, token.address);
+    await checkErrorRevert(
+      colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 50, token.address),
+      "colony-funding-too-many-approvals"
+    );
     const approval = await colony.getTokenApproval(token.address, USER0);
     expect(approval).to.be.eq.BN(50);
     const allApprovals = await colony.getTotalTokenApproval(token.address);
@@ -94,8 +97,11 @@ contract("Colony Arbitrary Transactions", (accounts) => {
     expect(approval).to.eq.BN(20);
     let allApprovals = await colony.getTotalTokenApproval(token.address);
     expect(allApprovals).to.eq.BN(20);
-    await checkErrorRevert(colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 81, token.address), "colony-funding-too-many-approvals");
-    await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 80, token.address);
+    await checkErrorRevert(
+      colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 81, token.address),
+      "colony-funding-too-many-approvals"
+    );
+    await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 80, token.address);
     // Pot still thinks it has 20 tokens in it
     let potBalance = await colony.getFundingPotBalance(1, token.address);
     expect(potBalance).to.eq.BN(20);

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -290,7 +290,17 @@ contract("Colony Expenditure", (accounts) => {
       await checkErrorRevert(colony.finalizeExpenditure(expenditureId, { from: ADMIN }), "colony-expenditure-not-funded");
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD,
+        token.address
+      );
 
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
     });
@@ -319,7 +329,17 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD,
+        token.address
+      );
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -338,8 +358,28 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayout(expenditureId, SLOT0, otherToken.address, WAD, { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, otherToken.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD,
+        token.address
+      );
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD,
+        otherToken.address
+      );
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const tokenBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -357,7 +397,17 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD,
+        token.address
+      );
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
       await colony.claimExpenditurePayout(expenditureId, SLOT0, token.address);
 
@@ -371,7 +421,17 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayoutModifier(1, UINT256_MAX, expenditureId, SLOT0, WAD.neg());
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD,
+        token.address
+      );
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const balanceBefore = await colony.getFundingPotBalance(domain1.fundingPotId, token.address);
@@ -391,7 +451,17 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayoutModifier(1, UINT256_MAX, expenditureId, SLOT0, WAD.divn(3).neg()); // 2/3 payout
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD,
+        token.address
+      );
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const balanceBefore = await colony.getFundingPotBalance(domain1.fundingPotId, token.address);
@@ -411,7 +481,17 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditureSkill(expenditureId, SLOT0, GLOBAL_SKILL_ID, { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD,
+        token.address
+      );
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
       await colony.claimExpenditurePayout(expenditureId, SLOT0, token.address);
 
@@ -438,7 +518,17 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayoutModifier(1, UINT256_MAX, expenditureId, SLOT0, WAD.divn(2).neg());
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD,
+        token.address
+      );
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -465,7 +555,17 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayoutModifier(1, UINT256_MAX, expenditureId, SLOT0, WAD);
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD,
+        token.address
+      );
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -490,7 +590,17 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayoutModifier(1, UINT256_MAX, expenditureId, SLOT0, MAX_PAYOUT_MODIFIER);
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, MAX_PAYOUT, token.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        MAX_PAYOUT,
+        token.address
+      );
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
       await colony.claimExpenditurePayout(expenditureId, SLOT0, token.address);
 
@@ -511,7 +621,17 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditureState(1, UINT256_MAX, expenditureId, EXPENDITURESLOTS_SLOT, [MAPPING, ARRAY], ["0x0", bn2bytes32(new BN(1))], day32);
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD,
+        token.address
+      );
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       await checkErrorRevert(colony.claimExpenditurePayout(expenditureId, SLOT0, token.address), "colony-expenditure-cannot-claim");
@@ -543,16 +663,36 @@ contract("Colony Expenditure", (accounts) => {
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD,
+        token.address
+      );
 
       // Try to move funds back
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, expenditure.fundingPotId, domain1.fundingPotId, WAD, token.address),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, expenditure.fundingPotId, domain1.fundingPotId, WAD, token.address),
         "colony-funding-expenditure-bad-state"
       );
 
       await colony.cancelExpenditure(expenditureId, { from: ADMIN });
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, expenditure.fundingPotId, domain1.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        expenditure.fundingPotId,
+        domain1.fundingPotId,
+        WAD,
+        token.address
+      );
     });
   });
 

--- a/test/contracts-network/colony-funding.js
+++ b/test/contracts-network/colony-funding.js
@@ -148,8 +148,9 @@ contract("Colony Funding", (accounts) => {
       const taskId = await makeTask({ colony });
       const task = await colony.getTask(taskId);
 
+      const moveFundsBetweenPots = colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)"];
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 51, otherToken.address, { from: WORKER }),
+        moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 51, otherToken.address, { from: WORKER }),
         "ds-auth-unauthorized"
       );
 

--- a/test/contracts-network/colony-funding.js
+++ b/test/contracts-network/colony-funding.js
@@ -86,7 +86,7 @@ contract("Colony Funding", (accounts) => {
       await fundColonyWithTokens(colony, otherToken, 100);
       const taskId = await makeTask({ colony });
       const task = await colony.getTask(taskId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 51, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 51, otherToken.address);
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
       const pot2Balance = await colony.getFundingPotBalance(2, otherToken.address);
@@ -98,7 +98,7 @@ contract("Colony Funding", (accounts) => {
     it("should not let tokens be moved between the same pot", async () => {
       await fundColonyWithTokens(colony, otherToken, 1);
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 1, 1, otherToken.address),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 1, 1, otherToken.address),
         "colony-funding-cannot-move-funds-between-the-same-pot"
       );
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
@@ -111,7 +111,7 @@ contract("Colony Funding", (accounts) => {
       const task = await colony.getTask(taskId);
 
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 0, task.fundingPotId, 1, otherToken.address),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 0, task.fundingPotId, 1, otherToken.address),
         "colony-funding-cannot-move-funds-from-rewards-pot"
       );
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
@@ -130,7 +130,7 @@ contract("Colony Funding", (accounts) => {
       const task = await colony.getTask(taskId);
 
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 51, otherToken.address, { from: WORKER }),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 51, otherToken.address, { from: WORKER }),
         "ds-auth-unauthorized"
       );
 
@@ -208,7 +208,7 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 0, Payout 0
       // FundingPot was equal to payout, transition to pot being equal by changing pot (17)
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 0, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 0, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
@@ -227,13 +227,13 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot Balance: 0, Payout: 40
       // FundingPot was below payout, transition to being equal by increasing pot (1)
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 40, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 40, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot Balance: 40, Payout 40
       // FundingPot was equal to payout, transition to being above by increasing pot (5)
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 40, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 40, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
@@ -265,14 +265,14 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 80, Payout 40
       // FundingPot was above payout, transition to being equal by decreasing pot (11)
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 40, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 40, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 40, Payout 40
       // FundingPot was equal to payout, transition to pot being below payout by changing pot (7)
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 20, otherToken.address),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 20, otherToken.address),
         "colony-funding-task-bad-state"
       );
 
@@ -285,7 +285,7 @@ contract("Colony Funding", (accounts) => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 20],
       });
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 20, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 20, otherToken.address);
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -297,14 +297,14 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 20, Payout 40
       // FundingPot was below payout, change to being above by changing pot (3)
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 60, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 60, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // FundingPot 80, Payout 40
       // FundingPot was above payout, change to being below by changing pot (9)
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 60, otherToken.address),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 60, otherToken.address),
         "colony-funding-task-bad-state"
       );
 
@@ -317,7 +317,7 @@ contract("Colony Funding", (accounts) => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 20],
       });
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 60, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 60, otherToken.address);
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -355,7 +355,7 @@ contract("Colony Funding", (accounts) => {
 
       // FundingPot 20, Payout 5
       // FundingPot was above, change to being above by changing pot (15)
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 10, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 10, otherToken.address);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
@@ -388,7 +388,7 @@ contract("Colony Funding", (accounts) => {
       // FundingPot 10, Payout 30
       // FundingPot was below payout, change to being below by changing pot (13)
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 5, otherToken.address),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 5, otherToken.address),
         "colony-funding-task-bad-state"
       );
 
@@ -401,7 +401,7 @@ contract("Colony Funding", (accounts) => {
         sigTypes: [0],
         args: [taskId, otherToken.address, 5],
       });
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 5, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 5, otherToken.address);
       await executeSignedTaskChange({
         colony,
         taskId,
@@ -480,7 +480,7 @@ contract("Colony Funding", (accounts) => {
       const task = await colony.getTask(taskId);
 
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 40, otherToken.address),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 40, otherToken.address),
         "colony-funding-task-bad-state"
       );
 
@@ -493,11 +493,11 @@ contract("Colony Funding", (accounts) => {
       const taskId = await setupFinalizedTask({ colonyNetwork, colony, token: otherToken });
 
       const task = await colony.getTask(taskId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 10, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 10, otherToken.address);
       await colony.claimTaskPayout(taskId, MANAGER_ROLE, otherToken.address);
       await colony.claimTaskPayout(taskId, WORKER_ROLE, otherToken.address);
       await colony.claimTaskPayout(taskId, EVALUATOR_ROLE, otherToken.address);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 10, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 10, otherToken.address);
 
       const colonyPotBalance = await colony.getFundingPotBalance(2, otherToken.address);
       expect(colonyPotBalance).to.be.zero;
@@ -520,7 +520,7 @@ contract("Colony Funding", (accounts) => {
       const remainingPotBalance = await colony.getFundingPotBalance(task.fundingPotId, token.address);
       expect(remainingPotBalance).to.eq.BN(WORKER_PAYOUT);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, remainingPotBalance, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, remainingPotBalance, token.address);
 
       const potBalance = await colony.getFundingPotBalance(task.fundingPotId, token.address);
       expect(potBalance).to.be.zero;
@@ -570,7 +570,7 @@ contract("Colony Funding", (accounts) => {
       await colony.claimColonyFunds(ethers.constants.AddressZero);
       const taskId = await makeTask({ colony });
       const task = await colony.getTask(taskId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 51, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 51, ethers.constants.AddressZero);
       const colonyPotBalance = await colony.getFundingPotBalance(1, ethers.constants.AddressZero);
       const colonyEtherBalance = await web3GetBalance(colony.address);
       const pot2Balance = await colony.getFundingPotBalance(2, ethers.constants.AddressZero);
@@ -627,13 +627,13 @@ contract("Colony Funding", (accounts) => {
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
       // Fund the pot equal to manager payout 40 = 40
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 40, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 40, ethers.constants.AddressZero);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // Cannot bring pot balance below current payout
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 30, ethers.constants.AddressZero),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 30, ethers.constants.AddressZero),
         "colony-funding-task-bad-state"
       );
 
@@ -650,18 +650,18 @@ contract("Colony Funding", (accounts) => {
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 
       // Fund the pot equal to manager payout, plus 10, 50 < 60
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 20, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, task.fundingPotId, 20, ethers.constants.AddressZero);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
 
       // Cannot bring pot balance below current payout
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 30, ethers.constants.AddressZero),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 30, ethers.constants.AddressZero),
         "colony-funding-task-bad-state"
       );
 
       // Can remove surplus 50 = 50
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 10, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, task.fundingPotId, 1, 10, ethers.constants.AddressZero);
       fundingPot = await colony.getFundingPot(task.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.be.zero;
     });

--- a/test/contracts-network/colony-payment.js
+++ b/test/contracts-network/colony-payment.js
@@ -186,7 +186,7 @@ contract("Colony Payment", (accounts) => {
       expect(fundingPotPayoutForToken).to.eq.BN(WAD);
 
       await fundColonyWithTokens(colony, token, 40);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 40, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 40, token.address);
       const fundingPotBalanceForToken = await colony.getFundingPotBalance(payment.fundingPotId, token.address);
       expect(fundingPotBalanceForToken).to.eq.BN(40);
     });
@@ -213,7 +213,7 @@ contract("Colony Payment", (accounts) => {
       paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
       await fundColonyWithTokens(colony, token, 40);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 40, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 40, token.address);
     });
 
     it("can finalize payment when it is fully funded", async () => {
@@ -229,7 +229,7 @@ contract("Colony Payment", (accounts) => {
 
     it("cannnot finalize payment if it is NOT fully funded", async () => {
       const payment = await colony.getPayment(paymentId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, payment.fundingPotId, 1, 1, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, payment.fundingPotId, 1, 1, token.address);
       expect(payment.finalized).to.be.false;
 
       await checkErrorRevert(colony.finalizePayment(1, UINT256_MAX, paymentId), "colony-payment-not-funded");
@@ -275,7 +275,7 @@ contract("Colony Payment", (accounts) => {
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
       await colony.finalizePayment(1, UINT256_MAX, paymentId);
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -293,7 +293,7 @@ contract("Colony Payment", (accounts) => {
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
       await colony.finalizePayment(1, UINT256_MAX, paymentId);
 
       const recipientBalanceBefore = await token.balanceOf(RECIPIENT);
@@ -311,7 +311,7 @@ contract("Colony Payment", (accounts) => {
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), token.address);
       await colony.finalizePayment(1, UINT256_MAX, paymentId);
       await colony.claimPayment(paymentId, token.address);
 
@@ -324,7 +324,7 @@ contract("Colony Payment", (accounts) => {
       const paymentId = await colony.getPaymentCount();
       const payment = await colony.getPayment(paymentId);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 9999, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 9999, token.address);
       await checkErrorRevert(colony.claimPayment(paymentId, token.address), "colony-payment-not-finalized");
     });
 
@@ -338,11 +338,11 @@ contract("Colony Payment", (accounts) => {
       let fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(2);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 199, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 199, token.address);
       fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(2);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, 100, otherToken.address);
       fundingPot = await colony.getFundingPot(payment.fundingPotId);
       expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
 

--- a/test/contracts-network/colony-permissions.js
+++ b/test/contracts-network/colony-permissions.js
@@ -355,19 +355,72 @@ contract("ColonyPermissions", (accounts) => {
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       // Test we can move funds between domain 1 and 2, and also 2 and 3
+      // Deprecated version
+      await colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)"](
+        1,
+        UINT256_MAX,
+        0,
+        domain1.fundingPotId,
+        domain2.fundingPotId,
+        WAD,
+        token.address,
+        {
+          from: USER2,
+        }
+      );
+      await colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)"](
+        1,
+        0,
+        1,
+        domain2.fundingPotId,
+        domain3.fundingPotId,
+        WAD,
+        token.address,
+        { from: USER2 }
+      );
+
+      // Newest version
       await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address, {
         from: USER2,
       });
       await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 1, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 });
 
-      // But only with valid proofs
+      // But only with valid proofs. Deprecated version of this function
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 1, 1, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 }),
+        colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)"](
+          1,
+          1,
+          1,
+          domain2.fundingPotId,
+          domain3.fundingPotId,
+          WAD,
+          token.address,
+          { from: USER2 }
+        ),
         "ds-auth-invalid-domain-inheritence"
       );
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 0, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 }),
+        colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)"](
+          1,
+          0,
+          0,
+          domain2.fundingPotId,
+          domain3.fundingPotId,
+          WAD,
+          token.address,
+          { from: USER2 }
+        ),
         "ds-auth-invalid-domain-inheritence"
+      );
+
+      // The newest version
+      await checkErrorRevert(
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 1, 1, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 }),
+        "colony-invalid-domain-inheritence"
+      );
+      await checkErrorRevert(
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 0, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 }),
+        "colony-invalid-domain-inheritence"
       );
     });
 

--- a/test/contracts-network/colony-permissions.js
+++ b/test/contracts-network/colony-permissions.js
@@ -120,7 +120,7 @@ contract("ColonyPermissions", (accounts) => {
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
 
       // Founder can move funds from domain 1 to domain 2.
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address);
 
       // User1 can only move funds from domain 2 into domain 2 task.
       await colony.setFundingRole(1, 0, USER1, 2, true);
@@ -128,13 +128,17 @@ contract("ColonyPermissions", (accounts) => {
       expect(hasRole).to.be.true;
 
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address, { from: USER1 }),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address, {
+          from: USER1,
+        }),
         "ds-auth-unauthorized"
       );
 
       const taskId = await makeTask({ colonyNetwork, colony, domainId: 2 });
       const task = await colony.getTask(taskId);
-      await colony.moveFundsBetweenPots(2, UINT256_MAX, UINT256_MAX, domain2.fundingPotId, task.fundingPotId, WAD, token.address, { from: USER1 });
+      await colony.moveFundsBetweenPots(2, UINT256_MAX, 2, UINT256_MAX, UINT256_MAX, domain2.fundingPotId, task.fundingPotId, WAD, token.address, {
+        from: USER1,
+      });
     });
 
     it("should allow users with administration permission manipulate expenditures in their domains only", async () => {
@@ -351,16 +355,18 @@ contract("ColonyPermissions", (accounts) => {
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       // Test we can move funds between domain 1 and 2, and also 2 and 3
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address, { from: USER2 });
-      await colony.moveFundsBetweenPots(1, 0, 1, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 });
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address, {
+        from: USER2,
+      });
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 1, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 });
 
       // But only with valid proofs
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, 1, 1, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 }),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 1, 1, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 }),
         "ds-auth-invalid-domain-inheritence"
       );
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, 0, 0, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 }),
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 0, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 }),
         "ds-auth-invalid-domain-inheritence"
       );
     });

--- a/test/contracts-network/colony-reward-payouts.js
+++ b/test/contracts-network/colony-reward-payouts.js
@@ -193,7 +193,7 @@ contract("Colony Reward Payouts", (accounts) => {
       await colony.claimColonyFunds(token.address);
       // Move all of them in to the reward pot
       const amount = await colony.getFundingPotBalance(1, token.address);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, amount, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, amount, token.address);
 
       const tx1 = await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
       const payoutId1 = tx1.logs[0].args.rewardPayoutId;
@@ -259,7 +259,7 @@ contract("Colony Reward Payouts", (accounts) => {
       let { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
 
-      await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, newToken.address);
+      await newColony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, newToken.address);
 
       const { logs } = await newColony.startNextRewardPayout(newToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
@@ -294,7 +294,7 @@ contract("Colony Reward Payouts", (accounts) => {
       const colonyWideReputationKey = makeReputationKey(newColony.address, rootDomainSkill);
       const { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
-      await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, newToken.address);
+      await newColony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, newToken.address);
 
       await checkErrorRevert(
         newColony.startNextRewardPayout(newToken.address, ...colonyWideReputationProof),
@@ -308,10 +308,10 @@ contract("Colony Reward Payouts", (accounts) => {
     });
 
     it("should be able to create parallel payouts of the same token", async () => {
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
     });
@@ -320,7 +320,7 @@ contract("Colony Reward Payouts", (accounts) => {
       const tx1 = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId1 = tx1.logs[0].args.rewardPayoutId;
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       const tx2 = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId2 = tx2.logs[0].args.rewardPayoutId;
@@ -335,7 +335,7 @@ contract("Colony Reward Payouts", (accounts) => {
       const payoutId1 = tx1.logs[0].args.rewardPayoutId;
       await forwardTime(SECONDS_PER_DAY * 60 + 1, this);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.finalizeRewardPayout(payoutId1);
 
       const tx2 = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
@@ -369,7 +369,7 @@ contract("Colony Reward Payouts", (accounts) => {
 
       await forwardTime(SECONDS_PER_DAY * 60 + 1, this);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.finalizeRewardPayout(payoutId1);
 
       const tx2 = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
@@ -414,7 +414,7 @@ contract("Colony Reward Payouts", (accounts) => {
       const { key, value, branchMask, siblings } = await client.getReputationProofObject(colonyWideReputationKey);
       colonyWideReputationProof = [key, value, branchMask, siblings];
 
-      await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, newToken.address);
+      await newColony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, newToken.address);
 
       await checkErrorRevert(
         newColony.startNextRewardPayout(newToken.address, ...colonyWideReputationProof),
@@ -895,7 +895,7 @@ contract("Colony Reward Payouts", (accounts) => {
         await tokenLocking.methods["deposit(address,uint256,bool)"](newToken.address, tokensPerUser, true, { from: userAddress3 });
         await forwardTime(1, this);
 
-        await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, payoutToken.address);
+        await newColony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, payoutToken.address);
 
         const { logs } = await newColony.startNextRewardPayout(payoutToken.address, ...colonyWideReputationProof);
         const payoutId = logs[0].args.rewardPayoutId;

--- a/test/contracts-network/colony-staking.js
+++ b/test/contracts-network/colony-staking.js
@@ -41,7 +41,7 @@ contract("Colony Staking", (accounts) => {
     await colony.setExpenditureRecipient(1, 1, USER1);
 
     await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-    await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 3, WAD.muln(200), token.address);
+    await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 3, WAD.muln(200), token.address);
     await colony.setExpenditurePayout(1, 0, token.address, WAD.muln(100));
     await colony.setExpenditurePayout(1, 1, token.address, WAD.muln(100));
 

--- a/test/contracts-network/colony-task.js
+++ b/test/contracts-network/colony-task.js
@@ -1355,12 +1355,12 @@ contract("ColonyTask", (accounts) => {
       // but we need some Ether, too
       await colony.send(101);
       await colony.claimColonyFunds(ethers.constants.AddressZero);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domainPotId, taskPotId, 100, ethers.constants.AddressZero);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, domainPotId, taskPotId, 100, ethers.constants.AddressZero);
 
       // And another token
       await otherToken.mint(colony.address, 101);
       await colony.claimColonyFunds(otherToken.address);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domainPotId, taskPotId, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, domainPotId, taskPotId, 100, otherToken.address);
 
       // Keep track of original Ether balance in funding pots
       const originalDomainEtherBalance = await colony.getFundingPotBalance(domainPotId, ethers.constants.AddressZero);
@@ -1382,9 +1382,29 @@ contract("ColonyTask", (accounts) => {
         args: [taskId],
       });
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, taskPotId, domainPotId, originalTaskEtherBalance, ethers.constants.AddressZero);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, taskPotId, domainPotId, originalTaskTokenBalance, token.address);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, taskPotId, domainPotId, originalTaskOtherTokenBalance, otherToken.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        taskPotId,
+        domainPotId,
+        originalTaskEtherBalance,
+        ethers.constants.AddressZero
+      );
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, taskPotId, domainPotId, originalTaskTokenBalance, token.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        taskPotId,
+        domainPotId,
+        originalTaskOtherTokenBalance,
+        otherToken.address
+      );
 
       const cancelledTaskEtherBalance = await colony.getFundingPotBalance(taskPotId, ethers.constants.AddressZero);
       const cancelledDomainEtherBalance = await colony.getFundingPotBalance(domainPotId, ethers.constants.AddressZero);

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -351,7 +351,7 @@ contract("Colony", (accounts) => {
 
     it("cannot burn more tokens than are in the root funding pot", async () => {
       const amount = await colony.getFundingPotBalance(1, token.address);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, amount.divn(2), token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, amount.divn(2), token.address);
 
       await checkErrorRevert(colony.burnTokens(token.address, amount), "colony-not-enough-tokens");
     });

--- a/test/contracts-network/reputation-update.js
+++ b/test/contracts-network/reputation-update.js
@@ -367,7 +367,17 @@ contract("Reputation Updates", (accounts) => {
       const domain1 = await metaColony.getDomain(1);
 
       const expenditure = await metaColony.getExpenditure(expenditureId);
-      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, clnyToken.address);
+      await metaColony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD,
+        clnyToken.address
+      );
       await metaColony.finalizeExpenditure(expenditureId);
       await metaColony.claimExpenditurePayout(expenditureId, SLOT0, clnyToken.address);
 
@@ -382,7 +392,17 @@ contract("Reputation Updates", (accounts) => {
       const paymentId = await metaColony.getPaymentCount();
 
       const payment = await metaColony.getPayment(paymentId);
-      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), clnyToken.address);
+      await metaColony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        1,
+        payment.fundingPotId,
+        WAD.add(WAD.divn(10)),
+        clnyToken.address
+      );
       await metaColony.finalizePayment(1, UINT256_MAX, paymentId);
       await metaColony.claimPayment(paymentId, clnyToken.address);
 
@@ -412,7 +432,17 @@ contract("Reputation Updates", (accounts) => {
       const paymentId = await metaColony.getPaymentCount();
 
       const payment = await metaColony.getPayment(paymentId);
-      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, WAD.add(WAD.divn(10)), otherToken.address);
+      await metaColony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        1,
+        payment.fundingPotId,
+        WAD.add(WAD.divn(10)),
+        otherToken.address
+      );
       await metaColony.finalizePayment(1, UINT256_MAX, paymentId);
       await metaColony.claimPayment(paymentId, otherToken.address);
 

--- a/test/contracts-network/token-locking.js
+++ b/test/contracts-network/token-locking.js
@@ -145,7 +145,7 @@ contract("Token Locking", (addresses) => {
 
     it("should not be able to deposit tokens while they are locked", async () => {
       await fundColonyWithTokens(colony, token);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
       await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
 
       await checkErrorRevert(
@@ -164,7 +164,7 @@ contract("Token Locking", (addresses) => {
 
     it("should be able to send tokens directly to the user if they are locked", async () => {
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
 
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
@@ -224,7 +224,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       await checkErrorRevert(
         tokenLocking.methods["withdraw(address,uint256,bool)"](token.address, usersTokens, false, { from: userAddress }),
@@ -236,7 +236,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       await tokenLocking.methods["withdraw(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
     });
@@ -245,7 +245,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
       await tokenLocking.incrementLockCounterTo(token.address, payoutId, { from: userAddress });
@@ -271,7 +271,7 @@ contract("Token Locking", (addresses) => {
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
 
       await fundColonyWithTokens(colony, token);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
       await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
       await tokenLocking.transfer(token.address, usersTokens, otherUserAddress, true, { from: userAddress });
 
@@ -284,7 +284,7 @@ contract("Token Locking", (addresses) => {
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
 
       await fundColonyWithTokens(colony, token);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
       await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
 
       await checkErrorRevert(
@@ -298,7 +298,7 @@ contract("Token Locking", (addresses) => {
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
 
       await fundColonyWithTokens(colony, token);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, token.address);
       await colony.startNextRewardPayout(token.address, ...colonyWideReputationProof);
 
       await tokenLocking.transfer(token.address, usersTokens, otherUserAddress, true, { from: userAddress });
@@ -387,7 +387,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       const tx = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       await expectEvent(tx, "TokenLocked(address indexed,address indexed,uint256)", [token.address, colony.address, 1]);
     });
@@ -396,7 +396,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const totalLockCount = await tokenLocking.getTotalLockCount(token.address);
       expect(totalLockCount).to.eq.BN(1);
@@ -406,7 +406,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
 
@@ -417,7 +417,7 @@ contract("Token Locking", (addresses) => {
 
     it("should not be able to waive to id that does not exist", async () => {
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       await checkErrorRevert(tokenLocking.incrementLockCounterTo(token.address, 10, { from: userAddress }), "colony-token-locking-invalid-lock-id");
     });
@@ -432,7 +432,7 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       const { logs } = await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = logs[0].args.rewardPayoutId;
       await checkErrorRevert(
@@ -445,9 +445,9 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await fundColonyWithTokens(colony, otherToken);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
       await colony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
 
       const totalLockCount = await tokenLocking.getTotalLockCount(token.address);

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -467,7 +467,6 @@ contract("Voting Reputation", (accounts) => {
       const domainAction = await encodeTxData(colony, "makeTask", [1, UINT256_MAX, FAKE, 1, 0, 0]);
 
       await voting.createRootMotion(ADDRESS_ZERO, rootAction, domain1Key, domain1Value, domain1Mask, domain1Siblings);
-      await voting.createDomainMotion(1, UINT256_MAX, ADDRESS_ZERO, domainAction, domain1Key, domain1Value, domain1Mask, domain1Siblings);
       await voting.createDomainMotion(1, UINT256_MAX, domainAction, domain1Key, domain1Value, domain1Mask, domain1Siblings);
     });
 

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -470,6 +470,36 @@ contract("Voting Reputation", (accounts) => {
       await voting.createDomainMotion(1, UINT256_MAX, ADDRESS_ZERO, domainAction, domain1Key, domain1Value, domain1Mask, domain1Siblings);
       await voting.createDomainMotion(1, UINT256_MAX, domainAction, domain1Key, domain1Value, domain1Mask, domain1Siblings);
     });
+
+    it("when creating a motion for moveFundsBetweenPots, permissions are correctly respected", async () => {
+      // Move funds between domain 2 and domain 3 pots using the old deprecated function
+      // This should not be allowed - it doesn't conform to the standard permission proofs, and so can't
+      // be checked
+      let action = await encodeTxData(colony, "moveFundsBetweenPots", [1, 0, 1, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address]);
+      const key = makeReputationKey(colony.address, domain2.skillId);
+      const value = makeReputationValue(WAD, 6);
+      const [mask, siblings] = await reputationTree.getProof(key);
+      checkErrorRevert(voting.createMotion(2, UINT256_MAX, ADDRESS_ZERO, action, key, value, mask, siblings), "voting-rep-disallowed-function");
+
+      // Now we make an action with the new moveFundsBetweenPots
+      action = await encodeTxData(colony, "moveFundsBetweenPots", [
+        1,
+        UINT256_MAX,
+        1,
+        0,
+        1,
+        domain2.fundingPotId,
+        domain3.fundingPotId,
+        WAD,
+        token.address,
+      ]);
+
+      // This is not allowed to be created in domain 2
+      await checkErrorRevert(voting.createMotion(2, UINT256_MAX, ADDRESS_ZERO, action, key, value, mask, siblings), "voting-rep-invalid-domain-id");
+
+      // But is in the root domain
+      await voting.createMotion(1, UINT256_MAX, ADDRESS_ZERO, action, domain1Key, domain1Value, domain1Mask, domain1Siblings);
+    });
   });
 
   describe("staking on motions", async () => {

--- a/test/reputation-system/dispute-resolution-misbehaviour.js
+++ b/test/reputation-system/dispute-resolution-misbehaviour.js
@@ -309,7 +309,17 @@ contract("Reputation Mining - disputes resolution misbehaviour", (accounts) => {
         await metaColony.addPayment(1, UINT256_MAX, accountsForTest[i], clnyToken.address, 40, 1, 0);
         const paymentId = await metaColony.getPaymentCount();
         const payment = await metaColony.getPayment(paymentId);
-        await metaColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, payment.fundingPotId, INITIAL_FUNDING, clnyToken.address);
+        await metaColony.moveFundsBetweenPots(
+          1,
+          UINT256_MAX,
+          1,
+          UINT256_MAX,
+          UINT256_MAX,
+          1,
+          payment.fundingPotId,
+          INITIAL_FUNDING,
+          clnyToken.address
+        );
         await metaColony.finalizePayment(1, UINT256_MAX, paymentId);
 
         // These have to be done sequentially because this function uses the total number of tasks as a proxy for getting the

--- a/test/reputation-system/root-hash-submissions.js
+++ b/test/reputation-system/root-hash-submissions.js
@@ -771,7 +771,7 @@ contract("Reputation mining - root hash submissions", (accounts) => {
       await metaColony.claimColonyFunds(clnyToken.address);
       // Move all of them in to the reward pot
       const amount = await metaColony.getFundingPotBalance(1, clnyToken.address);
-      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, amount, clnyToken.address);
+      await metaColony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, amount, clnyToken.address);
 
       const result = await metaColony.getDomain(1);
       const rootDomainSkill = result.skillId;


### PR DESCRIPTION
This is my take at fixing up `moveFundsBetweenPots` so that what movement of funds are allowed is consistent regardless of whether the function is being executed directly or a motion has been made.

I tried a couple of other ways, but there just simply isn't enough information provided in the combination of the existing action and the existing motion creation function. You have to prove:

The domain I have the permission in is a parent of the 'fromPot' domain
The domain I have the permission in is a parent of the 'toPot' domain
The domain the vote is taking place in is a parent of the 'fromPot' domain
The domain the vote is taking place in is a parent of the 'toPot' domain

But we only have three proofs, between `createMotion` and the action if we create special functions to extract the second proof from the action. The action would provide the first two, but there's no way to prove both of the second with a single proof.

Stepping back, I realised that we're in this predicament is because there is an ambiguity in the general case for `moveFundsBetweenPots` as to which domain we're acting in. Consider the domain hierarchy:

```
      A 
      |
      B
    /   \
   C     D
```

Let's say I have the permission explicitly in A, and I want to move funds from C to D. What domain am I acting in? We could say it's A by convention, but that would mean it would be impossible to have a vote in B about this, which clearly should be allowed. There's no way to specify which domain we're acting in. So the solution I've implemented here adds a new `moveFundsBetweenPots` that removes this ambiguity. It still includes multiple domain proofs, but those now prove that the domain we're acting in is a parent of C and a parent of D and so don't need to be considered for the creation of the motion, nor do they need to meet the unofficial standard we've adopted (which the proof for 'which domain we're acting in' does, and therefore plays nicely with the motions and disputes).