### PR TITLE
Add new Expenditure functionality

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -500,6 +500,9 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
 
     sig = bytes4(keccak256("setDefaultGlobalClaimDelay(uint256)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
+
+    sig = bytes4(keccak256("setExpenditureMetadata(uint256,uint256,uint256,string)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Arbitration), address(this), sig, true);
   }
 
   function checkNotAdditionalProtectedVariable(uint256 _slot) public view recovery {

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -117,6 +117,7 @@ contract ColonyAuthority is CommonAuthority {
     // Added in colony v8 (ebony-lwss)
     addRoleCapability(ROOT_ROLE, "makeArbitraryTransactions(address[],bytes[],bool)");
     addRoleCapability(ROOT_ROLE, "setDefaultGlobalClaimDelay(uint256)");
+    addRoleCapability(ARBITRATION_ROLE, "setExpenditureMetadata(uint256,uint256,uint256,string)");
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -149,6 +149,13 @@ interface ColonyDataTypes {
   /// @param claimDelay Additional amount of time to hold the funds
   event ExpenditureClaimDelaySet(address agent, uint256 indexed expenditureId, uint256 indexed slot, uint256 claimDelay);
 
+  /// @notice Event logged when an expenditure slot payout modifier changes
+  /// @param agent The address that is responsible for triggering this event
+  /// @param expenditureId Id of the expenditure
+  /// @param slot Expenditure slot being changed
+  /// @param payoutModifier The payout modifier for the slot
+  event ExpenditurePayoutModifierSet(address agent, uint256 indexed expenditureId, uint256 indexed slot, int256 payoutModifier);
+
   /// @notice Event logged when a new payment is added
   /// @param agent The address that is responsible for triggering this event
   /// @param paymentId The newly added payment id

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -100,12 +100,17 @@ interface ColonyDataTypes {
   /// @param owner The new owner of the expenditure
   event ExpenditureTransferred(address agent, uint256 indexed expenditureId, address indexed owner);
 
-  /// @notice Event logged when a expenditure has been cancelled
+  /// @notice Event logged when an expenditure has been cancelled
   /// @param agent The address that is responsible for triggering this event
   /// @param expenditureId Id of the cancelled expenditure
   event ExpenditureCancelled(address agent, uint256 indexed expenditureId);
 
-  /// @notice Event logged when a expenditure has been finalized
+  /// @notice Event logged when an expenditure has been locked
+  /// @param agent The address that is responsible for triggering this event
+  /// @param expenditureId Id of the locked expenditure
+  event ExpenditureLocked(address agent, uint256 indexed expenditureId);
+
+  /// @notice Event logged when an expenditure has been finalized
   /// @param agent The address that is responsible for triggering this event
   /// @param expenditureId Id of the finalized expenditure
   event ExpenditureFinalized(address agent, uint256 indexed expenditureId);
@@ -117,20 +122,27 @@ interface ColonyDataTypes {
   /// @param recipient Address of the recipient
   event ExpenditureRecipientSet(address agent, uint256 indexed expenditureId, uint256 indexed slot, address indexed recipient);
 
-  /// @notice Event logged when a expenditure's skill changes
+  /// @notice Event logged when an expenditure's skill changes
   /// @param agent The address that is responsible for triggering this event
   /// @param expenditureId Id of the expenditure
   /// @param slot Slot receiving the skill
   /// @param skillId Id of the set skill
   event ExpenditureSkillSet(address agent, uint256 indexed expenditureId, uint256 indexed slot, uint256 indexed skillId);
 
-  /// @notice Event logged when a expenditure payout changes
+  /// @notice Event logged when an expenditure payout changes
   /// @param agent The address that is responsible for triggering this event
   /// @param expenditureId Id of the expenditure
   /// @param slot Expenditure slot of the payout being changed
   /// @param token Token of the payout funding
   /// @param amount Amount of the payout funding
   event ExpenditurePayoutSet(address agent, uint256 indexed expenditureId, uint256 indexed slot, address indexed token, uint256 amount);
+
+  /// @notice Event logged when an expenditure slot claim delay changes
+  /// @param agent The address that is responsible for triggering this event
+  /// @param expenditureId Id of the expenditure
+  /// @param slot Expenditure slot being changed
+  /// @param claimDelay Additional amount of time to hold the funds
+  event ExpenditureClaimDelaySet(address agent, uint256 indexed expenditureId, uint256 indexed slot, uint256 claimDelay);
 
   /// @notice Event logged when a new payment is added
   /// @param agent The address that is responsible for triggering this event
@@ -310,7 +322,7 @@ interface ColonyDataTypes {
     uint256[] skills;
   }
 
-  enum ExpenditureStatus { Active, Cancelled, Finalized }
+  enum ExpenditureStatus { Draft, Cancelled, Finalized, Locked }
 
   struct Payment {
     address payable recipient;

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -247,6 +247,7 @@ interface ColonyDataTypes {
 
   /// @notice Event logged when domain metadata is updated
   /// @param agent The address that is responsible for triggering this event
+  /// @param domainId Id of the newly-created Domain
   /// @param metadata IPFS hash of the metadata
   event DomainMetadata(address agent, uint256 indexed domainId, string metadata);
 

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -115,6 +115,11 @@ interface ColonyDataTypes {
   /// @param expenditureId Id of the finalized expenditure
   event ExpenditureFinalized(address agent, uint256 indexed expenditureId);
 
+  /// @notice Event logged when expenditure metadata is set
+  /// @param agent The address that is responsible for triggering this event
+  /// @param metadata IPFS hash of the metadata
+  event ExpenditureMetadataSet(address agent, string metadata);
+
   /// @notice Event logged when an expenditure's recipient is set
   /// @param agent The address that is responsible for triggering this event
   /// @param expenditureId Id of the expenditure
@@ -235,7 +240,7 @@ interface ColonyDataTypes {
 
   /// @notice Event logged when domain metadata is updated
   /// @param agent The address that is responsible for triggering this event
-  /// @param domainId Id of the newly-created Domain
+  /// @param metadata IPFS hash of the metadata
   event DomainMetadata(address agent, uint256 indexed domainId, string metadata);
 
   /// @notice Event logged when Colony metadata is updated
@@ -250,7 +255,7 @@ interface ColonyDataTypes {
   /// @notice Emit a metadata string for a transaction
   /// @param agent Agent emitting the annotation
   /// @param txHash Hash of transaction being annotated (0x0 for current tx)
-  /// @param metadata String of metadata for tx
+  /// @param metadata IPFS hash of the metadata
   event Annotation(address indexed agent, bytes32 indexed txHash, string metadata);
 
   /// @notice Event logged when a payment has its payout set

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -117,8 +117,9 @@ interface ColonyDataTypes {
 
   /// @notice Event logged when expenditure metadata is set
   /// @param agent The address that is responsible for triggering this event
+  /// @param expenditureId Id of the expenditure
   /// @param metadata IPFS hash of the metadata
-  event ExpenditureMetadataSet(address agent, string metadata);
+  event ExpenditureMetadataSet(address agent, uint256 indexed expenditureId, string metadata);
 
   /// @notice Event logged when an expenditure's recipient is set
   /// @param agent The address that is responsible for triggering this event

--- a/contracts/colony/ColonyExpenditure.sol
+++ b/contracts/colony/ColonyExpenditure.sol
@@ -68,7 +68,7 @@ contract ColonyExpenditure is ColonyStorage {
     public
     stoppable
     expenditureExists(_id)
-    expenditureDraft(_id)
+    expenditureActive(_id)
     expenditureOnlyOwner(_id)
   {
     expenditures[_id].owner = _newOwner;
@@ -122,14 +122,9 @@ contract ColonyExpenditure is ColonyStorage {
     public
     stoppable
     expenditureExists(_id)
+    expenditureActive(_id)
     expenditureOnlyOwner(_id)
   {
-    require(
-      expenditures[_id].status == ExpenditureStatus.Draft ||
-      expenditures[_id].status == ExpenditureStatus.Locked,
-      "colony-expenditure-not-draft-or-active"
-    );
-
     FundingPot storage fundingPot = fundingPots[expenditures[_id].fundingPotId];
     require(fundingPot.payoutsWeCannotMake == 0, "colony-expenditure-not-funded");
 

--- a/contracts/colony/ColonyExpenditure.sol
+++ b/contracts/colony/ColonyExpenditure.sol
@@ -134,6 +134,30 @@ contract ColonyExpenditure is ColonyStorage {
     emit ExpenditureFinalized(msg.sender, _id);
   }
 
+  function setExpenditureMetadata(uint256 _id, string memory _metadata)
+    public
+    stoppable
+    expenditureExists(_id)
+    expenditureDraft(_id)
+    expenditureOnlyOwner(_id)
+  {
+    emit ExpenditureMetadataSet(msg.sender, _metadata);
+  }
+
+  function setExpenditureMetadata(
+    uint256 _permissionDomainId,
+    uint256 _childSkillIndex,
+    uint256 _id,
+    string memory _metadata
+  )
+    public
+    stoppable
+    expenditureExists(_id)
+    authDomain(_permissionDomainId, _childSkillIndex, expenditures[_id].domainId)
+  {
+    emit ExpenditureMetadataSet(msg.sender, _metadata);
+  }
+
   function setExpenditureRecipients(uint256 _id, uint256[] memory _slots, address payable[] memory _recipients)
     public
     stoppable

--- a/contracts/colony/ColonyExpenditure.sol
+++ b/contracts/colony/ColonyExpenditure.sol
@@ -220,6 +220,22 @@ contract ColonyExpenditure is ColonyStorage {
     }
   }
 
+  function setExpenditurePayoutModifiers(uint256 _id, uint256[] memory _slots, int256[] memory _payoutModifiers)
+    public
+    stoppable
+    expenditureExists(_id)
+    expenditureLocked(_id)
+    expenditureOnlyOwner(_id)
+  {
+    require(_slots.length == _payoutModifiers.length, "colony-expenditure-bad-slots");
+
+    for (uint256 i; i < _slots.length; i++) {
+      expenditureSlots[_id][_slots[i]].payoutModifier = _payoutModifiers[i];
+
+      emit ExpenditurePayoutModifierSet(msg.sender, _id, _slots[i], _payoutModifiers[i]);
+    }
+  }
+
   // Deprecated
   function setExpenditureRecipient(uint256 _id, uint256 _slot, address payable _recipient)
     public

--- a/contracts/colony/ColonyExpenditure.sol
+++ b/contracts/colony/ColonyExpenditure.sol
@@ -224,7 +224,7 @@ contract ColonyExpenditure is ColonyStorage {
     public
     stoppable
     expenditureExists(_id)
-    expenditureLocked(_id)
+    expenditureDraft(_id)
     expenditureOnlyOwner(_id)
   {
     require(_slots.length == _payoutModifiers.length, "colony-expenditure-bad-slots");

--- a/contracts/colony/ColonyExpenditure.sol
+++ b/contracts/colony/ColonyExpenditure.sol
@@ -68,7 +68,7 @@ contract ColonyExpenditure is ColonyStorage {
     public
     stoppable
     expenditureExists(_id)
-    expenditureActive(_id)
+    expenditureDraftOrLocked(_id)
     expenditureOnlyOwner(_id)
   {
     expenditures[_id].owner = _newOwner;
@@ -87,7 +87,7 @@ contract ColonyExpenditure is ColonyStorage {
     stoppable
     authDomain(_permissionDomainId, _childSkillIndex, expenditures[_id].domainId)
     expenditureExists(_id)
-    expenditureActive(_id)
+    expenditureDraftOrLocked(_id)
   {
     expenditures[_id].owner = _newOwner;
 
@@ -122,7 +122,7 @@ contract ColonyExpenditure is ColonyStorage {
     public
     stoppable
     expenditureExists(_id)
-    expenditureActive(_id)
+    expenditureDraftOrLocked(_id)
     expenditureOnlyOwner(_id)
   {
     FundingPot storage fundingPot = fundingPots[expenditures[_id].fundingPotId];
@@ -141,7 +141,7 @@ contract ColonyExpenditure is ColonyStorage {
     expenditureDraft(_id)
     expenditureOnlyOwner(_id)
   {
-    emit ExpenditureMetadataSet(msg.sender, _metadata);
+    emit ExpenditureMetadataSet(msg.sender, _id, _metadata);
   }
 
   function setExpenditureMetadata(
@@ -155,7 +155,7 @@ contract ColonyExpenditure is ColonyStorage {
     expenditureExists(_id)
     authDomain(_permissionDomainId, _childSkillIndex, expenditures[_id].domainId)
   {
-    emit ExpenditureMetadataSet(msg.sender, _metadata);
+    emit ExpenditureMetadataSet(msg.sender, _id, _metadata);
   }
 
   function setExpenditureRecipients(uint256 _id, uint256[] memory _slots, address payable[] memory _recipients)

--- a/contracts/colony/ColonyExpenditure.sol
+++ b/contracts/colony/ColonyExpenditure.sol
@@ -187,7 +187,7 @@ contract ColonyExpenditure is ColonyStorage {
     for (uint256 i; i < _slots.length; i++) {
       require(
         _skillIds[i] > 0 && _skillIds[i] <= colonyNetworkContract.getSkillCount(),
-        "colony-skill-does-not-exist"
+        "colony-expenditure-skill-does-not-exist"
       );
 
       Skill memory skill = colonyNetworkContract.getSkill(_skillIds[i]);

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -565,7 +565,7 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
   public
   stoppable
   expenditureExists(_id)
-  expenditureActive(_id)
+  expenditureDraft(_id)
   expenditureOnlyOwner(_id)
   validPayoutAmount(_amount)
   {

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -573,19 +573,21 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     FundingPot storage fundingPot = fundingPots[expenditures[_id].fundingPotId];
     assert(fundingPot.associatedType == FundingPotAssociatedType.Expenditure);
 
+    uint256 currentTotal = fundingPot.payouts[_token];
+
     for (uint256 i; i < _slots.length; i++) {
       require(_amounts[i] <= MAX_PAYOUT, "colony-payout-too-large");
 
-      uint256 currentTotal = fundingPot.payouts[_token];
       uint256 currentPayout = expenditureSlotPayouts[_id][_slots[i]][_token];
 
       expenditureSlotPayouts[_id][_slots[i]][_token] = _amounts[i];
       fundingPot.payouts[_token] = add(sub(currentTotal, currentPayout), _amounts[i]);
 
-      updatePayoutsWeCannotMakeAfterBudgetChange(expenditures[_id].fundingPotId, _token, currentTotal);
 
       emit ExpenditurePayoutSet(msg.sender, _id, _slots[i], _token, _amounts[i]);
     }
+
+    updatePayoutsWeCannotMakeAfterBudgetChange(expenditures[_id].fundingPotId, _token, currentTotal);
   }
 
   function setExpenditurePayout(uint256 _id, uint256 _slot, address _token, uint256 _amount)

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -568,6 +568,8 @@ contract ColonyFunding is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
   expenditureDraft(_id)
   expenditureOnlyOwner(_id)
   {
+    require(_slots.length == _amounts.length, "colony-expenditure-bad-slots");
+
     FundingPot storage fundingPot = fundingPots[expenditures[_id].fundingPotId];
     assert(fundingPot.associatedType == FundingPotAssociatedType.Expenditure);
 

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -169,11 +169,11 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, ColonyNetworkDataTypes
     _;
   }
 
-  modifier expenditureActive(uint256 _id) {
+  modifier expenditureDraftOrLocked(uint256 _id) {
     require(
       expenditures[_id].status == ExpenditureStatus.Draft ||
       expenditures[_id].status == ExpenditureStatus.Locked,
-      "colony-expenditure-not-active"
+      "colony-expenditure-not-draft-or-locked"
     );
     _;
   }

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -164,6 +164,11 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, ColonyNetworkDataTypes
     _;
   }
 
+  modifier expenditureLocked(uint256 _id) {
+    require(expenditures[_id].status == ExpenditureStatus.Locked, "colony-expenditure-not-locked");
+    _;
+  }
+
   modifier expenditureActive(uint256 _id) {
     require(
       expenditures[_id].status == ExpenditureStatus.Draft ||

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -164,6 +164,15 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, ColonyNetworkDataTypes
     _;
   }
 
+  modifier expenditureActive(uint256 _id) {
+    require(
+      expenditures[_id].status == ExpenditureStatus.Draft ||
+      expenditures[_id].status == ExpenditureStatus.Locked,
+      "colony-expenditure-not-active"
+    );
+    _;
+  }
+
   modifier expenditureFinalized(uint256 _id) {
     require(expenditures[_id].status == ExpenditureStatus.Finalized, "colony-expenditure-not-finalized");
     _;

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -159,8 +159,8 @@ contract ColonyStorage is CommonStorage, ColonyDataTypes, ColonyNetworkDataTypes
     _;
   }
 
-  modifier expenditureActive(uint256 _id) {
-    require(expenditures[_id].status == ExpenditureStatus.Active, "colony-expenditure-not-active");
+  modifier expenditureDraft(uint256 _id) {
+    require(expenditures[_id].status == ExpenditureStatus.Draft, "colony-expenditure-not-draft");
     _;
   }
 

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -369,6 +369,7 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _id Expenditure identifier
   function finalizeExpenditure(uint256 _id) external;
 
+  /// @notice Deprecated
   /// @notice Sets the recipient on an expenditure slot. Can only be called by expenditure owner.
   /// @param _id Id of the expenditure
   /// @param _slot Slot for the recipient address
@@ -377,10 +378,11 @@ interface IColony is ColonyDataTypes, IRecovery {
 
   /// @notice Sets the recipients in sequential expenditure slots. Can only be called by expenditure owner.
   /// @param _id Id of the expenditure
-  /// @param _firstSlot Starting slot to set recipients
+  /// @param _slots Array of slots to set recipients
   /// @param _recipients Addresses of the recipients
-  function setExpenditureRecipients(uint256 _id, uint256 _firstSlot, address payable[] memory _recipients) external;
+  function setExpenditureRecipients(uint256 _id, uint256[] memory _slots, address payable[] memory _recipients) external;
 
+  /// @notice Deprecated
   /// @notice Set the token payout on an expenditure slot. Can only be called by expenditure owner.
   /// @param _id Id of the expenditure
   /// @param _slot Number of the slot
@@ -390,11 +392,12 @@ interface IColony is ColonyDataTypes, IRecovery {
 
   /// @notice Set the token payouts in sequential expenditure slots. Can only be called by expenditure owner.
   /// @param _id Id of the expenditure
-  /// @param _firstSlot Starting slot to set payouts
+  /// @param _slots Array of slots to set payouts
   /// @param _token Address of the token, `0x0` value indicates Ether
   /// @param _amounts Payout amounts
-  function setExpenditurePayouts(uint256 _id, uint256 _firstSlot, address _token, uint256[] memory _amounts) external;
+  function setExpenditurePayouts(uint256 _id, uint256[] memory _slots, address _token, uint256[] memory _amounts) external;
 
+  /// @notice Deprecated
   /// @notice Sets the skill on an expenditure slot. Can only be called by expenditure owner.
   /// @param _id Expenditure identifier
   /// @param _slot Number of the slot
@@ -403,10 +406,11 @@ interface IColony is ColonyDataTypes, IRecovery {
 
   /// @notice Sets the skill on an expenditure slot. Can only be called by expenditure owner.
   /// @param _id Expenditure identifier
-  /// @param _firstSlot Starting slot to set skills
+  /// @param _slots Array of slots to set skills
   /// @param _skillIds Ids of the new skills to set
-  function setExpenditureSkills(uint256 _id, uint256 _firstSlot, uint256[] memory _skillIds) external;
+  function setExpenditureSkills(uint256 _id, uint256[] memory _slots, uint256[] memory _skillIds) external;
 
+  /// @notice Deprecated
   /// @notice Sets the claim delay on an expenditure slot. Can only be called by expenditure owner.
   /// @param _id Expenditure identifier
   /// @param _slot Number of the slot
@@ -415,9 +419,9 @@ interface IColony is ColonyDataTypes, IRecovery {
 
   /// @notice Sets the claim delays in sequential expenditure slots. Can only be called by expenditure owner.
   /// @param _id Expenditure identifier
-  /// @param _firstSlot Starting slot to set claim delays
+  /// @param _slots Array of slots to set claim delays
   /// @param _claimDelays Durations of time (in seconds) to delay
-  function setExpenditureClaimDelays(uint256 _id, uint256 _firstSlot, uint256[] memory _claimDelays) external;
+  function setExpenditureClaimDelays(uint256 _id, uint256[] memory _slots, uint256[] memory _claimDelays) external;
 
   /// @notice Set arbitrary state on an expenditure slot. Can only be called by Arbitration role.
   /// @param _permissionDomainId The domainId in which I have the permission to take this action

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -375,6 +375,12 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _recipient Address of the recipient
   function setExpenditureRecipient(uint256 _id, uint256 _slot, address payable _recipient) external;
 
+  /// @notice Sets the recipients in sequential expenditure slots. Can only be called by expenditure owner.
+  /// @param _id Id of the expenditure
+  /// @param _firstSlot Starting slot to set recipients
+  /// @param _recipients Addresses of the recipients
+  function setExpenditureRecipients(uint256 _id, uint256 _firstSlot, address payable[] memory _recipients) external;
+
   /// @notice Set the token payout on an expenditure slot. Can only be called by expenditure owner.
   /// @param _id Id of the expenditure
   /// @param _slot Number of the slot
@@ -382,17 +388,36 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _amount Payout amount
   function setExpenditurePayout(uint256 _id, uint256 _slot, address _token, uint256 _amount) external;
 
+  /// @notice Set the token payouts in sequential expenditure slots. Can only be called by expenditure owner.
+  /// @param _id Id of the expenditure
+  /// @param _firstSlot Starting slot to set payouts
+  /// @param _token Address of the token, `0x0` value indicates Ether
+  /// @param _amounts Payout amounts
+  function setExpenditurePayouts(uint256 _id, uint256 _firstSlot, address _token, uint256[] memory _amounts) external;
+
   /// @notice Sets the skill on an expenditure slot. Can only be called by expenditure owner.
   /// @param _id Expenditure identifier
   /// @param _slot Number of the slot
   /// @param _skillId Id of the new skill to set
   function setExpenditureSkill(uint256 _id, uint256 _slot, uint256 _skillId) external;
 
+  /// @notice Sets the skill on an expenditure slot. Can only be called by expenditure owner.
+  /// @param _id Expenditure identifier
+  /// @param _firstSlot Starting slot to set skills
+  /// @param _skillIds Ids of the new skills to set
+  function setExpenditureSkills(uint256 _id, uint256 _firstSlot, uint256[] memory _skillIds) external;
+
   /// @notice Sets the claim delay on an expenditure slot. Can only be called by expenditure owner.
   /// @param _id Expenditure identifier
   /// @param _slot Number of the slot
   /// @param _claimDelay Duration of time (in seconds) to delay
   function setExpenditureClaimDelay(uint256 _id, uint256 _slot, uint256 _claimDelay) external;
+
+  /// @notice Sets the claim delays in sequential expenditure slots. Can only be called by expenditure owner.
+  /// @param _id Expenditure identifier
+  /// @param _firstSlot Starting slot to set claim delays
+  /// @param _claimDelays Durations of time (in seconds) to delay
+  function setExpenditureClaimDelays(uint256 _id, uint256 _firstSlot, uint256[] memory _claimDelays) external;
 
   /// @notice Set arbitrary state on an expenditure slot. Can only be called by Arbitration role.
   /// @param _permissionDomainId The domainId in which I have the permission to take this action

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -361,7 +361,11 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _id Expenditure identifier
   function cancelExpenditure(uint256 _id) external;
 
-  /// @notice Finalizes the expenditure and prevents further editing. Can only be called by expenditure owner.
+  /// @notice Locks the expenditure and prevents further editing. Can only be called by expenditure owner.
+  /// @param _id Expenditure identifier
+  function lockExpenditure(uint256 _id) external;
+
+  /// @notice Finalizes the expenditure and allows for funds to be claimed. Can only be called by expenditure owner.
   /// @param _id Expenditure identifier
   function finalizeExpenditure(uint256 _id) external;
 
@@ -384,38 +388,11 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _skillId Id of the new skill to set
   function setExpenditureSkill(uint256 _id, uint256 _slot, uint256 _skillId) external;
 
-  /// @notice DEPRECATED Set the payout modifier on an expenditure slot. Can only be called by Arbitration role.
-  /// @dev This is now deprecated and will be removed in a future version
-  /// @dev Note that when determining payouts the payoutModifier is incremented by WAD and converted into payoutScalar
-  /// @param _permissionDomainId The domainId in which I have the permission to take this action
-  /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`,
-  /// (only used if `_permissionDomainId` is different to `_domainId`)
+  /// @notice Sets the claim delay on an expenditure slot. Can only be called by expenditure owner.
   /// @param _id Expenditure identifier
   /// @param _slot Number of the slot
-  /// @param _payoutModifier Modifier to their payout (between -1 and 1, denominated in WADs, 0 means no modification)
-  function setExpenditurePayoutModifier(
-    uint256 _permissionDomainId,
-    uint256 _childSkillIndex,
-    uint256 _id,
-    uint256 _slot,
-    int256 _payoutModifier
-    ) external;
-
-  /// @notice DEPRECATED Set the claim delay on an expenditure slot. Can only be called by Arbitration role.
-  /// @dev This is now deprecated and will be removed in a future version
-  /// @param _permissionDomainId The domainId in which I have the permission to take this action
-  /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`,
-  /// (only used if `_permissionDomainId` is different to `_domainId`)
-  /// @param _id Expenditure identifier
-  /// @param _slot Number of the slot
-  /// @param _claimDelay Time (in seconds) to delay claiming payout after finalization
-  function setExpenditureClaimDelay(
-    uint256 _permissionDomainId,
-    uint256 _childSkillIndex,
-    uint256 _id,
-    uint256 _slot,
-    uint256 _claimDelay
-    ) external;
+  /// @param _claimDelay Duration of time (in seconds) to delay
+  function setExpenditureClaimDelay(uint256 _id, uint256 _slot, uint256 _claimDelay) external;
 
   /// @notice Set arbitrary state on an expenditure slot. Can only be called by Arbitration role.
   /// @param _permissionDomainId The domainId in which I have the permission to take this action

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -369,6 +369,18 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _id Expenditure identifier
   function finalizeExpenditure(uint256 _id) external;
 
+  /// @notice Sets the metadata for an expenditure. Can only be called by expenditure owner.
+  /// @param _id Id of the expenditure
+  /// @param _metadata IPFS hash of the metadata
+  function setExpenditureMetadata(uint256 _id, string memory _metadata) external;
+
+  /// @notice Sets the metadata for an expenditure. Can only be called by Arbitration role.
+  /// @param _permissionDomainId The domainId in which I have the permission to take this action
+  /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`,
+  /// @param _id Id of the expenditure
+  /// @param _metadata IPFS hash of the metadata
+  function setExpenditureMetadata(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, string memory _metadata) external;
+
   /// @notice Deprecated
   /// @notice Sets the recipient on an expenditure slot. Can only be called by expenditure owner.
   /// @param _id Id of the expenditure

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -388,7 +388,7 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _recipient Address of the recipient
   function setExpenditureRecipient(uint256 _id, uint256 _slot, address payable _recipient) external;
 
-  /// @notice Sets the recipients in sequential expenditure slots. Can only be called by expenditure owner.
+  /// @notice Sets the recipients in given expenditure slots. Can only be called by expenditure owner.
   /// @param _id Id of the expenditure
   /// @param _slots Array of slots to set recipients
   /// @param _recipients Addresses of the recipients
@@ -402,7 +402,7 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _amount Payout amount
   function setExpenditurePayout(uint256 _id, uint256 _slot, address _token, uint256 _amount) external;
 
-  /// @notice Set the token payouts in sequential expenditure slots. Can only be called by expenditure owner.
+  /// @notice Set the token payouts in given expenditure slots. Can only be called by expenditure owner.
   /// @param _id Id of the expenditure
   /// @param _slots Array of slots to set payouts
   /// @param _token Address of the token, `0x0` value indicates Ether
@@ -429,11 +429,17 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _claimDelay Duration of time (in seconds) to delay
   function setExpenditureClaimDelay(uint256 _id, uint256 _slot, uint256 _claimDelay) external;
 
-  /// @notice Sets the claim delays in sequential expenditure slots. Can only be called by expenditure owner.
+  /// @notice Sets the claim delays in given expenditure slots. Can only be called by expenditure owner.
   /// @param _id Expenditure identifier
   /// @param _slots Array of slots to set claim delays
   /// @param _claimDelays Durations of time (in seconds) to delay
   function setExpenditureClaimDelays(uint256 _id, uint256[] memory _slots, uint256[] memory _claimDelays) external;
+
+  /// @notice Sets the claim delays in given expenditure slots. Can only be called by expenditure owner.
+  /// @param _id Expenditure identifier
+  /// @param _slots Array of slots to set payout modifiers
+  /// @param _payoutModifiers Values (between +/- WAD) to modify the payout & reputation bonus
+  function setExpenditurePayoutModifiers(uint256 _id, uint256[] memory _slots, int256[] memory _payoutModifiers) external;
 
   /// @notice Set arbitrary state on an expenditure slot. Can only be called by Arbitration role.
   /// @param _permissionDomainId The domainId in which I have the permission to take this action

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -435,7 +435,7 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @param _claimDelays Durations of time (in seconds) to delay
   function setExpenditureClaimDelays(uint256 _id, uint256[] memory _slots, uint256[] memory _claimDelays) external;
 
-  /// @notice Sets the claim delays in given expenditure slots. Can only be called by expenditure owner.
+  /// @notice Sets the payout modifiers in given expenditure slots. Can only be called by expenditure owner.
   /// @param _id Expenditure identifier
   /// @param _slots Array of slots to set payout modifiers
   /// @param _payoutModifiers Values (between +/- WAD) to modify the payout & reputation bonus

--- a/contracts/extensions/EvaluatedExpenditure.sol
+++ b/contracts/extensions/EvaluatedExpenditure.sol
@@ -61,6 +61,12 @@ contract EvaluatedExpenditure is ColonyExtension {
     selfdestruct(address(uint160(address(colony))));
   }
 
+  /// @notice Sets the payout modifiers in given expenditure slots, using the arbitration permission
+  /// @param _permissionDomainId The domainId in which the extension has the arbitration permission
+  /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`
+  /// @param _id Expenditure identifier
+  /// @param _slots Array of slots to set payout modifiers
+  /// @param _payoutModifiers Values (between +/- WAD) to modify the payout & reputation bonus
   function setExpenditurePayoutModifiers(
     uint256 _permissionDomainId,
     uint256 _childSkillIndex,

--- a/contracts/extensions/EvaluatedExpenditure.sol
+++ b/contracts/extensions/EvaluatedExpenditure.sol
@@ -1,0 +1,99 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity 0.7.3;
+pragma experimental ABIEncoderV2;
+
+import "./ColonyExtension.sol";
+
+// ignore-file-swc-108
+
+
+contract EvaluatedExpenditure is ColonyExtension {
+
+  uint256 constant EXPENDITURESLOTS_SLOT = 26;
+  uint256 constant PAYOUT_MODIFIER_OFFSET = 2;
+  bool constant MAPPING = false;
+  bool constant ARRAY = true;
+
+  /// @notice Returns the identifier of the extension
+  function identifier() public override pure returns (bytes32) {
+    return keccak256("EvaluatedExpenditure");
+  }
+
+  /// @notice Returns the version of the extension
+  function version() public override pure returns (uint256) {
+    return 1;
+  }
+
+  /// @notice Configures the extension
+  /// @param _colony The colony in which the extension holds permissions
+  function install(address _colony) public override auth {
+    require(address(colony) == address(0x0), "extension-already-installed");
+
+    colony = IColony(_colony);
+  }
+
+  /// @notice Called when upgrading the extension
+  function finishUpgrade() public override auth {}
+
+  /// @notice Called when deprecating (or undeprecating) the extension
+  function deprecate(bool _deprecated) public override auth {
+    deprecated = _deprecated;
+  }
+
+  /// @notice Called when uninstalling the extension
+  function uninstall() public override auth {
+    selfdestruct(address(uint160(address(colony))));
+  }
+
+  function setExpenditurePayoutModifiers(
+    uint256 _permissionDomainId,
+    uint256 _childSkillIndex,
+    uint256 _id,
+    uint256[] memory _slots,
+    int256[] memory _payoutModifiers
+  )
+    public
+  {
+    require(_slots.length == _payoutModifiers.length, "evaluated-expenditure-bad-slots");
+    require(colony.getExpenditure(_id).owner == msg.sender, "evaluated-expenditure-not-owner");
+
+    bool[] memory mask = new bool[](2);
+    bytes32[] memory keys = new bytes32[](2);
+
+    mask[0] = MAPPING;
+    mask[1] = ARRAY;
+
+    keys[1] = bytes32(PAYOUT_MODIFIER_OFFSET);
+
+    for (uint256 i; i < _slots.length; i++) {
+      keys[0] = bytes32(_slots[i]);
+
+      colony.setExpenditureState(
+        _permissionDomainId,
+        _childSkillIndex,
+        _id,
+        EXPENDITURESLOTS_SLOT,
+        mask,
+        keys,
+        bytes32(_payoutModifiers[i])
+      );
+    }
+  }
+
+}

--- a/contracts/extensions/VotingReputation.sol
+++ b/contracts/extensions/VotingReputation.sol
@@ -872,6 +872,7 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs {
       uint256 winShare = wmul(winFraction, 2 * WAD); // On a scale of 0-2 WAD
 
       if (winShare > WAD || (winShare == WAD && _vote == NAY)) {
+        // 50% gets 0% of loser's stake, 100% gets 100% of loser's stake, linear in between
         stakerReward = wmul(stakeFraction, add(winnerStake, wmul(loserStake, winShare - WAD)));
       } else {
         stakerReward = wmul(stakeFraction, wmul(loserStake, winShare));

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -1389,6 +1389,20 @@ Sets the claim delay on an expenditure slot. Can only be called by expenditure o
 |_claimDelay|uint256|Duration of time (in seconds) to delay
 
 
+### `setExpenditureClaimDelays`
+
+Sets the claim delays in sequential expenditure slots. Can only be called by expenditure owner.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_id|uint256|Expenditure identifier
+|_firstSlot|uint256|Starting slot to set claim delays
+|_claimDelays|uint256[]|Durations of time (in seconds) to delay
+
+
 ### `setExpenditurePayout`
 
 Set the token payout on an expenditure slot. Can only be called by expenditure owner.
@@ -1402,6 +1416,21 @@ Set the token payout on an expenditure slot. Can only be called by expenditure o
 |_slot|uint256|Number of the slot
 |_token|address|Address of the token, `0x0` value indicates Ether
 |_amount|uint256|Payout amount
+
+
+### `setExpenditurePayouts`
+
+Set the token payouts in sequential expenditure slots. Can only be called by expenditure owner.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_id|uint256|Id of the expenditure
+|_firstSlot|uint256|Starting slot to set payouts
+|_token|address|Address of the token, `0x0` value indicates Ether
+|_amounts|uint256[]|Payout amounts
 
 
 ### `setExpenditureRecipient`
@@ -1418,6 +1447,20 @@ Sets the recipient on an expenditure slot. Can only be called by expenditure own
 |_recipient|address|Address of the recipient
 
 
+### `setExpenditureRecipients`
+
+Sets the recipients in sequential expenditure slots. Can only be called by expenditure owner.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_id|uint256|Id of the expenditure
+|_firstSlot|uint256|Starting slot to set recipients
+|_recipients|address[]|Addresses of the recipients
+
+
 ### `setExpenditureSkill`
 
 Sets the skill on an expenditure slot. Can only be called by expenditure owner.
@@ -1430,6 +1473,20 @@ Sets the skill on an expenditure slot. Can only be called by expenditure owner.
 |_id|uint256|Expenditure identifier
 |_slot|uint256|Number of the slot
 |_skillId|uint256|Id of the new skill to set
+
+
+### `setExpenditureSkills`
+
+Sets the skill on an expenditure slot. Can only be called by expenditure owner.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_id|uint256|Expenditure identifier
+|_firstSlot|uint256|Starting slot to set skills
+|_skillIds|uint256[]|Ids of the new skills to set
 
 
 ### `setExpenditureState`

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -383,7 +383,7 @@ Executes a task role update transaction `_data` which is approved and signed by 
 
 ### `finalizeExpenditure`
 
-Finalizes the expenditure and prevents further editing. Can only be called by expenditure owner.
+Finalizes the expenditure and allows for funds to be claimed. Can only be called by expenditure owner.
 
 
 **Parameters**
@@ -1039,6 +1039,18 @@ Install an extension to the colony. Secured function to authorised members.
 |version|uint256|The new extension version to install
 
 
+### `lockExpenditure`
+
+Locks the expenditure and prevents further editing. Can only be called by expenditure owner.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_id|uint256|Expenditure identifier
+
+
 ### `lockToken`
 
 Lock the colony's token. Can only be called by a network-managed extension.
@@ -1365,19 +1377,16 @@ Update the default global claim delay for expenditures
 
 ### `setExpenditureClaimDelay`
 
-DEPRECATED Set the claim delay on an expenditure slot. Can only be called by Arbitration role.
+Sets the claim delay on an expenditure slot. Can only be called by expenditure owner.
 
-*Note: This is now deprecated and will be removed in a future version*
 
 **Parameters**
 
 |Name|Type|Description|
 |---|---|---|
-|_permissionDomainId|uint256|The domainId in which I have the permission to take this action
-|_childSkillIndex|uint256|The index that the `_domainId` is relative to `_permissionDomainId`, (only used if `_permissionDomainId` is different to `_domainId`)
 |_id|uint256|Expenditure identifier
 |_slot|uint256|Number of the slot
-|_claimDelay|uint256|Time (in seconds) to delay claiming payout after finalization
+|_claimDelay|uint256|Duration of time (in seconds) to delay
 
 
 ### `setExpenditurePayout`
@@ -1393,23 +1402,6 @@ Set the token payout on an expenditure slot. Can only be called by expenditure o
 |_slot|uint256|Number of the slot
 |_token|address|Address of the token, `0x0` value indicates Ether
 |_amount|uint256|Payout amount
-
-
-### `setExpenditurePayoutModifier`
-
-DEPRECATED Set the payout modifier on an expenditure slot. Can only be called by Arbitration role.
-
-*Note: This is now deprecated and will be removed in a future version*
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_permissionDomainId|uint256|The domainId in which I have the permission to take this action
-|_childSkillIndex|uint256|The index that the `_domainId` is relative to `_permissionDomainId`, (only used if `_permissionDomainId` is different to `_domainId`)
-|_id|uint256|Expenditure identifier
-|_slot|uint256|Number of the slot
-|_payoutModifier|int256|Modifier to their payout (between -1 and 1, denominated in WADs, 0 means no modification)
 
 
 ### `setExpenditureRecipient`

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -1403,6 +1403,34 @@ Sets the claim delays in sequential expenditure slots. Can only be called by exp
 |_claimDelays|uint256[]|Durations of time (in seconds) to delay
 
 
+### `setExpenditureMetadata`
+
+Sets the metadata for an expenditure. Can only be called by expenditure owner.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_id|uint256|Id of the expenditure
+|_metadata|string|IPFS hash of the metadata
+
+
+### `setExpenditureMetadata`
+
+Sets the metadata for an expenditure. Can only be called by Arbitration role.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_permissionDomainId|uint256|The domainId in which I have the permission to take this action
+|_childSkillIndex|uint256|The index that the `_domainId` is relative to `_permissionDomainId`,
+|_id|uint256|Id of the expenditure
+|_metadata|string|IPFS hash of the metadata
+
+
 ### `setExpenditurePayout`
 
 Set the token payout on an expenditure slot. Can only be called by expenditure owner.

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -1448,7 +1448,7 @@ Set the token payout on an expenditure slot. Can only be called by expenditure o
 
 ### `setExpenditurePayoutModifiers`
 
-Sets the claim delays in given expenditure slots. Can only be called by expenditure owner.
+Sets the payout modifiers in given expenditure slots. Can only be called by expenditure owner.
 
 
 **Parameters**

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -1391,7 +1391,7 @@ Sets the claim delay on an expenditure slot. Can only be called by expenditure o
 
 ### `setExpenditureClaimDelays`
 
-Sets the claim delays in sequential expenditure slots. Can only be called by expenditure owner.
+Sets the claim delays in given expenditure slots. Can only be called by expenditure owner.
 
 
 **Parameters**
@@ -1446,9 +1446,23 @@ Set the token payout on an expenditure slot. Can only be called by expenditure o
 |_amount|uint256|Payout amount
 
 
+### `setExpenditurePayoutModifiers`
+
+Sets the claim delays in given expenditure slots. Can only be called by expenditure owner.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_id|uint256|Expenditure identifier
+|_slots|uint256[]|Array of slots to set payout modifiers
+|_payoutModifiers|int256[]|Values (between +/- WAD) to modify the payout & reputation bonus
+
+
 ### `setExpenditurePayouts`
 
-Set the token payouts in sequential expenditure slots. Can only be called by expenditure owner.
+Set the token payouts in given expenditure slots. Can only be called by expenditure owner.
 
 
 **Parameters**
@@ -1477,7 +1491,7 @@ Sets the recipient on an expenditure slot. Can only be called by expenditure own
 
 ### `setExpenditureRecipients`
 
-Sets the recipients in sequential expenditure slots. Can only be called by expenditure owner.
+Sets the recipients in given expenditure slots. Can only be called by expenditure owner.
 
 
 **Parameters**

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -1399,7 +1399,7 @@ Sets the claim delays in sequential expenditure slots. Can only be called by exp
 |Name|Type|Description|
 |---|---|---|
 |_id|uint256|Expenditure identifier
-|_firstSlot|uint256|Starting slot to set claim delays
+|_slots|uint256[]|Array of slots to set claim delays
 |_claimDelays|uint256[]|Durations of time (in seconds) to delay
 
 
@@ -1428,7 +1428,7 @@ Set the token payouts in sequential expenditure slots. Can only be called by exp
 |Name|Type|Description|
 |---|---|---|
 |_id|uint256|Id of the expenditure
-|_firstSlot|uint256|Starting slot to set payouts
+|_slots|uint256[]|Array of slots to set payouts
 |_token|address|Address of the token, `0x0` value indicates Ether
 |_amounts|uint256[]|Payout amounts
 
@@ -1457,7 +1457,7 @@ Sets the recipients in sequential expenditure slots. Can only be called by expen
 |Name|Type|Description|
 |---|---|---|
 |_id|uint256|Id of the expenditure
-|_firstSlot|uint256|Starting slot to set recipients
+|_slots|uint256[]|Array of slots to set recipients
 |_recipients|address[]|Addresses of the recipients
 
 
@@ -1485,7 +1485,7 @@ Sets the skill on an expenditure slot. Can only be called by expenditure owner.
 |Name|Type|Description|
 |---|---|---|
 |_id|uint256|Expenditure identifier
-|_firstSlot|uint256|Starting slot to set skills
+|_slots|uint256[]|Array of slots to set skills
 |_skillIds|uint256[]|Ids of the new skills to set
 
 

--- a/migrations/9_setup_extensions.js
+++ b/migrations/9_setup_extensions.js
@@ -5,6 +5,7 @@ const { soliditySha3 } = require("web3-utils");
 const { setupEtherRouter } = require("../helpers/upgradable-contracts");
 
 const CoinMachine = artifacts.require("./CoinMachine");
+const EvaluatedExpenditure = artifacts.require("./EvaluatedExpenditure");
 const FundingQueue = artifacts.require("./FundingQueue");
 const OneTxPayment = artifacts.require("./OneTxPayment");
 const VotingReputation = artifacts.require("./VotingReputation");
@@ -35,6 +36,7 @@ module.exports = async function (deployer, network, accounts) {
   const colonyNetwork = await IColonyNetwork.at(etherRouterDeployed.address);
 
   await addExtension(colonyNetwork, "CoinMachine", CoinMachine);
+  await addExtension(colonyNetwork, "EvaluatedExpenditure", EvaluatedExpenditure);
   await addExtension(colonyNetwork, "FundingQueue", FundingQueue);
   await addExtension(colonyNetwork, "OneTxPayment", OneTxPayment);
   await addExtension(colonyNetwork, "VotingReputation", VotingReputation);

--- a/scripts/check-recovery.js
+++ b/scripts/check-recovery.js
@@ -41,6 +41,7 @@ walkSync("./contracts/").forEach((contractName) => {
       "contracts/ens/ENSRegistry.sol",
       "contracts/extensions/CoinMachine.sol",
       "contracts/extensions/ColonyExtension.sol",
+      "contracts/extensions/EvaluatedExpenditure.sol",
       "contracts/extensions/FundingQueue.sol",
       "contracts/extensions/OneTxPayment.sol",
       "contracts/extensions/TokenSupplier.sol",

--- a/scripts/check-storage.js
+++ b/scripts/check-storage.js
@@ -25,6 +25,7 @@ walkSync("./contracts/").forEach((contractName) => {
       "contracts/common/Resolver.sol",
       "contracts/ens/ENSRegistry.sol", // Not directly used by any colony contracts
       "contracts/extensions/CoinMachine.sol",
+      "contracts/extensions/EvaluatedExpenditure.sol",
       "contracts/extensions/FundingQueue.sol",
       "contracts/extensions/ColonyExtension.sol",
       "contracts/extensions/OneTxPayment.sol",

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,11 +154,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("1c5205bbb858af71b9482918915a6516710b98d59ff770236f2922387d90c0cc");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("edafcc7d7bdda9ed53433adc580d22368240f0e0a100b9fd80004f65d815fc45");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("452949b2a851b900d1a400235c2c80f11c6c09eaaea4d81ed48dd595cfaf8456");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("7b1cb5a6aeaba5fb34659939733501b9455e23a6b5ac2b40fee740c65b650a73");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("821b923a384ce2f5ef5b7d83dd562af2385be5b8fa47afd513801b2bbb48f616");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("f310fa6b8457504fc0146364be4928ba608ae9a8d61abddbf78f3cd4f909d1e7");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("0a68382597cca56e865cb241c87102ce58b099d6eb4dafd466ab71c12802d2f6");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("80844ccb9352ebec4e7266e03fc17cc0dc7929f063ebba2e9351b7db189f6e6d");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("7fad525e1ecd8a701224c766c3b6341334ed52d73114b4ec243d18280f2afd46");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("37e6b9b7b5c615f7fa2fb6a2bab8eb86f3233716944ae9c3e6050b411af53cfe");
     });
   });
 });

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,8 +154,8 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("06a3ae170ff6ba05d5b1b4b22046c697b23a9d2c97af0bd92a1ebcbd01e7c078");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("1229c843866830f223030def91a84368a2c06231175ee9d7a29303b846fc4827");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("55779b88bac4206c6ed791b93fa3a386c2e71b52d896d262c6b69c476a6968fe");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("abe2e24d6c366741cfb171ba03e452a705ef3ffce1715348fdfaccbdfd44fab2");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("78294685a492256887e3159e26071ba06d62883c72ccb26fd323a883eefc30fd");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("e105190bcd647989da1579ac209ae54ed63e08224fbb2469bad9f596773fe558");
       expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("8bab6ab2024de44a08765ee14ec3d6bdc0fa5ae2a5ee221c9f928345a3710658");

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,11 +154,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("f310fa6b8457504fc0146364be4928ba608ae9a8d61abddbf78f3cd4f909d1e7");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("0a68382597cca56e865cb241c87102ce58b099d6eb4dafd466ab71c12802d2f6");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("80844ccb9352ebec4e7266e03fc17cc0dc7929f063ebba2e9351b7db189f6e6d");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("7fad525e1ecd8a701224c766c3b6341334ed52d73114b4ec243d18280f2afd46");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("37e6b9b7b5c615f7fa2fb6a2bab8eb86f3233716944ae9c3e6050b411af53cfe");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("28bcab16c4b1d7ed65fc934f10de1b544f10d66d74e7bfbec342214aa9aca926");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("16f9debdd39ae1d42bcddcf13b4188f35cf921b18ff272710c462e517f48539a");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("36c9792c4fbdc81cb2619d16fa58a8f9ab5af41002ad967d38d87a27913999fd");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("bd8946245ce77d01bfd8786ca1cfe3880bb41a1c947494fec20057e8b6f72e09");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("f2e777a97442bd7a026c6ac077c7007884a0c104ad8752a5463d94c9c9cdb207");
     });
   });
 });

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,11 +154,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("28bcab16c4b1d7ed65fc934f10de1b544f10d66d74e7bfbec342214aa9aca926");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("16f9debdd39ae1d42bcddcf13b4188f35cf921b18ff272710c462e517f48539a");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("36c9792c4fbdc81cb2619d16fa58a8f9ab5af41002ad967d38d87a27913999fd");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("bd8946245ce77d01bfd8786ca1cfe3880bb41a1c947494fec20057e8b6f72e09");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("f2e777a97442bd7a026c6ac077c7007884a0c104ad8752a5463d94c9c9cdb207");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("06a3ae170ff6ba05d5b1b4b22046c697b23a9d2c97af0bd92a1ebcbd01e7c078");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("1229c843866830f223030def91a84368a2c06231175ee9d7a29303b846fc4827");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("78294685a492256887e3159e26071ba06d62883c72ccb26fd323a883eefc30fd");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("e105190bcd647989da1579ac209ae54ed63e08224fbb2469bad9f596773fe558");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("8bab6ab2024de44a08765ee14ec3d6bdc0fa5ae2a5ee221c9f928345a3710658");
     });
   });
 });

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -303,14 +303,8 @@ contract("Colony Expenditure", (accounts) => {
       expect(expenditure.status).to.eq.BN(LOCKED);
     });
 
-    it("should not allow the owner to transfer the expenditure", async () => {
-      await colony.lockExpenditure(expenditureId, { from: ADMIN });
-
-      await checkErrorRevert(colony.transferExpenditure(expenditureId, USER, { from: ADMIN }), "colony-expenditure-not-draft");
-    });
-
     it("should not allow the owner to cancel the expenditure", async () => {
-      await colony.lockExpenditure(expenditureId, { from: ADMIN });
+      await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
       await checkErrorRevert(colony.cancelExpenditure(expenditureId, { from: ADMIN }), "colony-expenditure-not-draft");
     });
@@ -365,6 +359,12 @@ contract("Colony Expenditure", (accounts) => {
       expenditure = await colony.getExpenditure(expenditureId);
       expect(expenditure.status).to.eq.BN(FINALIZED);
       expect(expenditure.finalizedTimestamp).to.eq.BN(currTime);
+    });
+
+    it("should not allow the owner to transfer the expenditure", async () => {
+      await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
+
+      await checkErrorRevert(colony.transferExpenditure(expenditureId, USER, { from: ADMIN }), "colony-expenditure-not-active");
     });
 
     it("cannot finalize expenditure if it is not fully funded", async () => {

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -194,6 +194,10 @@ contract("Colony Expenditure", (accounts) => {
       expect(expenditureSlot.recipient).to.equal(USER);
     });
 
+    it("should not allow owners to update many slot recipients with mismatched arguments", async () => {
+      await checkErrorRevert(colony.setExpenditureRecipients(expenditureId, [SLOT0, SLOT1], [USER], { from: ADMIN }), "colony-expenditure-bad-slots");
+    });
+
     it("should allow owners to update a slot skill", async () => {
       await colony.setExpenditureSkill(expenditureId, SLOT0, GLOBAL_SKILL_ID, { from: ADMIN });
 
@@ -210,6 +214,17 @@ contract("Colony Expenditure", (accounts) => {
       expect(expenditureSlot.skills[0]).to.eq.BN(GLOBAL_SKILL_ID);
       expenditureSlot = await colony.getExpenditureSlot(expenditureId, SLOT2);
       expect(expenditureSlot.skills[0]).to.eq.BN(GLOBAL_SKILL_ID);
+    });
+
+    it("should not allow owners to update many slot skills with mismatched arguments", async () => {
+      await checkErrorRevert(
+        colony.setExpenditureSkills(expenditureId, [SLOT0, SLOT1], [GLOBAL_SKILL_ID], { from: ADMIN }),
+        "colony-expenditure-bad-slots"
+      );
+    });
+
+    it("should not allow owners to update many slot skills with nonexistent skills", async () => {
+      await checkErrorRevert(colony.setExpenditureSkills(expenditureId, [SLOT0], [100], { from: ADMIN }), "colony-expenditure-skill-does-not-exist");
     });
 
     it("should allow owners to update a slot claim delay", async () => {
@@ -230,6 +245,10 @@ contract("Colony Expenditure", (accounts) => {
       expect(expenditureSlot.claimDelay).to.eq.BN(20);
     });
 
+    it("should not allow owners to update many slot claim delays with mismatched arguments", async () => {
+      await checkErrorRevert(colony.setExpenditureClaimDelays(expenditureId, [SLOT0, SLOT1], [10], { from: ADMIN }), "colony-expenditure-bad-slots");
+    });
+
     it("should allow owners to update many slot payout modifiers at once", async () => {
       await colony.setExpenditurePayoutModifiers(expenditureId, [SLOT1, SLOT2], [WAD.divn(2), WAD], { from: ADMIN });
 
@@ -239,6 +258,13 @@ contract("Colony Expenditure", (accounts) => {
       expect(expenditureSlot.payoutModifier).to.eq.BN(WAD.divn(2));
       expenditureSlot = await colony.getExpenditureSlot(expenditureId, SLOT2);
       expect(expenditureSlot.payoutModifier).to.eq.BN(WAD);
+    });
+
+    it("should not allow owners to update many slot payout modifiers with mismatched arguments", async () => {
+      await checkErrorRevert(
+        colony.setExpenditurePayoutModifiers(expenditureId, [SLOT0, SLOT1], [WAD], { from: ADMIN }),
+        "colony-expenditure-bad-slots"
+      );
     });
 
     it("should allow owners to update many slot payouts at once", async () => {
@@ -251,6 +277,13 @@ contract("Colony Expenditure", (accounts) => {
       expect(payout).to.eq.BN(10);
       payout = await colony.getExpenditureSlotPayout(expenditureId, SLOT2, token.address);
       expect(payout).to.eq.BN(20);
+    });
+
+    it("should not allow owners to update many slot payouts with mismatched arguments", async () => {
+      await checkErrorRevert(
+        colony.setExpenditurePayouts(expenditureId, [SLOT0, SLOT1], token.address, [WAD], { from: ADMIN }),
+        "colony-expenditure-bad-slots"
+      );
     });
 
     it("should not allow owners to set a non-global skill or a deprecated global skill", async () => {

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -4,7 +4,7 @@ import bnChai from "bn-chai";
 import { BN } from "bn.js";
 import { ethers } from "ethers";
 
-import { UINT256_MAX, INT128_MAX, WAD, SECONDS_PER_DAY, MAX_PAYOUT, GLOBAL_SKILL_ID } from "../../helpers/constants";
+import { UINT256_MAX, INT128_MAX, WAD, SECONDS_PER_DAY, MAX_PAYOUT, GLOBAL_SKILL_ID, IPFS_HASH } from "../../helpers/constants";
 import { checkErrorRevert, expectEvent, getTokenArgs, forwardTime, getBlockTime, bn2bytes32 } from "../../helpers/test-helper";
 import { fundColonyWithTokens, setupRandomColony } from "../../helpers/test-data-generator";
 
@@ -160,6 +160,20 @@ contract("Colony Expenditure", (accounts) => {
 
     it("should error if the expenditure does not exist", async () => {
       await checkErrorRevert(colony.setExpenditureSkill(100, SLOT0, GLOBAL_SKILL_ID, { from: ADMIN }), "colony-expenditure-does-not-exist");
+    });
+
+    it("should allow owners to update the metadata", async () => {
+      const setExpenditureMetadata = colony.methods["setExpenditureMetadata(uint256,string)"];
+      const tx = await setExpenditureMetadata(expenditureId, IPFS_HASH, { from: ADMIN });
+
+      await expectEvent(tx, "ExpenditureMetadataSet", [ADMIN, IPFS_HASH]);
+    });
+
+    it("should allow arbitrators to update the metadata", async () => {
+      const setExpenditureMetadata = colony.methods["setExpenditureMetadata(uint256,uint256,uint256,string)"];
+      const tx = await setExpenditureMetadata(1, UINT256_MAX, expenditureId, IPFS_HASH, { from: ARBITRATOR });
+
+      await expectEvent(tx, "ExpenditureMetadataSet", [ARBITRATOR, IPFS_HASH]);
     });
 
     it("should allow owners to update a slot recipient", async () => {

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -166,14 +166,14 @@ contract("Colony Expenditure", (accounts) => {
       const setExpenditureMetadata = colony.methods["setExpenditureMetadata(uint256,string)"];
       const tx = await setExpenditureMetadata(expenditureId, IPFS_HASH, { from: ADMIN });
 
-      await expectEvent(tx, "ExpenditureMetadataSet", [ADMIN, IPFS_HASH]);
+      await expectEvent(tx, "ExpenditureMetadataSet", [ADMIN, expenditureId, IPFS_HASH]);
     });
 
     it("should allow arbitrators to update the metadata", async () => {
       const setExpenditureMetadata = colony.methods["setExpenditureMetadata(uint256,uint256,uint256,string)"];
       const tx = await setExpenditureMetadata(1, UINT256_MAX, expenditureId, IPFS_HASH, { from: ARBITRATOR });
 
-      await expectEvent(tx, "ExpenditureMetadataSet", [ARBITRATOR, IPFS_HASH]);
+      await expectEvent(tx, "ExpenditureMetadataSet", [ARBITRATOR, expenditureId, IPFS_HASH]);
     });
 
     it("should allow owners to update a slot recipient", async () => {
@@ -451,7 +451,7 @@ contract("Colony Expenditure", (accounts) => {
     it("should not allow the owner to transfer the expenditure", async () => {
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
 
-      await checkErrorRevert(colony.transferExpenditure(expenditureId, USER, { from: ADMIN }), "colony-expenditure-not-active");
+      await checkErrorRevert(colony.transferExpenditure(expenditureId, USER, { from: ADMIN }), "colony-expenditure-not-draft-or-locked");
     });
 
     it("cannot finalize expenditure if it is not fully funded", async () => {

--- a/test/extensions/evaluated-expenditures.js
+++ b/test/extensions/evaluated-expenditures.js
@@ -1,0 +1,131 @@
+/* globals artifacts */
+
+import chai from "chai";
+import bnChai from "bn-chai";
+import { ethers } from "ethers";
+import { soliditySha3 } from "web3-utils";
+
+import { UINT256_MAX, WAD } from "../../helpers/constants";
+import { setupEtherRouter } from "../../helpers/upgradable-contracts";
+import { checkErrorRevert, web3GetCode } from "../../helpers/test-helper";
+import { setupColonyNetwork, setupRandomColony, setupMetaColonyWithLockedCLNYToken } from "../../helpers/test-data-generator";
+
+const { expect } = chai;
+chai.use(bnChai(web3.utils.BN));
+
+const EvaluatedExpenditure = artifacts.require("EvaluatedExpenditure");
+const Resolver = artifacts.require("Resolver");
+const ColonyExtension = artifacts.require("ColonyExtension");
+
+const EVALUATED_EXPENDITURE = soliditySha3("EvaluatedExpenditure");
+
+contract("EvaluatedExpenditure", (accounts) => {
+  let colonyNetwork;
+  let colony;
+  let evaluatedExpenditure;
+  let evaluatedExpenditureVersion;
+
+  const USER0 = accounts[0];
+  const USER1 = accounts[1];
+
+  before(async () => {
+    colonyNetwork = await setupColonyNetwork();
+    const { metaColony } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork);
+
+    const evaluatedExpenditureImplementation = await EvaluatedExpenditure.new();
+    const resolver = await Resolver.new();
+    await setupEtherRouter("EvaluatedExpenditure", { EvaluatedExpenditure: evaluatedExpenditureImplementation.address }, resolver);
+    await metaColony.addExtensionToNetwork(EVALUATED_EXPENDITURE, resolver.address);
+
+    const versionSig = await resolver.stringToSig("version()");
+    const target = await resolver.lookup(versionSig);
+    const extensionImplementation = await ColonyExtension.at(target);
+    evaluatedExpenditureVersion = await extensionImplementation.version();
+  });
+
+  beforeEach(async () => {
+    ({ colony } = await setupRandomColony(colonyNetwork));
+
+    await colony.installExtension(EVALUATED_EXPENDITURE, evaluatedExpenditureVersion);
+
+    const evaluatedExpenditureAddress = await colonyNetwork.getExtensionInstallation(EVALUATED_EXPENDITURE, colony.address);
+    evaluatedExpenditure = await EvaluatedExpenditure.at(evaluatedExpenditureAddress);
+
+    await colony.setArbitrationRole(1, UINT256_MAX, evaluatedExpenditure.address, 1, true);
+  });
+
+  describe("managing the extension", async () => {
+    it("can install the extension manually", async () => {
+      evaluatedExpenditure = await EvaluatedExpenditure.new();
+      await evaluatedExpenditure.install(colony.address);
+
+      await checkErrorRevert(evaluatedExpenditure.install(colony.address), "extension-already-installed");
+
+      const identifier = await evaluatedExpenditure.identifier();
+      const version = await evaluatedExpenditure.version();
+      expect(identifier).to.equal(EVALUATED_EXPENDITURE);
+      expect(version).to.eq.BN(evaluatedExpenditureVersion);
+
+      const capabilityRoles = await evaluatedExpenditure.getCapabilityRoles("0x0");
+      expect(capabilityRoles).to.equal(ethers.constants.HashZero);
+
+      await evaluatedExpenditure.finishUpgrade();
+      await evaluatedExpenditure.deprecate(true);
+      await evaluatedExpenditure.uninstall();
+
+      const code = await web3GetCode(evaluatedExpenditure.address);
+      expect(code).to.equal("0x");
+    });
+
+    it("can install the extension with the extension manager", async () => {
+      ({ colony } = await setupRandomColony(colonyNetwork));
+      await colony.installExtension(EVALUATED_EXPENDITURE, evaluatedExpenditureVersion, { from: USER0 });
+
+      await checkErrorRevert(
+        colony.installExtension(EVALUATED_EXPENDITURE, evaluatedExpenditureVersion, { from: USER0 }),
+        "colony-network-extension-already-installed"
+      );
+
+      await checkErrorRevert(colony.uninstallExtension(EVALUATED_EXPENDITURE, { from: USER1 }), "ds-auth-unauthorized");
+
+      await colony.uninstallExtension(EVALUATED_EXPENDITURE, { from: USER0 });
+    });
+  });
+
+  describe("using the extension", async () => {
+    let expenditureId;
+
+    beforeEach(async () => {
+      await colony.makeExpenditure(1, UINT256_MAX, 1);
+      expenditureId = await colony.getExpenditureCount();
+
+      await colony.lockExpenditure(expenditureId);
+    });
+
+    it("can set the payout modifier in the locked state", async () => {
+      let expenditureSlot;
+
+      expenditureSlot = await colony.getExpenditureSlot(expenditureId, 0);
+      expect(expenditureSlot.payoutModifier).to.be.zero;
+
+      await evaluatedExpenditure.setExpenditurePayoutModifiers(1, UINT256_MAX, expenditureId, [0], [WAD], { from: USER0 });
+
+      expenditureSlot = await colony.getExpenditureSlot(expenditureId, 0);
+      expect(expenditureSlot.payoutModifier).to.eq.BN(WAD);
+    });
+
+    it("cannot set the payout modifier with bad arguments", async () => {
+      await checkErrorRevert(
+        evaluatedExpenditure.setExpenditurePayoutModifiers(1, UINT256_MAX, expenditureId, [0], [], { from: USER0 }),
+        "evaluated-expenditure-bad-slots"
+      );
+    });
+
+    it("cannot set the payout modifier if not the owner", async () => {
+      await checkErrorRevert(
+        evaluatedExpenditure.setExpenditurePayoutModifiers(1, UINT256_MAX, expenditureId, [0], [WAD], { from: USER1 }),
+        "evaluated-expenditure-not-owner"
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #950 

- Add an optional `Locked` state where the owner can no longer change values.
- Add a new `Active` pseudo-state, consisting of either `Draft` or `Locked`.
- Restricted editing and cancellation to `Draft`, allow to transfer and finalize from `Active`.
- Add utility functions to set recipients, skills, claimDelays, and payouts in batches.
- Add ability to emit metadata for expenditures.
- Allow the owner to edit the payout modifiers, in the `Draft` state.
- Introduce an extension, `EvaluatedExpenditures`, which allows the owner to edit the payout modifiers in the `Locked` state.