### PR TITLE
Change how rewards are calculated for vote revealers

### DIFF
--- a/contracts/extensions/VotingReputation.sol
+++ b/contracts/extensions/VotingReputation.sol
@@ -809,7 +809,7 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs {
   /// @return The voter reward
   function getVoterReward(uint256 _motionId, uint256 _voterRep) public view returns (uint256) {
     Motion storage motion = motions[_motionId];
-    uint256 fractionUserReputation = wdiv(_voterRep, motion.skillRep);
+    uint256 fractionUserReputation = wdiv(_voterRep, motion.repSubmitted);
     uint256 totalStake = add(motion.stakes[YAY], motion.stakes[NAY]);
     return wmul(wmul(fractionUserReputation, totalStake), voterRewardFraction);
   }

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,8 +154,8 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("e4110f26ac3aaca989a3fb584334f0c3e0a9c20143cc024611ec08dcca0c3e81");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("7e85895a0000e69596b99e5979c4e41fa708f3070413c0fd0d07665cd24a8e56");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("fba87fb21ad92181a0293eb6ebea6534e3ffdbf4aadeea738760fb4cdd2f4495");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("b72949c9bec989c65b9afed3eaf23706f48e12a01a45d9d0a5a5490180461f81");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("4eac8ccffe8b2eebb1da321e5544c8334005fe0e9afbaa1a4d654abf14515ede");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("f7ce25312c171119867cd296607295d7a781cfb87fc6088c09787919b3ff3b25");
       expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("621840deab018bf9f7bb35d60a503c0d2abfb4b0e5bc6ae72a7c4d9a6870e680");


### PR DESCRIPTION
These changes mean that more of the reward pool will be paid out - essentially, the pool is split (notionally) between all those who voted, rather than all of those who could have voted. Note that you are still required to reveal your vote to receive the rewards, so it remains possible for much of the pool to not be paid out if many people who voted do not reveal their vote for whatever reason.

I've also added a new function called `getVoterRewardRange` which can be used to see what the potential payout for a user will be should they choose to vote and then reveal.