### PR TITLE
Per-user Coin Machine limits

### DIFF
--- a/contracts/extensions/CoinMachine.sol
+++ b/contracts/extensions/CoinMachine.sol
@@ -62,7 +62,7 @@ contract CoinMachine is ColonyExtension {
   bool evolvePrice; // If we should evolve the price or not
 
   uint256 soldTotal; // Total tokens sold by the coin machine
-  uint256 userLimit; // Limit any address can buy of the total amount (as WAD percentage)
+  uint256 userLimit; // Limit any address can buy of the total amount (as WAD-denominated fraction)
 
   mapping(address => uint256) soldUser; // Tokens sold to a particular user
 
@@ -154,6 +154,7 @@ contract CoinMachine is ColonyExtension {
     require(_targetPerPeriod > 0, "coin-machine-target-too-small");
     require(_maxPerPeriod >= _targetPerPeriod, "coin-machine-max-too-small");
     require(_userLimit <= WAD, "coin-machine-limit-too-large");
+    require(_userLimit > 0, "coin-machine-limit-too-small");
 
     token = _token;
     purchaseToken = _purchaseToken;
@@ -362,7 +363,7 @@ contract CoinMachine is ColonyExtension {
   /// @notice Get the maximum amount of tokens a user can purchase
   function getMaxPurchase(address _user) public view returns (uint256) {
     // ((max(soldTotal, targetPerPeriod) * userLimit) - soldUser) / (1 - userLimit)
-    return (userLimit == WAD) ? UINT256_MAX : wdiv(
+    return (userLimit == WAD || whitelist == address(0x0)) ? UINT256_MAX : wdiv(
       sub(wmul(max(soldTotal, targetPerPeriod), userLimit), soldUser[_user]),
       sub(WAD, userLimit)
     );

--- a/contracts/extensions/CoinMachine.sol
+++ b/contracts/extensions/CoinMachine.sol
@@ -95,6 +95,7 @@ contract CoinMachine is ColonyExtension {
   /// @notice Called when upgrading the extension
   function finishUpgrade() public override auth {
     token = colony.getToken();
+    userLimitFraction = WAD;
 
     setPriceEvolution(getTokenBalance() > 0 && !deprecated);
   }
@@ -202,6 +203,8 @@ contract CoinMachine is ColonyExtension {
     uint256 maxPurchase = getMaxPurchase(msg.sender);
     uint256 numTokens = min(maxPurchase, _numTokens);
     uint256 totalCost = wmul(numTokens, activePrice);
+
+    if (numTokens <= 0) { return; }
 
     activeIntake = add(activeIntake, totalCost);
     activeSold = add(activeSold, numTokens);

--- a/contracts/extensions/ColonyExtension.sol
+++ b/contracts/extensions/ColonyExtension.sol
@@ -26,6 +26,8 @@ import "./../colony/ColonyDataTypes.sol";
 
 abstract contract ColonyExtension is DSAuth, DSMath {
 
+  uint256 constant UINT256_MAX = 2**256 - 1;
+
   event ExtensionInitialised();
 
   address resolver; // Align storage with EtherRouter

--- a/contracts/extensions/FundingQueue.sol
+++ b/contracts/extensions/FundingQueue.sol
@@ -38,7 +38,6 @@ contract FundingQueue is ColonyExtension, PatriciaTreeProofs {
 
   // Constants
   uint256 constant HEAD = 0;
-  uint256 constant UINT256_MAX = (2 ** 256) - 1;
   uint256 constant STAKE_FRACTION = WAD / 1000; // 0.1%
   uint256 constant COOLDOWN_PERIOD = 14 days;
 

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -26,7 +26,6 @@ import "./ColonyExtension.sol";
 contract OneTxPayment is ColonyExtension {
   event OneTxPaymentMade(address agent, uint256 fundamentalId, uint256 nPayouts);
 
-  uint256 constant UINT256_MAX = 2**256 - 1;
   ColonyDataTypes.ColonyRole constant ADMINISTRATION = ColonyDataTypes.ColonyRole.Administration;
   ColonyDataTypes.ColonyRole constant FUNDING = ColonyDataTypes.ColonyRole.Funding;
 

--- a/contracts/extensions/VotingReputation.sol
+++ b/contracts/extensions/VotingReputation.sol
@@ -39,7 +39,6 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs {
   event MotionEventSet(uint256 indexed motionId, uint256 eventIndex);
 
   // Constants
-  uint256 constant UINT256_MAX = 2**256 - 1;
   uint256 constant UINT128_MAX = 2**128 - 1;
 
   uint256 constant NAY = 0;

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,8 +154,8 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("e10e816b235f21825b73d4e90c2114cd2fbc68f2d49d3c4081b8536747b70e24");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("76a5c2ea62ee88ed3992e3278cdbb821da482b4d5c3f40ed79ed4f3ee530520f");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("2d8b407a3d5d1a48b07a00c968942ee7cb384961a5f166035a194cf7f8bd3245");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("36096952d464e6c70a0a3aa2ecf068dff7bc6af70ffe022d57d8e2342d39f989");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("6bee0085d000fc929e06c1281c162eaa7ac22ff9e2dcc520066e5e7720de6394");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("bcfee6939c375d042704e338652a1e2d1e6f7b0e69587b79e72bde08ca777927");
       expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("8b9242eb6e0fd017538f71e90c6ce9793839743e869bed54030861d3594453b1");

--- a/test/contracts-network/colony-arbitrary-transactions.js
+++ b/test/contracts-network/colony-arbitrary-transactions.js
@@ -163,7 +163,7 @@ contract("Colony Arbitrary Transactions", (accounts) => {
 
     const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
     const coinMachine = await CoinMachine.at(coinMachineAddress);
-    await coinMachine.initialise(token.address, ethers.constants.AddressZero, 60 * 60, 10, WAD, WAD, WAD, ADDRESS_ZERO);
+    await coinMachine.initialise(token.address, ethers.constants.AddressZero, 60 * 60, 10, WAD, WAD, WAD, WAD, ADDRESS_ZERO);
     await token.mint(coinMachine.address, WAD);
 
     const action = await encodeTxData(coinMachine, "buyTokens", [WAD]);

--- a/test/extensions/coin-machine.js
+++ b/test/extensions/coin-machine.js
@@ -50,6 +50,7 @@ contract("Coin Machine", (accounts) => {
 
   const USER0 = accounts[0];
   const USER1 = accounts[1];
+  const USER2 = accounts[2];
 
   const ADDRESS_ZERO = ethers.constants.AddressZero;
 
@@ -123,7 +124,7 @@ contract("Coin Machine", (accounts) => {
     it("can send unsold tokens back to the colony", async () => {
       await token.mint(coinMachine.address, WAD, { from: USER0 });
 
-      await coinMachine.initialise(token.address, ADDRESS_ZERO, 60 * 60, 10, WAD, WAD, WAD, ADDRESS_ZERO);
+      await coinMachine.initialise(token.address, ADDRESS_ZERO, 60 * 60, 10, WAD, WAD, WAD, WAD, ADDRESS_ZERO);
 
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
 
@@ -132,11 +133,15 @@ contract("Coin Machine", (accounts) => {
     });
 
     it("can initialise", async () => {
-      await expectEvent(coinMachine.initialise(token.address, purchaseToken.address, 60, 511, 10, 10, 0, ADDRESS_ZERO), "ExtensionInitialised", []);
+      await expectEvent(
+        coinMachine.initialise(token.address, purchaseToken.address, 60, 511, 10, 10, WAD, 0, ADDRESS_ZERO),
+        "ExtensionInitialised",
+        []
+      );
     });
 
     it("can handle a large windowSize", async () => {
-      await coinMachine.initialise(token.address, purchaseToken.address, 60, 511, 10, 10, 0, ADDRESS_ZERO);
+      await coinMachine.initialise(token.address, purchaseToken.address, 60, 511, 10, 10, WAD, 0, ADDRESS_ZERO);
 
       // Advance an entire window
       await forwardTime(60 * 511 + 1, this);
@@ -146,43 +151,47 @@ contract("Coin Machine", (accounts) => {
 
     it("cannot initialise with bad arguments", async () => {
       await checkErrorRevert(
-        coinMachine.initialise(ADDRESS_ZERO, purchaseToken.address, 60, 511, 10, 10, 0, ADDRESS_ZERO),
+        coinMachine.initialise(ADDRESS_ZERO, purchaseToken.address, 60, 511, 10, 10, WAD, 0, ADDRESS_ZERO),
         "coin-machine-invalid-token"
       );
       await checkErrorRevert(
-        coinMachine.initialise(token.address, purchaseToken.address, 0, 511, 10, 10, 0, ADDRESS_ZERO),
+        coinMachine.initialise(token.address, purchaseToken.address, 0, 511, 10, 10, WAD, 0, ADDRESS_ZERO),
         "coin-machine-period-too-small"
       );
       await checkErrorRevert(
-        coinMachine.initialise(token.address, purchaseToken.address, 60, 0, 10, 10, 0, ADDRESS_ZERO),
+        coinMachine.initialise(token.address, purchaseToken.address, 60, 0, 10, 10, WAD, 0, ADDRESS_ZERO),
         "coin-machine-window-too-small"
       );
       await checkErrorRevert(
-        coinMachine.initialise(token.address, purchaseToken.address, 60, 512, 10, 10, 0, ADDRESS_ZERO),
+        coinMachine.initialise(token.address, purchaseToken.address, 60, 512, 10, 10, WAD, 0, ADDRESS_ZERO),
         "coin-machine-window-too-large"
       );
       await checkErrorRevert(
-        coinMachine.initialise(token.address, purchaseToken.address, 60, 511, 0, 10, 0, ADDRESS_ZERO),
+        coinMachine.initialise(token.address, purchaseToken.address, 60, 511, 0, 10, WAD, 0, ADDRESS_ZERO),
         "coin-machine-target-too-small"
       );
       await checkErrorRevert(
-        coinMachine.initialise(token.address, purchaseToken.address, 60, 511, 10, 9, 0, ADDRESS_ZERO),
+        coinMachine.initialise(token.address, purchaseToken.address, 60, 511, 10, 9, WAD, 0, ADDRESS_ZERO),
         "coin-machine-max-too-small"
+      );
+      await checkErrorRevert(
+        coinMachine.initialise(token.address, purchaseToken.address, 60, 511, 10, 10, WAD.addn(1), 0, ADDRESS_ZERO),
+        "coin-machine-limit-too-large"
       );
     });
 
     it("cannot initialise twice", async () => {
-      await coinMachine.initialise(token.address, purchaseToken.address, 60, 511, 10, 10, 0, ADDRESS_ZERO);
+      await coinMachine.initialise(token.address, purchaseToken.address, 60, 511, 10, 10, WAD, 0, ADDRESS_ZERO);
 
       await checkErrorRevert(
-        coinMachine.initialise(token.address, purchaseToken.address, 60, 511, 10, 10, 0, ADDRESS_ZERO),
+        coinMachine.initialise(token.address, purchaseToken.address, 60, 511, 10, 10, WAD, 0, ADDRESS_ZERO),
         "coin-machine-already-initialised"
       );
     });
 
     it("cannot initialise if not root", async () => {
       await checkErrorRevert(
-        coinMachine.initialise(token.address, purchaseToken.address, 60, 511, 10, 10, 0, ADDRESS_ZERO, { from: USER1 }),
+        coinMachine.initialise(token.address, purchaseToken.address, 60, 511, 10, 10, WAD, 0, ADDRESS_ZERO, { from: USER1 }),
         "coin-machine-caller-not-root"
       );
     });
@@ -199,6 +208,7 @@ contract("Coin Machine", (accounts) => {
         10, // number of periods for averaging
         WAD.muln(100), // tokens per period
         WAD.muln(200), // max per period
+        WAD, // user limit percentage
         WAD, // starting price
         ADDRESS_ZERO // whitelist address
       );
@@ -264,7 +274,7 @@ contract("Coin Machine", (accounts) => {
 
       await otherToken.mint(coinMachine.address, UINT128_MAX);
 
-      await coinMachine.initialise(otherToken.address, purchaseToken.address, 60 * 60, 10, WAD.muln(100), WAD.muln(200), WAD, ADDRESS_ZERO);
+      await coinMachine.initialise(otherToken.address, purchaseToken.address, 60 * 60, 10, WAD.muln(100), WAD.muln(200), WAD, WAD, ADDRESS_ZERO);
 
       await purchaseToken.mint(USER0, WAD, { from: USER0 });
       await purchaseToken.approve(coinMachine.address, WAD, { from: USER0 });
@@ -283,7 +293,7 @@ contract("Coin Machine", (accounts) => {
 
       await token.mint(coinMachine.address, WAD);
 
-      await coinMachine.initialise(token.address, purchaseToken.address, 60 * 60, 10, WAD.muln(100), WAD.muln(200), WAD, ADDRESS_ZERO);
+      await coinMachine.initialise(token.address, purchaseToken.address, 60 * 60, 10, WAD.muln(100), WAD.muln(200), WAD, WAD, ADDRESS_ZERO);
 
       await purchaseToken.mint(USER0, WAD.muln(2), { from: USER0 });
       await purchaseToken.approve(coinMachine.address, WAD.muln(2), { from: USER0 });
@@ -314,7 +324,7 @@ contract("Coin Machine", (accounts) => {
 
       await token.mint(coinMachine.address, WAD.muln(1000));
 
-      await coinMachine.initialise(token.address, purchaseToken.address, 60 * 60, 10, WAD.muln(100), WAD.muln(200), WAD, ADDRESS_ZERO);
+      await coinMachine.initialise(token.address, purchaseToken.address, 60 * 60, 10, WAD.muln(100), WAD.muln(200), WAD, WAD, ADDRESS_ZERO);
 
       await purchaseToken.mint(USER1, WAD, { from: USER0 });
       await purchaseToken.approve(coinMachine.address, WAD, { from: USER1 });
@@ -347,7 +357,7 @@ contract("Coin Machine", (accounts) => {
 
       await token.mint(coinMachine.address, UINT128_MAX);
 
-      await coinMachine.initialise(token.address, ADDRESS_ZERO, 60 * 60, 10, WAD.muln(100), WAD.muln(200), WAD, ADDRESS_ZERO);
+      await coinMachine.initialise(token.address, ADDRESS_ZERO, 60 * 60, 10, WAD.muln(100), WAD.muln(200), WAD, WAD, ADDRESS_ZERO);
 
       const currentPrice = await coinMachine.getCurrentPrice();
 
@@ -380,6 +390,56 @@ contract("Coin Machine", (accounts) => {
 
       const balance = await token.balanceOf(USER0);
       expect(balance).to.eq.BN(maxPerPeriod);
+    });
+
+    it("cannot buy more than ther user limit allows", async () => {
+      await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, coinMachineVersion, { from: USER0 });
+      const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
+      coinMachine = await CoinMachine.at(coinMachineAddress);
+
+      await token.mint(coinMachine.address, WAD.muln(1000));
+
+      await coinMachine.initialise(token.address, purchaseToken.address, 60 * 60, 10, WAD.muln(100), WAD.muln(200), WAD.divn(2), WAD, ADDRESS_ZERO);
+      const periodLength = await coinMachine.getPeriodLength();
+
+      await purchaseToken.mint(USER0, WAD.muln(500), { from: USER0 });
+      await purchaseToken.approve(coinMachine.address, WAD.muln(500), { from: USER0 });
+
+      await purchaseToken.mint(USER1, WAD.muln(500), { from: USER0 });
+      await purchaseToken.approve(coinMachine.address, WAD.muln(500), { from: USER1 });
+
+      await purchaseToken.mint(USER2, WAD.muln(500), { from: USER0 });
+      await purchaseToken.approve(coinMachine.address, WAD.muln(500), { from: USER2 });
+
+      let maxPurchase;
+
+      // totalSold is 0, so we use targetPerPeriod (100) as a pseudo-total
+      // The user can buy 100 tokens, because it thinks the total will be 200
+      maxPurchase = await coinMachine.getMaxPurchase(USER0);
+      expect(maxPurchase).to.eq.BN(WAD.muln(100));
+
+      await coinMachine.buyTokens(WAD.muln(100), { from: USER0 });
+      await coinMachine.buyTokens(WAD.muln(100), { from: USER1 });
+
+      await forwardTime(periodLength.toNumber(), this);
+
+      // Now totalSold is 200
+      // Since each owns half already, neither can buy, only a new user can
+      // The new user can buy 200 tokens, half of 400
+      maxPurchase = await coinMachine.getMaxPurchase(USER0);
+      expect(maxPurchase).to.be.zero;
+      maxPurchase = await coinMachine.getMaxPurchase(USER2);
+      expect(maxPurchase).to.eq.BN(WAD.muln(200));
+
+      await coinMachine.buyTokens(WAD.muln(200), { from: USER2 });
+
+      await forwardTime(periodLength.toNumber(), this);
+
+      // Now totalSold is 400
+      // Original users can buy 200 tokens, owning half (300) of 600
+      maxPurchase = await coinMachine.getMaxPurchase(USER0);
+      expect(maxPurchase).to.eq.BN(WAD.muln(200));
     });
 
     it("can buy tokens over multiple periods", async () => {
@@ -454,7 +514,7 @@ contract("Coin Machine", (accounts) => {
 
       await token.mint(coinMachine.address, WAD.muln(200));
 
-      await coinMachine.initialise(token.address, purchaseToken.address, 60 * 60, 10, WAD.muln(100), WAD.muln(200), WAD, ADDRESS_ZERO);
+      await coinMachine.initialise(token.address, purchaseToken.address, 60 * 60, 10, WAD.muln(100), WAD.muln(200), WAD, WAD, ADDRESS_ZERO);
 
       const periodLength = await coinMachine.getPeriodLength();
       const maxPerPeriod = await coinMachine.getMaxPerPeriod();
@@ -698,7 +758,7 @@ contract("Coin Machine", (accounts) => {
 
       await token.mint(coinMachine.address, UINT128_MAX);
 
-      await coinMachine.initialise(token.address, purchaseToken.address, 60 * 60, 10, WAD, WAD, WAD, ADDRESS_ZERO);
+      await coinMachine.initialise(token.address, purchaseToken.address, 60 * 60, 10, WAD, WAD, WAD, WAD, ADDRESS_ZERO);
 
       await purchaseToken.mint(USER0, WAD, { from: USER0 });
       await purchaseToken.approve(coinMachine.address, WAD, { from: USER0 });
@@ -720,7 +780,7 @@ contract("Coin Machine", (accounts) => {
 
       await token.mint(coinMachine.address, UINT128_MAX);
 
-      await coinMachine.initialise(token.address, purchaseToken.address, 60 * 60, 10, WAD, WAD, WAD, ADDRESS_ZERO);
+      await coinMachine.initialise(token.address, purchaseToken.address, 60 * 60, 10, WAD, WAD, WAD, WAD, ADDRESS_ZERO);
 
       await purchaseToken.mint(USER0, WAD, { from: USER0 });
       await purchaseToken.approve(coinMachine.address, WAD, { from: USER0 });
@@ -742,7 +802,7 @@ contract("Coin Machine", (accounts) => {
 
       await token.mint(coinMachine.address, UINT128_MAX);
 
-      await coinMachine.initialise(token.address, purchaseToken.address, 60 * 60, 10, WAD, WAD, WAD, whitelist.address);
+      await coinMachine.initialise(token.address, purchaseToken.address, 60 * 60, 10, WAD, WAD, WAD, WAD, whitelist.address);
 
       await colony.setAdministrationRole(1, UINT256_MAX, USER1, 1, true);
     });

--- a/test/extensions/coin-machine.js
+++ b/test/extensions/coin-machine.js
@@ -796,7 +796,7 @@ contract("Coin Machine", (accounts) => {
       expect(recordedAddress).to.equal(ADDRESS_ZERO);
     });
 
-    it("cannot buy more than ther user limit allows", async () => {
+    it("cannot buy more than their user limit allows", async () => {
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
       await colony.installExtension(COIN_MACHINE, coinMachineVersion, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);


### PR DESCRIPTION
Closes #952 

- Introduce a new initialisation parameter, `userLimitFraction`, which governs what % of the total sold amount any user can buy. If the total amount of tokens sold is less than `maxPerPeriod`, that value is used.
- Introduce `getUserLimit` which returns the total amount of tokens any given user can purchase, across many periods.
- Replace `getNumAvailable` with `getSellableTokens`, which does not take into account the token balance, only the remaining tokens in the period.
- Introduce `getMaxPurchase` which  returns the amount of tokens a user can purchase in the current period, taking into account all factors (token balance, user limits, and remaining tokens in the period)
