### PR TITLE
Bump version on OneTxPayment

### DIFF
--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -37,7 +37,7 @@ contract OneTxPayment is ColonyExtension {
 
   /// @notice Returns the version of the extension
   function version() public override pure returns (uint256) {
-    return 1;
+    return 2;
   }
 
   /// @notice Configures the extension

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,7 +154,7 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("aedd2a128409247f2d2a5cfe3140b863fdbf53eb1879936919c0a7be1a4d3c4f");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("e10e816b235f21825b73d4e90c2114cd2fbc68f2d49d3c4081b8536747b70e24");
       expect(colonyAccount.stateRoot.toString("hex")).to.equal("76a5c2ea62ee88ed3992e3278cdbb821da482b4d5c3f40ed79ed4f3ee530520f");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("6bee0085d000fc929e06c1281c162eaa7ac22ff9e2dcc520066e5e7720de6394");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("bcfee6939c375d042704e338652a1e2d1e6f7b0e69587b79e72bde08ca777927");


### PR DESCRIPTION
After #949, with the addition of `getCapabilityRoles` to extensions, we had to bump the version of all extensions that are currently deployed. This has tripped us up in QA with `oneTxPayment`, which I'm bumping here before deploying a new version of. The deployment of `VotingReputation` was bumped already, and nothing else is deployed, so I think this is all that's needed. We really need to figure out a better way of tracking this sort of thing though, for both ours and the frontend team's benefit.