### PR TITLE
A number (currently four) of smallish changes and improvements

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -57,7 +57,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
   returns (bool)
   {
     require(_targets.length == _actions.length, "colony-targets-and-actions-length-mismatch");
-    for (uint256 i = 0; i < _targets.length; i+= 1){
+    for (uint256 i; i < _targets.length; i+= 1){
       require(
         makeArbitraryTransactionFunctionality(_targets[i], _actions[i]),
         "colony-arbitrary-transaction-failed"

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -59,6 +59,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     require(_targets.length == _actions.length, "colony-targets-and-actions-length-mismatch");
     for (uint256 i; i < _targets.length; i += 1){
       bool success = true;
+      // slither-disable-next-line unused-return
       try this.makeSingleArbitraryTransaction(_targets[i], _actions[i]) returns (bool ret){
         if (_strict){
           success = ret;
@@ -75,8 +76,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
   }
 
   function makeSingleArbitraryTransaction(address _to, bytes memory _action)
-  external
-  self
+  external stoppable self
   returns (bool)
   {
     // Prevent transactions to network contracts

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -49,6 +49,27 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
   public stoppable auth
   returns (bool)
   {
+    return makeArbitraryTransactionFunctionality(_to, _action);
+  }
+
+  function makeArbitraryTransactions(address[] memory _targets, bytes[] memory _actions)
+  public stoppable auth
+  returns (bool)
+  {
+    require(_targets.length == _actions.length, "colony-targets-and-actions-length-mismatch");
+    for (uint256 i = 0; i < _targets.length; i+= 1){
+      require(
+        makeArbitraryTransactionFunctionality(_targets[i], _actions[i]),
+        "colony-arbitrary-transaction-failed"
+      );
+    }
+    return true;
+  }
+
+  function makeArbitraryTransactionFunctionality(address _to, bytes memory _action)
+  internal
+  returns (bool)
+  {
     // Prevent transactions to network contracts
     require(_to != address(this), "colony-cannot-target-self");
     require(_to != colonyNetworkAddress, "colony-cannot-target-network");
@@ -460,17 +481,13 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     emit ColonyUpgraded(msg.sender, currentVersion, _newVersion);
   }
 
-  // v5 to v6
+  // v7 to v8
   function finishUpgrade() public always {
     ColonyAuthority colonyAuthority = ColonyAuthority(address(authority));
     bytes4 sig;
 
-    sig = bytes4(keccak256("setUserRoles(uint256,uint256,address,uint256,bytes32)"));
+    sig = bytes4(keccak256("makeArbitraryTransactions(address[],bytes[])"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
-
-    sig = bytes4(keccak256("moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)"));
-    colonyAuthority.setRoleCapability(uint8(ColonyRole.Funding), address(this), sig, true);
-
   }
 
   function checkNotAdditionalProtectedVariable(uint256 _slot) public view recovery {

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -116,7 +116,7 @@ contract ColonyAuthority is CommonAuthority {
 
 
     // Added in colony v8
-    addRoleCapability(ROOT_ROLE, "makeArbitraryTransactions(address[],bytes[])");
+    addRoleCapability(ROOT_ROLE, "makeArbitraryTransactions(address[],bytes[],bool)");
 
   }
 

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -113,6 +113,11 @@ contract ColonyAuthority is CommonAuthority {
 
     // Added in colony v6 (d-lwss)
     addRoleCapability(FUNDING_ROLE, "moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)");
+
+
+    // Added in colony v8
+    addRoleCapability(ROOT_ROLE, "makeArbitraryTransactions(address[],bytes[])");
+
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -62,7 +62,7 @@ interface IColony is ColonyDataTypes, IRecovery {
 
   /// @notice Execute arbitrary transaction on behalf of the Colony
   /// DEPRECATED
-  /// @param _to Contract to receive the function call (cannot be network or token locking)
+  /// @param _to Contract to receive the function call (cannot be this contract, network or token locking)
   /// @param _action Bytes array encoding the function call and arguments
   /// @return success Boolean indicating whether the transaction succeeded
   function makeArbitraryTransaction(address _to, bytes memory _action) external returns (bool success);
@@ -70,8 +70,17 @@ interface IColony is ColonyDataTypes, IRecovery {
   /// @notice Execute arbitrary transactions on behalf of the Colony in series
   /// @param _targets Array of addressed to be targeted
   /// @param _actions Array of Bytes arrays encoding the function calls and arguments
+  /// @param _strict Boolean indicating whether if one transaction fails, the whole call to this function should fail.
   /// @return success Boolean indicating whether the transactions succeeded
-  function makeArbitraryTransactions(address[] memory _targets, bytes[] memory _actions) external returns (bool success);
+  function makeArbitraryTransactions(address[] memory _targets, bytes[] memory _actions, bool _strict) external returns (bool success);
+
+  /// @notice Executes a single arbitrary transaction
+  /// @dev Only callable by the colony itself. If you wish to use this functionality, you should
+  /// use the makeAbitraryTransactions function
+  /// @param _target Contract to receive the function call
+  /// @param _action Bytes array encoding the function call and arguments
+  /// @return success Boolean indicating whether the transactions succeeded
+  function makeSingleArbitraryTransaction(address _target, bytes memory _action) external returns (bool success);
 
   /// @notice Emit a metadata string for a transaction
   /// @param _txHash Hash of transaction being annotated (0x0 for current tx)

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -61,10 +61,17 @@ interface IColony is ColonyDataTypes, IRecovery {
   function getToken() external view returns (address tokenAddress);
 
   /// @notice Execute arbitrary transaction on behalf of the Colony
+  /// DEPRECATED
   /// @param _to Contract to receive the function call (cannot be network or token locking)
   /// @param _action Bytes array encoding the function call and arguments
   /// @return success Boolean indicating whether the transaction succeeded
   function makeArbitraryTransaction(address _to, bytes memory _action) external returns (bool success);
+
+  /// @notice Execute arbitrary transactions on behalf of the Colony in series
+  /// @param _targets Array of addressed to be targeted
+  /// @param _actions Array of Bytes arrays encoding the function calls and arguments
+  /// @return success Boolean indicating whether the transactions succeeded
+  function makeArbitraryTransactions(address[] memory _targets, bytes[] memory _actions) external returns (bool success);
 
   /// @notice Emit a metadata string for a transaction
   /// @param _txHash Hash of transaction being annotated (0x0 for current tx)

--- a/contracts/extensions/VotingReputation.sol
+++ b/contracts/extensions/VotingReputation.sol
@@ -265,6 +265,8 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs {
       if (skillId != actionDomainSkillId) {
         uint256 childSkillId = colonyNetwork.getChildSkillId(skillId, _childSkillIndex);
         require(childSkillId == actionDomainSkillId, "voting-rep-invalid-domain-id");
+      } else {
+        require(_childSkillIndex == UINT256_MAX, "voting-rep-invalid-domain-id");
       }
     }
 

--- a/contracts/tokenLocking/TokenLocking.sol
+++ b/contracts/tokenLocking/TokenLocking.sol
@@ -157,6 +157,7 @@ contract TokenLocking is TokenLockingStorage, DSMath { // ignore-swc-123
 
   function approveStake(address _user, uint256 _amount, address _token) public calledByColonyOrNetwork() {
     approvals[_user][_token][msg.sender] = add(approvals[_user][_token][msg.sender], _amount);
+    emit UserTokenApproved(_token, _user, msg.sender, _amount);
   }
 
   function obligateStake(address _user, uint256 _amount, address _token) public calledByColonyOrNetwork() {
@@ -165,11 +166,13 @@ contract TokenLocking is TokenLockingStorage, DSMath { // ignore-swc-123
     totalObligations[_user][_token] = add(totalObligations[_user][_token], _amount);
 
     require(userLocks[_token][_user].balance >= totalObligations[_user][_token], "colony-token-locking-insufficient-deposit");
+    emit UserTokenObligated(_token, _user, msg.sender, _amount);
   }
 
   function deobligateStake(address _user, uint256 _amount, address _token) public calledByColonyOrNetwork() {
     obligations[_user][_token][msg.sender] = sub(obligations[_user][_token][msg.sender], _amount);
     totalObligations[_user][_token] = sub(totalObligations[_user][_token], _amount);
+    emit UserTokenDeobligated(_token, _user, msg.sender, _amount);
   }
 
   function transferStake(address _user, uint256 _amount, address _token, address _recipient) public calledByColonyOrNetwork() {
@@ -181,6 +184,7 @@ contract TokenLocking is TokenLockingStorage, DSMath { // ignore-swc-123
     userLock.balance = sub(userLock.balance, _amount);
 
     makeConditionalDeposit(_token, _amount, _recipient);
+    emit StakeTransferred(_token, msg.sender, _user, _recipient, _amount);
   }
 
   function reward(address _recipient, uint256 _amount) public pure { // solhint-disable-line no-empty-blocks

--- a/contracts/tokenLocking/TokenLocking.sol
+++ b/contracts/tokenLocking/TokenLocking.sol
@@ -157,6 +157,7 @@ contract TokenLocking is TokenLockingStorage, DSMath { // ignore-swc-123
 
   function approveStake(address _user, uint256 _amount, address _token) public calledByColonyOrNetwork() {
     approvals[_user][_token][msg.sender] = add(approvals[_user][_token][msg.sender], _amount);
+
     emit UserTokenApproved(_token, _user, msg.sender, _amount);
   }
 
@@ -166,12 +167,14 @@ contract TokenLocking is TokenLockingStorage, DSMath { // ignore-swc-123
     totalObligations[_user][_token] = add(totalObligations[_user][_token], _amount);
 
     require(userLocks[_token][_user].balance >= totalObligations[_user][_token], "colony-token-locking-insufficient-deposit");
+
     emit UserTokenObligated(_token, _user, msg.sender, _amount);
   }
 
   function deobligateStake(address _user, uint256 _amount, address _token) public calledByColonyOrNetwork() {
     obligations[_user][_token][msg.sender] = sub(obligations[_user][_token][msg.sender], _amount);
     totalObligations[_user][_token] = sub(totalObligations[_user][_token], _amount);
+
     emit UserTokenDeobligated(_token, _user, msg.sender, _amount);
   }
 
@@ -184,6 +187,7 @@ contract TokenLocking is TokenLockingStorage, DSMath { // ignore-swc-123
     userLock.balance = sub(userLock.balance, _amount);
 
     makeConditionalDeposit(_token, _amount, _recipient);
+
     emit StakeTransferred(_token, msg.sender, _user, _recipient, _amount);
   }
 

--- a/contracts/tokenLocking/TokenLockingDataTypes.sol
+++ b/contracts/tokenLocking/TokenLockingDataTypes.sol
@@ -27,6 +27,10 @@ interface TokenLockingDataTypes {
   event UserTokenClaimed(address token, address user, uint256 amount);
   event UserTokenTransferred(address token, address user, address recipient, uint256 amount);
   event UserTokenWithdrawn(address token, address user, uint256 amount);
+  event UserTokenObligated(address token, address user, address obligatedBy, uint256 amount);
+  event UserTokenDeobligated(address token, address user, address obligatedBy, uint256 amount);
+  event UserTokenApproved(address token, address user, address approvedBy, uint256 amount);
+  event StakeTransferred(address token, address by, address from, address to, uint256 amount);
 
   struct Lock {
     // User's lock count

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -1060,7 +1060,7 @@ Execute arbitrary transaction on behalf of the Colony DEPRECATED
 
 |Name|Type|Description|
 |---|---|---|
-|_to|address|Contract to receive the function call (cannot be network or token locking)
+|_to|address|Contract to receive the function call (cannot be this contract, network or token locking)
 |_action|bytes|Bytes array encoding the function call and arguments
 
 **Return Parameters**
@@ -1080,6 +1080,7 @@ Execute arbitrary transactions on behalf of the Colony in series
 |---|---|---|
 |_targets|address[]|Array of addressed to be targeted
 |_actions|bytes[]|Array of Bytes arrays encoding the function calls and arguments
+|_strict|bool|Boolean indicating whether if one transaction fails, the whole call to this function should fail.
 
 **Return Parameters**
 
@@ -1105,6 +1106,25 @@ Add a new expenditure in the colony. Secured function to authorised members.
 |Name|Type|Description|
 |---|---|---|
 |expenditureId|uint256|Identifier of the newly created expenditure
+
+### `makeSingleArbitraryTransaction`
+
+Executes a single arbitrary transaction
+
+*Note: Only callable by the colony itself. If you wish to use this functionality, you should use the makeAbitraryTransactions function*
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_target|address|Contract to receive the function call
+|_action|bytes|Bytes array encoding the function call and arguments
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|success|bool|Boolean indicating whether the transactions succeeded
 
 ### `makeTask`
 

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -1053,7 +1053,7 @@ Lock the colony's token. Can only be called by a network-managed extension.
 
 ### `makeArbitraryTransaction`
 
-Execute arbitrary transaction on behalf of the Colony
+Execute arbitrary transaction on behalf of the Colony DEPRECATED
 
 
 **Parameters**
@@ -1068,6 +1068,24 @@ Execute arbitrary transaction on behalf of the Colony
 |Name|Type|Description|
 |---|---|---|
 |success|bool|Boolean indicating whether the transaction succeeded
+
+### `makeArbitraryTransactions`
+
+Execute arbitrary transactions on behalf of the Colony in series
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_targets|address[]|Array of addressed to be targeted
+|_actions|bytes[]|Array of Bytes arrays encoding the function calls and arguments
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|success|bool|Boolean indicating whether the transactions succeeded
 
 ### `makeExpenditure`
 

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,11 +154,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("e10e816b235f21825b73d4e90c2114cd2fbc68f2d49d3c4081b8536747b70e24");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("76a5c2ea62ee88ed3992e3278cdbb821da482b4d5c3f40ed79ed4f3ee530520f");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("6bee0085d000fc929e06c1281c162eaa7ac22ff9e2dcc520066e5e7720de6394");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("bcfee6939c375d042704e338652a1e2d1e6f7b0e69587b79e72bde08ca777927");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("8b9242eb6e0fd017538f71e90c6ce9793839743e869bed54030861d3594453b1");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("ebe76dae7af1b299fa6fb5ef64e7419a51ffd15c77a204fe34d7be0d54ab0569");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("ba08493b46245ce11425e5d558118c5c5f75d6e2df6120c39f9a04383e08fb3b");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("70ed1b2030754dc797666d004e6c49297bcccdc7674477513e1742d67eac923e");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("5f700cfd6583da84c8a91d0200b381787853845c69159a2aad22d3b445b561ff");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("e732a2ab75b6fd2f52b8bdc5bfb2cbd9ca63cb0e279db6cb4005afc83da1a1b9");
     });
   });
 });

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,11 +154,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("ebe76dae7af1b299fa6fb5ef64e7419a51ffd15c77a204fe34d7be0d54ab0569");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("ba08493b46245ce11425e5d558118c5c5f75d6e2df6120c39f9a04383e08fb3b");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("70ed1b2030754dc797666d004e6c49297bcccdc7674477513e1742d67eac923e");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("5f700cfd6583da84c8a91d0200b381787853845c69159a2aad22d3b445b561ff");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("e732a2ab75b6fd2f52b8bdc5bfb2cbd9ca63cb0e279db6cb4005afc83da1a1b9");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("5b71799641cc6edacc65b28714729701e048db0c2c4b9babf4bb2580abfad4dc");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("9fe5d3934ff460d5453c0f97c77dd9c41b5f807d954d5137ada49419e381d90c");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("8ec6f3339b3817e5a8d9df453d66f0a46e322ce8bed8df0c41493f537bbcd8b8");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("0e0b4f880064e4dcb74a1328e9404eb99f0a1cdd442a58e4e7a852c8ed4badea");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("97088e53d4c1392b9b758bbe10248c087bd5ca78df805c3d2c591c40d1ac74a5");
     });
   });
 });

--- a/test/contracts-network/colony-arbitrary-transactions.js
+++ b/test/contracts-network/colony-arbitrary-transactions.js
@@ -45,6 +45,17 @@ contract("Colony Arbitrary Transactions", (accounts) => {
     expect(balancePost.sub(balancePre)).to.eq.BN(WAD);
   });
 
+  it("should be able to make multiple arbitrary transactions", async () => {
+    const action = await encodeTxData(token, "mint", [WAD]);
+    const action2 = await encodeTxData(token, "mint", [WAD.muln(2)]);
+    const balancePre = await token.balanceOf(colony.address);
+
+    await colony.makeArbitraryTransactions([token.address, token.address], [action, action2]);
+
+    const balancePost = await token.balanceOf(colony.address);
+    expect(balancePost.sub(balancePre)).to.eq.BN(WAD.muln(3));
+  });
+
   it("should not be able to make arbitrary transactions if not root", async () => {
     const action = await encodeTxData(token, "mint", [WAD]);
 

--- a/test/contracts-network/colony-arbitrary-transactions.js
+++ b/test/contracts-network/colony-arbitrary-transactions.js
@@ -50,7 +50,43 @@ contract("Colony Arbitrary Transactions", (accounts) => {
     const action2 = await encodeTxData(token, "mint", [WAD.muln(2)]);
     const balancePre = await token.balanceOf(colony.address);
 
-    await colony.makeArbitraryTransactions([token.address, token.address], [action, action2]);
+    await colony.makeArbitraryTransactions([token.address, token.address], [action, action2], true);
+
+    const balancePost = await token.balanceOf(colony.address);
+    expect(balancePost.sub(balancePre)).to.eq.BN(WAD.muln(3));
+  });
+
+  it("should be able to make multiple arbitrary transactions and revert if one fails in strict mode", async () => {
+    const action = await encodeTxData(token, "mint", [WAD]);
+    const action2 = await encodeTxData(token, "mint", [WAD.muln(2)]);
+    const balancePre = await token.balanceOf(colony.address);
+
+    await checkErrorRevert(
+      colony.makeArbitraryTransactions([token.address, ADDRESS_ZERO], [action, action2], true),
+      "colony-arbitrary-transaction-failed"
+    );
+
+    const balancePost = await token.balanceOf(colony.address);
+    expect(balancePost).to.eq.BN(balancePre);
+  });
+
+  it("should be able to make multiple arbitrary transactions and not revert if one fails not in strict mode", async () => {
+    const action = await encodeTxData(token, "mint", [WAD]);
+    const action2 = await encodeTxData(token, "mint", [WAD.muln(2)]);
+    const balancePre = await token.balanceOf(colony.address);
+
+    await colony.makeArbitraryTransactions([token.address, ADDRESS_ZERO], [action, action2], false);
+
+    const balancePost = await token.balanceOf(colony.address);
+    expect(balancePost.sub(balancePre)).to.eq.BN(WAD);
+  });
+
+  it("should be able to make multiple arbitrary transactions", async () => {
+    const action = await encodeTxData(token, "mint", [WAD]);
+    const action2 = await encodeTxData(token, "mint", [WAD.muln(2)]);
+    const balancePre = await token.balanceOf(colony.address);
+
+    await colony.makeArbitraryTransactions([token.address, token.address], [action, action2], true);
 
     const balancePost = await token.balanceOf(colony.address);
     expect(balancePost.sub(balancePre)).to.eq.BN(WAD.muln(3));

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -371,6 +371,15 @@ contract("Voting Reputation", (accounts) => {
       expect(motion.skillId).to.eq.BN(domain1.skillId);
     });
 
+    it("cannot create a domain motion in the root domain with an invalid reputation proof", async () => {
+      // Create motion in domain of action (1)
+      const action = await encodeTxData(colony, "makeTask", [1, UINT256_MAX, FAKE, 1, 0, 0]);
+      await checkErrorRevert(
+        voting.createMotion(1, 0, ADDRESS_ZERO, action, domain1Key, domain1Value, domain1Mask, domain1Siblings),
+        "voting-rep-invalid-domain-id"
+      );
+    });
+
     it("can create a domain motion in a child domain", async () => {
       const key = makeReputationKey(colony.address, domain2.skillId);
       const value = makeReputationValue(WAD, 6);


### PR DESCRIPTION
## TokenLocking events

We were missing events for some function calls in TokenLocking. This adds them. Closes #957.

## VotingReputation reputation proof.

We were not checking that, in the case that the action domain and the voting domain were the same, that the supplied ChildSkillId was UINT256Max, which we do elsewhere. The only practical effect I can see right now was that motions-to-create-motions would be wrong, and that's a very niche case, but better to nip this one in the bud before it trips us up down the line.

## Multiple arbitrary transactions

Probably the biggest thing in this branch, but a pretty straightforward addition, as we've discussed - deprecating the old arbitrary transaction function and replacing it with something identical that loops over two arrays containing the target and the transaction data. Closes #933. The test is pretty basic - on reflection, perhaps it should be mint-and-claim, which was where this missing functionality was spotted during QA.

## Test extension management via vote

Couldn't see a reason why this wouldn't work, but was specifically queried by the frontend as they will be implementing it eventually, so added a test for a motion to add an extension. There are not currently corresponding tests for initialising / deprecating / uninstalling... should there be?
