### PR TITLE
Increase flexability miner shows towards mining cycle duration

### DIFF
--- a/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
@@ -27,7 +27,8 @@ import "./ReputationMiningCycleStorage.sol";
 contract ReputationMiningCycleCommon is ReputationMiningCycleStorage, PatriciaTreeProofs, DSMath {
   // Minimum reputation mining stake in CLNY
   uint256 constant MIN_STAKE = 2000 * WAD;
-  // Size of mining window in seconds
+  // Size of mining window in seconds. Should be consistent with decay constant
+  // in reputationMiningCycleRespond. If you change one, you should change the other.
   uint256 constant MINING_WINDOW_SIZE = 60 * 60 * 24; // 24 hours
 
   function expectedBranchMask(uint256 _nLeaves, uint256 _leaf) public pure returns (uint256) {

--- a/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
@@ -29,7 +29,7 @@ contract ReputationMiningCycleCommon is ReputationMiningCycleStorage, PatriciaTr
   uint256 constant MIN_STAKE = 2000 * WAD;
   // Size of mining window in seconds. Should be consistent with decay constant
   // in reputationMiningCycleRespond. If you change one, you should change the other.
-  uint256 constant MINING_WINDOW_SIZE = 60 * 60 * 24; // 24 hours
+  uint256 constant MINING_WINDOW_SIZE = 60 * 60 * 1; // 1 hour
 
   function expectedBranchMask(uint256 _nLeaves, uint256 _leaf) public pure returns (uint256) {
     // Gets the expected branchmask for a patricia tree which has nLeaves, with keys from 0 to nLeaves -1

--- a/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
@@ -88,6 +88,10 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleCommon {
   uint constant B_ORIGIN_ADJACENT_REPUTATION_KEY_HASH = 5;
   uint constant B_CHILD_ADJACENT_REPUTATION_KEY_HASH = 6;
 
+  // Mining cycle decay constants
+  // Note that these values and the mining window size (defined in ReputationMiningCycleCommon)
+  // need to be consistent with each other, but are not checked, in order for the decay
+  // rate to be as-expected.
   uint constant DECAY_NUMERATOR =    992327946262944; // 24-hr mining cycles
   uint constant DECAY_DENOMINATOR = 1000000000000000;
 

--- a/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
@@ -92,7 +92,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleCommon {
   // Note that these values and the mining window size (defined in ReputationMiningCycleCommon)
   // need to be consistent with each other, but are not checked, in order for the decay
   // rate to be as-expected.
-  uint constant DECAY_NUMERATOR =    992327946262944; // 24-hr mining cycles
+  uint constant DECAY_NUMERATOR =    999679150010889; // 24-hr mining cycles
   uint constant DECAY_DENOMINATOR = 1000000000000000;
 
   function getDecayConstant() public pure returns (uint256, uint256) {

--- a/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
@@ -92,7 +92,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleCommon {
   // Note that these values and the mining window size (defined in ReputationMiningCycleCommon)
   // need to be consistent with each other, but are not checked, in order for the decay
   // rate to be as-expected.
-  uint constant DECAY_NUMERATOR =    999679150010889; // 24-hr mining cycles
+  uint constant DECAY_NUMERATOR =    999679150010889; // 1-hr mining cycle
   uint constant DECAY_DENOMINATOR = 1000000000000000;
 
   function getDecayConstant() public pure returns (uint256, uint256) {

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -58,11 +58,11 @@ const FINALIZED_TASK_STATE = 2;
 
 const SECONDS_PER_DAY = 86400;
 
-const MINING_CYCLE_DURATION = 60 * 60 * 24; // 24 hours
+const MINING_CYCLE_DURATION = 60 * 60 * 1; // 1 hour
 const MINING_CYCLE_TIMEOUT = 60 * 10; // Ten minutes
 const SUBMITTER_ONLY_WINDOW = 60 * 10; // Ten minutes
 const DECAY_RATE = {
-  NUMERATOR:    new BN("992327946262944"), // eslint-disable-line prettier/prettier
+  NUMERATOR:    new BN("999679150010889"), // eslint-disable-line prettier/prettier
   DENOMINATOR: new BN("1000000000000000"),
 };
 

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -1079,7 +1079,7 @@ class ReputationMiner {
 
     this.miningCycleDuration = await repCycle.getMiningWindowDuration();
     this.miningCycleDuration = this.miningCycleDuration.toNumber();
-    this.constant = ethers.constants.MaxUint256.sub(1).div(this.miningCycleDuration);
+    this.constant = ethers.constants.MaxUint256.div(this.miningCycleDuration);
 
     if (calculatedPeriodLength !== this.miningCycleDuration) {
       this._adapter.log(

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -15,7 +15,7 @@ const sqlite = require("sqlite");
 const secretKey = "0xe5c050bb6bfdd9c29397b8fe6ed59ad2f7df83d6fd213b473f84b489205d9fc7";
 const minStake = ethers.BigNumber.from(10).pow(18).mul(2000);
 
-const DAY_IN_SECONDS = 3600 * 24;
+const DAY_IN_SECONDS = 60 * 60 * 24;
 
 class ReputationMiner {
   /**
@@ -1079,7 +1079,7 @@ class ReputationMiner {
 
     this.miningCycleDuration = await repCycle.getMiningWindowDuration();
     this.miningCycleDuration = this.miningCycleDuration.toNumber();
-    this.constant = ethers.BigNumber.from(2).pow(256).sub(1).div(this.miningCycleDuration);
+    this.constant = ethers.constants.MaxUint256.sub(1).div(this.miningCycleDuration);
 
     if (calculatedPeriodLength !== this.miningCycleDuration) {
       this._adapter.log(

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -296,10 +296,12 @@ class ReputationMinerClient {
         }
         await this._miner.updatePeriodLength(repCycle);
 
-        // If we don't see this next cycle completed in the period length and ten minutes, then report it
+        // If we don't see this next cycle completed at an appropriate time, then report it
+
+        const openTimestamp = await repCycle.getReputationMiningWindowOpenTimestamp();
         this.confirmTimeoutCheck = setTimeout(
           this.reportConfirmTimeout.bind(this),
-          (this._miner.getMiningCycleDuration() + 10 * MINUTE_IN_SECONDS) * 1000
+          (this._miner.getMiningCycleDuration() + 10 * MINUTE_IN_SECONDS - (Date.now() / 1000 - openTimestamp)) * 1000
         );
 
         // Let's process the reputation log if it's been this._processingDelay blocks

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -199,11 +199,7 @@ class ReputationMinerClient {
     const repCycle = await this._miner.getActiveRepCycle();
     await this._miner.updatePeriodLength(repCycle);
 
-    const openTimestamp = await repCycle.getReputationMiningWindowOpenTimestamp();
-    this.confirmTimeoutCheck = setTimeout(
-      this.reportConfirmTimeout.bind(this),
-      (this._miner.getMiningCycleDuration() + 10 * MINUTE_IN_SECONDS - (Date.now() / 1000 - openTimestamp)) * 1000
-    );
+    await this.setMiningCycleTimeout(repCycle);
 
     this.miningCycleAddress = repCycle.address;
 
@@ -298,11 +294,7 @@ class ReputationMinerClient {
 
         // If we don't see this next cycle completed at an appropriate time, then report it
 
-        const openTimestamp = await repCycle.getReputationMiningWindowOpenTimestamp();
-        this.confirmTimeoutCheck = setTimeout(
-          this.reportConfirmTimeout.bind(this),
-          (this._miner.getMiningCycleDuration() + 10 * MINUTE_IN_SECONDS - (Date.now() / 1000 - openTimestamp)) * 1000
-        );
+        await this.setMiningCycleTimeout(repCycle);
 
         // Let's process the reputation log if it's been this._processingDelay blocks
         if (this.blocksSinceCycleCompleted < this._processingDelay) {
@@ -576,6 +568,14 @@ class ReputationMinerClient {
     const maxEntries = Math.min(12, timeAbleToSubmitEntries.length);
 
     return timeAbleToSubmitEntries.slice(0, maxEntries);
+  }
+
+  async setMiningCycleTimeout(repCycle){
+    const openTimestamp = await repCycle.getReputationMiningWindowOpenTimestamp();
+    this.confirmTimeoutCheck = setTimeout(
+      this.reportConfirmTimeout.bind(this),
+      (this._miner.getMiningCycleDuration() + 10 * MINUTE_IN_SECONDS - (Date.now() / 1000 - openTimestamp)) * 1000
+    );
   }
 
   async submitEntry(entryIndex) {


### PR DESCRIPTION
The 24 hour duration was hard coded in a fair number of places. This PR removes that dependency, and means that, going forward, changing the mining cycle duration will just involve replacing the `miningCycleResolver` address on the network contract, with no miner changes required.

This PR also drops us down to a 1 hour duration on the contracts side. Deployments wise, I will deploy a new version of the miner, which should work with the old cycle, and then deploy the new resolver to switch us to the one hour period once we see that's working.