### PR TITLE
Allow motion stakes to be claimed even if no reward coming

### DIFF
--- a/contracts/extensions/VotingReputation.sol
+++ b/contracts/extensions/VotingReputation.sol
@@ -633,7 +633,7 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs {
 
     (uint256 stakerReward, uint256 repPenalty) = getStakerReward(_motionId, _staker, _vote);
 
-    require(stakerReward > 0, "voting-rep-nothing-to-claim");
+    require(stakes[_motionId][_staker][_vote] > 0, "voting-rep-nothing-to-claim");
     delete stakes[_motionId][_staker][_vote];
 
     tokenLocking.transfer(token, stakerReward, _staker, true);

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -1749,6 +1749,7 @@ contract("Voting Reputation", (accounts) => {
       await voting.finalizeMotion(motionId);
 
       await voting.claimReward(motionId, 1, UINT256_MAX, USER0, YAY);
+      await expectEvent(voting.claimReward(motionId, 1, UINT256_MAX, USER1, NAY), "MotionRewardClaimed", [motionId, USER1, NAY, 0]);
 
       await checkErrorRevert(voting.claimReward(motionId, 1, UINT256_MAX, USER0, YAY), "voting-rep-nothing-to-claim");
     });


### PR DESCRIPTION
In the drop-down for a colony's native token in the app, there are three classes of token. One of those classes is the number of tokens a user has staked. Currently, this is obtained by looking at all the `MotionStaked` events from the reputation voting extensions, and removing any that have a corresponding `MotionRewardClaimed` event, leaving only `MotionStaked` events that, presumably, correspond to unclaimed, staked tokens.

However, if someone has staked, and is getting nothing back (because they were on the losing side and suffered a 100%-0% defeat in the voting), we currently don't let them claim, which means no `MotionRewardClaimed` event is sent, and so it looks like those tokens are staked perpetually. And on some level, they are - they're just not getting them back.

This PR means that even if someone is not getting any rewards back, they can claim, and not be confused where their staked tokens are (or are not). A claim transaction is still not able to be made twice for the same stake, however.