### PR TITLE
Mining client updates due to the real world

### DIFF
--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -22,6 +22,7 @@ const {
   network,
   localPort,
   localProviderAddress,
+  providerAddress,
   syncFrom,
   auto,
   oracle,
@@ -36,6 +37,7 @@ if ((!minerAddress && !privateKey) || !colonyNetworkAddress || !syncFrom) {
   process.exit();
 }
 
+
 const loader = new TruffleLoader({
   contractDir: path.resolve(__dirname, "..", "..", "..", "build", "contracts")
 });
@@ -48,7 +50,13 @@ if (network) {
   }
   provider = new ethers.providers.InfuraProvider(network);
 } else {
-  provider = new ethers.providers.JsonRpcProvider(`http://${localProviderAddress || "localhost"}:${localPort || "8545"}`);
+  let rpcEndpoint = providerAddress;
+
+  if (!rpcEndpoint) {
+      rpcEndpoint = `http://${localProviderAddress || "localhost"}:${localPort || "8545"}`;
+  }
+
+  provider = new ethers.providers.JsonRpcProvider(rpcEndpoint);
 }
 
 let adapterObject;


### PR DESCRIPTION
With the mining client out in the real world, and not just on QA, we encountered a couple of hiccups.

1. 1Gwei for gas on Xdai is no longer always enough. So introduce querying the blockscout endpoint to figure out what an appropriate gas price is. In addition, we now go for 'average' rather than 'safeLow' to help guard against a sudden change in gas price. The Blockscout endpoint (for xdai) and the Etherscan endpoint for mainnet are annoyingly different - there's a factor of 10, and some of the gas labels are different, but I've tried to accommodate for the (relevant) differences.
2. Introduce a new argument for the miner, `--providerAddress`, that allows an arbitrary RPC endpoint to be specified. This was because as it was, it was impossible to point the miner at e.g. a Quicknode endpoint. The old related arguments have been left in, but will be ignored if `--providerAddress` has been used as well.