### PR TITLE
Only bring up oracle once initialisation complete

### DIFF
--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -46,6 +46,7 @@ class ReputationMinerClient {
     this.lockedForBlockProcessing;
     this._adapter = adapter;
     this._processingDelay = processingDelay;
+    this.oraclePort = oraclePort;
 
     if (typeof this._processingDelay === "undefined") {
       this._processingDelay = 10;
@@ -161,10 +162,6 @@ class ReputationMinerClient {
           return res.status(500).send({ message: "An error occurred querying the reputation" });
         }
       });
-
-      this.server = this._app.listen(oraclePort, () => {
-        this._adapter.log(`⭐️ Reputation oracle running on port ${this.server.address().port}`);
-      });
     }
   }
 
@@ -230,6 +227,11 @@ class ReputationMinerClient {
     this.chainId = network.chainId;
 
     this._adapter.log("🏁 Initialised");
+    if (this._oracle) {
+      this.server = this._app.listen(this.oraclePort, () => {
+       this._adapter.log(`⭐️ Reputation oracle running on port ${this.server.address().port}`);
+     });
+    }
   }
 
   async updateGasEstimate(type) {


### PR DESCRIPTION
As we enter the 'real world' with more and more use of the app, we're discovering things about the miner and oracle. There way the miner was set up, if it was queried before it had come up, it crashed and refused to respond to future requests. By moving the server creation to after all other initialisation processes have been completed, we avoid this issue.

Note this is going in to `master` - this fix is already deployed to the nodes we're running.