### PR TITLE
Correctly track whether miner has submitted in cycle

### DIFF
--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -312,6 +312,7 @@ class ReputationMinerClient {
         // And if appropriate, sort out our potential submissions for the next cycle.
         if (this._auto){
           this.best12Submissions = await this.getTwelveBestSubmissions();
+          this.submissionIndex = 0; // Reset that we've not submitted any
         }
 
         this.miningCycleAddress = addr;
@@ -466,9 +467,7 @@ class ReputationMinerClient {
 
         const responsePossible = await repCycle.getResponsePossible(disputeStages.CONFIRM_NEW_HASH, entry.lastResponseTimestamp);
         if (responsePossible){
-          this.best12Submissions = []; // Clear the submissions
-          this.submissionIndex = 0;
-          await this.updateGasEstimate('safeLow');
+          await this.updateGasEstimate('average');
           await this.confirmEntry();
         }
       }


### PR DESCRIPTION
Been working on running multiple miners on QA. Had an issue where multiple miners would work, but only for one cycle. After correctly submitting the first time, one of the (two) miners would just not submit in any subsequent cycles. They would after a restart, though. The reason was this line - which is correct, but in the wrong place.

In the original position, it meant that `submissionIndex`, which tracks how far through the possible submission array the client has submitted this cycle, was only reset for the client that submitted the `confirmHash` transaction. That's obviously incorrect, and should be reset when the cycle completes and the active mining cycle contract address changes - as at the start of a new cycle, no-one has submitted anything.

This is going in to `master`, as it is already deployed on QA and will be deployed to production once I am happy there's nothing else lurking here (i.e. after a good number of cycles).