### PR TITLE
Add support for local skills

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -238,15 +238,16 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
     require(rootLocalSkill != 0, "colony-local-skill-tree-not-initialised");
 
     uint256 newLocalSkill = IColonyNetwork(colonyNetworkAddress).addSkill(rootLocalSkill);
-    localSkills[newLocalSkill] = LocalSkill({ exists: true, deprecated: false });
+    localSkills[newLocalSkill] = true;
 
-    emit LocalSkillAdded(msg.sender, newLocalSkill);
+    emit LocalSkillAdded(msgSender(), newLocalSkill);
   }
 
+  // TODO: add de-deprecation once network support is added
   function deprecateLocalSkill(uint256 _localSkillId, bool _deprecated) public stoppable auth {
-    localSkills[_localSkillId].deprecated = _deprecated;
+    IColonyNetwork(colonyNetworkAddress).deprecateSkill(_localSkillId);
 
-    emit LocalSkillDeprecated(msg.sender, _localSkillId, _deprecated);
+    emit LocalSkillDeprecated(msgSender(), _localSkillId, true);
   }
 
   function getRootLocalSkill() public view returns (uint256) {

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -85,45 +85,6 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
     emit ArbitraryReputationUpdate(msgSender(), _user, _skillId, _amount);
   }
 
-  function initialiseColony(address _colonyNetworkAddress, address _token) public stoppable {
-    require(_colonyNetworkAddress != address(0x0), "colony-network-cannot-be-zero");
-    require(_token != address(0x0), "colony-token-cannot-be-zero");
-
-    require(colonyNetworkAddress == address(0x0), "colony-already-initialised-network");
-    require(token == address(0x0), "colony-already-initialised-token");
-
-    colonyNetworkAddress = _colonyNetworkAddress;
-    token = _token;
-    tokenLockingAddress = IColonyNetwork(colonyNetworkAddress).getTokenLocking();
-
-    // Initialise the task update reviewers
-    setFunctionReviewers(bytes4(keccak256("setTaskBrief(uint256,bytes32)")), TaskRole.Manager, TaskRole.Worker);
-    setFunctionReviewers(bytes4(keccak256("setTaskDueDate(uint256,uint256)")), TaskRole.Manager, TaskRole.Worker);
-    setFunctionReviewers(bytes4(keccak256("setTaskSkill(uint256,uint256)")), TaskRole.Manager, TaskRole.Worker);
-    // We are setting a manager to both reviewers, but it will require just one signature from manager
-    setFunctionReviewers(bytes4(keccak256("setTaskManagerPayout(uint256,address,uint256)")), TaskRole.Manager, TaskRole.Manager);
-    setFunctionReviewers(bytes4(keccak256("setTaskEvaluatorPayout(uint256,address,uint256)")), TaskRole.Manager, TaskRole.Evaluator);
-    setFunctionReviewers(bytes4(keccak256("setTaskWorkerPayout(uint256,address,uint256)")), TaskRole.Manager, TaskRole.Worker);
-    setFunctionReviewers(bytes4(keccak256("removeTaskEvaluatorRole(uint256)")), TaskRole.Manager, TaskRole.Evaluator);
-    setFunctionReviewers(bytes4(keccak256("removeTaskWorkerRole(uint256)")), TaskRole.Manager, TaskRole.Worker);
-    setFunctionReviewers(bytes4(keccak256("cancelTask(uint256)")), TaskRole.Manager, TaskRole.Worker);
-
-    setRoleAssignmentFunction(bytes4(keccak256("setTaskManagerRole(uint256,address,uint256,uint256)")));
-    setRoleAssignmentFunction(bytes4(keccak256("setTaskEvaluatorRole(uint256,address)")));
-    setRoleAssignmentFunction(bytes4(keccak256("setTaskWorkerRole(uint256,address)")));
-
-    // Initialise the local skill and domain trees
-    IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
-    uint256 rootDomainSkill = colonyNetwork.getSkillCount();
-    initialiseDomain(rootDomainSkill);
-    initialiseRootLocalSkill();
-
-    // Set initial colony reward inverse amount to the max indicating a zero rewards to start with
-    rewardInverse = 2**256 - 1;
-
-    emit ColonyInitialised(msgSender(), _colonyNetworkAddress, _token);
-  }
-
   function editColony(string memory _metadata) public
   stoppable
   auth {
@@ -274,6 +235,8 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
   }
 
   function addLocalSkill() public stoppable auth {
+    require(rootLocalSkill != 0, "colony-local-skill-tree-not-initialised");
+
     uint256 newLocalSkill = IColonyNetwork(colonyNetworkAddress).addSkill(rootLocalSkill);
     localSkills[newLocalSkill] = LocalSkill({ exists: true, deprecated: false });
 
@@ -288,65 +251,6 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
 
   function getRootLocalSkill() public view returns (uint256) {
     return rootLocalSkill;
-  }
-
-  function addDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _parentDomainId) public
-  stoppable
-  domainNotDeprecated(_parentDomainId)
-  authDomain(_permissionDomainId, _childSkillIndex, _parentDomainId)
-  {
-    addDomain(_permissionDomainId, _childSkillIndex, _parentDomainId, "");
-  }
-
-  function addDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _parentDomainId, string memory _metadata) public
-  stoppable
-  authDomain(_permissionDomainId, _childSkillIndex, _parentDomainId)
-  {
-    // Note: Remove when we want to allow more domain hierarchy levels
-    require(_parentDomainId == 1, "colony-parent-domain-not-root");
-
-    uint256 parentSkillId = domains[_parentDomainId].skillId;
-
-    // Setup new domain skill
-    IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
-    // slither-disable-next-line reentrancy-no-eth
-    uint256 newDomainSkill = colonyNetwork.addSkill(parentSkillId);
-
-    // Add domain to local mapping
-    initialiseDomain(newDomainSkill);
-
-    if (keccak256(abi.encodePacked(_metadata)) != keccak256(abi.encodePacked(""))) {
-      emit DomainMetadata(msgSender(), domainCount, _metadata);
-    }
-  }
-
-  function editDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _domainId, string memory _metadata) public
-  stoppable
-  authDomain(_permissionDomainId, _childSkillIndex, _domainId)
-  {
-    if (keccak256(abi.encodePacked(_metadata)) != keccak256(abi.encodePacked(""))) {
-      emit DomainMetadata(msgSender(), _domainId, _metadata);
-    }
-  }
-
-  function deprecateDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _domainId, bool _deprecated) public
-  stoppable
-  authDomain(_permissionDomainId, _childSkillIndex, _domainId)
-  {
-    if (domains[_domainId].deprecated != _deprecated) {
-      domains[_domainId].deprecated = _deprecated;
-
-      emit DomainDeprecated(msgSender(), _domainId, _deprecated);
-    }
-
-  }
-
-  function getDomain(uint256 _domainId) public view returns (Domain memory domain) {
-    domain = domains[_domainId];
-  }
-
-  function getDomainCount() public view returns (uint256) {
-    return domainCount;
   }
 
   function verifyReputationProof(bytes memory key, bytes memory value, uint256 branchMask, bytes32[] memory siblings)
@@ -407,8 +311,6 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
 
     sig = bytes4(keccak256("deprecateLocalSkill(uint256,bool)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
-
-    if (rootLocalSkill == 0) initialiseRootLocalSkill();
 
     sig = bytes4(keccak256("deprecateDomain(uint256,uint256,uint256,bool)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Architecture), address(this), sig, true);
@@ -486,39 +388,6 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
 
   function getTotalTokenApproval(address _token) public view returns (uint256) {
     return tokenApprovalTotals[_token];
-  }
-
-  function initialiseRootLocalSkill() internal {
-    assert(rootLocalSkill == 0);
-    rootLocalSkill = IColonyNetwork(colonyNetworkAddress).initialiseRootLocalSkill();
-  }
-
-  function initialiseDomain(uint256 _skillId) internal skillExists(_skillId) {
-    domainCount += 1;
-    // Create a new funding pot
-    fundingPotCount += 1;
-    fundingPots[fundingPotCount].associatedType = FundingPotAssociatedType.Domain;
-    fundingPots[fundingPotCount].associatedTypeId = domainCount;
-
-    // Create a new domain with the given skill and new funding pot
-    domains[domainCount] = Domain({
-      skillId: _skillId,
-      fundingPotId: fundingPotCount,
-      deprecated: false
-    });
-
-    emit DomainAdded(msgSender(), domainCount);
-    emit FundingPotAdded(fundingPotCount);
-  }
-
-  function setFunctionReviewers(bytes4 _sig, TaskRole _firstReviewer, TaskRole _secondReviewer)
-  private
-  {
-    reviewers[_sig] = [_firstReviewer, _secondReviewer];
-  }
-
-  function setRoleAssignmentFunction(bytes4 _sig) private {
-    roleAssignmentSigs[_sig] = true;
   }
 
 }

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -314,6 +314,8 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
 
     sig = bytes4(keccak256("deprecateDomain(uint256,uint256,uint256,bool)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Architecture), address(this), sig, true);
+
+    IColony(address(this)).initialiseRootLocalSkill();
   }
 
   function getMetatransactionNonce(address _user) override public view returns (uint256 nonce){

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -54,7 +54,7 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
   }
 
   function emitSkillReputationReward(uint256 _skillId, address _user, int256 _amount)
-  public stoppable auth validGlobalSkill(_skillId)
+  public stoppable auth validSkill(_skillId)
   {
     require(_amount > 0, "colony-reward-must-be-positive");
     IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, _skillId);
@@ -77,7 +77,7 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
   }
 
   function emitSkillReputationPenalty(uint256 _skillId, address _user, int256 _amount)
-  public stoppable auth validGlobalSkill(_skillId)
+  public stoppable auth validSkill(_skillId)
   {
     require(_amount <= 0, "colony-penalty-cannot-be-positive");
     IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, _skillId);

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -173,7 +173,7 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
   stoppable
   auth
   {
-    IColonyNetwork(colonyNetworkAddress).deprecateSkill(_skillId);
+    IColonyNetwork(colonyNetworkAddress).deprecateSkill(_skillId, true);
   }
 
   function setNetworkFeeInverse(uint256 _feeInverse) public
@@ -243,11 +243,10 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
     emit LocalSkillAdded(msgSender(), newLocalSkill);
   }
 
-  // TODO: add de-deprecation once network support is added
   function deprecateLocalSkill(uint256 _localSkillId, bool _deprecated) public stoppable auth {
-    IColonyNetwork(colonyNetworkAddress).deprecateSkill(_localSkillId);
+    IColonyNetwork(colonyNetworkAddress).deprecateSkill(_localSkillId, _deprecated);
 
-    emit LocalSkillDeprecated(msgSender(), _localSkillId, true);
+    emit LocalSkillDeprecated(msgSender(), _localSkillId, _deprecated);
   }
 
   function getRootLocalSkill() public view returns (uint256) {

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -169,6 +169,7 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
     return IColonyNetwork(colonyNetworkAddress).addSkill(0); // ignore-swc-107
   }
 
+  // slither-disable-next-line unused-return
   function deprecateGlobalSkill(uint256 _skillId) public
   stoppable
   auth
@@ -244,9 +245,9 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
   }
 
   function deprecateLocalSkill(uint256 _localSkillId, bool _deprecated) public stoppable auth {
-    IColonyNetwork(colonyNetworkAddress).deprecateSkill(_localSkillId, _deprecated);
-
-    emit LocalSkillDeprecated(msgSender(), _localSkillId, _deprecated);
+    if (IColonyNetwork(colonyNetworkAddress).deprecateSkill(_localSkillId, _deprecated)) {
+      emit LocalSkillDeprecated(msgSender(), _localSkillId, _deprecated);
+    }
   }
 
   function getRootLocalSkill() public view returns (uint256) {

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -316,6 +316,7 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
     sig = bytes4(keccak256("deprecateDomain(uint256,uint256,uint256,bool)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Architecture), address(this), sig, true);
 
+    delete rootLocalSkill; // In case the colony has set this slot in recovery mode
     IColony(address(this)).initialiseRootLocalSkill();
   }
 
@@ -335,6 +336,7 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
 
   function checkNotAdditionalProtectedVariable(uint256 _slot) public view recovery {
     require(_slot != COLONY_NETWORK_SLOT, "colony-protected-variable");
+    require(_slot != ROOT_LOCAL_SKILL_SLOT, "colony-protected-variable");
   }
 
   function approveStake(address _approvee, uint256 _domainId, uint256 _amount) public stoppable {

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -54,7 +54,7 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
   }
 
   function emitSkillReputationReward(uint256 _skillId, address _user, int256 _amount)
-  public stoppable auth validSkill(_skillId)
+  public stoppable auth validGlobalOrLocalSkill(_skillId)
   {
     require(_amount > 0, "colony-reward-must-be-positive");
     IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, _skillId);
@@ -77,7 +77,7 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
   }
 
   function emitSkillReputationPenalty(uint256 _skillId, address _user, int256 _amount)
-  public stoppable auth validSkill(_skillId)
+  public stoppable auth validGlobalOrLocalSkill(_skillId)
   {
     require(_amount <= 0, "colony-penalty-cannot-be-positive");
     IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, _skillId);

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -120,6 +120,8 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ARBITRATION_ROLE, "setExpenditureMetadata(uint256,uint256,uint256,string)");
 
     // Added in colony v9 (f-lwss)
+    addRoleCapability(ROOT_ROLE, "addLocalSkill()");
+    addRoleCapability(ROOT_ROLE, "deprecateLocalSkill(uint256,bool)");
     addRoleCapability(ARCHITECTURE_ROLE, "deprecateDomain(uint256,uint256,uint256,bool)");
   }
 

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -427,11 +427,9 @@ interface ColonyDataTypes {
   struct Domain {
     uint256 skillId;
     uint256 fundingPotId;
-    bool deprecated;
   }
 
   struct LocalSkill {
     bool exists;
-    bool deprecated;
   }
 }

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -241,6 +241,17 @@ interface ColonyDataTypes {
   /// @param taskId Id of the canceled task
   event TaskCanceled(uint256 indexed taskId);
 
+  /// @notice Event logged when a new local skill is added
+  /// @param agent The address that is responsible for triggering this event
+  /// @param localSkillId Id of the newly-created local skill
+  event LocalSkillAdded(address agent, uint256 localSkillId);
+
+  /// @notice Event logged when a new local skill is added
+  /// @param agent The address that is responsible for triggering this event
+  /// @param localSkillId Id of the newly-created local skill
+  /// @param deprecated Deprecation status of the local skill
+  event LocalSkillDeprecated(address agent, uint256 localSkillId, bool deprecated);
+
   /// @notice Event logged when a new Domain is added
   /// @param agent The address that is responsible for triggering this event
   /// @param domainId Id of the newly-created Domain
@@ -416,6 +427,11 @@ interface ColonyDataTypes {
   struct Domain {
     uint256 skillId;
     uint256 fundingPotId;
+    bool deprecated;
+  }
+
+  struct LocalSkill {
+    bool exists;
     bool deprecated;
   }
 }

--- a/contracts/colony/ColonyDomains.sol
+++ b/contracts/colony/ColonyDomains.sol
@@ -138,12 +138,12 @@ contract ColonyDomains is ColonyStorage {
     emit FundingPotAdded(fundingPotCount);
   }
 
-  function initialiseRootLocalSkill() public {
+  // Internal
+
+  function initialiseRootLocalSkill() internal {
     require(rootLocalSkill == 0, "colony-root-local-skill-initialised");
     rootLocalSkill = IColonyNetwork(colonyNetworkAddress).initialiseRootLocalSkill();
   }
-
-  // Internal
 
   function setFunctionReviewers(bytes4 _sig, TaskRole _firstReviewer, TaskRole _secondReviewer)
   private

--- a/contracts/colony/ColonyDomains.sol
+++ b/contracts/colony/ColonyDomains.sol
@@ -101,15 +101,14 @@ contract ColonyDomains is ColonyStorage {
     }
   }
 
+  // TODO: add de-deprecation once network support is added
   function deprecateDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _domainId, bool _deprecated) public
   stoppable
   authDomain(_permissionDomainId, _childSkillIndex, _domainId)
   {
-    if (domains[_domainId].deprecated != _deprecated) {
-      domains[_domainId].deprecated = _deprecated;
+    IColonyNetwork(colonyNetworkAddress).deprecateSkill(domains[_domainId].skillId);
 
-      emit DomainDeprecated(msgSender(), _domainId, _deprecated);
-    }
+    emit DomainDeprecated(msgSender(), _domainId, true);
   }
 
   function initialiseRootLocalSkill() public stoppable {
@@ -137,8 +136,7 @@ contract ColonyDomains is ColonyStorage {
     // Create a new domain with the given skill and new funding pot
     domains[domainCount] = Domain({
       skillId: _skillId,
-      fundingPotId: fundingPotCount,
-      deprecated: false
+      fundingPotId: fundingPotCount
     });
 
     emit DomainAdded(msgSender(), domainCount);

--- a/contracts/colony/ColonyDomains.sol
+++ b/contracts/colony/ColonyDomains.sol
@@ -112,6 +112,11 @@ contract ColonyDomains is ColonyStorage {
     }
   }
 
+  function initialiseRootLocalSkill() public stoppable {
+    require(rootLocalSkill == 0, "colony-root-local-skill-initialised");
+    rootLocalSkill = IColonyNetwork(colonyNetworkAddress).initialiseRootLocalSkill();
+  }
+
   function getDomain(uint256 _domainId) public view returns (Domain memory domain) {
     domain = domains[_domainId];
   }
@@ -119,6 +124,8 @@ contract ColonyDomains is ColonyStorage {
   function getDomainCount() public view returns (uint256) {
     return domainCount;
   }
+
+  // Internal
 
   function initialiseDomain(uint256 _skillId) internal skillExists(_skillId) {
     domainCount += 1;
@@ -136,13 +143,6 @@ contract ColonyDomains is ColonyStorage {
 
     emit DomainAdded(msgSender(), domainCount);
     emit FundingPotAdded(fundingPotCount);
-  }
-
-  // Internal
-
-  function initialiseRootLocalSkill() internal {
-    require(rootLocalSkill == 0, "colony-root-local-skill-initialised");
-    rootLocalSkill = IColonyNetwork(colonyNetworkAddress).initialiseRootLocalSkill();
   }
 
   function setFunctionReviewers(bytes4 _sig, TaskRole _firstReviewer, TaskRole _secondReviewer)

--- a/contracts/colony/ColonyDomains.sol
+++ b/contracts/colony/ColonyDomains.sol
@@ -1,0 +1,158 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity 0.7.3;
+pragma experimental ABIEncoderV2;
+
+import "./ColonyStorage.sol";
+
+
+contract ColonyDomains is ColonyStorage {
+
+  function initialiseColony(address _colonyNetworkAddress, address _token) public stoppable {
+    require(_colonyNetworkAddress != address(0x0), "colony-network-cannot-be-zero");
+    require(_token != address(0x0), "colony-token-cannot-be-zero");
+
+    require(colonyNetworkAddress == address(0x0), "colony-already-initialised-network");
+    require(token == address(0x0), "colony-already-initialised-token");
+
+    colonyNetworkAddress = _colonyNetworkAddress;
+    token = _token;
+    tokenLockingAddress = IColonyNetwork(colonyNetworkAddress).getTokenLocking();
+
+    // Initialise the task update reviewers
+    setFunctionReviewers(bytes4(keccak256("setTaskBrief(uint256,bytes32)")), TaskRole.Manager, TaskRole.Worker);
+    setFunctionReviewers(bytes4(keccak256("setTaskDueDate(uint256,uint256)")), TaskRole.Manager, TaskRole.Worker);
+    setFunctionReviewers(bytes4(keccak256("setTaskSkill(uint256,uint256)")), TaskRole.Manager, TaskRole.Worker);
+    // We are setting a manager to both reviewers, but it will require just one signature from manager
+    setFunctionReviewers(bytes4(keccak256("setTaskManagerPayout(uint256,address,uint256)")), TaskRole.Manager, TaskRole.Manager);
+    setFunctionReviewers(bytes4(keccak256("setTaskEvaluatorPayout(uint256,address,uint256)")), TaskRole.Manager, TaskRole.Evaluator);
+    setFunctionReviewers(bytes4(keccak256("setTaskWorkerPayout(uint256,address,uint256)")), TaskRole.Manager, TaskRole.Worker);
+    setFunctionReviewers(bytes4(keccak256("removeTaskEvaluatorRole(uint256)")), TaskRole.Manager, TaskRole.Evaluator);
+    setFunctionReviewers(bytes4(keccak256("removeTaskWorkerRole(uint256)")), TaskRole.Manager, TaskRole.Worker);
+    setFunctionReviewers(bytes4(keccak256("cancelTask(uint256)")), TaskRole.Manager, TaskRole.Worker);
+
+    setRoleAssignmentFunction(bytes4(keccak256("setTaskManagerRole(uint256,address,uint256,uint256)")));
+    setRoleAssignmentFunction(bytes4(keccak256("setTaskEvaluatorRole(uint256,address)")));
+    setRoleAssignmentFunction(bytes4(keccak256("setTaskWorkerRole(uint256,address)")));
+
+    // Initialise the local skill and domain trees
+    IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
+    uint256 rootDomainSkill = colonyNetwork.getSkillCount();
+    initialiseDomain(rootDomainSkill);
+    initialiseRootLocalSkill();
+
+    // Set initial colony reward inverse amount to the max indicating a zero rewards to start with
+    rewardInverse = 2**256 - 1;
+
+    emit ColonyInitialised(msgSender(), _colonyNetworkAddress, _token);
+  }
+
+  function addDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _parentDomainId) public
+  stoppable
+  domainNotDeprecated(_parentDomainId)
+  authDomain(_permissionDomainId, _childSkillIndex, _parentDomainId)
+  {
+    addDomain(_permissionDomainId, _childSkillIndex, _parentDomainId, "");
+  }
+
+  function addDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _parentDomainId, string memory _metadata) public
+  stoppable
+  authDomain(_permissionDomainId, _childSkillIndex, _parentDomainId)
+  {
+    // Note: Remove when we want to allow more domain hierarchy levels
+    require(_parentDomainId == 1, "colony-parent-domain-not-root");
+
+    uint256 parentSkillId = domains[_parentDomainId].skillId;
+
+    // Setup new domain skill
+    IColonyNetwork colonyNetwork = IColonyNetwork(colonyNetworkAddress);
+    // slither-disable-next-line reentrancy-no-eth
+    uint256 newDomainSkill = colonyNetwork.addSkill(parentSkillId);
+
+    // Add domain to local mapping
+    initialiseDomain(newDomainSkill);
+
+    if (keccak256(abi.encodePacked(_metadata)) != keccak256(abi.encodePacked(""))) {
+      emit DomainMetadata(msgSender(), domainCount, _metadata);
+    }
+  }
+
+  function editDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _domainId, string memory _metadata) public
+  stoppable
+  authDomain(_permissionDomainId, _childSkillIndex, _domainId)
+  {
+    if (keccak256(abi.encodePacked(_metadata)) != keccak256(abi.encodePacked(""))) {
+      emit DomainMetadata(msgSender(), _domainId, _metadata);
+    }
+  }
+
+  function deprecateDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _domainId, bool _deprecated) public
+  stoppable
+  authDomain(_permissionDomainId, _childSkillIndex, _domainId)
+  {
+    if (domains[_domainId].deprecated != _deprecated) {
+      domains[_domainId].deprecated = _deprecated;
+
+      emit DomainDeprecated(msgSender(), _domainId, _deprecated);
+    }
+  }
+
+  function getDomain(uint256 _domainId) public view returns (Domain memory domain) {
+    domain = domains[_domainId];
+  }
+
+  function getDomainCount() public view returns (uint256) {
+    return domainCount;
+  }
+
+  function initialiseDomain(uint256 _skillId) internal skillExists(_skillId) {
+    domainCount += 1;
+    // Create a new funding pot
+    fundingPotCount += 1;
+    fundingPots[fundingPotCount].associatedType = FundingPotAssociatedType.Domain;
+    fundingPots[fundingPotCount].associatedTypeId = domainCount;
+
+    // Create a new domain with the given skill and new funding pot
+    domains[domainCount] = Domain({
+      skillId: _skillId,
+      fundingPotId: fundingPotCount,
+      deprecated: false
+    });
+
+    emit DomainAdded(msgSender(), domainCount);
+    emit FundingPotAdded(fundingPotCount);
+  }
+
+  function initialiseRootLocalSkill() public {
+    require(rootLocalSkill == 0, "colony-root-local-skill-initialised");
+    rootLocalSkill = IColonyNetwork(colonyNetworkAddress).initialiseRootLocalSkill();
+  }
+
+  // Internal
+
+  function setFunctionReviewers(bytes4 _sig, TaskRole _firstReviewer, TaskRole _secondReviewer)
+  private
+  {
+    reviewers[_sig] = [_firstReviewer, _secondReviewer];
+  }
+
+  function setRoleAssignmentFunction(bytes4 _sig) private {
+    roleAssignmentSigs[_sig] = true;
+  }
+
+}

--- a/contracts/colony/ColonyDomains.sol
+++ b/contracts/colony/ColonyDomains.sol
@@ -126,7 +126,7 @@ contract ColonyDomains is ColonyStorage {
 
   // Internal
 
-  function initialiseDomain(uint256 _skillId) internal skillExists(_skillId) {
+  function initialiseDomain(uint256 _skillId) internal {
     domainCount += 1;
     // Create a new funding pot
     fundingPotCount += 1;

--- a/contracts/colony/ColonyDomains.sol
+++ b/contracts/colony/ColonyDomains.sol
@@ -105,9 +105,10 @@ contract ColonyDomains is ColonyStorage {
   stoppable
   authDomain(_permissionDomainId, _childSkillIndex, _domainId)
   {
-    IColonyNetwork(colonyNetworkAddress).deprecateSkill(domains[_domainId].skillId, _deprecated);
+    if (IColonyNetwork(colonyNetworkAddress).deprecateSkill(domains[_domainId].skillId, _deprecated)) {
 
-    emit DomainDeprecated(msgSender(), _domainId, _deprecated);
+      emit DomainDeprecated(msgSender(), _domainId, _deprecated);
+    }
   }
 
   function initialiseRootLocalSkill() public stoppable {

--- a/contracts/colony/ColonyDomains.sol
+++ b/contracts/colony/ColonyDomains.sol
@@ -101,14 +101,13 @@ contract ColonyDomains is ColonyStorage {
     }
   }
 
-  // TODO: add de-deprecation once network support is added
   function deprecateDomain(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _domainId, bool _deprecated) public
   stoppable
   authDomain(_permissionDomainId, _childSkillIndex, _domainId)
   {
-    IColonyNetwork(colonyNetworkAddress).deprecateSkill(domains[_domainId].skillId);
+    IColonyNetwork(colonyNetworkAddress).deprecateSkill(domains[_domainId].skillId, _deprecated);
 
-    emit DomainDeprecated(msgSender(), _domainId, true);
+    emit DomainDeprecated(msgSender(), _domainId, _deprecated);
   }
 
   function initialiseRootLocalSkill() public stoppable {

--- a/contracts/colony/ColonyExpenditure.sol
+++ b/contracts/colony/ColonyExpenditure.sol
@@ -192,11 +192,8 @@ contract ColonyExpenditure is ColonyStorage {
       );
 
       Skill memory skill = colonyNetworkContract.getSkill(_skillIds[i]);
-      LocalSkill memory localSkill = localSkills[_skillIds[i]];
-
-      require(skill.globalSkill || localSkill.exists, "colony-not-valid-skill");
-      require(!skill.globalSkill || !skill.deprecated, "colony-deprecated-global-skill");
-      require(!localSkill.exists || !localSkill.deprecated, "colony-deprecated-local-skill");
+      require(skill.globalSkill || localSkills[_skillIds[i]], "colony-not-valid-skill");
+      require(!skill.deprecated, "colony-deprecated-skill");
 
       // We only allow setting of the first skill here.
       // If we allow more in the future, make sure to have a hard limit that

--- a/contracts/colony/ColonyExpenditure.sol
+++ b/contracts/colony/ColonyExpenditure.sol
@@ -186,7 +186,7 @@ contract ColonyExpenditure is ColonyStorage {
     IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
 
     for (uint256 i; i < _slots.length; i++) {
-      require(isValidSkill(_skillIds[i]), "colony-not-valid-skill");
+      require(isValidGlobalOrLocalSkill(_skillIds[i]), "colony-not-valid-global-or-local-skill");
 
       // We only allow setting of the first skill here.
       // If we allow more in the future, make sure to have a hard limit that

--- a/contracts/colony/ColonyExpenditure.sol
+++ b/contracts/colony/ColonyExpenditure.sol
@@ -186,14 +186,7 @@ contract ColonyExpenditure is ColonyStorage {
     IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
 
     for (uint256 i; i < _slots.length; i++) {
-      require(
-        _skillIds[i] > 0 && _skillIds[i] <= colonyNetworkContract.getSkillCount(),
-        "colony-expenditure-skill-does-not-exist"
-      );
-
-      Skill memory skill = colonyNetworkContract.getSkill(_skillIds[i]);
-      require(skill.globalSkill || localSkills[_skillIds[i]], "colony-not-valid-skill");
-      require(!skill.deprecated, "colony-deprecated-skill");
+      require(isValidSkill(_skillIds[i]), "colony-not-valid-skill");
 
       // We only allow setting of the first skill here.
       // If we allow more in the future, make sure to have a hard limit that

--- a/contracts/colony/ColonyExpenditure.sol
+++ b/contracts/colony/ColonyExpenditure.sol
@@ -192,8 +192,11 @@ contract ColonyExpenditure is ColonyStorage {
       );
 
       Skill memory skill = colonyNetworkContract.getSkill(_skillIds[i]);
-      require(skill.globalSkill, "colony-not-global-skill");
-      require(!skill.deprecated, "colony-deprecated-global-skill");
+      LocalSkill memory localSkill = localSkills[_skillIds[i]];
+
+      require(skill.globalSkill || localSkill.exists, "colony-not-valid-skill");
+      require(!skill.globalSkill || !skill.deprecated, "colony-deprecated-global-skill");
+      require(!localSkill.exists || !localSkill.deprecated, "colony-deprecated-local-skill");
 
       // We only allow setting of the first skill here.
       // If we allow more in the future, make sure to have a hard limit that

--- a/contracts/colony/ColonyPayment.sol
+++ b/contracts/colony/ColonyPayment.sol
@@ -110,8 +110,7 @@ contract ColonyPayment is ColonyStorage {
   stoppable
   authDomain(_permissionDomainId, _childSkillIndex, payments[_id].domainId)
   paymentNotFinalized(_id)
-  skillExists(_skillId)
-  validGlobalSkill(_skillId)
+  validSkill(_skillId)
   {
     payments[_id].skills[0] = _skillId;
 

--- a/contracts/colony/ColonyPayment.sol
+++ b/contracts/colony/ColonyPayment.sol
@@ -110,7 +110,7 @@ contract ColonyPayment is ColonyStorage {
   stoppable
   authDomain(_permissionDomainId, _childSkillIndex, payments[_id].domainId)
   paymentNotFinalized(_id)
-  validSkill(_skillId)
+  validGlobalOrLocalSkill(_skillId)
   {
     payments[_id].skills[0] = _skillId;
 

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -203,7 +203,7 @@ contract ColonyStorage is ColonyDataTypes, ColonyNetworkDataTypes, DSMath, Commo
   }
 
   modifier validSkill(uint256 _skillId) {
-    require(isValidSkill(_skillId), "colony-not-valid-skill");
+    require(isValidGlobalOrLocalSkill(_skillId), "colony-not-valid-global-or-local-skill");
     _;
   }
 
@@ -325,7 +325,7 @@ contract ColonyStorage is ColonyDataTypes, ColonyNetworkDataTypes, DSMath, Commo
     }
   }
 
-  function isValidSkill(uint256 skillId) internal view returns (bool) {
+  function isValidGlobalOrLocalSkill(uint256 skillId) internal view returns (bool) {
     Skill memory skill = IColonyNetwork(colonyNetworkAddress).getSkill(skillId);
     return (skill.globalSkill || localSkills[skillId]) && !skill.deprecated;
   }

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -108,7 +108,7 @@ contract ColonyStorage is ColonyDataTypes, ColonyNetworkDataTypes, DSMath, Commo
   mapping(address => uint256) metatransactionNonces; // Storage slot 35
 
   uint256 rootLocalSkill; // Storage slot 36
-  mapping (uint256 => LocalSkill) localSkills; // Storage slot 37
+  mapping (uint256 => bool) localSkills; // Storage slot 37
 
   // Constants
 
@@ -119,7 +119,10 @@ contract ColonyStorage is ColonyDataTypes, ColonyNetworkDataTypes, DSMath, Commo
   // Modifiers
 
   modifier domainNotDeprecated(uint256 _id) {
-    require(!domains[_id].deprecated, "colony-domain-deprecated");
+    require(
+      !IColonyNetwork(colonyNetworkAddress).getSkill(domains[_id].skillId).deprecated,
+      "colony-domain-deprecated"
+    );
     _;
   }
 

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -107,6 +107,9 @@ contract ColonyStorage is ColonyDataTypes, ColonyNetworkDataTypes, DSMath, Commo
   uint256 constant METATRANSACTION_NONCES_SLOT = 35;
   mapping(address => uint256) metatransactionNonces; // Storage slot 35
 
+  uint256 rootLocalSkill; // Storage slot 36
+  mapping (uint256 => LocalSkill) localSkills; // Storage slot 37
+
   // Constants
 
   uint256 constant MAX_PAYOUT = 2**128 - 1; // 340,282,366,920,938,463,463 WADs

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -202,7 +202,7 @@ contract ColonyStorage is ColonyDataTypes, ColonyNetworkDataTypes, DSMath, Commo
     _;
   }
 
-  modifier validSkill(uint256 _skillId) {
+  modifier validGlobalOrLocalSkill(uint256 _skillId) {
     require(isValidGlobalOrLocalSkill(_skillId), "colony-not-valid-global-or-local-skill");
     _;
   }

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -202,17 +202,8 @@ contract ColonyStorage is ColonyDataTypes, ColonyNetworkDataTypes, DSMath, Commo
     _;
   }
 
-  modifier validGlobalSkill(uint256 _skillId) {
-    IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
-    Skill memory skill = colonyNetworkContract.getSkill(_skillId);
-    require(skill.globalSkill, "colony-not-global-skill");
-    require(!skill.deprecated, "colony-deprecated-global-skill");
-    _;
-  }
-
-  modifier skillExists(uint256 _skillId) {
-    IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
-    require(_skillId > 0 && _skillId <= colonyNetworkContract.getSkillCount(), "colony-skill-does-not-exist");
+  modifier validSkill(uint256 _skillId) {
+    require(isValidSkill(_skillId), "colony-not-valid-skill");
     _;
   }
 
@@ -334,6 +325,10 @@ contract ColonyStorage is ColonyDataTypes, ColonyNetworkDataTypes, DSMath, Commo
     }
   }
 
+  function isValidSkill(uint256 skillId) internal view returns (bool) {
+    Skill memory skill = IColonyNetwork(colonyNetworkAddress).getSkill(skillId);
+    return (skill.globalSkill || localSkills[skillId]) && !skill.deprecated;
+  }
 
   function domainExists(uint256 domainId) internal view returns (bool) {
     return domainId > 0 && domainId <= domainCount;

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -33,6 +33,7 @@ import "./ColonyDataTypes.sol";
 
 contract ColonyStorage is ColonyDataTypes, ColonyNetworkDataTypes, DSMath, CommonStorage {
   uint256 constant COLONY_NETWORK_SLOT = 6;
+  uint256 constant ROOT_LOCAL_SKILL_SLOT = 36;
 
   // Storage
 

--- a/contracts/colony/ColonyTask.sol
+++ b/contracts/colony/ColonyTask.sol
@@ -338,9 +338,8 @@ contract ColonyTask is ColonyStorage {
   function setTaskSkill(uint256 _id, uint256 _skillId) public
   stoppable
   taskExists(_id)
-  skillExists(_skillId)
   taskNotComplete(_id)
-  validGlobalSkill(_skillId)
+  validSkill(_skillId)
   self()
   {
     tasks[_id].skills[0] = _skillId;

--- a/contracts/colony/ColonyTask.sol
+++ b/contracts/colony/ColonyTask.sol
@@ -339,7 +339,7 @@ contract ColonyTask is ColonyStorage {
   stoppable
   taskExists(_id)
   taskNotComplete(_id)
-  validSkill(_skillId)
+  validGlobalOrLocalSkill(_skillId)
   self()
   {
     tasks[_id].skills[0] = _skillId;

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -282,6 +282,18 @@ interface IColony is ColonyDataTypes, IRecovery, IBasicMetaTransaction {
   /// @param extensionId keccak256 hash of the extension name, used as an indentifier
   function uninstallExtension(bytes32 extensionId) external;
 
+  /// @notice Add a new local skill for the colony. Secured function to authorised members.
+  function addLocalSkill() external;
+
+  /// @notice Deprecate a local skill for the colony. Secured function to authorised members.
+  /// @param localSkillId Id for the local skill
+  /// @param deprecated Deprecation status to set for the skill
+  function deprecateLocalSkill(uint256 localSkillId, bool deprecated) external;
+
+  /// @notice Get the root local skill id
+  /// @return rootLocalSkill The root local skill id
+  function getRootLocalSkill() external view returns (uint256 rootLocalSkill);
+
   /// @notice Add a colony domain, and its respective local skill under skill with id `_parentSkillId`.
   /// New funding pot is created and associated with the domain here.
   /// @param _permissionDomainId The domainId in which I have the permission to take this action

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -282,9 +282,6 @@ interface IColony is ColonyDataTypes, IRecovery, IBasicMetaTransaction {
   /// @param extensionId keccak256 hash of the extension name, used as an indentifier
   function uninstallExtension(bytes32 extensionId) external;
 
-  /// @notice Initialise the local skill tree for the colony.
-  function initialiseRootLocalSkill() external;
-
   /// @notice Add a new local skill for the colony. Secured function to authorised members.
   function addLocalSkill() external;
 

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -282,6 +282,9 @@ interface IColony is ColonyDataTypes, IRecovery, IBasicMetaTransaction {
   /// @param extensionId keccak256 hash of the extension name, used as an indentifier
   function uninstallExtension(bytes32 extensionId) external;
 
+  /// @notice Initialise the local skill tree for the colony.
+  function initialiseRootLocalSkill() external;
+
   /// @notice Add a new local skill for the colony. Secured function to authorised members.
   function addLocalSkill() external;
 

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -259,10 +259,15 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage {
     }
   }
 
-  function deprecateSkill(uint256 _skillId) public stoppable
+  function deprecateSkill(uint256 _skillId, bool _deprecated) public stoppable
   allowedToAddSkill(skills[_skillId].nParents == 0)
   {
-    skills[_skillId].deprecated = true;
+    skills[_skillId].deprecated = _deprecated;
+  }
+
+  function deprecateSkill(uint256 _skillId) public stoppable
+  {
+    deprecateSkill(_skillId, true);
   }
 
   function initialiseRootLocalSkill() public

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -280,6 +280,14 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage {
     skills[_skillId].deprecated = true;
   }
 
+  function initialiseRootLocalSkill() public
+  stoppable
+  calledByColony
+  returns (uint256)
+  {
+    return skillCount++;
+  }
+
   function appendReputationUpdateLog(address _user, int _amount, uint _skillId) public
   stoppable
   calledByColony
@@ -366,7 +374,7 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage {
 
     colonyAuthority.setOwner(address(etherRouter));
 
-    // Initialise the root (domain) local skill with defaults by just incrementing the skillCount
+    // Initialise the domain tree with defaults by just incrementing the skillCount
     skillCount += 1;
     colonyCount += 1;
     colonies[colonyCount] = address(colony);

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -197,9 +197,9 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage {
     return changed;
   }
 
-  function deprecateSkill(uint256 _skillId) public stoppable returns (bool)
-  {
-    return deprecateSkill(_skillId, true);
+  // DEPRECATED
+  function deprecateSkill(uint256 _skillId) public stoppable {
+    deprecateSkill(_skillId, true);
   }
 
   function initialiseRootLocalSkill() public

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -190,13 +190,16 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage {
 
   function deprecateSkill(uint256 _skillId, bool _deprecated) public stoppable
   allowedToAddSkill(skills[_skillId].nParents == 0)
+  returns (bool)
   {
+    bool changed = skills[_skillId].deprecated != _deprecated;
     skills[_skillId].deprecated = _deprecated;
+    return changed;
   }
 
-  function deprecateSkill(uint256 _skillId) public stoppable
+  function deprecateSkill(uint256 _skillId) public stoppable returns (bool)
   {
-    deprecateSkill(_skillId, true);
+    return deprecateSkill(_skillId, true);
   }
 
   function initialiseRootLocalSkill() public
@@ -251,6 +254,18 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage {
 
   function getMetatransactionNonce(address _user) override public view returns (uint256 nonce){
     return metatransactionNonces[_user];
+  }
+
+  function setPayoutWhitelist(address _token, bool _status) public stoppable
+  calledByMetaColony
+  {
+    payoutWhitelist[_token] = _status;
+
+    emit TokenWhitelisted(_token, _status);
+  }
+
+  function getPayoutWhitelist(address _token) public view returns (bool) {
+    return payoutWhitelist[_token];
   }
 
   function incrementMetatransactionNonce(address _user) override internal {

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -116,7 +116,7 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage {
     metaColony = createColony(_tokenAddress, currentColonyVersion, "", "");
 
     // Add the special mining skill
-    reputationMiningSkillId = this.addSkill(skillCount);
+    reputationMiningSkillId = this.addSkill(skillCount - 1);
 
     emit MetaColonyCreated(metaColony, _tokenAddress, skillCount);
   }

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -29,21 +29,6 @@ import "./ColonyNetworkStorage.sol";
 
 
 contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage {
-  // Meta Colony allowed to manage Global skills
-  // All colonies are able to manage their Local (domain associated) skills
-  modifier allowedToAddSkill(bool globalSkill) {
-    if (globalSkill) {
-      require(msgSender() == metaColony, "colony-must-be-meta-colony");
-    } else {
-      require(_isColony[msgSender()] || msgSender() == address(this), "colony-caller-must-be-colony");
-    }
-    _;
-  }
-
-  modifier skillExists(uint skillId) {
-    require(skillCount >= skillId, "colony-invalid-skill-id");
-    _;
-  }
 
   function isColony(address _colony) public view returns (bool) {
     return _isColony[_colony];
@@ -328,18 +313,6 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage {
     feeInverse = _feeInverse;
 
     emit NetworkFeeInverseSet(_feeInverse);
-  }
-
-  function getPayoutWhitelist(address _token) public view returns (bool) {
-    return payoutWhitelist[_token];
-  }
-
-  function setPayoutWhitelist(address _token, bool _status) public stoppable
-  calledByMetaColony
-  {
-    payoutWhitelist[_token] = _status;
-
-    emit TokenWhitelisted(_token, _status);
   }
 
   function getMetatransactionNonce(address _user) override public view returns (uint256 nonce){

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -260,7 +260,7 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage {
   }
 
   function deprecateSkill(uint256 _skillId) public stoppable
-  allowedToAddSkill(true)
+  allowedToAddSkill(skills[_skillId].nParents == 0)
   {
     skills[_skillId].deprecated = true;
   }

--- a/contracts/colonyNetwork/ColonyNetworkDeployer.sol
+++ b/contracts/colonyNetwork/ColonyNetworkDeployer.sol
@@ -1,0 +1,143 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity 0.7.3;
+pragma experimental "ABIEncoderV2";
+
+import "./../common/EtherRouter.sol";
+import "./../colony/ColonyAuthority.sol";
+import "./../colony/IColony.sol";
+import "./ColonyNetworkStorage.sol";
+import "./IColonyNetwork.sol";
+
+
+contract ColonyNetworkDeployer is ColonyNetworkStorage {
+
+  function createMetaColony(address _tokenAddress) public
+  stoppable
+  auth
+  {
+    require(metaColony == address(0x0), "colony-meta-colony-exists-already");
+
+    metaColony = createColony(_tokenAddress, currentColonyVersion, "", "");
+
+    // Add the special mining skill
+    reputationMiningSkillId = IColonyNetwork(address(this)).addSkill(skillCount - 1);
+
+    emit MetaColonyCreated(metaColony, _tokenAddress, skillCount);
+  }
+
+  // DEPRECATED, only deploys version 3 colonies.
+  function createColony(address _tokenAddress) public
+  stoppable
+  returns (address)
+  {
+    return createColony(_tokenAddress, 3, "", "");
+  }
+
+  // DEPRECATED, only deploys version 4 colonies.
+  function createColony(
+    address _tokenAddress,
+    uint256 _version, // solhint-disable-line no-unused-vars
+    string memory _colonyName,
+    string memory _orbitdb, // solhint-disable-line no-unused-vars
+    bool _useExtensionManager // solhint-disable-line no-unused-vars
+  ) public stoppable returns (address)
+  {
+    return createColony(_tokenAddress, 4, _colonyName, "");
+  }
+
+  function createColony(
+    address _tokenAddress,
+    uint256 _version,
+    string memory _colonyName
+  ) public stoppable returns (address)
+  {
+    return createColony(_tokenAddress, _version, _colonyName, "");
+  }
+
+  function createColony(
+    address _tokenAddress,
+    uint256 _version,
+    string memory _colonyName,
+    string memory _metadata
+  ) public stoppable returns (address)
+  {
+    uint256 version = (_version == 0) ? currentColonyVersion : _version;
+    address colonyAddress = deployColony(_tokenAddress, version);
+
+    if (bytes(_colonyName).length > 0) {
+      IColony(colonyAddress).registerColonyLabel(_colonyName, "");
+    }
+
+    if (keccak256(abi.encodePacked(_metadata)) != keccak256(abi.encodePacked(""))) {
+      IColony(colonyAddress).editColony(_metadata);
+    }
+
+    setFounderPermissions(colonyAddress);
+
+    return colonyAddress;
+  }
+
+  function deployColony(address _tokenAddress, uint256 _version) internal returns (address) {
+    require(_tokenAddress != address(0x0), "colony-token-invalid-address");
+    require(colonyVersionResolver[_version] != address(0x00), "colony-network-invalid-version");
+
+    EtherRouter etherRouter = new EtherRouter();
+    IColony colony = IColony(address(etherRouter));
+
+    address resolverForColonyVersion = colonyVersionResolver[_version]; // ignore-swc-107
+    etherRouter.setResolver(resolverForColonyVersion); // ignore-swc-113
+
+    // Creating new instance of colony's authority
+    ColonyAuthority colonyAuthority = new ColonyAuthority(address(colony));
+
+    DSAuth dsauth = DSAuth(etherRouter);
+    dsauth.setAuthority(colonyAuthority);
+
+    colonyAuthority.setOwner(address(etherRouter));
+
+    // Initialise the domain tree with defaults by just incrementing the skillCount
+    skillCount += 1;
+    colonyCount += 1;
+    colonies[colonyCount] = address(colony);
+    _isColony[address(colony)] = true;
+
+    colony.initialiseColony(address(this), _tokenAddress);
+
+    emit ColonyAdded(colonyCount, address(etherRouter), _tokenAddress);
+
+    return address(etherRouter);
+  }
+
+  function setFounderPermissions(address _colonyAddress) internal {
+    require(DSAuth(_colonyAddress).owner() == address(this), "colony-network-not-colony-owner");
+
+    // Assign all permissions in root domain
+    IColony colony = IColony(_colonyAddress);
+    colony.setRecoveryRole(msgSender());
+    colony.setRootRole(msgSender(), true);
+    colony.setArbitrationRole(1, UINT256_MAX, msgSender(), 1, true);
+    colony.setArchitectureRole(1, UINT256_MAX, msgSender(), 1, true);
+    colony.setFundingRole(1, UINT256_MAX, msgSender(), 1, true);
+    colony.setAdministrationRole(1, UINT256_MAX, msgSender(), 1, true);
+
+    // Colony will not have owner
+    DSAuth dsauth = DSAuth(_colonyAddress);
+    dsauth.setOwner(address(0x0));
+  }
+}

--- a/contracts/colonyNetwork/ColonyNetworkExtensions.sol
+++ b/contracts/colonyNetwork/ColonyNetworkExtensions.sol
@@ -107,6 +107,14 @@ contract ColonyNetworkExtensions is ColonyNetworkStorage {
     emit ExtensionUninstalled(_extensionId, msgSender());
   }
 
+  function setPayoutWhitelist(address _token, bool _status) public stoppable
+  calledByMetaColony
+  {
+    payoutWhitelist[_token] = _status;
+
+    emit TokenWhitelisted(_token, _status);
+  }
+
   // Public view functions
 
   function getExtensionResolver(bytes32 _extensionId, uint256 _version)
@@ -123,6 +131,10 @@ contract ColonyNetworkExtensions is ColonyNetworkStorage {
     returns (address)
   {
     return installations[_extensionId][_colony];
+  }
+
+  function getPayoutWhitelist(address _token) public view returns (bool) {
+    return payoutWhitelist[_token];
   }
 
   // Internal functions

--- a/contracts/colonyNetwork/ColonyNetworkExtensions.sol
+++ b/contracts/colonyNetwork/ColonyNetworkExtensions.sol
@@ -107,14 +107,6 @@ contract ColonyNetworkExtensions is ColonyNetworkStorage {
     emit ExtensionUninstalled(_extensionId, msgSender());
   }
 
-  function setPayoutWhitelist(address _token, bool _status) public stoppable
-  calledByMetaColony
-  {
-    payoutWhitelist[_token] = _status;
-
-    emit TokenWhitelisted(_token, _status);
-  }
-
   // Public view functions
 
   function getExtensionResolver(bytes32 _extensionId, uint256 _version)
@@ -131,10 +123,6 @@ contract ColonyNetworkExtensions is ColonyNetworkStorage {
     returns (address)
   {
     return installations[_extensionId][_colony];
-  }
-
-  function getPayoutWhitelist(address _token) public view returns (bool) {
-    return payoutWhitelist[_token];
   }
 
   // Internal functions

--- a/contracts/colonyNetwork/ColonyNetworkStorage.sol
+++ b/contracts/colonyNetwork/ColonyNetworkStorage.sol
@@ -122,4 +122,20 @@ contract ColonyNetworkStorage is ColonyNetworkDataTypes, DSMath, CommonStorage {
     assert(msgSender() == msg.sender);
     _;
   }
+
+  // Meta Colony allowed to manage Global skills
+  // All colonies are able to manage their Local (domain associated) skills
+  modifier allowedToAddSkill(bool globalSkill) {
+    if (globalSkill) {
+      require(msgSender() == metaColony, "colony-must-be-meta-colony");
+    } else {
+      require(_isColony[msgSender()] || msgSender() == address(this), "colony-caller-must-be-colony");
+    }
+    _;
+  }
+
+  modifier skillExists(uint skillId) {
+    require(skillCount >= skillId, "colony-invalid-skill-id");
+    _;
+  }
 }

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -96,7 +96,12 @@ interface IColonyNetwork is ColonyNetworkDataTypes, IRecovery, IBasicMetaTransac
   /// @return skill The Skill struct
   function getSkill(uint256 _skillId) external view returns (Skill memory skill);
 
-  /// @notice Mark a global skill as deprecated which stops new tasks and payments from using it.
+  /// @notice Set deprecation status for a skill
+  /// @param _skillId Id of the skill
+  /// @param _deprecated Deprecation status
+  function deprecateSkill(uint256 _skillId, bool _deprecated) external;
+
+  /// @notice Mark a skill as deprecated which stops new tasks and payments from using it.
   /// @param _skillId Id of the skill
   function deprecateSkill(uint256 _skillId) external;
 

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -100,6 +100,10 @@ interface IColonyNetwork is ColonyNetworkDataTypes, IRecovery, IBasicMetaTransac
   /// @param _skillId Id of the skill
   function deprecateSkill(uint256 _skillId) external;
 
+  /// @notice Initialise the local skills tree for a colony
+  /// @return rootLocalSkillId The root local skill
+  function initialiseRootLocalSkill() external returns (uint256 rootLocalSkillId);
+
   /// @notice Adds a reputation update entry to log.
   /// @dev Errors if it is called by anyone but a colony or if skill with id `_skillId` does not exist or.
   /// @param _user The address of the user for the reputation update

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -99,11 +99,13 @@ interface IColonyNetwork is ColonyNetworkDataTypes, IRecovery, IBasicMetaTransac
   /// @notice Set deprecation status for a skill
   /// @param _skillId Id of the skill
   /// @param _deprecated Deprecation status
-  function deprecateSkill(uint256 _skillId, bool _deprecated) external;
+  /// @return changed Whether the deprecated state was changed
+  function deprecateSkill(uint256 _skillId, bool _deprecated) external returns (bool changed);
 
   /// @notice Mark a skill as deprecated which stops new tasks and payments from using it.
   /// @param _skillId Id of the skill
-  function deprecateSkill(uint256 _skillId) external;
+  /// @return changed Whether the deprecated state was changed
+  function deprecateSkill(uint256 _skillId) external returns (bool changed);
 
   /// @notice Initialise the local skills tree for a colony
   /// @return rootLocalSkillId The root local skill

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -103,9 +103,9 @@ interface IColonyNetwork is ColonyNetworkDataTypes, IRecovery, IBasicMetaTransac
   function deprecateSkill(uint256 _skillId, bool _deprecated) external returns (bool changed);
 
   /// @notice Mark a skill as deprecated which stops new tasks and payments from using it.
+  /// @dev This function is deprecated and will be removed in a future release
   /// @param _skillId Id of the skill
-  /// @return changed Whether the deprecated state was changed
-  function deprecateSkill(uint256 _skillId) external returns (bool changed);
+  function deprecateSkill(uint256 _skillId) external;
 
   /// @notice Initialise the local skills tree for a colony
   /// @return rootLocalSkillId The root local skill

--- a/contracts/testHelpers/NoLimitSubdomains.sol
+++ b/contracts/testHelpers/NoLimitSubdomains.sol
@@ -36,7 +36,7 @@ contract NoLimitSubdomains is ColonyStorage {
     initialiseDomain(newLocalSkill);
   }
 
-  function initialiseDomain(uint256 _skillId) internal skillExists(_skillId) {
+  function initialiseDomain(uint256 _skillId) internal {
     domainCount += 1;
     // Create a new funding pot
     fundingPotCount += 1;

--- a/contracts/testHelpers/NoLimitSubdomains.sol
+++ b/contracts/testHelpers/NoLimitSubdomains.sol
@@ -46,8 +46,7 @@ contract NoLimitSubdomains is ColonyStorage {
     // Create a new domain with the given skill and new funding pot
     domains[domainCount] = Domain({
       skillId: _skillId,
-      fundingPotId: fundingPotCount,
-      deprecated: false
+      fundingPotId: fundingPotCount
     });
 
     emit DomainAdded(msg.sender, domainCount);

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -38,6 +38,13 @@ Add a colony domain, and its respective local skill under skill with id `_parent
 |_metadata|string|Metadata relating to the domain. Expected to be the IPFS hash of a JSON blob, but not enforced by the contracts.
 
 
+### `addLocalSkill`
+
+Add a new local skill for the colony. Secured function to authorised members.
+
+
+
+
 ### `addPayment`
 
 Add a new payment in the colony. Secured function to authorised members.
@@ -274,6 +281,19 @@ Set the deprecation of an extension in a colony. Secured function to authorised 
 |---|---|---|
 |extensionId|bytes32|keccak256 hash of the extension name, used as an indentifier
 |deprecated|bool|Whether to deprecate the extension or not
+
+
+### `deprecateLocalSkill`
+
+Deprecate a local skill for the colony. Secured function to authorised members.
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|localSkillId|uint256|Id for the local skill
+|deprecated|bool|Deprecation status to set for the skill
 
 
 ### `editColony`
@@ -795,6 +815,18 @@ Get useful information about specific reward payout.
 |Name|Type|Description|
 |---|---|---|
 |rewardPayoutCycle|RewardPayoutCycle|RewardPayoutCycle, containing propertes:  `reputationState` Reputation root hash at the time of creation,  `colonyWideReputation` Colony wide reputation in `reputationState`,  `totalTokens` Total colony tokens at the time of creation,  `amount` Total amount of tokens taken aside for reward payout,  `tokenAddress` Token address,  `blockTimestamp` Block number at the time of creation.
+
+### `getRootLocalSkill`
+
+Get the root local skill id
+
+
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|rootLocalSkill|uint256|The root local skill id
 
 ### `getTask`
 

--- a/docs/_Interface_IColony.md
+++ b/docs/_Interface_IColony.md
@@ -1073,6 +1073,13 @@ Called once when the colony is created to initialise certain storage slot values
 |_token|address|Address of the colony ERC20 Token
 
 
+### `initialiseRootLocalSkill`
+
+Initialise the local skill tree for the colony.
+
+
+
+
 ### `installExtension`
 
 Install an extension to the colony. Secured function to authorised members.

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -708,6 +708,18 @@ Creates initial inactive reputation mining cycle.
 
 
 
+### `initialiseRootLocalSkill`
+
+Initialise the local skills tree for a colony
+
+
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|rootLocalSkillId|uint256|The root local skill
+
 ### `installExtension`
 
 Install an extension in a colony. Can only be called by a Colony.

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -276,7 +276,7 @@ Set the deprecation of an extension in a colony. Can only be called by a Colony.
 
 ### `deprecateSkill`
 
-Mark a global skill as deprecated which stops new tasks and payments from using it.
+Mark a skill as deprecated which stops new tasks and payments from using it.
 
 
 **Parameters**
@@ -284,6 +284,19 @@ Mark a global skill as deprecated which stops new tasks and payments from using 
 |Name|Type|Description|
 |---|---|---|
 |_skillId|uint256|Id of the skill
+
+
+### `deprecateSkill`
+
+Set deprecation status for a skill
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_skillId|uint256|Id of the skill
+|_deprecated|bool|Deprecation status
 
 
 ### `getChildSkillId`

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -66,7 +66,7 @@ const DECAY_RATE = {
   DENOMINATOR: new BN("1000000000000000"),
 };
 
-const GLOBAL_SKILL_ID = new BN("3"); // Not a root global skill ID or anything, just the first global skill's ID
+const GLOBAL_SKILL_ID = new BN("4"); // Not a root global skill ID or anything, just the first global skill's ID
 
 module.exports = {
   UINT256_MAX,

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -18,6 +18,7 @@ import {
   WORKER_ROLE,
   SPECIFICATION_HASH,
   DELIVERABLE_HASH,
+  GLOBAL_SKILL_ID,
 } from "./constants";
 
 import { getTokenArgs, web3GetAccounts, getChildSkillIndex, web3SignTypedData } from "./test-helper";
@@ -35,7 +36,7 @@ const Resolver = artifacts.require("Resolver");
 const MetaTxToken = artifacts.require("MetaTxToken");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 
-export async function makeTask({ colonyNetwork, colony, hash = SPECIFICATION_HASH, domainId = 1, skillId = 3, dueDate = 0, manager }) {
+export async function makeTask({ colonyNetwork, colony, hash = SPECIFICATION_HASH, domainId = 1, skillId = GLOBAL_SKILL_ID, dueDate = 0, manager }) {
   const accounts = await web3GetAccounts();
   manager = manager || accounts[0]; // eslint-disable-line no-param-reassign
 

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -17,7 +17,7 @@ const NoLimitSubdomains = artifacts.require("NoLimitSubdomains");
 const TaskSkillEditing = artifacts.require("TaskSkillEditing");
 const Resolver = artifacts.require("Resolver");
 const ContractEditing = artifacts.require("ContractEditing");
-const Colony = artifacts.require("Colony");
+const ColonyDomains = artifacts.require("ColonyDomains");
 
 const { expect } = chai;
 
@@ -905,7 +905,7 @@ export async function removeSubdomainLimit(colonyNetwork) {
 }
 
 export async function restoreSubdomainLimit(colonyNetwork) {
-  const originalSubdomains = await Colony.new();
+  const originalSubdomains = await ColonyDomains.new();
   const latestVersion = await colonyNetwork.getCurrentColonyVersion();
   const resolverAddress = await colonyNetwork.getColonyVersionResolver(latestVersion);
   const resolver = await Resolver.at(resolverAddress);

--- a/helpers/upgradable-contracts.js
+++ b/helpers/upgradable-contracts.js
@@ -100,6 +100,7 @@ export async function setupUpgradableColonyNetwork(
   etherRouter,
   resolver,
   colonyNetwork,
+  colonyNetworkDeployer,
   colonyNetworkMining,
   colonyNetworkAuction,
   colonyNetworkENS,
@@ -108,6 +109,7 @@ export async function setupUpgradableColonyNetwork(
 ) {
   const deployedImplementations = {};
   deployedImplementations.ColonyNetwork = colonyNetwork.address;
+  deployedImplementations.ColonyNetworkDeployer = colonyNetworkDeployer.address;
   deployedImplementations.ColonyNetworkMining = colonyNetworkMining.address;
   deployedImplementations.ColonyNetworkAuction = colonyNetworkAuction.address;
   deployedImplementations.ColonyNetworkENS = colonyNetworkENS.address;

--- a/helpers/upgradable-contracts.js
+++ b/helpers/upgradable-contracts.js
@@ -72,6 +72,7 @@ export async function setupEtherRouter(interfaceContract, deployedImplementation
 
 export async function setupColonyVersionResolver(
   colony,
+  colonyDomains,
   colonyExpenditure,
   colonyTask,
   colonyPayment,
@@ -83,6 +84,7 @@ export async function setupColonyVersionResolver(
 ) {
   const deployedImplementations = {};
   deployedImplementations.Colony = colony.address;
+  deployedImplementations.ColonyDomains = colonyDomains.address;
   deployedImplementations.ColonyExpenditure = colonyExpenditure.address;
   deployedImplementations.ColonyTask = colonyTask.address;
   deployedImplementations.ColonyRoles = colonyRoles.address;

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -2,6 +2,7 @@
 
 const ContractRecovery = artifacts.require("./ContractRecovery");
 const ColonyNetwork = artifacts.require("./ColonyNetwork");
+const ColonyNetworkDeployer = artifacts.require("./ColonyNetworkDeployer");
 const ColonyNetworkMining = artifacts.require("./ColonyNetworkMining");
 const ColonyNetworkAuction = artifacts.require("./ColonyNetworkAuction");
 const ColonyNetworkENS = artifacts.require("./ColonyNetworkENS");
@@ -22,6 +23,7 @@ artifacts.require("./ReputationMiningCycle");
 module.exports = (deployer, network) => {
   console.log(`## ${network} network ##`);
   deployer.deploy(ColonyNetwork);
+  deployer.deploy(ColonyNetworkDeployer);
   deployer.deploy(ColonyNetworkMining);
   deployer.deploy(ColonyNetworkAuction);
   deployer.deploy(ColonyNetworkENS);

--- a/migrations/3_setup_colony_network.js
+++ b/migrations/3_setup_colony_network.js
@@ -6,6 +6,7 @@ const { setupUpgradableColonyNetwork } = require("../helpers/upgradable-contract
 const ColonyNetworkAuthority = artifacts.require("./ColonyNetworkAuthority");
 const ContractRecovery = artifacts.require("./ContractRecovery");
 const ColonyNetwork = artifacts.require("./ColonyNetwork");
+const ColonyNetworkDeployer = artifacts.require("./ColonyNetworkDeployer");
 const ColonyNetworkMining = artifacts.require("./ColonyNetworkMining");
 const ColonyNetworkAuction = artifacts.require("./ColonyNetworkAuction");
 const ColonyNetworkENS = artifacts.require("./ColonyNetworkENS");
@@ -16,6 +17,7 @@ const Resolver = artifacts.require("./Resolver");
 // eslint-disable-next-line no-unused-vars
 module.exports = async function (deployer) {
   const colonyNetwork = await ColonyNetwork.deployed();
+  const colonyNetworkDeployer = await ColonyNetworkDeployer.deployed();
   const colonyNetworkMining = await ColonyNetworkMining.deployed();
   const colonyNetworkAuction = await ColonyNetworkAuction.deployed();
   const colonyNetworkENS = await ColonyNetworkENS.deployed();
@@ -28,6 +30,7 @@ module.exports = async function (deployer) {
     etherRouter,
     resolver,
     colonyNetwork,
+    colonyNetworkDeployer,
     colonyNetworkMining,
     colonyNetworkAuction,
     colonyNetworkENS,

--- a/migrations/4_setup_colony_version_resolver.js
+++ b/migrations/4_setup_colony_version_resolver.js
@@ -3,6 +3,7 @@
 const { setupColonyVersionResolver } = require("../helpers/upgradable-contracts");
 
 const Colony = artifacts.require("./Colony");
+const ColonyDomains = artifacts.require("./ColonyDomains");
 const ColonyFunding = artifacts.require("./ColonyFunding");
 const ColonyExpenditure = artifacts.require("./ColonyExpenditure");
 const ColonyRoles = artifacts.require("./ColonyRoles");
@@ -18,6 +19,7 @@ const IColonyNetwork = artifacts.require("./IColonyNetwork");
 module.exports = async function (deployer) {
   // Create a new Colony (version) and setup a new Resolver for it
   const colony = await Colony.new();
+  const colonyDomains = await ColonyDomains.new();
   const colonyFunding = await ColonyFunding.new();
   const colonyExpenditure = await ColonyExpenditure.new();
   const colonyRoles = await ColonyRoles.new();
@@ -34,6 +36,7 @@ module.exports = async function (deployer) {
   // Register the new Colony contract version with the newly setup Resolver
   await setupColonyVersionResolver(
     colony,
+    colonyDomains,
     colonyExpenditure,
     colonyTask,
     colonyPayment,

--- a/migrations/8_setup_meta_colony.js
+++ b/migrations/8_setup_meta_colony.js
@@ -56,6 +56,7 @@ module.exports = async function (deployer, network, accounts) {
 
   // Set up functional resolvers that identify correctly as previous versions.
   const Colony = artifacts.require("./Colony");
+  const ColonyDomains = artifacts.require("./ColonyDomains");
   const ColonyFunding = artifacts.require("./ColonyFunding");
   const ColonyExpenditure = artifacts.require("./ColonyExpenditure");
   const ColonyRoles = artifacts.require("./ColonyRoles");
@@ -65,6 +66,7 @@ module.exports = async function (deployer, network, accounts) {
   const ColonyArbitraryTransaction = artifacts.require("./ColonyArbitraryTransaction");
 
   const colony = await Colony.new();
+  const colonyDomains = await ColonyDomains.new();
   const colonyFunding = await ColonyFunding.new();
   const colonyExpenditure = await ColonyExpenditure.new();
   const colonyRoles = await ColonyRoles.new();
@@ -76,6 +78,7 @@ module.exports = async function (deployer, network, accounts) {
   const resolver3 = await Resolver.new();
   await setupColonyVersionResolver(
     colony,
+    colonyDomains,
     colonyExpenditure,
     colonyTask,
     colonyPayment,
@@ -92,6 +95,7 @@ module.exports = async function (deployer, network, accounts) {
   const resolver4 = await Resolver.new();
   await setupColonyVersionResolver(
     colony,
+    colonyDomains,
     colonyExpenditure,
     colonyTask,
     colonyPayment,

--- a/migrations/8_setup_meta_colony.js
+++ b/migrations/8_setup_meta_colony.js
@@ -109,7 +109,7 @@ module.exports = async function (deployer, network, accounts) {
   await colonyNetwork.startNextCycle();
 
   const skillCount = await colonyNetwork.getSkillCount();
-  assert.equal(skillCount.toNumber(), 3);
+  assert.equal(skillCount.toNumber(), 4);
 
   console.log("### Meta Colony created at", metaColony.address);
 };

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -122,7 +122,7 @@ contract("All", function (accounts) {
         taskId,
         signers: [MANAGER],
         sigTypes: [0],
-        args: [taskId, 7],
+        args: [taskId, GLOBAL_SKILL_ID],
       });
 
       // setTaskBrief

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,11 +154,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("a71c208d4d7103e6b983019d357c1bbfbe8caa1a0cf877e49ce2b524d8e93a90");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("bbf1666aaf7868b88d481a7e93494220e890ed49e9dbdca70496cec4044e88ff");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("8154464132136ceac323a3ab182ff4a8d71a5d36a18aed66904bd59f6fc05f67");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("0f3602ab3701c339df648b7634cbb189d6bf27c2def7170aec3151850bee83f0");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("062d78c5a9b1ca48f2c21fd13c0664eb6eddcb914634199d945145860039e6ba");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("e70625d050c702331a52664add39e5ac64fded6a11bb8836143280c1a887de1a");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("8f7bd7254265034b3830cb19335160ca2b74d7ac74aab7151baefbfab64d0ff2");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("bbe095b668f3de3991ffe03a8d2eb8688374a598d9922e28eb04f3977826309c");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("9ee0d346e2a597ee9083711e9c7f6f414bff6b9f0ae7f88f7db534a2280964c0");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("9484aed2f25183c3d88967bb90ef988c5d83a2813aa7cf931a89a741f4a845c0");
     });
   });
 });

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,11 +154,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("4b33c6ecc4cdb85217bb207c5fe83f315947716edc9e69ca4f825b271a73fa66");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("f76b564446d2c023cf887feb6bf0d3a09e6659f12f7f86a896affac7fc03fcfd");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("114b65e001ab37d07caf85521f32707401b67ca490333207b31e313567333176");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("8882b29a20fbfc26fc4840ddb02d6e996d7feeb96331179bd6c828f93ce9bcf4");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("1bc2c121f8fa63ce3fc8e79eea3da1fd62028f8e0cca435b04fbca39beeb3089");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("a71c208d4d7103e6b983019d357c1bbfbe8caa1a0cf877e49ce2b524d8e93a90");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("bbf1666aaf7868b88d481a7e93494220e890ed49e9dbdca70496cec4044e88ff");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("8154464132136ceac323a3ab182ff4a8d71a5d36a18aed66904bd59f6fc05f67");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("0f3602ab3701c339df648b7634cbb189d6bf27c2def7170aec3151850bee83f0");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("062d78c5a9b1ca48f2c21fd13c0664eb6eddcb914634199d945145860039e6ba");
     });
   });
 });

--- a/test-upgrade/colony-upgrade.js
+++ b/test-upgrade/colony-upgrade.js
@@ -1,5 +1,5 @@
 /* globals artifacts */
-import { currentBlockTime } from "../helpers/test-helper";
+import { currentBlockTime, getColonyEditable } from "../helpers/test-helper";
 import { setupColonyVersionResolver } from "../helpers/upgradable-contracts";
 import { ROOT_ROLE, SPECIFICATION_HASH, SPECIFICATION_HASH_UPDATED } from "../helpers/constants";
 import { makeTask, setupRandomColony } from "../helpers/test-data-generator";
@@ -77,6 +77,11 @@ contract("Colony contract upgrade", (accounts) => {
     updatedColonyVersion = await colonyNetwork.getCurrentColonyVersion();
 
     // Upgrade our existing colony
+    // 8->9 upgrade, unlike other upgrades to date, not idempotent, so have to delete
+    // the local root skill id
+    const editableColony = await getColonyEditable(colony, colonyNetwork);
+    await editableColony.setStorageSlot(36, "0x0000000000000000000000000000000000000000000000000000000000000000");
+
     await colony.upgrade(updatedColonyVersion);
     updatedColony = await IUpdatedColony.at(colony.address);
   });

--- a/test-upgrade/colony-upgrade.js
+++ b/test-upgrade/colony-upgrade.js
@@ -8,6 +8,7 @@ const IColonyNetwork = artifacts.require("IColonyNetwork");
 const IMetaColony = artifacts.require("IMetaColony");
 const EtherRouter = artifacts.require("EtherRouter");
 const Resolver = artifacts.require("Resolver");
+const ColonyDomains = artifacts.require("ColonyDomains");
 const ColonyExpenditure = artifacts.require("ColonyExpenditure");
 const ColonyTask = artifacts.require("ColonyTask");
 const ColonyPayment = artifacts.require("ColonyPayment");
@@ -39,6 +40,7 @@ contract("Colony contract upgrade", (accounts) => {
 
     ({ colony, token } = await setupRandomColony(colonyNetwork));
 
+    const colonyDomains = await ColonyDomains.new();
     const colonyExpenditure = await ColonyExpenditure.new();
     const colonyTask = await ColonyTask.new();
     const colonyPayment = await ColonyPayment.new();
@@ -57,6 +59,7 @@ contract("Colony contract upgrade", (accounts) => {
     await resolver.register("isUpdated()", updatedColonyContract.address);
     await setupColonyVersionResolver(
       updatedColonyContract,
+      colonyDomains,
       colonyExpenditure,
       colonyTask,
       colonyPayment,

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -252,11 +252,11 @@ contract("Colony Expenditure", (accounts) => {
       const localSkillId = await colonyNetwork.getSkillCount();
       await colony.deprecateLocalSkill(localSkillId, true);
 
-      await checkErrorRevert(colony.setExpenditureSkill(expenditureId, SLOT0, localSkillId, { from: ADMIN }), "colony-deprecated-local-skill");
+      await checkErrorRevert(colony.setExpenditureSkill(expenditureId, SLOT0, localSkillId, { from: ADMIN }), "colony-not-valid-skill");
     });
 
     it("should not allow owners to update many slot skills with nonexistent skills", async () => {
-      await checkErrorRevert(colony.setExpenditureSkills(expenditureId, [SLOT0], [100], { from: ADMIN }), "colony-expenditure-skill-does-not-exist");
+      await checkErrorRevert(colony.setExpenditureSkills(expenditureId, [SLOT0], [100], { from: ADMIN }), "colony-not-valid-skill");
     });
 
     it("should allow owners to update a slot claim delay", async () => {
@@ -325,7 +325,7 @@ contract("Colony Expenditure", (accounts) => {
       const skillId = await colonyNetwork.getSkillCount();
       await metaColony.deprecateGlobalSkill(skillId);
 
-      await checkErrorRevert(colony.setExpenditureSkill(expenditureId, SLOT0, skillId, { from: ADMIN }), "colony-deprecated-global-skill");
+      await checkErrorRevert(colony.setExpenditureSkill(expenditureId, SLOT0, skillId, { from: ADMIN }), "colony-not-valid-skill");
     });
 
     it("should not allow non-owners to update skills or payouts", async () => {

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -244,7 +244,10 @@ contract("Colony Expenditure", (accounts) => {
       await otherColony.addLocalSkill();
       const localSkillId = await colonyNetwork.getSkillCount();
 
-      await checkErrorRevert(colony.setExpenditureSkill(expenditureId, SLOT0, localSkillId, { from: ADMIN }), "colony-not-valid-skill");
+      await checkErrorRevert(
+        colony.setExpenditureSkill(expenditureId, SLOT0, localSkillId, { from: ADMIN }),
+        "colony-not-valid-global-or-local-skill"
+      );
     });
 
     it("should not allow owners to update a slot skill with a deprecated local skill", async () => {
@@ -252,11 +255,14 @@ contract("Colony Expenditure", (accounts) => {
       const localSkillId = await colonyNetwork.getSkillCount();
       await colony.deprecateLocalSkill(localSkillId, true);
 
-      await checkErrorRevert(colony.setExpenditureSkill(expenditureId, SLOT0, localSkillId, { from: ADMIN }), "colony-not-valid-skill");
+      await checkErrorRevert(
+        colony.setExpenditureSkill(expenditureId, SLOT0, localSkillId, { from: ADMIN }),
+        "colony-not-valid-global-or-local-skill"
+      );
     });
 
     it("should not allow owners to update many slot skills with nonexistent skills", async () => {
-      await checkErrorRevert(colony.setExpenditureSkills(expenditureId, [SLOT0], [100], { from: ADMIN }), "colony-not-valid-skill");
+      await checkErrorRevert(colony.setExpenditureSkills(expenditureId, [SLOT0], [100], { from: ADMIN }), "colony-not-valid-global-or-local-skill");
     });
 
     it("should allow owners to update a slot claim delay", async () => {
@@ -319,13 +325,13 @@ contract("Colony Expenditure", (accounts) => {
     });
 
     it("should not allow owners to set a non-global/local skill or a deprecated global skill", async () => {
-      await checkErrorRevert(colony.setExpenditureSkill(expenditureId, SLOT0, 2, { from: ADMIN }), "colony-not-valid-skill");
+      await checkErrorRevert(colony.setExpenditureSkill(expenditureId, SLOT0, 2, { from: ADMIN }), "colony-not-valid-global-or-local-skill");
 
       await metaColony.addGlobalSkill();
       const skillId = await colonyNetwork.getSkillCount();
       await metaColony.deprecateGlobalSkill(skillId);
 
-      await checkErrorRevert(colony.setExpenditureSkill(expenditureId, SLOT0, skillId, { from: ADMIN }), "colony-not-valid-skill");
+      await checkErrorRevert(colony.setExpenditureSkill(expenditureId, SLOT0, skillId, { from: ADMIN }), "colony-not-valid-global-or-local-skill");
     });
 
     it("should not allow non-owners to update skills or payouts", async () => {

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -318,8 +318,8 @@ contract("Colony Expenditure", (accounts) => {
       );
     });
 
-    it("should not allow owners to set a non-global skill or a deprecated global skill", async () => {
-      await checkErrorRevert(colony.setExpenditureSkill(expenditureId, SLOT0, 2, { from: ADMIN }), "colony-not-global-skill");
+    it("should not allow owners to set a non-global/local skill or a deprecated global skill", async () => {
+      await checkErrorRevert(colony.setExpenditureSkill(expenditureId, SLOT0, 2, { from: ADMIN }), "colony-not-valid-skill");
 
       await metaColony.addGlobalSkill();
       const skillId = await colonyNetwork.getSkillCount();

--- a/test/contracts-network/colony-payment.js
+++ b/test/contracts-network/colony-payment.js
@@ -105,7 +105,7 @@ contract("Colony Payment", (accounts) => {
 
       await checkErrorRevert(
         colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, 0, 1, skillId, { from: COLONY_ADMIN }),
-        "colony-not-valid-skill"
+        "colony-not-valid-global-or-local-skill"
       );
     });
 
@@ -163,7 +163,10 @@ contract("Colony Payment", (accounts) => {
       const skillId = await colonyNetwork.getSkillCount();
       await metaColony.deprecateGlobalSkill(skillId);
 
-      await checkErrorRevert(colony.setPaymentSkill(1, UINT256_MAX, paymentId, skillId, { from: COLONY_ADMIN }), "colony-not-valid-skill");
+      await checkErrorRevert(
+        colony.setPaymentSkill(1, UINT256_MAX, paymentId, skillId, { from: COLONY_ADMIN }),
+        "colony-not-valid-global-or-local-skill"
+      );
     });
 
     it("should not allow non-admins to update recipient", async () => {

--- a/test/contracts-network/colony-payment.js
+++ b/test/contracts-network/colony-payment.js
@@ -5,7 +5,7 @@ import BN from "bn.js";
 import { ethers } from "ethers";
 import { soliditySha3 } from "web3-utils";
 
-import { UINT256_MAX, WAD, MAX_PAYOUT } from "../../helpers/constants";
+import { UINT256_MAX, WAD, MAX_PAYOUT, GLOBAL_SKILL_ID } from "../../helpers/constants";
 import { checkErrorRevert, getTokenArgs, expectEvent } from "../../helpers/test-helper";
 import { fundColonyWithTokens, setupRandomColony } from "../../helpers/test-data-generator";
 import { setupEtherRouter } from "../../helpers/upgradable-contracts";
@@ -147,10 +147,12 @@ contract("Colony Payment", (accounts) => {
 
       let payment = await colony.getPayment(paymentId);
       expect(payment.skills[0]).to.eq.BN(0);
-      const tx = await colony.setPaymentSkill(1, UINT256_MAX, paymentId, 3, { from: COLONY_ADMIN });
+
+      const tx = await colony.setPaymentSkill(1, UINT256_MAX, paymentId, GLOBAL_SKILL_ID, { from: COLONY_ADMIN });
       payment = await colony.getPayment(paymentId);
-      expect(payment.skills[0]).to.eq.BN(3);
-      await expectEvent(tx, "PaymentSkillSet", [COLONY_ADMIN, paymentId, 3]);
+      expect(payment.skills[0]).to.eq.BN(GLOBAL_SKILL_ID);
+
+      await expectEvent(tx, "PaymentSkillSet", [COLONY_ADMIN, paymentId, GLOBAL_SKILL_ID]);
     });
 
     it("should not allow admins to update payment with deprecated global skill", async () => {

--- a/test/contracts-network/colony-payment.js
+++ b/test/contracts-network/colony-payment.js
@@ -105,7 +105,7 @@ contract("Colony Payment", (accounts) => {
 
       await checkErrorRevert(
         colony.addPayment(1, UINT256_MAX, RECIPIENT, token.address, 0, 1, skillId, { from: COLONY_ADMIN }),
-        "colony-deprecated-global-skill"
+        "colony-not-valid-skill"
       );
     });
 
@@ -163,7 +163,7 @@ contract("Colony Payment", (accounts) => {
       const skillId = await colonyNetwork.getSkillCount();
       await metaColony.deprecateGlobalSkill(skillId);
 
-      await checkErrorRevert(colony.setPaymentSkill(1, UINT256_MAX, paymentId, skillId, { from: COLONY_ADMIN }), "colony-deprecated-global-skill");
+      await checkErrorRevert(colony.setPaymentSkill(1, UINT256_MAX, paymentId, skillId, { from: COLONY_ADMIN }), "colony-not-valid-skill");
     });
 
     it("should not allow non-admins to update recipient", async () => {

--- a/test/contracts-network/colony-permissions.js
+++ b/test/contracts-network/colony-permissions.js
@@ -338,7 +338,7 @@ contract("ColonyPermissions", (accounts) => {
       tx = await colony.emitSkillReputationReward(GLOBAL_SKILL_ID, USER2, 100, { from: FOUNDER });
       await expectEvent(tx, "ArbitraryReputationUpdate", [FOUNDER, USER2, GLOBAL_SKILL_ID, 100]);
 
-      await checkErrorRevert(colony.emitSkillReputationReward(0, USER2, 100, { from: FOUNDER }), "colony-not-global-skill");
+      await checkErrorRevert(colony.emitSkillReputationReward(0, USER2, 100, { from: FOUNDER }), "colony-not-valid-skill");
       await checkErrorRevert(colony.emitSkillReputationReward(GLOBAL_SKILL_ID, USER2, -100, { from: FOUNDER }), "colony-reward-must-be-positive");
       await checkErrorRevert(colony.emitSkillReputationReward(GLOBAL_SKILL_ID, USER2, 100, { from: USER1 }), "ds-auth-unauthorized");
     });
@@ -359,7 +359,7 @@ contract("ColonyPermissions", (accounts) => {
       tx = await colony.emitSkillReputationPenalty(GLOBAL_SKILL_ID, USER2, -100, { from: USER1 });
       await expectEvent(tx, "ArbitraryReputationUpdate", [USER1, USER2, GLOBAL_SKILL_ID, -100]);
 
-      await checkErrorRevert(colony.emitSkillReputationPenalty(0, USER2, 100, { from: USER1 }), "colony-not-global-skill");
+      await checkErrorRevert(colony.emitSkillReputationPenalty(0, USER2, 100, { from: USER1 }), "colony-not-valid-skill");
       await checkErrorRevert(colony.emitSkillReputationPenalty(GLOBAL_SKILL_ID, USER2, 100, { from: USER1 }), "colony-penalty-cannot-be-positive");
       await checkErrorRevert(colony.emitSkillReputationPenalty(GLOBAL_SKILL_ID, USER2, -100, { from: USER2 }), "ds-auth-unauthorized");
     });

--- a/test/contracts-network/colony-permissions.js
+++ b/test/contracts-network/colony-permissions.js
@@ -338,7 +338,7 @@ contract("ColonyPermissions", (accounts) => {
       tx = await colony.emitSkillReputationReward(GLOBAL_SKILL_ID, USER2, 100, { from: FOUNDER });
       await expectEvent(tx, "ArbitraryReputationUpdate", [FOUNDER, USER2, GLOBAL_SKILL_ID, 100]);
 
-      await checkErrorRevert(colony.emitSkillReputationReward(0, USER2, 100, { from: FOUNDER }), "colony-not-valid-skill");
+      await checkErrorRevert(colony.emitSkillReputationReward(0, USER2, 100, { from: FOUNDER }), "colony-not-valid-global-or-local-skill");
       await checkErrorRevert(colony.emitSkillReputationReward(GLOBAL_SKILL_ID, USER2, -100, { from: FOUNDER }), "colony-reward-must-be-positive");
       await checkErrorRevert(colony.emitSkillReputationReward(GLOBAL_SKILL_ID, USER2, 100, { from: USER1 }), "ds-auth-unauthorized");
     });
@@ -359,7 +359,7 @@ contract("ColonyPermissions", (accounts) => {
       tx = await colony.emitSkillReputationPenalty(GLOBAL_SKILL_ID, USER2, -100, { from: USER1 });
       await expectEvent(tx, "ArbitraryReputationUpdate", [USER1, USER2, GLOBAL_SKILL_ID, -100]);
 
-      await checkErrorRevert(colony.emitSkillReputationPenalty(0, USER2, 100, { from: USER1 }), "colony-not-valid-skill");
+      await checkErrorRevert(colony.emitSkillReputationPenalty(0, USER2, 100, { from: USER1 }), "colony-not-valid-global-or-local-skill");
       await checkErrorRevert(colony.emitSkillReputationPenalty(GLOBAL_SKILL_ID, USER2, 100, { from: USER1 }), "colony-penalty-cannot-be-positive");
       await checkErrorRevert(colony.emitSkillReputationPenalty(GLOBAL_SKILL_ID, USER2, -100, { from: USER2 }), "ds-auth-unauthorized");
     });

--- a/test/contracts-network/colony-permissions.js
+++ b/test/contracts-network/colony-permissions.js
@@ -128,17 +128,35 @@ contract("ColonyPermissions", (accounts) => {
       expect(hasRole).to.be.true;
 
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address, {
-          from: USER1,
-        }),
+        colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)"](
+          1,
+          UINT256_MAX,
+          1,
+          UINT256_MAX,
+          0,
+          domain1.fundingPotId,
+          domain2.fundingPotId,
+          WAD,
+          token.address,
+          { from: USER1 }
+        ),
         "ds-auth-unauthorized"
       );
 
       const taskId = await makeTask({ colonyNetwork, colony, domainId: 2 });
       const task = await colony.getTask(taskId);
-      await colony.moveFundsBetweenPots(2, UINT256_MAX, 2, UINT256_MAX, UINT256_MAX, domain2.fundingPotId, task.fundingPotId, WAD, token.address, {
-        from: USER1,
-      });
+      await colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)"](
+        2,
+        UINT256_MAX,
+        2,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain2.fundingPotId,
+        task.fundingPotId,
+        WAD,
+        token.address,
+        { from: USER1 }
+      );
     });
 
     it("should allow users with administration permission manipulate expenditures in their domains only", async () => {
@@ -392,10 +410,31 @@ contract("ColonyPermissions", (accounts) => {
       );
 
       // Newest version
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, 0, domain1.fundingPotId, domain2.fundingPotId, WAD, token.address, {
-        from: USER2,
-      });
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 1, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 });
+      await colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)"](
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        0,
+        domain1.fundingPotId,
+        domain2.fundingPotId,
+        WAD,
+        token.address,
+        { from: USER2 }
+      );
+
+      await colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)"](
+        1,
+        UINT256_MAX,
+        1,
+        0,
+        1,
+        domain2.fundingPotId,
+        domain3.fundingPotId,
+        WAD,
+        token.address,
+        { from: USER2 }
+      );
 
       // But only with valid proofs. Deprecated version of this function
       await checkErrorRevert(
@@ -427,11 +466,34 @@ contract("ColonyPermissions", (accounts) => {
 
       // The newest version
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 1, 1, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 }),
+        colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)"](
+          1,
+          UINT256_MAX,
+          1,
+          1,
+          1,
+          domain2.fundingPotId,
+          domain3.fundingPotId,
+          WAD,
+          token.address,
+          { from: USER2 }
+        ),
         "colony-invalid-domain-inheritence"
       );
+
       await checkErrorRevert(
-        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 0, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address, { from: USER2 }),
+        colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)"](
+          1,
+          UINT256_MAX,
+          1,
+          0,
+          0,
+          domain2.fundingPotId,
+          domain3.fundingPotId,
+          WAD,
+          token.address,
+          { from: USER2 }
+        ),
         "colony-invalid-domain-inheritence"
       );
     });

--- a/test/contracts-network/colony-recovery.js
+++ b/test/contracts-network/colony-recovery.js
@@ -202,6 +202,7 @@ contract("Colony Recovery", (accounts) => {
       await checkErrorRevert(colony.setStorageSlotRecovery(2, "0xdeadbeef"), "colony-common-protected-variable");
       // '6' is a protected location in Colony, but not ColonyNetwork. We get a different error.
       await checkErrorRevert(colony.setStorageSlotRecovery(6, "0xdeadbeef"), "colony-protected-variable");
+      await checkErrorRevert(colony.setStorageSlotRecovery(36, "0xdeadbeef"), "colony-protected-variable");
     });
 
     it("should not allow editing of a protected variable in a mapping", async () => {

--- a/test/contracts-network/colony-task.js
+++ b/test/contracts-network/colony-task.js
@@ -181,7 +181,7 @@ contract("ColonyTask", (accounts) => {
     });
 
     it("should log TaskAdded and FundingPotAdded events", async () => {
-      await expectAllEvents(colony.makeTask(1, UINT256_MAX, SPECIFICATION_HASH, 1, 3, 0), ["TaskAdded", "FundingPotAdded"]);
+      await expectAllEvents(colony.makeTask(1, UINT256_MAX, SPECIFICATION_HASH, 1, GLOBAL_SKILL_ID, 0), ["TaskAdded", "FundingPotAdded"]);
     });
 
     it("should optionally set the skill and due date", async () => {
@@ -321,7 +321,7 @@ contract("ColonyTask", (accounts) => {
         functionName: "setTaskSkill",
         signers: [MANAGER],
         sigTypes: [0],
-        args: [taskId, 3], // skillId 3
+        args: [taskId, GLOBAL_SKILL_ID],
       });
 
       executeSignedRoleAssignment({

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -223,11 +223,6 @@ contract("Colony", (accounts) => {
       await expectEvent(colony.deprecateDomain(1, 0, 2, true), "DomainDeprecated", [USER0, 2, true]);
     });
 
-    it("should not log the DomainDeprecated event if the state did not change", async () => {
-      await colony.addDomain(1, UINT256_MAX, 1);
-      await expectNoEvent(colony.deprecateDomain(1, 0, 2, false), "DomainDeprecated");
-    });
-
     it("should not be able to perform prohibited actions in the domain", async () => {
       await colony.addDomain(1, UINT256_MAX, 1);
       await colony.deprecateDomain(1, 0, 2, true);

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -169,6 +169,23 @@ contract("Colony", (accounts) => {
     });
   });
 
+  describe("when adding local skills", () => {
+    it("should log the LocalSkillAdded event", async () => {
+      const tx = await colony.addLocalSkill();
+
+      const skillCount = await colonyNetwork.getSkillCount();
+      await expectEvent(tx, "LocalSkillAdded", [accounts[0], skillCount]);
+    });
+
+    it("should allow root users to deprecate local skills", async () => {
+      await colony.addLocalSkill();
+      const skillCount = await colonyNetwork.getSkillCount();
+
+      const tx = await colony.deprecateLocalSkill(skillCount, true);
+      await expectEvent(tx, "LocalSkillDeprecated", [accounts[0], skillCount, true]);
+    });
+  });
+
   describe("when adding domains", () => {
     it("should log DomainAdded and FundingPotAdded and DomainMetadata events", async () => {
       let tx = await colony.addDomain(1, UINT256_MAX, 1);

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -170,6 +170,11 @@ contract("Colony", (accounts) => {
   });
 
   describe("when adding local skills", () => {
+    it("should be able to get the rootLocalSkill", async () => {
+      const rootLocalSkill = await colony.getRootLocalSkill();
+      expect(rootLocalSkill).to.eq.BN(5);
+    });
+
     it("should log the LocalSkillAdded event", async () => {
       const tx = await colony.addLocalSkill();
 
@@ -183,6 +188,14 @@ contract("Colony", (accounts) => {
 
       const tx = await colony.deprecateLocalSkill(skillCount, true);
       await expectEvent(tx, "LocalSkillDeprecated", [accounts[0], skillCount, true]);
+    });
+
+    it("should not emit an event if deprecation is a no-op", async () => {
+      await colony.addLocalSkill();
+      const skillCount = await colonyNetwork.getSkillCount();
+
+      const tx = await colony.deprecateLocalSkill(skillCount, false);
+      await expectNoEvent(tx, "LocalSkillDeprecated");
     });
   });
 

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -172,7 +172,9 @@ contract("Colony", (accounts) => {
   describe("when adding local skills", () => {
     it("should be able to get the rootLocalSkill", async () => {
       const rootLocalSkill = await colony.getRootLocalSkill();
-      expect(rootLocalSkill).to.eq.BN(5);
+      // If run as the only test, it's 5. If it's in the test suite as a whole, because there's a
+      // 'beforeEach' that creates colonies, it depends how many there have been.
+      expect(rootLocalSkill).to.be.gte.BN(5);
     });
 
     it("should log the LocalSkillAdded event", async () => {

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -128,9 +128,9 @@ contract("Colony", (accounts) => {
       // The first pot should have been created and assigned to the domain
       expect(domain.fundingPotId).to.eq.BN(1);
 
-      // A root skill should have been created for the Colony
+      // A domain skill should have been created for the Colony
       const rootLocalSkillId = await colonyNetwork.getSkillCount();
-      expect(domain.skillId).to.eq.BN(rootLocalSkillId);
+      expect(domain.skillId).to.eq.BN(rootLocalSkillId.subn(1));
     });
 
     it("should let funding pot information be read", async () => {
@@ -244,6 +244,7 @@ contract("Colony", (accounts) => {
 
     it("should assign reputation correctly", async () => {
       const skillCount = await colonyNetwork.getSkillCount();
+      const rootDomainSkillId = skillCount.subn(1);
 
       await colony.mintTokens(WAD.muln(14));
       await colony.claimColonyFunds(token.address);
@@ -255,7 +256,7 @@ contract("Colony", (accounts) => {
       const updateLog = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(0);
       expect(updateLog.user).to.eq.BN(INITIAL_ADDRESSES[0]);
       expect(updateLog.amount).to.eq.BN(INITIAL_REPUTATIONS[0]);
-      expect(updateLog.skillId).to.eq.BN(skillCount);
+      expect(updateLog.skillId).to.eq.BN(rootDomainSkillId);
     });
 
     it("should assign tokens correctly", async () => {

--- a/test/contracts-network/meta-colony.js
+++ b/test/contracts-network/meta-colony.js
@@ -63,11 +63,11 @@ contract("Meta Colony", (accounts) => {
   });
 
   describe("when adding skills to the tree by adding domains", () => {
-    before(async () => {
+    beforeEach(async () => {
       await removeSubdomainLimit(colonyNetwork); // Temporary for tests until we allow subdomain depth > 1
     });
 
-    after(async () => {
+    afterEach(async () => {
       await restoreSubdomainLimit(colonyNetwork);
     });
 

--- a/test/contracts-network/meta-colony.js
+++ b/test/contracts-network/meta-colony.js
@@ -485,12 +485,12 @@ contract("Meta Colony", (accounts) => {
 
     it("should NOT be able to set nonexistent skill on task", async () => {
       const taskId = await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskSkill(taskId, 100), "colony-skill-does-not-exist");
+      await checkErrorRevert(colony.setTaskSkill(taskId, 100), "colony-not-valid-skill");
     });
 
     it("should NOT be able to set local skill on task", async () => {
       const taskId = await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskSkill(taskId, 1), "colony-not-global-skill");
+      await checkErrorRevert(colony.setTaskSkill(taskId, 1), "colony-not-valid-skill");
     });
 
     it("should NOT be able to set a deprecated skill on task", async () => {
@@ -499,7 +499,7 @@ contract("Meta Colony", (accounts) => {
       const skillId = await colonyNetwork.getSkillCount();
       await metaColony.deprecateGlobalSkill(skillId);
 
-      await checkErrorRevert(colony.setTaskSkill(taskId, skillId), "colony-deprecated-global-skill");
+      await checkErrorRevert(colony.setTaskSkill(taskId, skillId), "colony-not-valid-skill");
     });
   });
 

--- a/test/contracts-network/meta-colony.js
+++ b/test/contracts-network/meta-colony.js
@@ -36,6 +36,15 @@ contract("Meta Colony", (accounts) => {
     colonyNetwork = await setupColonyNetwork();
     ({ metaColony, clnyToken } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
 
+    // Skills:
+    // 1: Metacolony root domain skill
+    // 2: Metacolony root local skill
+    // 3: Metacolony mining skill
+    // 4: First global skill
+
+    const skillCount = await colonyNetwork.getSkillCount();
+    expect(skillCount).to.eq.BN(4);
+
     await colonyNetwork.initialiseReputationMining();
     await colonyNetwork.startNextCycle();
   });
@@ -66,21 +75,22 @@ contract("Meta Colony", (accounts) => {
       await metaColony.addDomain(1, UINT256_MAX, 1);
 
       const skillCount = await colonyNetwork.getSkillCount();
-      expect(skillCount).to.eq.BN(4);
+      expect(skillCount).to.eq.BN(5);
 
-      const newSkill = await colonyNetwork.getSkill(skillCount);
-      expect(newSkill.nParents).to.eq.BN(1);
-      expect(newSkill.nChildren).to.be.zero;
+      const newDomainSkill = await colonyNetwork.getSkill(skillCount);
+      expect(newDomainSkill.nParents).to.eq.BN(1);
+      expect(newDomainSkill.nChildren).to.be.zero;
 
       // Check nChildren of the skill corresponding to the root domain in the metacolony is now 2
-      const rootSkill = await colonyNetwork.getSkill(1);
-      expect(rootSkill.nChildren).to.eq.BN(2);
+      const rootDomain = await metaColony.getDomain(1);
+      const rootDomainSkill = await colonyNetwork.getSkill(rootDomain.skillId);
+      expect(rootDomainSkill.nChildren).to.eq.BN(2);
 
       // Check rootSkill.children first element is the id of the new skill
-      const rootSkillChild = await colonyNetwork.getChildSkillId(1, 0);
-      const rootSkillChild2 = await colonyNetwork.getChildSkillId(1, 1);
-      expect(rootSkillChild).to.eq.BN(2);
-      expect(rootSkillChild2).to.eq.BN(4);
+      const rootSkillChild = await colonyNetwork.getChildSkillId(rootDomain.skillId, 0);
+      const rootSkillChild2 = await colonyNetwork.getChildSkillId(rootDomain.skillId, 1);
+      expect(rootSkillChild).to.eq.BN(3);
+      expect(rootSkillChild2).to.eq.BN(5);
     });
 
     it("should not allow a non-root role in the metacolony to add a global skill", async () => {
@@ -93,31 +103,32 @@ contract("Meta Colony", (accounts) => {
       await metaColony.addDomain(1, UINT256_MAX, 1);
 
       const skillCount = await colonyNetwork.getSkillCount();
-      expect(skillCount).to.eq.BN(6);
+      expect(skillCount).to.eq.BN(7);
 
-      const newSkill1 = await colonyNetwork.getSkill(4);
+      const newSkill1 = await colonyNetwork.getSkill(5);
       expect(newSkill1.nParents).to.eq.BN(1);
       expect(newSkill1.nChildren).to.be.zero;
 
-      const newSkill2 = await colonyNetwork.getSkill(5);
+      const newSkill2 = await colonyNetwork.getSkill(6);
       expect(newSkill2.nParents).to.eq.BN(1);
       expect(newSkill2.nChildren).to.be.zero;
 
-      const newSkill3 = await colonyNetwork.getSkill(6);
+      const newSkill3 = await colonyNetwork.getSkill(7);
       expect(newSkill3.nParents).to.eq.BN(1);
       expect(newSkill3.nChildren).to.be.zero;
 
       // Check rootSkill.nChildren is now 4
-      const rootSkill = await colonyNetwork.getSkill(1);
-      expect(rootSkill.nChildren).to.eq.BN(4);
+      const rootDomain = await metaColony.getDomain(1);
+      const rootDomainSkill = await colonyNetwork.getSkill(rootDomain.skillId);
+      expect(rootDomainSkill.nChildren).to.eq.BN(4);
 
-      // Check rootSkill.children contains the ids of the new skills
-      const rootSkillChild1 = await colonyNetwork.getChildSkillId(1, 1);
-      expect(rootSkillChild1).to.eq.BN(4);
-      const rootSkillChild2 = await colonyNetwork.getChildSkillId(1, 2);
-      expect(rootSkillChild2).to.eq.BN(5);
-      const rootSkillChild3 = await colonyNetwork.getChildSkillId(1, 3);
-      expect(rootSkillChild3).to.eq.BN(6);
+      // Check rootDomainSkill.children contains the ids of the new skills
+      const rootDomainSkillChild1 = await colonyNetwork.getChildSkillId(1, 1);
+      expect(rootDomainSkillChild1).to.eq.BN(5);
+      const rootDomainSkillChild2 = await colonyNetwork.getChildSkillId(1, 2);
+      expect(rootDomainSkillChild2).to.eq.BN(6);
+      const rootDomainSkillChild3 = await colonyNetwork.getChildSkillId(1, 3);
+      expect(rootDomainSkillChild3).to.eq.BN(7);
     });
 
     it("should NOT be able to add a domain that has a non existent parent", async () => {
@@ -127,7 +138,7 @@ contract("Meta Colony", (accounts) => {
 
       await checkErrorRevert(metaColony.addDomain(1, UINT256_MAX, 6), "ds-auth-child-domain-does-not-exist");
       const skillCount = await colonyNetwork.getSkillCount();
-      expect(skillCount).to.eq.BN(5);
+      expect(skillCount).to.eq.BN(6);
     });
 
     it("should NOT be able to add a child skill to a local skill parent", async () => {
@@ -139,89 +150,101 @@ contract("Meta Colony", (accounts) => {
       const domain1Slot = soliditySha3(1, 20);
       // Which means the skill is in that slot (it's the first entry in the struct)
       // Edit that slot
-      await metaColony.setStorageSlotRecovery(domain1Slot, "0x0000000000000000000000000000000000000000000000000000000000000003");
+      await metaColony.setStorageSlotRecovery(domain1Slot, "0x0000000000000000000000000000000000000000000000000000000000000004");
       // Leave recovery mode
       await metaColony.approveExitRecovery();
       await metaColony.exitRecoveryMode();
       // Try to add a child
       await checkErrorRevert(metaColony.addDomain(1, UINT256_MAX, 1), "colony-global-and-local-skill-trees-are-separate");
       const skillCount = await colonyNetwork.getSkillCount();
-      expect(skillCount).to.eq.BN(3);
+      expect(skillCount).to.eq.BN(4);
     });
 
     it("should be able to add skills in the middle of the skills tree", async () => {
       // Why this random addGlobalSkill in the middle? It means we can use effectively the same tests
       // below, but with skill ID 7 replaced with skill ID 2. While porting everything to the tag cloud
       // arrangement, I was very interested in changing tests as little as possible.
-      await metaColony.addDomain(1, UINT256_MAX, 1); // Domain ID 2, skill id 4
-      await metaColony.addDomain(1, UINT256_MAX, 1); // Domain ID 3, skill id 5
-      await metaColony.addDomain(1, 2, 3); // Domain ID 4, skill id 6
-      await metaColony.addGlobalSkill(); // Skill id 7
-      await metaColony.addDomain(1, 1, 2); // Domain ID 5, skill id 8
-      await metaColony.addDomain(1, 2, 3); // Domain ID 6, skill id 9
 
-      const rootSkill = await colonyNetwork.getSkill(1);
-      expect(rootSkill.nParents).to.be.zero;
-      expect(rootSkill.nChildren).to.eq.BN(6);
-      const rootSkillChildSkillId1 = await colonyNetwork.getChildSkillId(1, 0);
-      expect(rootSkillChildSkillId1).to.eq.BN(2);
-      const rootSkillChildSkillId2 = await colonyNetwork.getChildSkillId(1, 1);
-      expect(rootSkillChildSkillId2).to.eq.BN(4);
-      const rootSkillChildSkillId3 = await colonyNetwork.getChildSkillId(1, 2);
-      expect(rootSkillChildSkillId3).to.eq.BN(5);
-      const rootSkillChildSkillId4 = await colonyNetwork.getChildSkillId(1, 3);
-      expect(rootSkillChildSkillId4).to.eq.BN(6);
-      const rootSkillChildSkillId5 = await colonyNetwork.getChildSkillId(1, 4);
-      expect(rootSkillChildSkillId5).to.eq.BN(8);
-      const rootSkillChildSkillId6 = await colonyNetwork.getChildSkillId(1, 5);
-      expect(rootSkillChildSkillId6).to.eq.BN(9);
+      await metaColony.addDomain(1, UINT256_MAX, 1); // Domain ID 2, skill id 5
+      await metaColony.addDomain(1, UINT256_MAX, 1); // Domain ID 3, skill id 6
+      await metaColony.addDomain(1, 2, 3); // Domain ID 4, skill id 7
+      await metaColony.addGlobalSkill(); // Skill id 8
+      await metaColony.addDomain(1, 1, 2); // Domain ID 5, skill id 9
+      await metaColony.addDomain(1, 2, 3); // Domain ID 6, skill id 10
 
-      const skill1 = await colonyNetwork.getSkill(4);
+      // 1 -> 2 -> 5
+      //   -> 3 -> 4
+      //        -> 6
+
+      const rootDomain = await metaColony.getDomain(1);
+      const rootDomainSkill = await colonyNetwork.getSkill(rootDomain.skillId);
+      expect(rootDomainSkill.nParents).to.be.zero;
+      expect(rootDomainSkill.nChildren).to.eq.BN(6);
+      const rootDomainSkillChildSkillId1 = await colonyNetwork.getChildSkillId(rootDomain.skillId, 0);
+      expect(rootDomainSkillChildSkillId1).to.eq.BN(3);
+      const rootDomainSkillChildSkillId2 = await colonyNetwork.getChildSkillId(rootDomain.skillId, 1);
+      expect(rootDomainSkillChildSkillId2).to.eq.BN(5);
+      const rootDomainSkillChildSkillId3 = await colonyNetwork.getChildSkillId(rootDomain.skillId, 2);
+      expect(rootDomainSkillChildSkillId3).to.eq.BN(6);
+      const rootDomainSkillChildSkillId4 = await colonyNetwork.getChildSkillId(rootDomain.skillId, 3);
+      expect(rootDomainSkillChildSkillId4).to.eq.BN(7);
+      const rootDomainSkillChildSkillId5 = await colonyNetwork.getChildSkillId(rootDomain.skillId, 4);
+      expect(rootDomainSkillChildSkillId5).to.eq.BN(9);
+      const rootDomainSkillChildSkillId6 = await colonyNetwork.getChildSkillId(rootDomain.skillId, 5);
+      expect(rootDomainSkillChildSkillId6).to.eq.BN(10);
+
+      let skillId = 5;
+      const skill1 = await colonyNetwork.getSkill(skillId);
       expect(skill1.nParents).to.eq.BN(1);
       expect(skill1.nChildren).to.eq.BN(1);
-      const skill1ParentSkillId1 = await colonyNetwork.getParentSkillId(4, 0);
+      const skill1ParentSkillId1 = await colonyNetwork.getParentSkillId(skillId, 0);
       expect(skill1ParentSkillId1).to.eq.BN(1);
-      const skill1ChildSkillId1 = await colonyNetwork.getChildSkillId(4, 0);
-      expect(skill1ChildSkillId1).to.eq.BN(8);
+      const skill1ChildSkillId1 = await colonyNetwork.getChildSkillId(skillId, 0);
+      expect(skill1ChildSkillId1).to.eq.BN(9);
 
-      const skill2 = await colonyNetwork.getSkill(5);
+      skillId = 6;
+      const skill2 = await colonyNetwork.getSkill(skillId);
       expect(skill2.nParents).to.eq.BN(1);
       expect(skill2.nChildren).to.eq.BN(2);
-      const skill2ParentSkillId1 = await colonyNetwork.getParentSkillId(5, 0);
+      const skill2ParentSkillId1 = await colonyNetwork.getParentSkillId(skillId, 0);
       expect(skill2ParentSkillId1).to.eq.BN(1);
-      const skill2ChildSkillId1 = await colonyNetwork.getChildSkillId(5, 0);
-      expect(skill2ChildSkillId1).to.eq.BN(6);
-      const skill2ChildSkillId2 = await colonyNetwork.getChildSkillId(5, 1);
-      expect(skill2ChildSkillId2).to.eq.BN(9);
+      const skill2ChildSkillId1 = await colonyNetwork.getChildSkillId(skillId, 0);
+      expect(skill2ChildSkillId1).to.eq.BN(7);
+      const skill2ChildSkillId2 = await colonyNetwork.getChildSkillId(skillId, 1);
+      expect(skill2ChildSkillId2).to.eq.BN(10);
 
-      const skill3 = await colonyNetwork.getSkill(6);
+      skillId = 7;
+      const skill3 = await colonyNetwork.getSkill(skillId);
       expect(skill3.nParents).to.eq.BN(2);
       expect(skill3.nChildren).to.be.zero;
-      const skill3ParentSkillId1 = await colonyNetwork.getParentSkillId(6, 0);
-      expect(skill3ParentSkillId1).to.eq.BN(5);
-      const skill3ParentSkillId2 = await colonyNetwork.getParentSkillId(6, 1);
+      const skill3ParentSkillId1 = await colonyNetwork.getParentSkillId(skillId, 0);
+      expect(skill3ParentSkillId1).to.eq.BN(6);
+      const skill3ParentSkillId2 = await colonyNetwork.getParentSkillId(skillId, 1);
       expect(skill3ParentSkillId2).to.eq.BN(1);
 
-      const skill4 = await colonyNetwork.getSkill(2);
+      skillId = 3;
+      const skill4 = await colonyNetwork.getSkill(skillId);
       expect(skill4.nParents).to.eq.BN(1);
       expect(skill4.nChildren).to.be.zero;
-      const skill4ParentSkillId1 = await colonyNetwork.getParentSkillId(2, 0);
+      const skill4ParentSkillId1 = await colonyNetwork.getParentSkillId(skillId, 0);
       expect(skill4ParentSkillId1).to.eq.BN(1);
 
-      const skill5 = await colonyNetwork.getSkill(8);
+      skillId = 9;
+      const skill5 = await colonyNetwork.getSkill(skillId);
       expect(skill5.nParents).to.eq.BN(2);
       expect(skill5.nChildren).to.be.zero;
-      const skill5ParentSkillId1 = await colonyNetwork.getParentSkillId(8, 0);
-      expect(skill5ParentSkillId1).to.eq.BN(4);
-      const skill5ParentSkillId2 = await colonyNetwork.getParentSkillId(8, 1);
+      const skill5ParentSkillId1 = await colonyNetwork.getParentSkillId(skillId, 0);
+      expect(skill5ParentSkillId1).to.eq.BN(5);
+      const skill5ParentSkillId2 = await colonyNetwork.getParentSkillId(skillId, 1);
       expect(skill5ParentSkillId2).to.eq.BN(1);
 
-      const skill6 = await colonyNetwork.getSkill(9);
+      skillId = 10;
+      const skill6 = await colonyNetwork.getSkill(skillId);
       expect(skill6.nParents).to.eq.BN(2);
       expect(skill6.nChildren).to.be.zero;
-      const skill6ParentSkillId1 = await colonyNetwork.getParentSkillId(9, 0);
-      expect(skill6ParentSkillId1).to.eq.BN(5);
-      const skill6ParentSkillId2 = await colonyNetwork.getParentSkillId(9, 1);
+      const skill6ParentSkillId1 = await colonyNetwork.getParentSkillId(skillId, 0);
+      expect(skill6ParentSkillId1).to.eq.BN(6);
+      const skill6ParentSkillId2 = await colonyNetwork.getParentSkillId(skillId, 1);
       expect(skill6ParentSkillId2).to.eq.BN(1);
     });
 
@@ -236,40 +259,40 @@ contract("Meta Colony", (accounts) => {
       await metaColony.addDomain(1, 7, 8);
       await metaColony.addDomain(1, 8, 9);
 
-      // 1 -> 4 -> 5 -> 6 -> 7 -> 8 -> 9 -> 10 -> 11 -> 12
+      // 1 -> 5 -> 6 -> 7 -> 8 -> 9 -> 10 -> 11 -> 12 -> 13
 
-      const skill = await colonyNetwork.getSkill(12);
+      const skill = await colonyNetwork.getSkill(13);
       const numParents = skill.nParents;
       const numChildren = skill.nChildren;
       expect(numParents).to.eq.BN(9);
       expect(numChildren).to.be.zero;
 
       let parentId;
-      parentId = await colonyNetwork.getParentSkillId(12, 0);
+      parentId = await colonyNetwork.getParentSkillId(13, 0);
+      expect(parentId).to.eq.BN(12);
+      parentId = await colonyNetwork.getParentSkillId(13, 1);
       expect(parentId).to.eq.BN(11);
-      parentId = await colonyNetwork.getParentSkillId(12, 1);
+      parentId = await colonyNetwork.getParentSkillId(13, 2);
       expect(parentId).to.eq.BN(10);
-      parentId = await colonyNetwork.getParentSkillId(12, 2);
+      parentId = await colonyNetwork.getParentSkillId(13, 3);
       expect(parentId).to.eq.BN(9);
-      parentId = await colonyNetwork.getParentSkillId(12, 3);
+      parentId = await colonyNetwork.getParentSkillId(13, 4);
       expect(parentId).to.eq.BN(8);
-      parentId = await colonyNetwork.getParentSkillId(12, 4);
+      parentId = await colonyNetwork.getParentSkillId(13, 5);
       expect(parentId).to.eq.BN(7);
-      parentId = await colonyNetwork.getParentSkillId(12, 5);
+      parentId = await colonyNetwork.getParentSkillId(13, 6);
       expect(parentId).to.eq.BN(6);
-      parentId = await colonyNetwork.getParentSkillId(12, 6);
+      parentId = await colonyNetwork.getParentSkillId(13, 7);
       expect(parentId).to.eq.BN(5);
-      parentId = await colonyNetwork.getParentSkillId(12, 7);
-      expect(parentId).to.eq.BN(4);
-      parentId = await colonyNetwork.getParentSkillId(12, 8);
+      parentId = await colonyNetwork.getParentSkillId(13, 8);
       expect(parentId).to.eq.BN(1);
 
       // Higher indices return 0
-      parentId = await colonyNetwork.getParentSkillId(12, 9);
+      parentId = await colonyNetwork.getParentSkillId(13, 10);
       expect(parentId).to.be.zero;
-      parentId = await colonyNetwork.getParentSkillId(12, 10);
+      parentId = await colonyNetwork.getParentSkillId(13, 11);
       expect(parentId).to.be.zero;
-      parentId = await colonyNetwork.getParentSkillId(12, 100);
+      parentId = await colonyNetwork.getParentSkillId(13, 100);
       expect(parentId).to.be.zero;
     });
 
@@ -297,22 +320,23 @@ contract("Meta Colony", (accounts) => {
       const newDomainId = await metaColony.getDomainCount();
 
       const skillCount = await colonyNetwork.getSkillCount();
-      expect(skillCount).to.eq.BN(4);
+      expect(skillCount).to.eq.BN(5);
       const domainCount = await metaColony.getDomainCount();
       expect(domainCount).to.eq.BN(2);
 
       const newDomain = await metaColony.getDomain(newDomainId);
-      expect(newDomain.skillId).to.eq.BN(4);
+      expect(newDomain.skillId).to.eq.BN(5);
       expect(newDomain.fundingPotId).to.eq.BN(2);
 
       // Check root local skill.nChildren is now 2
       // One special mining skill, and the skill associated with the domain we just added
-      const rootLocalSkill = await colonyNetwork.getSkill(1);
-      expect(rootLocalSkill.nChildren).to.eq.BN(2);
+      const rootDomain = await metaColony.getDomain(1);
+      const rootDomainSkill = await colonyNetwork.getSkill(rootDomain.skillId);
+      expect(rootDomainSkill.nChildren).to.eq.BN(2);
 
       // Check root local skill.children second element is the id of the new skill
-      const rootSkillChild = await colonyNetwork.getChildSkillId(1, 1);
-      expect(rootSkillChild).to.eq.BN(4);
+      const rootDomainSkillChild = await colonyNetwork.getChildSkillId(1, 1);
+      expect(rootDomainSkillChild).to.eq.BN(5);
     });
 
     it("should NOT be able to add a child domain more than one level away from the root domain", async () => {
@@ -322,7 +346,7 @@ contract("Meta Colony", (accounts) => {
       await checkErrorRevert(metaColony.addDomain(1, 1, 2), "colony-parent-domain-not-root");
 
       const skillCount = await colonyNetwork.getSkillCount();
-      expect(skillCount).to.eq.BN(4);
+      expect(skillCount).to.eq.BN(5);
       const domainCount = await metaColony.getDomainCount();
       expect(domainCount).to.eq.BN(2);
     });
@@ -343,40 +367,40 @@ contract("Meta Colony", (accounts) => {
       await colony.addDomain(1, UINT256_MAX, 1);
 
       const skillCount = await colonyNetwork.getSkillCount();
-      expect(skillCount).to.eq.BN(7);
+      expect(skillCount).to.eq.BN(9);
       const domainCount = await colony.getDomainCount();
       expect(domainCount).to.eq.BN(4);
 
       const rootDomain = await colony.getDomain(1);
-      expect(rootDomain.skillId).to.eq.BN(4);
+      expect(rootDomain.skillId).to.eq.BN(5);
       expect(rootDomain.fundingPotId).to.eq.BN(1);
 
       const newDomain2 = await colony.getDomain(2);
-      expect(newDomain2.skillId).to.eq.BN(5);
+      expect(newDomain2.skillId).to.eq.BN(7);
       expect(newDomain2.fundingPotId).to.eq.BN(2);
 
       const newDomain3 = await colony.getDomain(3);
-      expect(newDomain3.skillId).to.eq.BN(6);
+      expect(newDomain3.skillId).to.eq.BN(8);
       expect(newDomain3.fundingPotId).to.eq.BN(3);
 
-      // Check root local skill.nChildren is now 3
-      const rootLocalSkill = await colonyNetwork.getSkill(4);
+      // Check root domain skill.nChildren is now 3
+      const rootLocalSkill = await colonyNetwork.getSkill(rootDomain.skillId);
       expect(rootLocalSkill.nChildren).to.eq.BN(3);
 
       // Check root local skill.children are the ids of the new skills
-      const rootSkillChild1 = await colonyNetwork.getChildSkillId(4, 0);
-      expect(rootSkillChild1).to.eq.BN(5);
-      const rootSkillChild2 = await colonyNetwork.getChildSkillId(4, 1);
-      expect(rootSkillChild2).to.eq.BN(6);
-      const rootSkillChild3 = await colonyNetwork.getChildSkillId(4, 2);
-      expect(rootSkillChild3).to.eq.BN(7);
+      const rootSkillChild1 = await colonyNetwork.getChildSkillId(rootDomain.skillId, 0);
+      expect(rootSkillChild1).to.eq.BN(7);
+      const rootSkillChild2 = await colonyNetwork.getChildSkillId(rootDomain.skillId, 1);
+      expect(rootSkillChild2).to.eq.BN(8);
+      const rootSkillChild3 = await colonyNetwork.getChildSkillId(rootDomain.skillId, 2);
+      expect(rootSkillChild3).to.eq.BN(9);
     });
 
     it("should NOT be able to add a new local skill by anyone but a Colony", async () => {
       await checkErrorRevert(colonyNetwork.addSkill(2), "colony-caller-must-be-colony");
 
       const skillCount = await colonyNetwork.getSkillCount();
-      expect(skillCount).to.eq.BN(4);
+      expect(skillCount).to.eq.BN(6);
     });
 
     it("should NOT be able to add a new root local skill", async () => {
@@ -414,6 +438,7 @@ contract("Meta Colony", (accounts) => {
     it("should be able to set global skill on task", async () => {
       await metaColony.addGlobalSkill();
       await metaColony.addGlobalSkill();
+      const globalSkillId = await colonyNetwork.getSkillCount();
 
       const taskId = await makeTask({ colony });
 
@@ -423,18 +448,19 @@ contract("Meta Colony", (accounts) => {
         functionName: "setTaskSkill",
         signers: [MANAGER],
         sigTypes: [0],
-        args: [taskId, 6],
+        args: [taskId, globalSkillId],
       });
 
       const task = await colony.getTask(taskId);
-      expect(task.skillIds[0]).to.eq.BN(6);
+      expect(task.skillIds[0]).to.eq.BN(globalSkillId);
     });
 
     it("should not allow anyone but the colony to set global skill on task", async () => {
       await metaColony.addGlobalSkill();
+      const globalSkillId = await colonyNetwork.getSkillCount();
 
       const taskId = await makeTask({ colony, skillId: 0 });
-      await checkErrorRevert(colony.setTaskSkill(taskId, 5, { from: OTHER_ACCOUNT }), "colony-not-self");
+      await checkErrorRevert(colony.setTaskSkill(taskId, globalSkillId, { from: OTHER_ACCOUNT }), "colony-not-self");
 
       const task = await colony.getTask(taskId);
       expect(task.skillIds[0]).to.be.zero;
@@ -447,9 +473,11 @@ contract("Meta Colony", (accounts) => {
     it("should NOT be able to set global skill on completed task", async () => {
       await metaColony.addGlobalSkill();
       await metaColony.addGlobalSkill();
+      const globalSkillId = await colonyNetwork.getSkillCount();
+
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       const taskId = await setupFinalizedTask({ colonyNetwork, colony });
-      await checkErrorRevert(colony.setTaskSkill(taskId, 5), "colony-task-complete");
+      await checkErrorRevert(colony.setTaskSkill(taskId, globalSkillId), "colony-task-complete");
 
       const task = await colony.getTask(taskId);
       expect(task.skillIds[0]).to.eq.BN(GLOBAL_SKILL_ID);
@@ -457,7 +485,7 @@ contract("Meta Colony", (accounts) => {
 
     it("should NOT be able to set nonexistent skill on task", async () => {
       const taskId = await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskSkill(taskId, 5), "colony-skill-does-not-exist");
+      await checkErrorRevert(colony.setTaskSkill(taskId, 100), "colony-skill-does-not-exist");
     });
 
     it("should NOT be able to set local skill on task", async () => {
@@ -506,13 +534,15 @@ contract("Meta Colony", (accounts) => {
 
   describe("when getting a skill", () => {
     it("should return a true flag if the skill is global", async () => {
-      const globalSkill = await colonyNetwork.getSkill(3);
+      const globalSkill = await colonyNetwork.getSkill(GLOBAL_SKILL_ID);
+
       expect(globalSkill.globalSkill).to.be.true;
     });
 
-    it("should return a false flag if the skill is local", async () => {
-      const localSkill = await colonyNetwork.getSkill(2);
-      expect(localSkill.globalSkill).to.be.false;
+    it("should return a false flag if the skill is a domain skill", async () => {
+      const domainSkill = await colonyNetwork.getSkill(3);
+
+      expect(domainSkill.globalSkill).to.be.false;
     });
   });
 

--- a/test/contracts-network/reputation-update.js
+++ b/test/contracts-network/reputation-update.js
@@ -420,7 +420,7 @@ contract("Reputation Updates", (accounts) => {
       repLogEntryManager = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(2);
       expect(repLogEntryManager.user).to.equal(RECIPIENT);
       expect(repLogEntryManager.amount).to.eq.BN(WAD);
-      expect(repLogEntryManager.skillId).to.eq.BN(3);
+      expect(repLogEntryManager.skillId).to.eq.BN(GLOBAL_SKILL_ID);
     });
 
     it("should not add entries to the reputation log for payments that are not in the colony home token", async () => {
@@ -470,6 +470,7 @@ contract("Reputation Updates", (accounts) => {
       await metaColony.finalizeTask(taskId);
       const numUpdates = await inactiveReputationMiningCycle.getReputationUpdateLogLength();
       expect(numUpdates).to.eq.BN(7);
+
       // Update 1 is the reputation miner reward.
       // Updates 2, 3, and 4 are the domain-reputation rewards for the task.
       // So update 5 is the update corresponding to the first skill in the task's array.
@@ -477,7 +478,7 @@ contract("Reputation Updates", (accounts) => {
       let logEntry = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(4);
       expect(logEntry.user).to.equal(WORKER);
       expect(logEntry.amount).to.eq.BN(WORKER_PAYOUT.divn(3));
-      expect(logEntry.skillId).to.eq.BN(3);
+      expect(logEntry.skillId).to.eq.BN(GLOBAL_SKILL_ID);
       expect(logEntry.nUpdates).to.eq.BN(2);
 
       logEntry = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(5);

--- a/test/contracts-network/router-resolver.js
+++ b/test/contracts-network/router-resolver.js
@@ -11,7 +11,7 @@ chai.use(bnChai(web3.utils.BN));
 const MultiSigWallet = artifacts.require("gnosis/MultiSigWallet");
 const EtherRouter = artifacts.require("EtherRouter");
 const Resolver = artifacts.require("Resolver");
-const ColonyNetwork = artifacts.require("ColonyNetwork");
+const ColonyNetworkDeployer = artifacts.require("ColonyNetworkDeployer");
 
 contract("EtherRouter / Resolver", (accounts) => {
   const COINBASE_ACCOUNT = accounts[0];
@@ -68,7 +68,7 @@ contract("EtherRouter / Resolver", (accounts) => {
 
   describe("Resolver", () => {
     it("should return correct destination for given function, including overloads", async () => {
-      const deployedColonyNetwork = await ColonyNetwork.deployed();
+      const deployedColonyNetwork = await ColonyNetworkDeployer.deployed();
       const signature = await resolver.stringToSig("createColony(address)");
       const overloadedSignature = await resolver.stringToSig("createColony(address,uint256,string,string)");
       const destination = await resolver.lookup(signature);

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -224,7 +224,7 @@ contract("One transaction payments", (accounts) => {
     it("should not allow an admin to specify a non-global skill", async () => {
       await checkErrorRevert(
         oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, 2),
-        "colony-not-valid-skill"
+        "colony-not-valid-global-or-local-skill"
       );
     });
 
@@ -235,7 +235,7 @@ contract("One transaction payments", (accounts) => {
 
       await checkErrorRevert(
         oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, skillId),
-        "colony-not-valid-skill"
+        "colony-not-valid-global-or-local-skill"
       );
     });
 
@@ -249,7 +249,7 @@ contract("One transaction payments", (accounts) => {
     it("should not allow an admin to specify a non-existent skill", async () => {
       await checkErrorRevert(
         oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, 99),
-        "colony-not-valid-skill"
+        "colony-not-valid-global-or-local-skill"
       );
     });
 

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -224,7 +224,7 @@ contract("One transaction payments", (accounts) => {
     it("should not allow an admin to specify a non-global skill", async () => {
       await checkErrorRevert(
         oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, 2),
-        "colony-not-global-skill"
+        "colony-not-valid-skill"
       );
     });
 
@@ -235,7 +235,7 @@ contract("One transaction payments", (accounts) => {
 
       await checkErrorRevert(
         oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, skillId),
-        "colony-deprecated-global-skill"
+        "colony-not-valid-skill"
       );
     });
 
@@ -249,7 +249,7 @@ contract("One transaction payments", (accounts) => {
     it("should not allow an admin to specify a non-existent skill", async () => {
       await checkErrorRevert(
         oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, 99),
-        "colony-skill-does-not-exist"
+        "colony-not-valid-skill"
       );
     });
 

--- a/test/reputation-system/client-calculations.js
+++ b/test/reputation-system/client-calculations.js
@@ -104,7 +104,7 @@ process.env.SOLIDITY_COVERAGE
             worker: OTHER,
             domainId: 3,
           });
-          // Skills in 1 / 4 / 5
+          // Skills in 1 / 5 / 6
           // OTHER: (100 / 100 / 100)
 
           await customSetupFinalizedTask({
@@ -152,19 +152,19 @@ process.env.SOLIDITY_COVERAGE
           await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
           await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
 
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 6, WORKER)].slice(2, 66), 16)).to.eq.BN(100);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, WORKER)].slice(2, 66), 16)).to.eq.BN(100);
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, WORKER)].slice(2, 66), 16)).to.eq.BN(100);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, WORKER)].slice(2, 66), 16)).to.eq.BN(100);
 
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, OTHER)].slice(2, 66), 16)).to.eq.BN(0);
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, OTHER)].slice(2, 66), 16)).to.eq.BN(900);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 6, OTHER)].slice(2, 66), 16)).to.eq.BN(0);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, OTHER)].slice(2, 66), 16)).to.eq.BN(900);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, OTHER)].slice(2, 66), 16)).to.eq.BN(1900);
 
           expect(
-            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ethers.constants.AddressZero)].slice(2, 66), 16)
+            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 6, ethers.constants.AddressZero)].slice(2, 66), 16)
           ).to.eq.BN(100);
           expect(
-            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ethers.constants.AddressZero)].slice(2, 66), 16)
+            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ethers.constants.AddressZero)].slice(2, 66), 16)
           ).to.eq.BN(1000);
           expect(
             new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ethers.constants.AddressZero)].slice(2, 66), 16)
@@ -179,7 +179,7 @@ process.env.SOLIDITY_COVERAGE
             worker: OTHER,
             domainId: 3,
           });
-          // Skills in 1 / 4 / 5
+          // Skills in 1 / 5 / 6
           // OTHER: (100 / 100 / 100)
 
           await customSetupFinalizedTask({
@@ -217,19 +217,19 @@ process.env.SOLIDITY_COVERAGE
           await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
           await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
 
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 6, WORKER)].slice(2, 66), 16)).to.eq.BN(100);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, WORKER)].slice(2, 66), 16)).to.eq.BN(100);
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, WORKER)].slice(2, 66), 16)).to.eq.BN(100);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, WORKER)].slice(2, 66), 16)).to.eq.BN(100);
 
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, OTHER)].slice(2, 66), 16)).to.eq.BN(80);
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, OTHER)].slice(2, 66), 16)).to.eq.BN(800);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 6, OTHER)].slice(2, 66), 16)).to.eq.BN(80);
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, OTHER)].slice(2, 66), 16)).to.eq.BN(800);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, OTHER)].slice(2, 66), 16)).to.eq.BN(800);
 
           expect(
-            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ethers.constants.AddressZero)].slice(2, 66), 16)
+            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 6, ethers.constants.AddressZero)].slice(2, 66), 16)
           ).to.eq.BN(180);
           expect(
-            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ethers.constants.AddressZero)].slice(2, 66), 16)
+            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ethers.constants.AddressZero)].slice(2, 66), 16)
           ).to.eq.BN(900);
           expect(
             new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ethers.constants.AddressZero)].slice(2, 66), 16)
@@ -244,7 +244,7 @@ process.env.SOLIDITY_COVERAGE
             worker: OTHER,
             domainId: 3,
           });
-          // Skills in 1 / 4 / 5
+          // Skills in 1 / 5 / 6
           // OTHER: (100 / 100 / 100)
 
           await customSetupFinalizedTask({
@@ -292,19 +292,19 @@ process.env.SOLIDITY_COVERAGE
           await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
           await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
 
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 6, WORKER)].slice(2, 66), 16)).to.eq.BN(100);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, WORKER)].slice(2, 66), 16)).to.eq.BN(100);
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, WORKER)].slice(2, 66), 16)).to.eq.BN(100);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, WORKER)].slice(2, 66), 16)).to.eq.BN(100);
 
+          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 6, OTHER)].slice(2, 66), 16)).to.eq.BN(0);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, OTHER)].slice(2, 66), 16)).to.eq.BN(0);
-          expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, OTHER)].slice(2, 66), 16)).to.eq.BN(0);
           expect(new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, OTHER)].slice(2, 66), 16)).to.eq.BN(500);
 
           expect(
-            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ethers.constants.AddressZero)].slice(2, 66), 16)
+            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 6, ethers.constants.AddressZero)].slice(2, 66), 16)
           ).to.eq.BN(100);
           expect(
-            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 4, ethers.constants.AddressZero)].slice(2, 66), 16)
+            new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 5, ethers.constants.AddressZero)].slice(2, 66), 16)
           ).to.eq.BN(100);
           expect(
             new BN(goodClient.reputations[ReputationMinerTestWrapper.getKey(metaColony.address, 1, ethers.constants.AddressZero)].slice(2, 66), 16)

--- a/test/reputation-system/client-core-functionality.js
+++ b/test/reputation-system/client-core-functionality.js
@@ -4,7 +4,6 @@ import path from "path";
 import request from "async-request";
 import chai from "chai";
 import bnChai from "bn-chai";
-import BN from "bn.js";
 
 import TruffleLoader from "../../packages/reputation-miner/TruffleLoader";
 import { DEFAULT_STAKE, INITIAL_FUNDING } from "../../helpers/constants";
@@ -152,7 +151,7 @@ process.env.SOLIDITY_COVERAGE
           await advanceMiningCycleNoContest({ colonyNetwork, client: reputationMiner, test: this });
 
           // Different URL so we don't hit the cache.
-          url = `http://127.0.0.1:3000/${rootHash2}/${metaColony.address}/2/${MINER1}`;
+          url = `http://127.0.0.1:3000/${rootHash2}/${metaColony.address}/${MINING_SKILL_ID}/${MINER1}`;
           res = await request(url);
           expect(res.statusCode).to.equal(200);
 
@@ -168,7 +167,7 @@ process.env.SOLIDITY_COVERAGE
           expect(value2).to.equal(oracleProofObject.value);
 
           // Different URL so we don't hit the cache.
-          url = `http://127.0.0.1:3000/${rootHash3}/${metaColony.address}/2/${MINER1}`;
+          url = `http://127.0.0.1:3000/${rootHash3}/${metaColony.address}/${MINING_SKILL_ID}/${MINER1}`;
           res = await request(url);
           expect(res.statusCode).to.equal(200);
 
@@ -193,7 +192,7 @@ process.env.SOLIDITY_COVERAGE
           await advanceMiningCycleNoContest({ colonyNetwork, client: reputationMiner, test: this });
 
           const rootHash = await reputationMiner.getRootHash();
-          const key = makeReputationKey(metaColony.address, new BN(2), MINER1);
+          const key = makeReputationKey(metaColony.address, MINING_SKILL_ID, MINER1);
           const value = reputationMiner.reputations[key];
 
           await advanceMiningCycleNoContest({ colonyNetwork, client: reputationMiner, test: this });
@@ -206,7 +205,7 @@ process.env.SOLIDITY_COVERAGE
 
           await client._miner.sync(startingBlockNumber, true); // eslint-disable-line no-underscore-dangle
 
-          let url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/${MINER1}/noProof`;
+          let url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/${MINING_SKILL_ID}/${MINER1}/noProof`;
           let res = await request(url);
           expect(res.statusCode).to.equal(200);
 
@@ -218,7 +217,7 @@ process.env.SOLIDITY_COVERAGE
           expect(value).to.equal(oracleProofObject.value);
 
           // Different URL so we don't hit the cache.
-          url = `http://127.0.0.1:3000/${rootHash2}/${metaColony.address}/2/${MINER1}/noProof`;
+          url = `http://127.0.0.1:3000/${rootHash2}/${metaColony.address}/${MINING_SKILL_ID}/${MINER1}/noProof`;
           res = await request(url);
           expect(res.statusCode).to.equal(200);
 
@@ -229,7 +228,7 @@ process.env.SOLIDITY_COVERAGE
           expect(key).to.equal(oracleProofObject.key);
           expect(value2).to.equal(oracleProofObject.value);
 
-          url = `http://127.0.0.1:3000/${rootHash3}/${metaColony.address}/2/${MINER1}/noProof`;
+          url = `http://127.0.0.1:3000/${rootHash3}/${metaColony.address}/${MINING_SKILL_ID}/${MINER1}/noProof`;
           res = await request(url);
           expect(res.statusCode).to.equal(200);
 
@@ -243,7 +242,7 @@ process.env.SOLIDITY_COVERAGE
 
         it("should correctly respond to a request for a valid key in a reputation state that never existed", async () => {
           const rootHash = await reputationMiner.getRootHash();
-          const url = `http://127.0.0.1:3000/0x${rootHash.slice(8)}000000/${metaColony.address}/2/${MINER1}`;
+          const url = `http://127.0.0.1:3000/0x${rootHash.slice(8)}000000/${metaColony.address}/${MINING_SKILL_ID}/${MINER1}`;
           const res = await request(url);
           expect(res.statusCode).to.equal(400);
           expect(JSON.parse(res.body).message).to.equal("No such reputation state");

--- a/test/reputation-system/client-core-functionality.js
+++ b/test/reputation-system/client-core-functionality.js
@@ -4,6 +4,7 @@ import path from "path";
 import request from "async-request";
 import chai from "chai";
 import bnChai from "bn-chai";
+import BN from "bn.js";
 
 import TruffleLoader from "../../packages/reputation-miner/TruffleLoader";
 import { DEFAULT_STAKE, INITIAL_FUNDING } from "../../helpers/constants";

--- a/test/reputation-system/client-core-functionality.js
+++ b/test/reputation-system/client-core-functionality.js
@@ -2,7 +2,6 @@
 
 import path from "path";
 import request from "async-request";
-import BN from "bn.js";
 import chai from "chai";
 import bnChai from "bn-chai";
 
@@ -34,6 +33,7 @@ process.env.SOLIDITY_COVERAGE
   ? contract.skip
   : contract("Reputation mining - client core functionality", (accounts) => {
       const MINER1 = accounts[5];
+      const MINING_SKILL_ID = 3;
 
       let colonyNetwork;
       let metaColony;
@@ -86,12 +86,12 @@ process.env.SOLIDITY_COVERAGE
       describe("core functionality", () => {
         it("should correctly respond to a request for a reputation state in the current state", async () => {
           const rootHash = await reputationMiner.getRootHash();
-          const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/${MINER1}`;
+          const url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/${MINING_SKILL_ID}/${MINER1}`;
           const res = await request(url);
           expect(res.statusCode).to.equal(200);
 
           const oracleProofObject = JSON.parse(res.body);
-          const key = makeReputationKey(metaColony.address, new BN(2), MINER1);
+          const key = makeReputationKey(metaColony.address, MINING_SKILL_ID, MINER1);
 
           const [branchMask, siblings] = await reputationMiner.getProof(key);
           const value = reputationMiner.reputations[key];
@@ -116,7 +116,7 @@ process.env.SOLIDITY_COVERAGE
           await advanceMiningCycleNoContest({ colonyNetwork, client: reputationMiner, test: this });
 
           const rootHash = await reputationMiner.getRootHash();
-          const key = makeReputationKey(metaColony.address, new BN(2), MINER1);
+          const key = makeReputationKey(metaColony.address, MINING_SKILL_ID, MINER1);
           const [branchMask, siblings] = await reputationMiner.getProof(key);
           const value = reputationMiner.reputations[key];
 
@@ -132,8 +132,9 @@ process.env.SOLIDITY_COVERAGE
 
           await client._miner.sync(startingBlockNumber, true); // eslint-disable-line no-underscore-dangle
 
-          let url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/2/${MINER1}`;
+          let url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/${MINING_SKILL_ID}/${MINER1}`;
           let res = await request(url);
+
           expect(res.statusCode).to.equal(200);
 
           let oracleProofObject = JSON.parse(res.body);

--- a/test/reputation-system/happy-paths.js
+++ b/test/reputation-system/happy-paths.js
@@ -95,6 +95,9 @@ contract("Reputation Mining - happy paths", (accounts) => {
   const MINER1 = accounts[5];
   const MINER2 = accounts[6];
 
+  const META_ROOT_SKILL = new BN(1);
+  const MINING_SKILL = new BN(3);
+
   before(async () => {
     // Setup a new network instance as we'll be modifying the global skills tree
     await setupNewNetworkInstance(MINER1, MINER2);
@@ -504,9 +507,6 @@ contract("Reputation Mining - happy paths", (accounts) => {
       await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
       expect(Object.keys(goodClient.reputations).length).to.equal(33);
 
-      const META_ROOT_SKILL = new BN(1);
-      const MINING_SKILL = new BN(2);
-
       const META_ROOT_SKILL_TOTAL = REWARD // eslint-disable-line prettier/prettier
         .add(MANAGER_PAYOUT.add(EVALUATOR_PAYOUT).add(WORKER_PAYOUT).muln(3)) // eslint-disable-line prettier/prettier
         .add(new BN(1000000000));
@@ -528,31 +528,31 @@ contract("Reputation Mining - happy paths", (accounts) => {
         { id: 7, skill: GLOBAL_SKILL_ID, account: undefined, value: WORKER_PAYOUT.muln(3) },
         { id: 8, skill: GLOBAL_SKILL_ID, account: WORKER, value: WORKER_PAYOUT.muln(3) },
         // Completing a task in global skill 3 and  domain 2 (which has corresponding skill 4)
-        { id: 9, skill: new BN(5), account: undefined, value: new BN(0) },
-        { id: 10, skill: new BN(6), account: undefined, value: new BN(0) },
-        { id: 11, skill: new BN(7), account: undefined, value: new BN(0) },
-        { id: 12, skill: new BN(8), account: undefined, value: new BN(0) },
-        { id: 13, skill: new BN(9), account: undefined, value: new BN(0) },
-        { id: 14, skill: new BN(10), account: undefined, value: new BN(0) },
-        { id: 15, skill: new BN(4), account: undefined, value: new BN(1000000000) },
-        { id: 16, skill: new BN(5), account: MANAGER, value: new BN(0) },
-        { id: 17, skill: new BN(6), account: MANAGER, value: new BN(0) },
-        { id: 18, skill: new BN(7), account: MANAGER, value: new BN(0) },
-        { id: 19, skill: new BN(8), account: MANAGER, value: new BN(0) },
-        { id: 20, skill: new BN(9), account: MANAGER, value: new BN(0) },
-        { id: 21, skill: new BN(10), account: MANAGER, value: new BN(0) },
-        { id: 22, skill: new BN(4), account: MANAGER, value: new BN(0) },
+        { id: 9, skill: new BN(6), account: undefined, value: new BN(0) },
+        { id: 10, skill: new BN(7), account: undefined, value: new BN(0) },
+        { id: 11, skill: new BN(8), account: undefined, value: new BN(0) },
+        { id: 12, skill: new BN(9), account: undefined, value: new BN(0) },
+        { id: 13, skill: new BN(10), account: undefined, value: new BN(0) },
+        { id: 14, skill: new BN(11), account: undefined, value: new BN(0) },
+        { id: 15, skill: new BN(5), account: undefined, value: new BN(1000000000) },
+        { id: 16, skill: new BN(6), account: MANAGER, value: new BN(0) },
+        { id: 17, skill: new BN(7), account: MANAGER, value: new BN(0) },
+        { id: 18, skill: new BN(8), account: MANAGER, value: new BN(0) },
+        { id: 19, skill: new BN(9), account: MANAGER, value: new BN(0) },
+        { id: 20, skill: new BN(10), account: MANAGER, value: new BN(0) },
+        { id: 21, skill: new BN(11), account: MANAGER, value: new BN(0) },
+        { id: 22, skill: new BN(5), account: MANAGER, value: new BN(0) },
         { id: 23, skill: new BN(1), account: EVALUATOR, value: new BN(1000000000) },
-        { id: 24, skill: new BN(4), account: EVALUATOR, value: new BN(1000000000) },
-        { id: 25, skill: new BN(5), account: accounts[3], value: new BN(0) },
-        { id: 26, skill: new BN(6), account: accounts[3], value: new BN(0) },
-        { id: 27, skill: new BN(7), account: accounts[3], value: new BN(0) },
-        { id: 28, skill: new BN(8), account: accounts[3], value: new BN(0) },
-        { id: 29, skill: new BN(9), account: accounts[3], value: new BN(0) },
-        { id: 30, skill: new BN(10), account: accounts[3], value: new BN(0) },
+        { id: 24, skill: new BN(5), account: EVALUATOR, value: new BN(1000000000) },
+        { id: 25, skill: new BN(6), account: accounts[3], value: new BN(0) },
+        { id: 26, skill: new BN(7), account: accounts[3], value: new BN(0) },
+        { id: 27, skill: new BN(8), account: accounts[3], value: new BN(0) },
+        { id: 28, skill: new BN(9), account: accounts[3], value: new BN(0) },
+        { id: 29, skill: new BN(10), account: accounts[3], value: new BN(0) },
+        { id: 30, skill: new BN(11), account: accounts[3], value: new BN(0) },
         { id: 31, skill: new BN(1), account: accounts[3], value: new BN(0) },
-        { id: 32, skill: new BN(4), account: accounts[3], value: new BN(0) },
-        { id: 33, skill: new BN(3), account: accounts[3], value: new BN(0) },
+        { id: 32, skill: new BN(5), account: accounts[3], value: new BN(0) },
+        { id: 33, skill: new BN(4), account: accounts[3], value: new BN(0) },
       ];
 
       reputationProps.forEach((reputationProp) => {
@@ -607,9 +607,6 @@ contract("Reputation Mining - happy paths", (accounts) => {
       await advanceMiningCycleNoContest({ colonyNetwork, test: this, client: goodClient });
       expect(Object.keys(goodClient.reputations).length).to.equal(37);
 
-      const META_ROOT_SKILL = new BN(1);
-      const MINING_SKILL = new BN(2);
-
       // = 1550000005802000000000
       const META_ROOT_SKILL_TOTAL = REWARD.add(MANAGER_PAYOUT)
         .add(EVALUATOR_PAYOUT)
@@ -631,13 +628,13 @@ contract("Reputation Mining - happy paths", (accounts) => {
         { id: 8, skill: GLOBAL_SKILL_ID, account: WORKER, value: WORKER_PAYOUT.add(new BN(3300000000000)) },
         {
           id: 9,
-          skill: new BN(9),
+          skill: new BN(10),
           account: undefined,
           value: new BN(1500000000000).add(new BN(7500000000000)).add(new BN(1000000000)).sub(new BN(4200000000000)),
         },
         {
           id: 10,
-          skill: new BN(8),
+          skill: new BN(9),
           account: undefined,
           value: new BN(1500000000000)
             .add(new BN(7500000000000))
@@ -648,7 +645,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
         },
         {
           id: 11,
-          skill: new BN(7),
+          skill: new BN(8),
           account: undefined,
           value: new BN(1500000000000)
             .add(new BN(7500000000000))
@@ -659,7 +656,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
         },
         {
           id: 12,
-          skill: new BN(6),
+          skill: new BN(7),
           account: undefined,
           value: new BN(1500000000000)
             .add(new BN(7500000000000))
@@ -670,7 +667,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
         },
         {
           id: 13,
-          skill: new BN(5),
+          skill: new BN(6),
           account: undefined,
           value: new BN(1500000000000)
             .add(new BN(7500000000000))
@@ -681,7 +678,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
         },
         {
           id: 14,
-          skill: new BN(4),
+          skill: new BN(5),
           account: undefined,
           value: new BN(1500000000000)
             .add(new BN(7500000000000))
@@ -692,32 +689,32 @@ contract("Reputation Mining - happy paths", (accounts) => {
         },
         {
           id: 15,
-          skill: new BN(10),
+          skill: new BN(11),
           account: undefined,
           value: new BN(1500000000000).add(new BN(7500000000000)).add(new BN(1000000000)).sub(new BN(4200000000000)),
         },
-        { id: 16, skill: new BN(9), account: MANAGER, value: new BN(1500000000000) },
-        { id: 17, skill: new BN(8), account: MANAGER, value: new BN(2500000000000) },
-        { id: 18, skill: new BN(7), account: MANAGER, value: new BN(2500000000000) },
-        { id: 19, skill: new BN(6), account: MANAGER, value: new BN(2500000000000) },
-        { id: 20, skill: new BN(5), account: MANAGER, value: new BN(2500000000000) },
-        { id: 21, skill: new BN(4), account: MANAGER, value: new BN(2500000000000) },
-        { id: 22, skill: new BN(10), account: MANAGER, value: new BN(1500000000000) },
-        { id: 23, skill: new BN(9), account: EVALUATOR, value: new BN(1000000000) },
-        { id: 24, skill: new BN(8), account: EVALUATOR, value: new BN(2000000000) },
-        { id: 25, skill: new BN(7), account: EVALUATOR, value: new BN(2000000000) },
-        { id: 26, skill: new BN(6), account: EVALUATOR, value: new BN(2000000000) },
-        { id: 27, skill: new BN(5), account: EVALUATOR, value: new BN(2000000000) },
-        { id: 28, skill: new BN(4), account: EVALUATOR, value: new BN(2000000000) },
+        { id: 16, skill: new BN(10), account: MANAGER, value: new BN(1500000000000) },
+        { id: 17, skill: new BN(9), account: MANAGER, value: new BN(2500000000000) },
+        { id: 18, skill: new BN(8), account: MANAGER, value: new BN(2500000000000) },
+        { id: 19, skill: new BN(7), account: MANAGER, value: new BN(2500000000000) },
+        { id: 20, skill: new BN(6), account: MANAGER, value: new BN(2500000000000) },
+        { id: 21, skill: new BN(5), account: MANAGER, value: new BN(2500000000000) },
+        { id: 22, skill: new BN(11), account: MANAGER, value: new BN(1500000000000) },
+        { id: 23, skill: new BN(10), account: EVALUATOR, value: new BN(1000000000) },
+        { id: 24, skill: new BN(9), account: EVALUATOR, value: new BN(2000000000) },
+        { id: 25, skill: new BN(8), account: EVALUATOR, value: new BN(2000000000) },
+        { id: 26, skill: new BN(7), account: EVALUATOR, value: new BN(2000000000) },
+        { id: 27, skill: new BN(6), account: EVALUATOR, value: new BN(2000000000) },
+        { id: 28, skill: new BN(5), account: EVALUATOR, value: new BN(2000000000) },
         { id: 29, skill: META_ROOT_SKILL, account: EVALUATOR, value: new BN(2000000000) },
-        { id: 30, skill: new BN(10), account: EVALUATOR, value: new BN(1000000000) },
-        { id: 31, skill: new BN(9), account: WORKER, value: new BN(3300000000000) },
-        { id: 32, skill: new BN(8), account: WORKER, value: new BN(3300000000000) },
-        { id: 33, skill: new BN(7), account: WORKER, value: new BN(3300000000000) },
-        { id: 34, skill: new BN(6), account: WORKER, value: new BN(3300000000000) },
-        { id: 35, skill: new BN(5), account: WORKER, value: new BN(3300000000000) },
-        { id: 36, skill: new BN(4), account: WORKER, value: new BN(3300000000000) },
-        { id: 37, skill: new BN(10), account: WORKER, value: new BN(3300000000000) },
+        { id: 30, skill: new BN(11), account: EVALUATOR, value: new BN(1000000000) },
+        { id: 31, skill: new BN(10), account: WORKER, value: new BN(3300000000000) },
+        { id: 32, skill: new BN(9), account: WORKER, value: new BN(3300000000000) },
+        { id: 33, skill: new BN(8), account: WORKER, value: new BN(3300000000000) },
+        { id: 34, skill: new BN(7), account: WORKER, value: new BN(3300000000000) },
+        { id: 35, skill: new BN(6), account: WORKER, value: new BN(3300000000000) },
+        { id: 36, skill: new BN(5), account: WORKER, value: new BN(3300000000000) },
+        { id: 37, skill: new BN(11), account: WORKER, value: new BN(3300000000000) },
       ];
 
       reputationProps.forEach((reputationProp) => {
@@ -754,45 +751,42 @@ contract("Reputation Mining - happy paths", (accounts) => {
 
       await goodClient.addLogContentsToReputationTree();
 
-      const META_ROOT_SKILL = 1;
-      const MINING_SKILL = 2;
-
       const reputationProps = [
         { id: 1, skillId: META_ROOT_SKILL, account: undefined, value: REWARD.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT).add(WORKER_PAYOUT) }, // eslint-disable-line prettier/prettier
         { id: 2, skillId: MINING_SKILL, account: undefined, value: REWARD },
         { id: 3, skillId: META_ROOT_SKILL, account: MINER1, value: REWARD },
         { id: 4, skillId: MINING_SKILL, account: MINER1, value: REWARD },
-        { id: 5, skillId: 9, account: undefined, value: WORKER_PAYOUT.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT) },
-        { id: 6, skillId: 8, account: undefined, value: WORKER_PAYOUT.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT) },
-        { id: 7, skillId: 7, account: undefined, value: WORKER_PAYOUT.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT) },
-        { id: 8, skillId: 6, account: undefined, value: WORKER_PAYOUT.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT) },
-        { id: 9, skillId: 5, account: undefined, value: WORKER_PAYOUT.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT) },
-        { id: 10, skillId: 4, account: undefined, value: WORKER_PAYOUT.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT) },
-        { id: 11, skillId: 10, account: undefined, value: WORKER_PAYOUT.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT) },
-        { id: 12, skillId: 9, account: MANAGER, value: MANAGER_PAYOUT },
-        { id: 13, skillId: 8, account: MANAGER, value: MANAGER_PAYOUT },
-        { id: 14, skillId: 7, account: MANAGER, value: MANAGER_PAYOUT },
-        { id: 15, skillId: 6, account: MANAGER, value: MANAGER_PAYOUT },
-        { id: 16, skillId: 5, account: MANAGER, value: MANAGER_PAYOUT },
-        { id: 17, skillId: 4, account: MANAGER, value: MANAGER_PAYOUT },
+        { id: 5, skillId: 10, account: undefined, value: WORKER_PAYOUT.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT) },
+        { id: 6, skillId: 9, account: undefined, value: WORKER_PAYOUT.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT) },
+        { id: 7, skillId: 8, account: undefined, value: WORKER_PAYOUT.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT) },
+        { id: 8, skillId: 7, account: undefined, value: WORKER_PAYOUT.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT) },
+        { id: 9, skillId: 6, account: undefined, value: WORKER_PAYOUT.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT) },
+        { id: 10, skillId: 5, account: undefined, value: WORKER_PAYOUT.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT) },
+        { id: 11, skillId: 11, account: undefined, value: WORKER_PAYOUT.add(MANAGER_PAYOUT).add(EVALUATOR_PAYOUT) },
+        { id: 12, skillId: 10, account: MANAGER, value: MANAGER_PAYOUT },
+        { id: 13, skillId: 9, account: MANAGER, value: MANAGER_PAYOUT },
+        { id: 14, skillId: 8, account: MANAGER, value: MANAGER_PAYOUT },
+        { id: 15, skillId: 7, account: MANAGER, value: MANAGER_PAYOUT },
+        { id: 16, skillId: 6, account: MANAGER, value: MANAGER_PAYOUT },
+        { id: 17, skillId: 5, account: MANAGER, value: MANAGER_PAYOUT },
         { id: 18, skillId: META_ROOT_SKILL, account: MANAGER, value: MANAGER_PAYOUT },
-        { id: 19, skillId: 10, account: MANAGER, value: MANAGER_PAYOUT },
-        { id: 20, skillId: 9, account: EVALUATOR, value: EVALUATOR_PAYOUT },
-        { id: 21, skillId: 8, account: EVALUATOR, value: EVALUATOR_PAYOUT },
-        { id: 22, skillId: 7, account: EVALUATOR, value: EVALUATOR_PAYOUT },
-        { id: 23, skillId: 6, account: EVALUATOR, value: EVALUATOR_PAYOUT },
-        { id: 24, skillId: 5, account: EVALUATOR, value: EVALUATOR_PAYOUT },
-        { id: 25, skillId: 4, account: EVALUATOR, value: EVALUATOR_PAYOUT },
+        { id: 19, skillId: 11, account: MANAGER, value: MANAGER_PAYOUT },
+        { id: 20, skillId: 10, account: EVALUATOR, value: EVALUATOR_PAYOUT },
+        { id: 21, skillId: 9, account: EVALUATOR, value: EVALUATOR_PAYOUT },
+        { id: 22, skillId: 8, account: EVALUATOR, value: EVALUATOR_PAYOUT },
+        { id: 23, skillId: 7, account: EVALUATOR, value: EVALUATOR_PAYOUT },
+        { id: 24, skillId: 6, account: EVALUATOR, value: EVALUATOR_PAYOUT },
+        { id: 25, skillId: 5, account: EVALUATOR, value: EVALUATOR_PAYOUT },
         { id: 26, skillId: META_ROOT_SKILL, account: EVALUATOR, value: EVALUATOR_PAYOUT },
-        { id: 27, skillId: 10, account: EVALUATOR, value: EVALUATOR_PAYOUT },
-        { id: 28, skillId: 9, account: WORKER, value: WORKER_PAYOUT },
-        { id: 29, skillId: 8, account: WORKER, value: WORKER_PAYOUT },
-        { id: 30, skillId: 7, account: WORKER, value: WORKER_PAYOUT },
-        { id: 31, skillId: 6, account: WORKER, value: WORKER_PAYOUT },
-        { id: 32, skillId: 5, account: WORKER, value: WORKER_PAYOUT },
-        { id: 33, skillId: 4, account: WORKER, value: WORKER_PAYOUT },
+        { id: 27, skillId: 11, account: EVALUATOR, value: EVALUATOR_PAYOUT },
+        { id: 28, skillId: 10, account: WORKER, value: WORKER_PAYOUT },
+        { id: 29, skillId: 9, account: WORKER, value: WORKER_PAYOUT },
+        { id: 30, skillId: 8, account: WORKER, value: WORKER_PAYOUT },
+        { id: 31, skillId: 7, account: WORKER, value: WORKER_PAYOUT },
+        { id: 32, skillId: 6, account: WORKER, value: WORKER_PAYOUT },
+        { id: 33, skillId: 5, account: WORKER, value: WORKER_PAYOUT },
         { id: 34, skillId: META_ROOT_SKILL, account: WORKER, value: WORKER_PAYOUT },
-        { id: 35, skillId: 10, account: WORKER, value: WORKER_PAYOUT },
+        { id: 35, skillId: 11, account: WORKER, value: WORKER_PAYOUT },
         { id: 36, skillId: GLOBAL_SKILL_ID, account: undefined, value: WORKER_PAYOUT },
         { id: 37, skillId: GLOBAL_SKILL_ID, account: WORKER, value: WORKER_PAYOUT },
       ];
@@ -846,7 +840,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
       await repCycle.submitRootHash(newRootHash, 10, "0x00", 10, { from: MINER1 });
       await repCycle.confirmNewHash(0, { from: MINER1 });
 
-      const key = makeReputationKey(metaColony.address, new BN("2"), MINER1);
+      const key = makeReputationKey(metaColony.address, MINING_SKILL, MINER1);
       const value = goodClient.reputations[key];
       const [branchMask, siblings] = await goodClient.getProof(key);
       // Checking all good parameters confirms a good proof
@@ -854,7 +848,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
       expect(isValid).to.be.true;
 
       // Check using a bad key confirms an invalid proof
-      const badKey = makeReputationKey("0xdeadbeef", new BN("2"), MINER1);
+      const badKey = makeReputationKey("0xdeadbeef", MINING_SKILL, MINER1);
       isValid = await metaColony.verifyReputationProof(badKey, value, branchMask, siblings, { from: MINER1 });
       expect(isValid).to.be.false;
 

--- a/test/reputation-system/root-hash-submissions.js
+++ b/test/reputation-system/root-hash-submissions.js
@@ -212,6 +212,8 @@ contract("Reputation mining - root hash submissions", (accounts) => {
     });
 
     it("should allow a user to back the same hash more than once in a same cycle with different entries, and be rewarded", async () => {
+      const miningSkillId = 3;
+
       await metaColony.setReputationMiningCycleReward(WAD.muln(10));
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
@@ -255,7 +257,7 @@ contract("Reputation mining - root hash submissions", (accounts) => {
       let repLogEntryMiner = await inactiveRepCycle.getReputationUpdateLogEntry(0);
       expect(repLogEntryMiner.user).to.equal(MINER1);
       expect(repLogEntryMiner.amount).to.eq.BN(r1);
-      expect(repLogEntryMiner.skillId).to.eq.BN(2);
+      expect(repLogEntryMiner.skillId).to.eq.BN(miningSkillId);
       expect(repLogEntryMiner.colony).to.equal(metaColony.address);
       expect(repLogEntryMiner.nUpdates).to.eq.BN(4);
       expect(repLogEntryMiner.nPreviousUpdates).to.be.zero;
@@ -263,7 +265,7 @@ contract("Reputation mining - root hash submissions", (accounts) => {
       repLogEntryMiner = await inactiveRepCycle.getReputationUpdateLogEntry(1);
       expect(repLogEntryMiner.user).to.equal(MINER1);
       expect(repLogEntryMiner.amount).to.eq.BN(r2);
-      expect(repLogEntryMiner.skillId).to.eq.BN(2);
+      expect(repLogEntryMiner.skillId).to.eq.BN(miningSkillId);
       expect(repLogEntryMiner.colony).to.equal(metaColony.address);
       expect(repLogEntryMiner.nUpdates).to.eq.BN(4);
       expect(repLogEntryMiner.nPreviousUpdates).to.eq.BN(4);
@@ -689,6 +691,8 @@ contract("Reputation mining - root hash submissions", (accounts) => {
     });
 
     it("should reward all stakers if they submitted the agreed new hash", async () => {
+      const miningSkillId = 3;
+
       await metaColony.setReputationMiningCycleReward(WAD.muln(10));
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
       await clnyToken.burn(REWARD, { from: MINER1 });
@@ -745,7 +749,7 @@ contract("Reputation mining - root hash submissions", (accounts) => {
       let repLogEntryMiner = await inactiveRepCycle.getReputationUpdateLogEntry(0);
       expect(repLogEntryMiner.user).to.equal(MINER1);
       expect(repLogEntryMiner.amount).to.eq.BN(r1);
-      expect(repLogEntryMiner.skillId).to.eq.BN(2);
+      expect(repLogEntryMiner.skillId).to.eq.BN(miningSkillId);
       expect(repLogEntryMiner.colony).to.equal(metaColony.address);
       expect(repLogEntryMiner.nUpdates).to.eq.BN(4);
       expect(repLogEntryMiner.nPreviousUpdates).to.be.zero;
@@ -753,7 +757,7 @@ contract("Reputation mining - root hash submissions", (accounts) => {
       repLogEntryMiner = await inactiveRepCycle.getReputationUpdateLogEntry(1);
       expect(repLogEntryMiner.user).to.equal(MINER2);
       expect(repLogEntryMiner.amount).to.eq.BN(r2);
-      expect(repLogEntryMiner.skillId).to.eq.BN(2);
+      expect(repLogEntryMiner.skillId).to.eq.BN(miningSkillId);
       expect(repLogEntryMiner.colony).to.equal(metaColony.address);
       expect(repLogEntryMiner.nUpdates).to.eq.BN(4);
       expect(repLogEntryMiner.nPreviousUpdates).to.eq.BN(4);

--- a/test/reputation-system/types-of-disagreement.js
+++ b/test/reputation-system/types-of-disagreement.js
@@ -25,7 +25,14 @@ import {
   setupMetaColonyWithLockedCLNYToken,
 } from "../../helpers/test-data-generator";
 
-import { INT128_MAX, DEFAULT_STAKE, INITIAL_FUNDING, MINING_CYCLE_DURATION, CHALLENGE_RESPONSE_WINDOW_DURATION } from "../../helpers/constants";
+import {
+  INT128_MAX,
+  DEFAULT_STAKE,
+  INITIAL_FUNDING,
+  MINING_CYCLE_DURATION,
+  CHALLENGE_RESPONSE_WINDOW_DURATION,
+  GLOBAL_SKILL_ID,
+} from "../../helpers/constants";
 
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
 import MaliciousReputationMinerExtraRep from "../../packages/reputation-miner/test/MaliciousReputationMinerExtraRep";
@@ -678,7 +685,7 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
       await setupFinalizedTask({
         colonyNetwork,
         colony: metaColony,
-        skillId: 3,
+        skillId: GLOBAL_SKILL_ID,
         managerPayout: 1000000000000,
         evaluatorPayout: 1000000000,
         workerPayout: 1000000000000,
@@ -693,7 +700,7 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
       await setupFinalizedTask({
         colonyNetwork,
         colony: metaColony,
-        skillId: 3,
+        skillId: GLOBAL_SKILL_ID,
         managerPayout: 1000000000000,
         evaluatorPayout: 1000000000,
         workerPayout,


### PR DESCRIPTION
<!--- Related item(s) from the GitHub Issue tracker, closing the completed items via this PR -->
Closes #978 

<!--- Summary of changes including design decisions -->

Adds functionality supporting local skills, including `addLocalSkill` and `deprecateLocalSkill`.

Local skills are implemented as a parallel skill tree to the domain skill tree (i.e. the root is a skill with no parents), and which have only one degree of depth (all local skills are children of the root local skill). Local skills can be set just like global skills onto expenditures.
