### PR TITLE
Add events for reputation award/smite

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -185,6 +185,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     require(_amount > 0, "colony-reward-must-be-positive");
     require(domainExists(_domainId), "colony-domain-does-not-exist");
     IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, domains[_domainId].skillId);
+
+    emit CustomReputationUpdate(msg.sender, _user, domains[_domainId].skillId, _amount);
   }
 
   function emitSkillReputationReward(uint256 _skillId, address _user, int256 _amount)
@@ -192,6 +194,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
   {
     require(_amount > 0, "colony-reward-must-be-positive");
     IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, _skillId);
+
+    emit CustomReputationUpdate(msg.sender, _user, _skillId, _amount);
   }
 
   function emitDomainReputationPenalty(
@@ -204,6 +208,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
   {
     require(_amount <= 0, "colony-penalty-cannot-be-positive");
     IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, domains[_domainId].skillId);
+
+    emit CustomReputationUpdate(msg.sender, _user, domains[_domainId].skillId, _amount);
   }
 
   function emitSkillReputationPenalty(uint256 _skillId, address _user, int256 _amount)
@@ -211,6 +217,8 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
   {
     require(_amount <= 0, "colony-penalty-cannot-be-positive");
     IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, _skillId);
+
+    emit CustomReputationUpdate(msg.sender, _user, _skillId, _amount);
   }
 
   function initialiseColony(address _colonyNetworkAddress, address _token) public stoppable {

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -186,7 +186,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     require(domainExists(_domainId), "colony-domain-does-not-exist");
     IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, domains[_domainId].skillId);
 
-    emit CustomReputationUpdate(msg.sender, _user, domains[_domainId].skillId, _amount);
+    emit ArbitraryReputationUpdate(msg.sender, _user, domains[_domainId].skillId, _amount);
   }
 
   function emitSkillReputationReward(uint256 _skillId, address _user, int256 _amount)
@@ -195,7 +195,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     require(_amount > 0, "colony-reward-must-be-positive");
     IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, _skillId);
 
-    emit CustomReputationUpdate(msg.sender, _user, _skillId, _amount);
+    emit ArbitraryReputationUpdate(msg.sender, _user, _skillId, _amount);
   }
 
   function emitDomainReputationPenalty(
@@ -209,7 +209,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     require(_amount <= 0, "colony-penalty-cannot-be-positive");
     IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, domains[_domainId].skillId);
 
-    emit CustomReputationUpdate(msg.sender, _user, domains[_domainId].skillId, _amount);
+    emit ArbitraryReputationUpdate(msg.sender, _user, domains[_domainId].skillId, _amount);
   }
 
   function emitSkillReputationPenalty(uint256 _skillId, address _user, int256 _amount)
@@ -218,7 +218,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
     require(_amount <= 0, "colony-penalty-cannot-be-positive");
     IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, _skillId);
 
-    emit CustomReputationUpdate(msg.sender, _user, _skillId, _amount);
+    emit ArbitraryReputationUpdate(msg.sender, _user, _skillId, _amount);
   }
 
   function initialiseColony(address _colonyNetworkAddress, address _token) public stoppable {

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -306,7 +306,7 @@ interface ColonyDataTypes {
   /// @param user The address that is having its reputation changed
   /// @param skillId The id of the skill the user is having their reputation changed in
   /// @param amount The (maximum) amount the address is having its reputation changed by
-  event CustomReputationUpdate(address agent, address user, uint256 skillId, int256 amount);
+  event ArbitraryReputationUpdate(address agent, address user, uint256 skillId, int256 amount);
 
   struct RewardPayoutCycle {
     // Reputation root hash at the time of reward payout creation

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -301,6 +301,13 @@ interface ColonyDataTypes {
   /// provided function
   event TokenUnlocked();
 
+  /// @notice Event logged when a manual reputation reward/penalty is made
+  /// @param agent The address that is responsible for triggering this event
+  /// @param user The address that is having its reputation changed
+  /// @param skillId The id of the skill the user is having their reputation changed in
+  /// @param amount The (maximum) amount the address is having its reputation changed by
+  event CustomReputationUpdate(address agent, address user, uint256 skillId, int256 amount);
+
   struct RewardPayoutCycle {
     // Reputation root hash at the time of reward payout creation
     bytes32 reputationState;

--- a/test/contracts-network/colony-permissions.js
+++ b/test/contracts-network/colony-permissions.js
@@ -310,7 +310,7 @@ contract("ColonyPermissions", (accounts) => {
       let tx = await colony.emitDomainReputationReward(3, USER2, 100, { from: FOUNDER });
 
       const domain = await colony.getDomain(3);
-      await expectEvent(tx, "CustomReputationUpdate", [FOUNDER, USER2, domain.skillId, 100]);
+      await expectEvent(tx, "ArbitraryReputationUpdate", [FOUNDER, USER2, domain.skillId, 100]);
 
       await checkErrorRevert(colony.emitDomainReputationReward(3, USER2, -100, { from: FOUNDER }), "colony-reward-must-be-positive");
       await checkErrorRevert(colony.emitDomainReputationReward(0, USER2, 100, { from: FOUNDER }), "colony-domain-does-not-exist");
@@ -318,7 +318,7 @@ contract("ColonyPermissions", (accounts) => {
 
       // Skill rewards
       tx = await colony.emitSkillReputationReward(GLOBAL_SKILL_ID, USER2, 100, { from: FOUNDER });
-      await expectEvent(tx, "CustomReputationUpdate", [FOUNDER, USER2, GLOBAL_SKILL_ID, 100]);
+      await expectEvent(tx, "ArbitraryReputationUpdate", [FOUNDER, USER2, GLOBAL_SKILL_ID, 100]);
 
       await checkErrorRevert(colony.emitSkillReputationReward(0, USER2, 100, { from: FOUNDER }), "colony-not-global-skill");
       await checkErrorRevert(colony.emitSkillReputationReward(GLOBAL_SKILL_ID, USER2, -100, { from: FOUNDER }), "colony-reward-must-be-positive");
@@ -333,13 +333,13 @@ contract("ColonyPermissions", (accounts) => {
       let tx = await colony.emitDomainReputationPenalty(1, 1, 3, USER2, -100, { from: USER1 });
 
       const domain = await colony.getDomain(3);
-      await expectEvent(tx, "CustomReputationUpdate", [USER1, USER2, domain.skillId, -100]);
+      await expectEvent(tx, "ArbitraryReputationUpdate", [USER1, USER2, domain.skillId, -100]);
 
       await checkErrorRevert(colony.emitDomainReputationPenalty(1, 1, 3, USER2, 100, { from: USER1 }), "colony-penalty-cannot-be-positive");
 
       // Skill penalties (root domain only)
       tx = await colony.emitSkillReputationPenalty(GLOBAL_SKILL_ID, USER2, -100, { from: USER1 });
-      await expectEvent(tx, "CustomReputationUpdate", [USER1, USER2, GLOBAL_SKILL_ID, -100]);
+      await expectEvent(tx, "ArbitraryReputationUpdate", [USER1, USER2, GLOBAL_SKILL_ID, -100]);
 
       await checkErrorRevert(colony.emitSkillReputationPenalty(0, USER2, 100, { from: USER1 }), "colony-not-global-skill");
       await checkErrorRevert(colony.emitSkillReputationPenalty(GLOBAL_SKILL_ID, USER2, 100, { from: USER1 }), "colony-penalty-cannot-be-positive");

--- a/test/contracts-network/colony-permissions.js
+++ b/test/contracts-network/colony-permissions.js
@@ -20,7 +20,7 @@ import {
 } from "../../helpers/constants";
 
 import { fundColonyWithTokens, makeTask, setupRandomColony } from "../../helpers/test-data-generator";
-import { checkErrorRevert } from "../../helpers/test-helper";
+import { checkErrorRevert, expectEvent } from "../../helpers/test-helper";
 import { executeSignedRoleAssignment } from "../../helpers/task-review-signing";
 
 const ethers = require("ethers");
@@ -307,13 +307,19 @@ contract("ColonyPermissions", (accounts) => {
 
     it("should allow users with root permission to emit positive reputation rewards", async () => {
       // Domain rewards
-      await colony.emitDomainReputationReward(3, USER2, 100, { from: FOUNDER });
+      let tx = await colony.emitDomainReputationReward(3, USER2, 100, { from: FOUNDER });
+
+      const domain = await colony.getDomain(3);
+      await expectEvent(tx, "CustomReputationUpdate", [FOUNDER, USER2, domain.skillId, 100]);
+
       await checkErrorRevert(colony.emitDomainReputationReward(3, USER2, -100, { from: FOUNDER }), "colony-reward-must-be-positive");
       await checkErrorRevert(colony.emitDomainReputationReward(0, USER2, 100, { from: FOUNDER }), "colony-domain-does-not-exist");
       await checkErrorRevert(colony.emitDomainReputationReward(3, USER2, 100, { from: USER1 }), "ds-auth-unauthorized");
 
       // Skill rewards
-      await colony.emitSkillReputationReward(GLOBAL_SKILL_ID, USER2, 100, { from: FOUNDER });
+      tx = await colony.emitSkillReputationReward(GLOBAL_SKILL_ID, USER2, 100, { from: FOUNDER });
+      await expectEvent(tx, "CustomReputationUpdate", [FOUNDER, USER2, GLOBAL_SKILL_ID, 100]);
+
       await checkErrorRevert(colony.emitSkillReputationReward(0, USER2, 100, { from: FOUNDER }), "colony-not-global-skill");
       await checkErrorRevert(colony.emitSkillReputationReward(GLOBAL_SKILL_ID, USER2, -100, { from: FOUNDER }), "colony-reward-must-be-positive");
       await checkErrorRevert(colony.emitSkillReputationReward(GLOBAL_SKILL_ID, USER2, 100, { from: USER1 }), "ds-auth-unauthorized");
@@ -324,11 +330,17 @@ contract("ColonyPermissions", (accounts) => {
       await colony.setArbitrationRole(1, 0, USER2, 2, true);
 
       // Domain penalties
-      await colony.emitDomainReputationPenalty(1, 1, 3, USER2, -100, { from: USER1 });
+      let tx = await colony.emitDomainReputationPenalty(1, 1, 3, USER2, -100, { from: USER1 });
+
+      const domain = await colony.getDomain(3);
+      await expectEvent(tx, "CustomReputationUpdate", [USER1, USER2, domain.skillId, -100]);
+
       await checkErrorRevert(colony.emitDomainReputationPenalty(1, 1, 3, USER2, 100, { from: USER1 }), "colony-penalty-cannot-be-positive");
 
       // Skill penalties (root domain only)
-      await colony.emitSkillReputationPenalty(GLOBAL_SKILL_ID, USER2, -100, { from: USER1 });
+      tx = await colony.emitSkillReputationPenalty(GLOBAL_SKILL_ID, USER2, -100, { from: USER1 });
+      await expectEvent(tx, "CustomReputationUpdate", [USER1, USER2, GLOBAL_SKILL_ID, -100]);
+
       await checkErrorRevert(colony.emitSkillReputationPenalty(0, USER2, 100, { from: USER1 }), "colony-not-global-skill");
       await checkErrorRevert(colony.emitSkillReputationPenalty(GLOBAL_SKILL_ID, USER2, 100, { from: USER1 }), "colony-penalty-cannot-be-positive");
       await checkErrorRevert(colony.emitSkillReputationPenalty(GLOBAL_SKILL_ID, USER2, -100, { from: USER2 }), "ds-auth-unauthorized");


### PR DESCRIPTION
Actions need events for the frontend to work properly, so we need to add them to these functions which the frontend team is developing against.

We believe that using the same event for all of these is fine, context (i.e. the skill id and the amount being positive/negative) should allow them to be distinguished.

Not wild about `customReputationUpdate` as a name, open to suggestions.