### PR TITLE
Cannot confirm failing motion before a week passed

### DIFF
--- a/contracts/extensions/VotingReputation.sol
+++ b/contracts/extensions/VotingReputation.sol
@@ -605,10 +605,30 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs {
 
     if (canExecute) {
       executed = executeCall(_motionId, motion.action);
-      require(executed || sub(block.timestamp, motion.events[REVEAL_END]) > 7 * 24 * 3600, "voting-execution-failed-not-one-week");
+      require(executed || failingExecutionAllowed(_motionId), "voting-execution-failed-not-one-week");
     }
 
     emit MotionFinalized(_motionId, motion.action, executed);
+  }
+
+
+  /// @notice Return whether a motion, assuming it's in the finalizable state,
+  // is allowed to finalize without the call executing successfully.
+  /// @param _motionId The id of the motion
+  /// @dev We are only expecting this to be called from finalize motion in the contracts.
+  /// It is marked as public only so that the frontend can use it.
+  function failingExecutionAllowed(uint256 _motionId) public returns (bool) {
+    Motion storage motion = motions[_motionId];
+    uint256 requiredStake = getRequiredStake(_motionId);
+
+    // Failing execution is allowed if we didn't fully stake, and it's been a week since staking ended
+    if (motion.stakes[YAY] < requiredStake || motion.stakes[NAY] < requiredStake) {
+      return block.timestamp >= motion.events[STAKE_END] + 7 days;
+    } else {
+      // It was fully staked, and went to a vote.
+      // Failing execution is also allowed if it's been a week since reveal ended
+      return block.timestamp >= motion.events[REVEAL_END] + 7 days;
+    }
   }
 
   /// @notice Claim the staker's reward

--- a/contracts/extensions/VotingReputation.sol
+++ b/contracts/extensions/VotingReputation.sol
@@ -605,6 +605,7 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs {
 
     if (canExecute) {
       executed = executeCall(_motionId, motion.action);
+      require(executed || sub(block.timestamp, motion.events[REVEAL_END]) > 7 * 24 * 3600, "voting-execution-failed-not-one-week");
     }
 
     emit MotionFinalized(_motionId, motion.action, executed);

--- a/contracts/extensions/VotingReputation.sol
+++ b/contracts/extensions/VotingReputation.sol
@@ -617,7 +617,7 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs {
   /// @param _motionId The id of the motion
   /// @dev We are only expecting this to be called from finalize motion in the contracts.
   /// It is marked as public only so that the frontend can use it.
-  function failingExecutionAllowed(uint256 _motionId) public returns (bool) {
+  function failingExecutionAllowed(uint256 _motionId) public view returns (bool) {
     Motion storage motion = motions[_motionId];
     uint256 requiredStake = getRequiredStake(_motionId);
 

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,8 +154,8 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("55779b88bac4206c6ed791b93fa3a386c2e71b52d896d262c6b69c476a6968fe");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("abe2e24d6c366741cfb171ba03e452a705ef3ffce1715348fdfaccbdfd44fab2");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("df68ec6b00dd34fba153ee53f394232281827260b87c96d2267e2142b2c54817");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("d8e895aa214956a2543325209231d4502c6c241027df357ce9bcf065215c4632");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("78294685a492256887e3159e26071ba06d62883c72ccb26fd323a883eefc30fd");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("e105190bcd647989da1579ac209ae54ed63e08224fbb2469bad9f596773fe558");
       expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("8bab6ab2024de44a08765ee14ec3d6bdc0fa5ae2a5ee221c9f928345a3710658");

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -1306,11 +1306,16 @@ contract("Voting Reputation", (accounts) => {
 
       await forwardTime(STAKE_PERIOD, this);
 
+      let failingExecutionAllowed = await voting.failingExecutionAllowed(motionId);
+      expect(failingExecutionAllowed).to.be.false;
+
       await checkErrorRevert(voting.finalizeMotion(motionId), "voting-execution-failed-not-one-week");
 
       // But after a week we can
       await forwardTime(FAIL_EXECUTION_TIMEOUT_PERIOD, this);
 
+      failingExecutionAllowed = await voting.failingExecutionAllowed(motionId);
+      expect(failingExecutionAllowed).to.be.true;
       // But still failed
       const { logs } = await voting.finalizeMotion(motionId);
       expect(logs[0].args.executed).to.be.false;


### PR DESCRIPTION
While we've been messing around with the gas estimation / buffer process on the frontend, it actually doesn't solve an underlying problem. A bad actor could, in theory, finalize a motion with exactly the right amount of gas that means the motion fails its execution but the finalize transaction succeeds. 

I believe this is the 'path of least resistance' to fix the issue. The frontend will require no changes, and a 'proper' solution can be incorporated down the road when the frontend team have bandwidth to change the flow in the frontend (e.g. why can't users claim their tokens once its finalizable? With this solution, in the event of a motion that's corresponding transaction is now failing, users will have to wait a week to be able to reclaim)