### PR TITLE
Bump colony version and add version check script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,9 @@ jobs:
           name: "Checking contract recovery modifiers"
           command: yarn run check:recoverymods
       - run:
+          name: "Checking contract versions"
+          command: yarn run check:versioning
+      - run:
           name: "Checking contract authDomain modifiers"
           command: yarn run check:auth
       - run:

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -29,7 +29,7 @@ contract Colony is ColonyStorage, PatriciaTreeProofs, MultiChain {
   // V8: Ebony Lightweight Spaceship
   // This function, exactly as defined, is used in build scripts. Take care when updating.
   // Version number should be upped with every change in Colony or its dependency contracts or libraries.
-  function version() public pure returns (uint256 colonyVersion) { return 8; }
+  function version() public pure returns (uint256 colonyVersion) { return 9; }
 
   function getColonyNetwork() public view returns (address) {
     return colonyNetworkAddress;

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -9,7 +9,7 @@ const INT256_MIN = new BN(2).pow(new BN(255)).mul(new BN(-1));
 const INT128_MAX = new BN(2).pow(new BN(127)).sub(new BN(1));
 const INT128_MIN = new BN(2).pow(new BN(127)).mul(new BN(-1));
 
-const CURR_VERSION = 8;
+const CURR_VERSION = 9;
 
 const RECOVERY_ROLE = 0;
 const ROOT_ROLE = 1;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "check:recoverymods": "./node_modules/@babel/node/bin/babel-node.js ./scripts/check-recovery.js",
     "check:coverage": "yarn istanbul-combine -d coverage-merged -p detail -r html -r json coverage-*/coverage-final.json && istanbul check-coverage ./coverage-merged/coverage-final.json --statements 99 --branches 94 --functions 99 --lines 99",
     "check:auth": "./node_modules/@babel/node/bin/babel-node.js ./scripts/check-auth.js",
+    "check:versioning": "bash ./scripts/versioningCheck.sh",
     "version:contracts": "bash ./scripts/version-contracts.sh",
     "generate:test:contracts": "bash ./scripts/generate-test-contracts.sh",
     "clean:test:contracts": "rimraf ./contracts/*Updated*.*",
@@ -60,7 +61,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn eslint-staged && yarn solhint-staged && yarn build:docs && git add docs"
+      "pre-commit": "yarn check:versioning && yarn eslint-staged && yarn solhint-staged && yarn build:docs && git add docs"
     }
   },
   "repository": {

--- a/scripts/versioningCheck.sh
+++ b/scripts/versioningCheck.sh
@@ -1,0 +1,44 @@
+LATEST_RELEASE=`curl --silent "https://api.github.com/repos/joinColony/colonyNetwork/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")'`
+
+# Are there changes in the colony contract?
+N=`git diff --cached --name-only $LATEST_RELEASE contracts/colony/ | wc -l`
+
+version_from_commit() {
+	COMMIT=$1;
+	FILE=$2;
+	VERSION="$(git show $COMMIT:$FILE | grep 'function version() public pure returns (uint256 colonyVersion) { return ' | sed 's/function version() public pure returns (uint256 colonyVersion) { return //' | sed 's/; }//' | sed 's/ //g')"
+	echo $VERSION
+}
+
+if [ $N -ne 0 ]; then
+	# We need to check if we've bumped the version
+	# What version does the latest release have
+	oldVersion="$(version_from_commit $LATEST_RELEASE 'contracts/colony/Colony.sol')"
+
+	# What version does the staged version have?
+	newVersion="$(version_from_commit '' 'contracts/colony/Colony.sol')"
+
+	if [ $newVersion -eq $oldVersion ]; then
+		echo "Version not bumped for Colony.sol when it should be"
+		exit 1;
+	fi
+fi
+
+# Now the same for the extensions
+for file in $(git diff --cached --name-only | grep -E 'contracts/extensions/')
+do
+	if [ $file = "contracts/extensions/ColonyExtension.sol" ]; then
+		continue
+	fi
+
+	oldVersion="$(version_from_commit $LATEST_RELEASE $file)"
+
+	# What version does the staged version have?
+	newVersion="$(version_from_commit '' $file)"
+
+	if [ $newVersion -eq $oldVersion ]; then
+		echo "Version not bumped for $file when it should be"
+		exit 1;
+	fi
+
+done

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,7 +154,7 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("6b2b49d0511c9ba1050df1531f86df8d9f96075d59e736fea51235f011e6865a");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("fc9c8702501fa11dce57db3f679b0909a2b252cf71a73aac17ef4a159271ff56");
       expect(colonyAccount.stateRoot.toString("hex")).to.equal("d8e895aa214956a2543325209231d4502c6c241027df357ce9bcf065215c4632");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("78294685a492256887e3159e26071ba06d62883c72ccb26fd323a883eefc30fd");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("e105190bcd647989da1579ac209ae54ed63e08224fbb2469bad9f596773fe558");


### PR DESCRIPTION
It's post-release, so to help with front-end dev we bump the version of the colony contract. I've also added a script that checks if a version should have been bumped and whether it has to help prevent things like #990 from happening again.