### PR TITLE
Improve oracle performance

### DIFF
--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -1392,7 +1392,8 @@ class ReputationMiner {
   async getAddressesWithReputation(reputationRootHash, colonyAddress, skillId) {
     const res = await this.queries.getAddressesWithReputation.all(reputationRootHash, colonyAddress.toLowerCase(), skillId);
     const addresses = res.map(x => x.user_address)
-    return addresses;
+    const reputations = res.map(x => new BN(x.value.slice(2, 66), 16).toString())
+    return { addresses, reputations };
   }
 
   async getReputationsForAddress(reputationRootHash, colonyAddress, userAddress) {

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -122,9 +122,13 @@ class ReputationMinerClient {
         ) {
           return res.status(400).send({ message: "One of the parameters was incorrect" });
         }
-        const addresses = await this._miner.getAddressesWithReputation(req.params.rootHash, req.params.colonyAddress, req.params.skillId);
+        const {
+          addresses,
+          reputations
+        } = await this._miner.getAddressesWithReputation(req.params.rootHash, req.params.colonyAddress, req.params.skillId);
+
         try {
-          return res.status(200).send({ addresses });
+          return res.status(200).send({ addresses, reputations });
         } catch (err) {
           return res.status(500).send({ message: "An error occurred querying the reputation" });
         }

--- a/test/reputation-system/client-core-functionality.js
+++ b/test/reputation-system/client-core-functionality.js
@@ -199,10 +199,12 @@ process.env.SOLIDITY_COVERAGE
           let url = `http://127.0.0.1:3000/${rootHash}/${metaColony.address}/1`;
           let res = await request(url);
           expect(res.statusCode).to.equal(200);
-          let { addresses } = JSON.parse(res.body);
+          let { addresses, reputations } = JSON.parse(res.body);
           expect(addresses.length).to.equal(2);
           expect(addresses[0]).to.equal(MINER1.toLowerCase());
           expect(addresses[1]).to.equal(accounts[6].toLowerCase());
+
+          expect(reputations.length).to.equal(2);
 
           // Let's check that once accounts[6] has more reputation again, it's listed first.
           await setupFinalizedTask({ colonyNetwork, colony: metaColony, token: clnyToken, worker: accounts[6], manager: accounts[6] });
@@ -216,10 +218,12 @@ process.env.SOLIDITY_COVERAGE
           res = await request(url);
           expect(res.statusCode).to.equal(200);
 
-          ({ addresses } = JSON.parse(res.body));
+          ({ addresses, reputations } = JSON.parse(res.body));
           expect(addresses.length).to.equal(2);
           expect(addresses[0]).to.equal(accounts[6].toLowerCase());
           expect(addresses[1]).to.equal(MINER1.toLowerCase());
+
+          expect(reputations.length).to.equal(2);
         });
 
         it("should correctly respond to a request for users that have a particular reputation in a colony that has an invalid address", async () => {


### PR DESCRIPTION
The real world really sucks, huh?

So even with the `/noProof/` endpoint, performance in production was poor. So I went down a profiling hole.

A big, easy win was adding relevant indexes to the DB. Without, even for the `noProof` endpoint, all of the relevant tables had to be examined. With them, the daemon [can be much more efficient](https://www.sqlitetutorial.net/sqlite-index/).

While I was in there, I took a look at the bottleneck for the endpoint that returns proofs, and it's 100% `soliditySha3`.

![screenshot-2021-10-21_17-10-14](https://user-images.githubusercontent.com/311812/138317380-43c77f52-6573-494b-9180-1793d7c5b1e3.png)

That's going to be much harder to win... it's not clear that a JS binding to a native implementation would be faster, as the data is small and there are overheads. If you dig all the way down, the implementation is [this one](https://github.com/paulmillr/noble-hashes), which claims to be excellent. 

As more and more reputations are added to the state, the performance of that endpoint is going to get worse and worse. It's okay-ish for now, but it's already close to unacceptable and, if we do nothing, will eventually get there. Making a PR for this quick win, though, seemed worthwhile.

I also activated [WAL mode](https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/performance.md) and added caching to another relevant endpoint, but neither of those helped noticeably when I was testing (and I wouldn't have expected the latter to, just something I noticed while I was looking).

