### PR TITLE
Do not use Fallback provider for now in miner/oracle

### DIFF
--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -213,7 +213,7 @@ class ReputationMiner {
     }
     this.justificationHashes = {};
     this.reverseReputationHashLookup = {};
-    const repCycle = await this.getActiveRepCycle(blockNumber)
+    const repCycle = await this.getActiveRepCycle(blockNumber);
     // Update fractions
     const decayFraction = await repCycle.getDecayConstant({ blockTag: blockNumber });
     this.decayNumerator = decayFraction.numerator;
@@ -700,7 +700,6 @@ class ReputationMiner {
    */
   async getActiveRepCycle(blockNumber = "latest") {
     const addr = await this.colonyNetwork.getReputationMiningCycle(true, { blockTag: blockNumber });
-
     if (addr === ethers.constants.AddressZero) {
       throw new Error(`No active mining cycle found for block number ${blockNumber}`);
     }

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -229,7 +229,7 @@ class ReputationMinerClient {
     await this._miner.createDB();
     await this._miner.loadState(latestReputationHash);
     if (this._miner.nReputations.eq(0)) {
-      this._adapter.log("No existing reputations found - need to sync");
+      this._adapter.log("Latest state not found - need to sync");
       await this._miner.sync(startingBlock, true);
     }
 

--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -95,7 +95,12 @@ if (network) {
   const providers = providerAddress.map(endpoint => new RetryProvider(endpoint, adapterObject));
   // This is, at best, a huge hack...
   providers.forEach(x => x.getNetwork());
-  provider = new ethers.providers.FallbackProvider(providers, 1)
+
+  // The Fallback provider somehow strips out blockTag, so isn't suitable for use during syncing.
+  // See https://github.com/ethers-io/ethers.js/discussions/1960
+  // When sorted, use this line instead.
+  // provider = new ethers.providers.FallbackProvider(providers, 1)
+  [ provider ] = providers;
 }
 
 const client = new ReputationMinerClient({


### PR DESCRIPTION
The best laid plans...

[It turns out](https://github.com/ethers-io/ethers.js/discussions/1960) that the fallback provider in Ethers does not support the `blockTag` override, which is fine when everything is working, but is a problem if the service falls behind/restarts and tries to sync. So remove it for now. Note that this means that we're only using one provider (all providers past the first that are passed on the command line are ignored).