### PR TITLE
Fix version check script, bump needed versions

### DIFF
--- a/contracts/extensions/CoinMachine.sol
+++ b/contracts/extensions/CoinMachine.sol
@@ -91,7 +91,7 @@ contract CoinMachine is ColonyExtension, BasicMetaTransaction {
 
   /// @notice Returns the version of the extension
   function version() public override pure returns (uint256) {
-    return 2;
+    return 3;
   }
 
   /// @notice Configures the extension

--- a/contracts/extensions/EvaluatedExpenditure.sol
+++ b/contracts/extensions/EvaluatedExpenditure.sol
@@ -39,7 +39,7 @@ contract EvaluatedExpenditure is ColonyExtension, BasicMetaTransaction {
 
   /// @notice Returns the version of the extension
   function version() public override pure returns (uint256) {
-    return 1;
+    return 2;
   }
 
   /// @notice Configures the extension

--- a/contracts/extensions/FundingQueue.sol
+++ b/contracts/extensions/FundingQueue.sol
@@ -90,7 +90,7 @@ contract FundingQueue is ColonyExtension, PatriciaTreeProofs, BasicMetaTransacti
 
   /// @notice Returns the version of the extension
   function version() public override pure returns (uint256) {
-    return 2;
+    return 3;
   }
 
   /// @notice Configures the extension

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -46,7 +46,7 @@ contract OneTxPayment is ColonyExtension, BasicMetaTransaction {
 
   /// @notice Returns the version of the extension
   function version() public override pure returns (uint256) {
-    return 2;
+    return 3;
   }
 
   /// @notice Configures the extension

--- a/contracts/extensions/TokenSupplier.sol
+++ b/contracts/extensions/TokenSupplier.sol
@@ -67,7 +67,7 @@ contract TokenSupplier is ColonyExtension, BasicMetaTransaction {
 
   /// @notice Returns the version of the extension
   function version() public override pure returns (uint256) {
-    return 2;
+    return 3;
   }
 
   /// @notice Configures the extension

--- a/contracts/extensions/VotingReputation.sol
+++ b/contracts/extensions/VotingReputation.sol
@@ -117,7 +117,7 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs, BasicMetaTrans
   /// @notice Return the version number
   /// @return The version number
   function version() public pure override returns (uint256) {
-    return 3;
+    return 4;
   }
 
   /// @notice Install the extension

--- a/contracts/extensions/Whitelist.sol
+++ b/contracts/extensions/Whitelist.sol
@@ -65,7 +65,7 @@ contract Whitelist is ColonyExtension, BasicMetaTransaction {
 
   /// @notice Returns the version of the extension
   function version() public override pure returns (uint256) {
-    return 1;
+    return 2;
   }
 
   /// @notice Configures the extension

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,7 +154,7 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("099e984edc5c6d9194d5b26a5ec058f2ba341cf591781fe94f65900f9a72fa7a");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("2775a8fe0a3e55074fbb08308652279918c69e3048ae61e049ed42dd2dfba1ee");
       expect(colonyAccount.stateRoot.toString("hex")).to.equal("ba1042d654baa721eb012da81409c1087a9447b8a36b6d844233826e5055fbfe");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("352feafb44e40c6097234df1a675c5cd618fd81c0f88e8c6478c838e788bd77a");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("474e00d9b002118dee0c336eaf0902b7719bb7d4a877e2d26f6a2452a5a89a6e");

--- a/test/contracts-network/colony-arbitrary-transactions.js
+++ b/test/contracts-network/colony-arbitrary-transactions.js
@@ -207,14 +207,14 @@ contract("Colony Arbitrary Transactions", (accounts) => {
   it("should not be able to make arbitrary transactions to the colony's own extensions", async () => {
     const COIN_MACHINE = soliditySha3("CoinMachine");
 
-    let coinMachineVersion = 0;
-    let coinMachineResolverAddress = ethers.constants.AddressZero;
+    const ethersProvider = new ethers.providers.JsonRpcProvider(web3.currentProvider.host);
+    const ethersColonyNetwork = new ethers.Contract(colonyNetwork.address, colonyNetwork.abi, ethersProvider);
 
-    while (coinMachineResolverAddress === ethers.constants.AddressZero) {
-      coinMachineVersion += 1;
-      coinMachineResolverAddress = await colonyNetwork.getExtensionResolver(COIN_MACHINE, coinMachineVersion);
-    }
-    await colony.installExtension(COIN_MACHINE, coinMachineVersion);
+    const eventFilter = ethersColonyNetwork.filters.ExtensionAddedToNetwork(COIN_MACHINE);
+    const events = await ethersColonyNetwork.queryFilter(eventFilter, 0);
+    const log = await ethersColonyNetwork.interface.parseLog(events[0]);
+
+    await colony.installExtension(COIN_MACHINE, log.args.version);
 
     const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
     const coinMachine = await CoinMachine.at(coinMachineAddress);

--- a/test/contracts-network/colony-arbitrary-transactions.js
+++ b/test/contracts-network/colony-arbitrary-transactions.js
@@ -206,7 +206,15 @@ contract("Colony Arbitrary Transactions", (accounts) => {
 
   it("should not be able to make arbitrary transactions to the colony's own extensions", async () => {
     const COIN_MACHINE = soliditySha3("CoinMachine");
-    await colony.installExtension(COIN_MACHINE, 2);
+
+    let coinMachineVersion = 0;
+    let coinMachineResolverAddress = ethers.constants.AddressZero;
+
+    while (coinMachineResolverAddress === ethers.constants.AddressZero) {
+      coinMachineVersion += 1;
+      coinMachineResolverAddress = await colonyNetwork.getExtensionResolver(COIN_MACHINE, coinMachineVersion);
+    }
+    await colony.installExtension(COIN_MACHINE, coinMachineVersion);
 
     const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
     const coinMachine = await CoinMachine.at(coinMachineAddress);


### PR DESCRIPTION
The version check script for extensions was wrong - when #962 was rebased, should have thrown a big wobbly. This fixes it, and increments all the versions that should have been at the time.