### PR TITLE
Faster tests

### DIFF
--- a/migrations/8_setup_meta_colony.js
+++ b/migrations/8_setup_meta_colony.js
@@ -15,7 +15,7 @@ const Version3 = artifacts.require("./Version3");
 const Version4 = artifacts.require("./Version4");
 const { setupColonyVersionResolver } = require("../helpers/upgradable-contracts");
 
-const DEFAULT_STAKE = "2000000000000000000000"; // MIN_STAKE
+const DEFAULT_STAKE = "2000000000000000000000000"; // DEFAULT_STAKE
 
 // eslint-disable-next-line no-unused-vars
 module.exports = async function (deployer, network, accounts) {

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,11 +154,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("59b3d732597e619bb7bf753b5df889205faea327270b7e81de2c95d6aeced50e");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("8089afb6c63a784603805b43201abba3ada8e15291f83bc1c4d19ce73e7a1d84");
       expect(colonyAccount.stateRoot.toString("hex")).to.equal("ba1042d654baa721eb012da81409c1087a9447b8a36b6d844233826e5055fbfe");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("352feafb44e40c6097234df1a675c5cd618fd81c0f88e8c6478c838e788bd77a");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("474e00d9b002118dee0c336eaf0902b7719bb7d4a877e2d26f6a2452a5a89a6e");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("5f5b79a400ce5a1a62416a7c8343245aacfa7f11ac97641c4ddefe7cce1927a2");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("c1527a6aa41a1e1805b133363ce9e9d4fe91c4fb8676920fa04b3eb9a7bb77bc");
     });
   });
 });

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -54,10 +54,12 @@ contract("Colony Expenditure", (accounts) => {
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
+
     const metaColonyAddress = await colonyNetwork.getMetaColony();
     metaColony = await IMetaColony.at(metaColonyAddress);
 
     ({ colony, token } = await setupRandomColony(colonyNetwork));
+
     await colony.setRewardInverse(100);
     await colony.setAdministrationRole(1, UINT256_MAX, ADMIN, 1, true);
     await colony.setArbitrationRole(1, UINT256_MAX, ARBITRATOR, 1, true);

--- a/test/contracts-network/colony-network-recovery.js
+++ b/test/contracts-network/colony-network-recovery.js
@@ -36,7 +36,7 @@ chai.use(bnChai(web3.utils.BN));
 const EtherRouter = artifacts.require("EtherRouter");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const IReputationMiningCycle = artifacts.require("IReputationMiningCycle");
-const IColony = artifacts.require("IColony");
+const IMetaColony = artifacts.require("IMetaColony");
 const Token = artifacts.require("Token");
 const ReputationMiningCycle = artifacts.require("ReputationMiningCycle");
 const ReputationMiningCycleRespond = artifacts.require("ReputationMiningCycleRespond");
@@ -60,8 +60,10 @@ contract("Colony Network Recovery", (accounts) => {
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
+
     const metaColonyAddress = await colonyNetwork.getMetaColony();
-    metaColony = await IColony.at(metaColonyAddress);
+    metaColony = await IMetaColony.at(metaColonyAddress);
+
     const clnyAddress = await metaColony.getToken();
     clny = await Token.at(clnyAddress);
 
@@ -447,7 +449,7 @@ contract("Colony Network Recovery", (accounts) => {
           const colonyNetworkAddress = colonyNetwork.address;
           const tokenLockingAddress = await colonyNetwork.getTokenLocking();
           const metaColonyAddress = await colonyNetwork.getMetaColony();
-          const myMetaColony = await IColony.at(metaColonyAddress);
+          const myMetaColony = await IMetaColony.at(metaColonyAddress);
           const myClnyAddress = await myMetaColony.getToken();
 
           // slot 3: colonyNetworkAddress

--- a/test/contracts-network/colony-payment.js
+++ b/test/contracts-network/colony-payment.js
@@ -34,6 +34,7 @@ contract("Colony Payment", (accounts) => {
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
+
     const metaColonyAddress = await colonyNetwork.getMetaColony();
     metaColony = await IMetaColony.at(metaColonyAddress);
 

--- a/test/contracts-network/colony-task.js
+++ b/test/contracts-network/colony-task.js
@@ -86,6 +86,7 @@ contract("ColonyTask", (accounts) => {
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
+
     const metaColonyAddress = await colonyNetwork.getMetaColony();
     metaColony = await IMetaColony.at(metaColonyAddress);
 

--- a/test/contracts-network/reputation-basic-functionality.js
+++ b/test/contracts-network/reputation-basic-functionality.js
@@ -33,12 +33,15 @@ contract("Reputation mining - basic functionality", (accounts) => {
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
-    const tokenLockingAddress = await colonyNetwork.getTokenLocking();
-    tokenLocking = await ITokenLocking.at(tokenLockingAddress);
+
     const metaColonyAddress = await colonyNetwork.getMetaColony();
     metaColony = await IMetaColony.at(metaColonyAddress);
+
     const clnyAddress = await metaColony.getToken();
     clnyToken = await Token.at(clnyAddress);
+
+    const tokenLockingAddress = await colonyNetwork.getTokenLocking();
+    tokenLocking = await ITokenLocking.at(tokenLockingAddress);
   });
 
   afterEach(async () => {

--- a/test/contracts-network/token-locking.js
+++ b/test/contracts-network/token-locking.js
@@ -53,6 +53,7 @@ contract("Token Locking", (addresses) => {
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
+
     const tokenLockingAddress = await colonyNetwork.getTokenLocking();
     tokenLocking = await ITokenLocking.at(tokenLockingAddress);
   });

--- a/test/extensions/coin-machine.js
+++ b/test/extensions/coin-machine.js
@@ -39,25 +39,27 @@ contract("Coin Machine", (accounts) => {
   let purchaseToken;
   let colonyNetwork;
   let coinMachine;
+  let version;
 
   const USER0 = accounts[0];
   const USER1 = accounts[1];
   const USER2 = accounts[2];
-
-  const VERSION = 3;
 
   const ADDRESS_ZERO = ethers.constants.AddressZero;
 
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
+
+    const extension = await CoinMachine.new();
+    version = await extension.version();
   });
 
   beforeEach(async () => {
     ({ colony, token } = await setupRandomColony(colonyNetwork));
     purchaseToken = await setupRandomToken();
 
-    await colony.installExtension(COIN_MACHINE, VERSION);
+    await colony.installExtension(COIN_MACHINE, version);
 
     const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
     coinMachine = await CoinMachine.at(coinMachineAddress);
@@ -76,9 +78,7 @@ contract("Coin Machine", (accounts) => {
       await checkErrorRevert(coinMachine.install(colony.address), "extension-already-installed");
 
       const identifier = await coinMachine.identifier();
-      const version = await coinMachine.version();
       expect(identifier).to.equal(COIN_MACHINE);
-      expect(version).to.eq.BN(VERSION);
 
       const capabilityRoles = await coinMachine.getCapabilityRoles("0x0");
       expect(capabilityRoles).to.equal(ethers.constants.HashZero);
@@ -93,9 +93,9 @@ contract("Coin Machine", (accounts) => {
 
     it("can install the extension with the extension manager", async () => {
       ({ colony } = await setupRandomColony(colonyNetwork));
-      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, version, { from: USER0 });
 
-      await checkErrorRevert(colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 }), "colony-network-extension-already-installed");
+      await checkErrorRevert(colony.installExtension(COIN_MACHINE, version, { from: USER0 }), "colony-network-extension-already-installed");
       await checkErrorRevert(colony.uninstallExtension(COIN_MACHINE, { from: USER1 }), "ds-auth-unauthorized");
 
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
@@ -272,7 +272,7 @@ contract("Coin Machine", (accounts) => {
       await otherToken.unlock();
 
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, version, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -291,7 +291,7 @@ contract("Coin Machine", (accounts) => {
 
     it("cannot buy more than the balance of tokens", async () => {
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, version, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -319,7 +319,7 @@ contract("Coin Machine", (accounts) => {
       expect(locked).to.equal(true);
 
       colony = await setupColony(colonyNetwork, token.address);
-      await colony.installExtension(COIN_MACHINE, VERSION);
+      await colony.installExtension(COIN_MACHINE, version);
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -355,7 +355,7 @@ contract("Coin Machine", (accounts) => {
 
     it("can buy tokens with eth", async () => {
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, version, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -385,7 +385,7 @@ contract("Coin Machine", (accounts) => {
 
     it("can refund eth if no tokens are purchased", async () => {
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, coinMachineVersion, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, version, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -493,7 +493,7 @@ contract("Coin Machine", (accounts) => {
 
     it("cannot adjust prices while the token balance is zero", async () => {
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, version, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -737,7 +737,7 @@ contract("Coin Machine", (accounts) => {
       colony = await setupColony(colonyNetwork, token.address);
       await token.unlock();
 
-      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, version, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -759,7 +759,7 @@ contract("Coin Machine", (accounts) => {
       await purchaseToken.unlock();
 
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, version, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -829,7 +829,7 @@ contract("Coin Machine", (accounts) => {
 
     it("cannot buy more than their user limit allows", async () => {
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, version, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -905,7 +905,7 @@ contract("Coin Machine", (accounts) => {
 
     it("cannot set a user limit without a whitelist", async () => {
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, version, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -917,7 +917,7 @@ contract("Coin Machine", (accounts) => {
 
     it("can calculate the max purchase at any given time", async () => {
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, version, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 

--- a/test/extensions/coin-machine.js
+++ b/test/extensions/coin-machine.js
@@ -7,7 +7,6 @@ import { ethers } from "ethers";
 import { soliditySha3 } from "web3-utils";
 
 import { UINT256_MAX, UINT128_MAX, WAD } from "../../helpers/constants";
-import { setupEtherRouter } from "../../helpers/upgradable-contracts";
 
 import {
   checkErrorRevert,
@@ -20,24 +19,17 @@ import {
   expectEvent,
 } from "../../helpers/test-helper";
 
-import {
-  setupColonyNetwork,
-  setupRandomToken,
-  setupRandomColony,
-  setupColony,
-  setupMetaColonyWithLockedCLNYToken,
-  getMetaTransactionParameters,
-} from "../../helpers/test-data-generator";
+import { setupRandomToken, setupRandomColony, setupColony, getMetaTransactionParameters } from "../../helpers/test-data-generator";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
 
+const IColonyNetwork = artifacts.require("IColonyNetwork");
+const EtherRouter = artifacts.require("EtherRouter");
 const Token = artifacts.require("Token");
 const TokenAuthority = artifacts.require("TokenAuthority");
 const CoinMachine = artifacts.require("CoinMachine");
 const Whitelist = artifacts.require("Whitelist");
-const Resolver = artifacts.require("Resolver");
-const ColonyExtension = artifacts.require("ColonyExtension");
 
 const COIN_MACHINE = soliditySha3("CoinMachine");
 
@@ -47,34 +39,25 @@ contract("Coin Machine", (accounts) => {
   let purchaseToken;
   let colonyNetwork;
   let coinMachine;
-  let coinMachineVersion;
 
   const USER0 = accounts[0];
   const USER1 = accounts[1];
   const USER2 = accounts[2];
 
+  const VERSION = 3;
+
   const ADDRESS_ZERO = ethers.constants.AddressZero;
 
   before(async () => {
-    colonyNetwork = await setupColonyNetwork();
-    const { metaColony } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork);
-
-    const coinMachineImplementation = await CoinMachine.new();
-    const resolver = await Resolver.new();
-    await setupEtherRouter("CoinMachine", { CoinMachine: coinMachineImplementation.address }, resolver);
-    await metaColony.addExtensionToNetwork(COIN_MACHINE, resolver.address);
-
-    const versionSig = await resolver.stringToSig("version()");
-    const target = await resolver.lookup(versionSig);
-    const extensionImplementation = await ColonyExtension.at(target);
-    coinMachineVersion = await extensionImplementation.version();
+    const etherRouter = await EtherRouter.deployed();
+    colonyNetwork = await IColonyNetwork.at(etherRouter.address);
   });
 
   beforeEach(async () => {
     ({ colony, token } = await setupRandomColony(colonyNetwork));
     purchaseToken = await setupRandomToken();
 
-    await colony.installExtension(COIN_MACHINE, coinMachineVersion);
+    await colony.installExtension(COIN_MACHINE, VERSION);
 
     const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
     coinMachine = await CoinMachine.at(coinMachineAddress);
@@ -95,7 +78,7 @@ contract("Coin Machine", (accounts) => {
       const identifier = await coinMachine.identifier();
       const version = await coinMachine.version();
       expect(identifier).to.equal(COIN_MACHINE);
-      expect(version).to.eq.BN(coinMachineVersion);
+      expect(version).to.eq.BN(VERSION);
 
       const capabilityRoles = await coinMachine.getCapabilityRoles("0x0");
       expect(capabilityRoles).to.equal(ethers.constants.HashZero);
@@ -110,13 +93,9 @@ contract("Coin Machine", (accounts) => {
 
     it("can install the extension with the extension manager", async () => {
       ({ colony } = await setupRandomColony(colonyNetwork));
-      await colony.installExtension(COIN_MACHINE, coinMachineVersion, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
 
-      await checkErrorRevert(
-        colony.installExtension(COIN_MACHINE, coinMachineVersion, { from: USER0 }),
-        "colony-network-extension-already-installed"
-      );
-
+      await checkErrorRevert(colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 }), "colony-network-extension-already-installed");
       await checkErrorRevert(colony.uninstallExtension(COIN_MACHINE, { from: USER1 }), "ds-auth-unauthorized");
 
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
@@ -293,7 +272,7 @@ contract("Coin Machine", (accounts) => {
       await otherToken.unlock();
 
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, coinMachineVersion, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -312,7 +291,7 @@ contract("Coin Machine", (accounts) => {
 
     it("cannot buy more than the balance of tokens", async () => {
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, coinMachineVersion, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -340,7 +319,7 @@ contract("Coin Machine", (accounts) => {
       expect(locked).to.equal(true);
 
       colony = await setupColony(colonyNetwork, token.address);
-      await colony.installExtension(COIN_MACHINE, coinMachineVersion);
+      await colony.installExtension(COIN_MACHINE, VERSION);
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -376,7 +355,7 @@ contract("Coin Machine", (accounts) => {
 
     it("can buy tokens with eth", async () => {
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, coinMachineVersion, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -514,7 +493,7 @@ contract("Coin Machine", (accounts) => {
 
     it("cannot adjust prices while the token balance is zero", async () => {
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, coinMachineVersion, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -758,7 +737,7 @@ contract("Coin Machine", (accounts) => {
       colony = await setupColony(colonyNetwork, token.address);
       await token.unlock();
 
-      await colony.installExtension(COIN_MACHINE, coinMachineVersion, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -780,7 +759,7 @@ contract("Coin Machine", (accounts) => {
       await purchaseToken.unlock();
 
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, coinMachineVersion, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -850,7 +829,7 @@ contract("Coin Machine", (accounts) => {
 
     it("cannot buy more than their user limit allows", async () => {
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, coinMachineVersion, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -926,7 +905,7 @@ contract("Coin Machine", (accounts) => {
 
     it("cannot set a user limit without a whitelist", async () => {
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, coinMachineVersion, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 
@@ -938,7 +917,7 @@ contract("Coin Machine", (accounts) => {
 
     it("can calculate the max purchase at any given time", async () => {
       await colony.uninstallExtension(COIN_MACHINE, { from: USER0 });
-      await colony.installExtension(COIN_MACHINE, coinMachineVersion, { from: USER0 });
+      await colony.installExtension(COIN_MACHINE, VERSION, { from: USER0 });
       const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
       coinMachine = await CoinMachine.at(coinMachineAddress);
 

--- a/test/extensions/evaluated-expenditures.js
+++ b/test/extensions/evaluated-expenditures.js
@@ -22,21 +22,23 @@ contract("EvaluatedExpenditure", (accounts) => {
   let colonyNetwork;
   let colony;
   let evaluatedExpenditure;
+  let version;
 
   const USER0 = accounts[0];
   const USER1 = accounts[1];
 
-  const VERSION = 2;
-
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
+
+    const extension = await EvaluatedExpenditure.new();
+    version = await extension.version();
   });
 
   beforeEach(async () => {
     ({ colony } = await setupRandomColony(colonyNetwork));
 
-    await colony.installExtension(EVALUATED_EXPENDITURE, VERSION);
+    await colony.installExtension(EVALUATED_EXPENDITURE, version);
 
     const evaluatedExpenditureAddress = await colonyNetwork.getExtensionInstallation(EVALUATED_EXPENDITURE, colony.address);
     evaluatedExpenditure = await EvaluatedExpenditure.at(evaluatedExpenditureAddress);
@@ -67,9 +69,9 @@ contract("EvaluatedExpenditure", (accounts) => {
 
     it("can install the extension with the extension manager", async () => {
       ({ colony } = await setupRandomColony(colonyNetwork));
-      await colony.installExtension(EVALUATED_EXPENDITURE, VERSION, { from: USER0 });
+      await colony.installExtension(EVALUATED_EXPENDITURE, version, { from: USER0 });
 
-      await checkErrorRevert(colony.installExtension(EVALUATED_EXPENDITURE, VERSION, { from: USER0 }), "colony-network-extension-already-installed");
+      await checkErrorRevert(colony.installExtension(EVALUATED_EXPENDITURE, version, { from: USER0 }), "colony-network-extension-already-installed");
       await checkErrorRevert(colony.uninstallExtension(EVALUATED_EXPENDITURE, { from: USER1 }), "ds-auth-unauthorized");
 
       await colony.uninstallExtension(EVALUATED_EXPENDITURE, { from: USER0 });

--- a/test/extensions/funding-queue.js
+++ b/test/extensions/funding-queue.js
@@ -42,6 +42,7 @@ contract("Funding Queues", (accounts) => {
   let colonyNetwork;
   let tokenLocking;
   let fundingQueue;
+  let version;
 
   let reputationTree;
 
@@ -64,8 +65,6 @@ contract("Funding Queues", (accounts) => {
   const USER1 = accounts[1];
   const MINER = accounts[5];
 
-  const VERSION = 3;
-
   const WAD2 = WAD.muln(2);
 
   const HEAD = 0;
@@ -84,6 +83,9 @@ contract("Funding Queues", (accounts) => {
     tokenLocking = await TokenLocking.at(tokenLockingAddress);
 
     await removeSubdomainLimit(colonyNetwork);
+
+    const extension = await FundingQueue.new();
+    version = await extension.version();
   });
 
   beforeEach(async () => {
@@ -95,7 +97,7 @@ contract("Funding Queues", (accounts) => {
     await colony.addDomain(1, 0, 2);
     domain1 = await colony.getDomain(1);
     domain2 = await colony.getDomain(2);
-    await colony.installExtension(FUNDING_QUEUE, VERSION);
+    await colony.installExtension(FUNDING_QUEUE, version);
 
     const fundingQueueAddress = await colonyNetwork.getExtensionInstallation(FUNDING_QUEUE, colony.address);
     fundingQueue = await FundingQueue.at(fundingQueueAddress);
@@ -172,9 +174,7 @@ contract("Funding Queues", (accounts) => {
       await checkErrorRevert(fundingQueue.install(colony.address), "extension-already-installed");
 
       const identifier = await fundingQueue.identifier();
-      const version = await fundingQueue.version();
       expect(identifier).to.equal(FUNDING_QUEUE);
-      expect(version).to.eq.BN(VERSION);
 
       const capabilityRoles = await fundingQueue.getCapabilityRoles("0x0");
       expect(capabilityRoles).to.equal(ethers.constants.HashZero);
@@ -189,9 +189,9 @@ contract("Funding Queues", (accounts) => {
 
     it("can install the extension with the extension manager", async () => {
       ({ colony } = await setupRandomColony(colonyNetwork));
-      await colony.installExtension(FUNDING_QUEUE, VERSION, { from: USER0 });
+      await colony.installExtension(FUNDING_QUEUE, version, { from: USER0 });
 
-      await checkErrorRevert(colony.installExtension(FUNDING_QUEUE, VERSION, { from: USER0 }), "colony-network-extension-already-installed");
+      await checkErrorRevert(colony.installExtension(FUNDING_QUEUE, version, { from: USER0 }), "colony-network-extension-already-installed");
       await checkErrorRevert(colony.uninstallExtension(FUNDING_QUEUE, { from: USER1 }), "ds-auth-unauthorized");
 
       await colony.uninstallExtension(FUNDING_QUEUE, { from: USER0 });

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -25,11 +25,10 @@ contract("One transaction payments", (accounts) => {
   let colonyNetwork;
   let metaColony;
   let oneTxPayment;
+  let version;
 
   const USER1 = accounts[1].toLowerCase() < accounts[2].toLowerCase() ? accounts[1] : accounts[2];
   const USER2 = accounts[1].toLowerCase() < accounts[2].toLowerCase() ? accounts[2] : accounts[1];
-
-  const VERSION = 3;
 
   const ROLES = rolesToBytes32([FUNDING_ROLE, ADMINISTRATION_ROLE]);
   const ADDRESS_ZERO = ethers.constants.AddressZero;
@@ -40,6 +39,9 @@ contract("One transaction payments", (accounts) => {
 
     const metaColonyAddress = await colonyNetwork.getMetaColony();
     metaColony = await IMetaColony.at(metaColonyAddress);
+
+    const extension = await OneTxPayment.new();
+    version = await extension.version();
   });
 
   beforeEach(async () => {
@@ -49,7 +51,7 @@ contract("One transaction payments", (accounts) => {
 
     await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
 
-    await colony.installExtension(ONE_TX_PAYMENT, VERSION);
+    await colony.installExtension(ONE_TX_PAYMENT, version);
     const oneTxPaymentAddress = await colonyNetwork.getExtensionInstallation(ONE_TX_PAYMENT, colony.address);
     oneTxPayment = await OneTxPayment.at(oneTxPaymentAddress);
 
@@ -65,9 +67,7 @@ contract("One transaction payments", (accounts) => {
       await checkErrorRevert(oneTxPayment.install(colony.address), "extension-already-installed");
 
       const identifier = await oneTxPayment.identifier();
-      const version = await oneTxPayment.version();
       expect(identifier).to.equal(ONE_TX_PAYMENT);
-      expect(version).to.eq.BN(VERSION);
 
       const capabilityRoles = await oneTxPayment.getCapabilityRoles("0x0");
       expect(capabilityRoles).to.equal(ethers.constants.HashZero);
@@ -82,9 +82,9 @@ contract("One transaction payments", (accounts) => {
 
     it("can install the extension with the extension manager", async () => {
       ({ colony } = await setupRandomColony(colonyNetwork));
-      await colony.installExtension(ONE_TX_PAYMENT, VERSION);
+      await colony.installExtension(ONE_TX_PAYMENT, version);
 
-      await checkErrorRevert(colony.installExtension(ONE_TX_PAYMENT, VERSION), "colony-network-extension-already-installed");
+      await checkErrorRevert(colony.installExtension(ONE_TX_PAYMENT, version), "colony-network-extension-already-installed");
       await checkErrorRevert(colony.uninstallExtension(ONE_TX_PAYMENT, { from: USER1 }), "ds-auth-unauthorized");
 
       await colony.uninstallExtension(ONE_TX_PAYMENT);

--- a/test/extensions/token-supplier.js
+++ b/test/extensions/token-supplier.js
@@ -7,21 +7,15 @@ import { ethers } from "ethers";
 import { soliditySha3 } from "web3-utils";
 
 import { UINT256_MAX, WAD, SECONDS_PER_DAY } from "../../helpers/constants";
+import { setupRandomColony, getMetaTransactionParameters } from "../../helpers/test-data-generator";
 import { checkErrorRevert, currentBlockTime, makeTxAtTimestamp, getBlockTime, forwardTime } from "../../helpers/test-helper";
-import {
-  setupColonyNetwork,
-  setupRandomColony,
-  setupMetaColonyWithLockedCLNYToken,
-  getMetaTransactionParameters,
-} from "../../helpers/test-data-generator";
-import { setupEtherRouter } from "../../helpers/upgradable-contracts";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
 
+const IColonyNetwork = artifacts.require("IColonyNetwork");
+const EtherRouter = artifacts.require("EtherRouter");
 const TokenSupplier = artifacts.require("TokenSupplier");
-const ColonyExtension = artifacts.require("ColonyExtension");
-const Resolver = artifacts.require("Resolver");
 
 const TOKEN_SUPPLIER = soliditySha3("TokenSupplier");
 
@@ -31,31 +25,23 @@ contract("Token Supplier", (accounts) => {
   let colonyNetwork;
 
   let tokenSupplier;
-  let tokenSupplierVersion;
 
   const USER0 = accounts[0];
   const USER1 = accounts[1];
   const USER2 = accounts[2];
 
+  const VERSION = 3;
+
   const SUPPLY_CEILING = WAD.muln(10);
 
   before(async () => {
-    colonyNetwork = await setupColonyNetwork();
-    const { metaColony } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork);
-
-    const tokenSupplierImplementation = await TokenSupplier.new();
-    const resolver = await Resolver.new();
-    await setupEtherRouter("TokenSupplier", { TokenSupplier: tokenSupplierImplementation.address }, resolver);
-    await metaColony.addExtensionToNetwork(TOKEN_SUPPLIER, resolver.address);
-    const versionSig = await resolver.stringToSig("version()");
-    const target = await resolver.lookup(versionSig);
-    const extensionImplementation = await ColonyExtension.at(target);
-    tokenSupplierVersion = await extensionImplementation.version();
+    const etherRouter = await EtherRouter.deployed();
+    colonyNetwork = await IColonyNetwork.at(etherRouter.address);
   });
 
   beforeEach(async () => {
     ({ colony, token } = await setupRandomColony(colonyNetwork));
-    await colony.installExtension(TOKEN_SUPPLIER, tokenSupplierVersion);
+    await colony.installExtension(TOKEN_SUPPLIER, VERSION);
     await colony.addDomain(1, UINT256_MAX, 1);
 
     const tokenSupplierAddress = await colonyNetwork.getExtensionInstallation(TOKEN_SUPPLIER, colony.address);
@@ -81,12 +67,9 @@ contract("Token Supplier", (accounts) => {
 
     it("can install the extension with the extension manager", async () => {
       ({ colony } = await setupRandomColony(colonyNetwork));
-      await colony.installExtension(TOKEN_SUPPLIER, tokenSupplierVersion, { from: USER0 });
+      await colony.installExtension(TOKEN_SUPPLIER, VERSION, { from: USER0 });
 
-      await checkErrorRevert(
-        colony.installExtension(TOKEN_SUPPLIER, tokenSupplierVersion, { from: USER0 }),
-        "colony-network-extension-already-installed"
-      );
+      await checkErrorRevert(colony.installExtension(TOKEN_SUPPLIER, VERSION, { from: USER0 }), "colony-network-extension-already-installed");
       await checkErrorRevert(colony.uninstallExtension(TOKEN_SUPPLIER, { from: USER1 }), "ds-auth-unauthorized");
 
       await colony.uninstallExtension(TOKEN_SUPPLIER, { from: USER0 });

--- a/test/extensions/token-supplier.js
+++ b/test/extensions/token-supplier.js
@@ -23,25 +23,26 @@ contract("Token Supplier", (accounts) => {
   let colony;
   let token;
   let colonyNetwork;
-
   let tokenSupplier;
+  let version;
 
   const USER0 = accounts[0];
   const USER1 = accounts[1];
   const USER2 = accounts[2];
-
-  const VERSION = 3;
 
   const SUPPLY_CEILING = WAD.muln(10);
 
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
+
+    const extension = await TokenSupplier.new();
+    version = await extension.version();
   });
 
   beforeEach(async () => {
     ({ colony, token } = await setupRandomColony(colonyNetwork));
-    await colony.installExtension(TOKEN_SUPPLIER, VERSION);
+    await colony.installExtension(TOKEN_SUPPLIER, version);
     await colony.addDomain(1, UINT256_MAX, 1);
 
     const tokenSupplierAddress = await colonyNetwork.getExtensionInstallation(TOKEN_SUPPLIER, colony.address);
@@ -67,9 +68,9 @@ contract("Token Supplier", (accounts) => {
 
     it("can install the extension with the extension manager", async () => {
       ({ colony } = await setupRandomColony(colonyNetwork));
-      await colony.installExtension(TOKEN_SUPPLIER, VERSION, { from: USER0 });
+      await colony.installExtension(TOKEN_SUPPLIER, version, { from: USER0 });
 
-      await checkErrorRevert(colony.installExtension(TOKEN_SUPPLIER, VERSION, { from: USER0 }), "colony-network-extension-already-installed");
+      await checkErrorRevert(colony.installExtension(TOKEN_SUPPLIER, version, { from: USER0 }), "colony-network-extension-already-installed");
       await checkErrorRevert(colony.uninstallExtension(TOKEN_SUPPLIER, { from: USER1 }), "ds-auth-unauthorized");
 
       await colony.uninstallExtension(TOKEN_SUPPLIER, { from: USER0 });

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -49,6 +49,7 @@ contract("Voting Reputation", (accounts) => {
   let tokenLocking;
 
   let voting;
+  let version;
 
   let reputationTree;
 
@@ -84,8 +85,6 @@ contract("Voting Reputation", (accounts) => {
   const USER2 = accounts[2];
   const MINER = accounts[5];
 
-  const VERSION = 4;
-
   const SALT = soliditySha3({ type: "string", value: shortid.generate() });
   const FAKE = soliditySha3({ type: "string", value: shortid.generate() });
 
@@ -117,6 +116,9 @@ contract("Voting Reputation", (accounts) => {
 
     const tokenLockingAddress = await colonyNetwork.getTokenLocking();
     tokenLocking = await TokenLocking.at(tokenLockingAddress);
+
+    const extension = await VotingReputation.new();
+    version = await extension.version();
   });
 
   beforeEach(async () => {
@@ -129,7 +131,7 @@ contract("Voting Reputation", (accounts) => {
     domain2 = await colony.getDomain(2);
     domain3 = await colony.getDomain(3);
 
-    await colony.installExtension(VOTING_REPUTATION, VERSION);
+    await colony.installExtension(VOTING_REPUTATION, version);
     const votingAddress = await colonyNetwork.getExtensionInstallation(VOTING_REPUTATION, colony.address);
     voting = await VotingReputation.at(votingAddress);
 
@@ -244,9 +246,7 @@ contract("Voting Reputation", (accounts) => {
       await checkErrorRevert(voting.install(colony.address), "extension-already-installed");
 
       const identifier = await voting.identifier();
-      const version = await voting.version();
       expect(identifier).to.equal(VOTING_REPUTATION);
-      expect(version).to.eq.BN(VERSION);
 
       const capabilityRoles = await voting.getCapabilityRoles("0x0");
       expect(capabilityRoles).to.equal(ethers.constants.HashZero);
@@ -261,9 +261,9 @@ contract("Voting Reputation", (accounts) => {
 
     it("can install the extension with the extension manager", async () => {
       ({ colony } = await setupRandomColony(colonyNetwork));
-      await colony.installExtension(VOTING_REPUTATION, VERSION, { from: USER0 });
+      await colony.installExtension(VOTING_REPUTATION, version, { from: USER0 });
 
-      await checkErrorRevert(colony.installExtension(VOTING_REPUTATION, VERSION, { from: USER0 }), "colony-network-extension-already-installed");
+      await checkErrorRevert(colony.installExtension(VOTING_REPUTATION, version, { from: USER0 }), "colony-network-extension-already-installed");
       await checkErrorRevert(colony.uninstallExtension(VOTING_REPUTATION, { from: USER1 }), "ds-auth-unauthorized");
 
       await colony.uninstallExtension(VOTING_REPUTATION, { from: USER0 });

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -7,7 +7,7 @@ import shortid from "shortid";
 import { ethers } from "ethers";
 import { soliditySha3 } from "web3-utils";
 
-import { UINT256_MAX, WAD, MINING_CYCLE_DURATION, SECONDS_PER_DAY, DEFAULT_STAKE, SUBMITTER_ONLY_WINDOW } from "../../helpers/constants";
+import { UINT256_MAX, WAD, MINING_CYCLE_DURATION, SECONDS_PER_DAY, SUBMITTER_ONLY_WINDOW } from "../../helpers/constants";
 
 import {
   checkErrorRevert,
@@ -21,27 +21,20 @@ import {
   expectEvent,
 } from "../../helpers/test-helper";
 
-import {
-  setupColonyNetwork,
-  setupMetaColonyWithLockedCLNYToken,
-  setupRandomColony,
-  giveUserCLNYTokensAndStake,
-  getMetaTransactionParameters,
-} from "../../helpers/test-data-generator";
-
-import { setupEtherRouter } from "../../helpers/upgradable-contracts";
+import { setupRandomColony, getMetaTransactionParameters } from "../../helpers/test-data-generator";
 
 import PatriciaTree from "../../packages/reputation-miner/patricia";
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
 
+const IColonyNetwork = artifacts.require("IColonyNetwork");
+const IMetaColony = artifacts.require("IMetaColony");
+const EtherRouter = artifacts.require("EtherRouter");
 const IReputationMiningCycle = artifacts.require("IReputationMiningCycle");
 const TokenLocking = artifacts.require("TokenLocking");
 const VotingReputation = artifacts.require("VotingReputation");
 const OneTxPayment = artifacts.require("OneTxPayment");
-const Resolver = artifacts.require("Resolver");
-const ColonyExtension = artifacts.require("ColonyExtension");
 
 const VOTING_REPUTATION = soliditySha3("VotingReputation");
 
@@ -54,7 +47,6 @@ contract("Voting Reputation", (accounts) => {
   let metaColony;
   let colonyNetwork;
   let tokenLocking;
-  let reputationVotingVersion;
 
   let voting;
 
@@ -92,6 +84,8 @@ contract("Voting Reputation", (accounts) => {
   const USER2 = accounts[2];
   const MINER = accounts[5];
 
+  const VERSION = 4;
+
   const SALT = soliditySha3({ type: "string", value: shortid.generate() });
   const FAKE = soliditySha3({ type: "string", value: shortid.generate() });
 
@@ -115,24 +109,14 @@ contract("Voting Reputation", (accounts) => {
   const YEAR = SECONDS_PER_DAY * 365;
 
   before(async () => {
-    colonyNetwork = await setupColonyNetwork();
-    ({ metaColony } = await setupMetaColonyWithLockedCLNYToken(colonyNetwork));
+    const etherRouter = await EtherRouter.deployed();
+    colonyNetwork = await IColonyNetwork.at(etherRouter.address);
 
-    await giveUserCLNYTokensAndStake(colonyNetwork, MINER, DEFAULT_STAKE);
-    await colonyNetwork.initialiseReputationMining();
-    await colonyNetwork.startNextCycle();
+    const metaColonyAddress = await colonyNetwork.getMetaColony();
+    metaColony = await IMetaColony.at(metaColonyAddress);
 
     const tokenLockingAddress = await colonyNetwork.getTokenLocking();
     tokenLocking = await TokenLocking.at(tokenLockingAddress);
-
-    const votingImplementation = await VotingReputation.new();
-    const resolver = await Resolver.new();
-    await setupEtherRouter("VotingReputation", { VotingReputation: votingImplementation.address }, resolver);
-    await metaColony.addExtensionToNetwork(VOTING_REPUTATION, resolver.address);
-    const versionSig = await resolver.stringToSig("version()");
-    const target = await resolver.lookup(versionSig);
-    const extensionImplementation = await ColonyExtension.at(target);
-    reputationVotingVersion = await extensionImplementation.version();
   });
 
   beforeEach(async () => {
@@ -145,7 +129,7 @@ contract("Voting Reputation", (accounts) => {
     domain2 = await colony.getDomain(2);
     domain3 = await colony.getDomain(3);
 
-    await colony.installExtension(VOTING_REPUTATION, reputationVotingVersion);
+    await colony.installExtension(VOTING_REPUTATION, VERSION);
     const votingAddress = await colonyNetwork.getExtensionInstallation(VOTING_REPUTATION, colony.address);
     voting = await VotingReputation.at(votingAddress);
 
@@ -262,7 +246,7 @@ contract("Voting Reputation", (accounts) => {
       const identifier = await voting.identifier();
       const version = await voting.version();
       expect(identifier).to.equal(VOTING_REPUTATION);
-      expect(version).to.eq.BN(reputationVotingVersion);
+      expect(version).to.eq.BN(VERSION);
 
       const capabilityRoles = await voting.getCapabilityRoles("0x0");
       expect(capabilityRoles).to.equal(ethers.constants.HashZero);
@@ -277,12 +261,9 @@ contract("Voting Reputation", (accounts) => {
 
     it("can install the extension with the extension manager", async () => {
       ({ colony } = await setupRandomColony(colonyNetwork));
-      await colony.installExtension(VOTING_REPUTATION, reputationVotingVersion, { from: USER0 });
+      await colony.installExtension(VOTING_REPUTATION, VERSION, { from: USER0 });
 
-      await checkErrorRevert(
-        colony.installExtension(VOTING_REPUTATION, reputationVotingVersion, { from: USER0 }),
-        "colony-network-extension-already-installed"
-      );
+      await checkErrorRevert(colony.installExtension(VOTING_REPUTATION, VERSION, { from: USER0 }), "colony-network-extension-already-installed");
       await checkErrorRevert(colony.uninstallExtension(VOTING_REPUTATION, { from: USER1 }), "ds-auth-unauthorized");
 
       await colony.uninstallExtension(VOTING_REPUTATION, { from: USER0 });
@@ -1253,17 +1234,13 @@ contract("Voting Reputation", (accounts) => {
     });
 
     it("can take an action to install an extension", async () => {
-      let installation = await colonyNetwork.getExtensionInstallation(soliditySha3("OneTxPayment"), colony.address);
+      const oneTxPayment = soliditySha3("OneTxPayment");
+      const oneTxPaymentVersion = 3;
+
+      let installation = await colonyNetwork.getExtensionInstallation(oneTxPayment, colony.address);
       expect(installation).to.be.equal(ADDRESS_ZERO);
 
-      const oneTxPaymentImplementation = await OneTxPayment.new();
-      const resolver = await Resolver.new();
-      await setupEtherRouter("OneTxPayment", { OneTxPayment: oneTxPaymentImplementation.address }, resolver);
-      await metaColony.addExtensionToNetwork(soliditySha3("OneTxPayment"), resolver.address);
-
-      const oneTxPaymentVersion = await oneTxPaymentImplementation.version();
-
-      const action = await encodeTxData(colony, "installExtension", [soliditySha3("OneTxPayment"), oneTxPaymentVersion]);
+      const action = await encodeTxData(colony, "installExtension", [oneTxPayment, oneTxPaymentVersion]);
       await voting.createMotion(1, UINT256_MAX, ADDRESS_ZERO, action, domain1Key, domain1Value, domain1Mask, domain1Siblings);
       motionId = await voting.getMotionCount();
 
@@ -1274,7 +1251,7 @@ contract("Voting Reputation", (accounts) => {
       const { logs } = await voting.finalizeMotion(motionId);
       expect(logs[1].args.executed).to.be.true;
 
-      installation = await colonyNetwork.getExtensionInstallation(soliditySha3("OneTxPayment"), colony.address);
+      installation = await colonyNetwork.getExtensionInstallation(oneTxPayment, colony.address);
       expect(installation).to.not.be.equal(ADDRESS_ZERO);
     });
 

--- a/test/extensions/whitelist.js
+++ b/test/extensions/whitelist.js
@@ -22,21 +22,23 @@ contract("Whitelist", (accounts) => {
   let colonyNetwork;
   let colony;
   let whitelist;
+  let version;
 
   const USER0 = accounts[0];
   const USER1 = accounts[1];
 
-  const VERSION = 2;
-
   before(async () => {
     const etherRouter = await EtherRouter.deployed();
     colonyNetwork = await IColonyNetwork.at(etherRouter.address);
+
+    const extension = await Whitelist.new();
+    version = await extension.version();
   });
 
   beforeEach(async () => {
     ({ colony } = await setupRandomColony(colonyNetwork));
 
-    await colony.installExtension(WHITELIST, VERSION);
+    await colony.installExtension(WHITELIST, version);
 
     const whitelistAddress = await colonyNetwork.getExtensionInstallation(WHITELIST, colony.address);
     whitelist = await Whitelist.at(whitelistAddress);
@@ -67,9 +69,9 @@ contract("Whitelist", (accounts) => {
 
     it("can install the extension with the extension manager", async () => {
       ({ colony } = await setupRandomColony(colonyNetwork));
-      await colony.installExtension(WHITELIST, VERSION, { from: USER0 });
+      await colony.installExtension(WHITELIST, version, { from: USER0 });
 
-      await checkErrorRevert(colony.installExtension(WHITELIST, VERSION, { from: USER0 }), "colony-network-extension-already-installed");
+      await checkErrorRevert(colony.installExtension(WHITELIST, version, { from: USER0 }), "colony-network-extension-already-installed");
       await checkErrorRevert(colony.uninstallExtension(WHITELIST, { from: USER1 }), "ds-auth-unauthorized");
 
       await colony.uninstallExtension(WHITELIST, { from: USER0 });

--- a/test/reputation-system/client-sync-functionality.js
+++ b/test/reputation-system/client-sync-functionality.js
@@ -5,7 +5,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 
 import TruffleLoader from "../../packages/reputation-miner/TruffleLoader";
-import { DEFAULT_STAKE, MIN_STAKE, INITIAL_FUNDING } from "../../helpers/constants";
+import { DEFAULT_STAKE, INITIAL_FUNDING } from "../../helpers/constants";
 import { forwardTime, currentBlock, advanceMiningCycleNoContest, getActiveRepCycle } from "../../helpers/test-helper";
 import { giveUserCLNYTokensAndStake, setupFinalizedTask, fundColonyWithTokens } from "../../helpers/test-data-generator";
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
@@ -59,7 +59,7 @@ process.env.SOLIDITY_COVERAGE
         await reputationMiner1.resetDB();
 
         const lock = await tokenLocking.getUserLock(clnyToken.address, MINER1);
-        expect(lock.balance).to.eq.BN(MIN_STAKE);
+        expect(lock.balance).to.eq.BN(DEFAULT_STAKE);
 
         // Advance two cycles to clear active and inactive state.
         await advanceMiningCycleNoContest({ colonyNetwork, test: this });


### PR DESCRIPTION
Speed up our test suite by removing redundant deployments & transactions, specifically the redundant network & metacolony deployments at the beginning of test suites (truffle's snapshotting feature appears to bring us back to the correct state automatically).

Non-rigorous profiling suggests that the tests are indeed faster, modulo any endogenous effect caused by Circle's infrastructure. See [original](https://app.circleci.com/pipelines/github/JoinColony/colonyNetwork/4011/workflows/460eccb6-82fc-4c5b-bb84-dbdb488baa8b/jobs/20286) and [improved](https://app.circleci.com/pipelines/github/JoinColony/colonyNetwork/4030/workflows/33d61557-f29e-4e70-94be-b09458fd299e/jobs/20400) build times.