### PR TITLE
Change how CoinMachine limits are enforced

### DIFF
--- a/contracts/extensions/CoinMachine.sol
+++ b/contracts/extensions/CoinMachine.sol
@@ -361,7 +361,7 @@ contract CoinMachine is ColonyExtension {
     return
       (userLimitFraction == WAD || whitelist == address(0x0)) ?
       UINT256_MAX :
-      sub(wmul(add(ERC20(token).balanceOf(address(this)), soldTotal), userLimitFraction), soldUser[_user])
+      sub(wmul(add(getTokenBalance(), soldTotal), userLimitFraction), soldUser[_user])
     ;
   }
 

--- a/contracts/extensions/CoinMachine.sol
+++ b/contracts/extensions/CoinMachine.sol
@@ -81,7 +81,7 @@ contract CoinMachine is ColonyExtension {
 
   /// @notice Returns the version of the extension
   function version() public override pure returns (uint256) {
-    return 2;
+    return 3;
   }
 
   /// @notice Configures the extension
@@ -358,11 +358,11 @@ contract CoinMachine is ColonyExtension {
 
   /// @notice Get the maximum amount of tokens a user can purchase in total
   function getUserLimit(address _user) public view returns (uint256) {
-    // ((max(soldTotal, targetPerPeriod) * userLimitFraction) - soldUser) / (1 - userLimitFraction)
-    return (userLimitFraction == WAD || whitelist == address(0x0)) ? UINT256_MAX : wdiv(
-      sub(wmul(max(soldTotal, targetPerPeriod), userLimitFraction), soldUser[_user]),
-      sub(WAD, userLimitFraction)
-    );
+    return
+      (userLimitFraction == WAD || whitelist == address(0x0)) ?
+      UINT256_MAX :
+      sub(wmul(add(ERC20(token).balanceOf(address(this)), soldTotal), userLimitFraction), soldUser[_user])
+    ;
   }
 
   /// @notice Get the maximum amount of tokens a user can purchase in a period

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,7 +154,7 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("6b2b49d0511c9ba1050df1531f86df8d9f96075d59e736fea51235f011e6865a");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("197678aa163dbee5ac0282328d4c46c371d879e823bfd4bb33cb69d47c19cb4a");
       expect(colonyAccount.stateRoot.toString("hex")).to.equal("d8e895aa214956a2543325209231d4502c6c241027df357ce9bcf065215c4632");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("78294685a492256887e3159e26071ba06d62883c72ccb26fd323a883eefc30fd");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("e105190bcd647989da1579ac209ae54ed63e08224fbb2469bad9f596773fe558");

--- a/test/contracts-network/colony-arbitrary-transactions.js
+++ b/test/contracts-network/colony-arbitrary-transactions.js
@@ -206,7 +206,7 @@ contract("Colony Arbitrary Transactions", (accounts) => {
 
   it("should not be able to make arbitrary transactions to the colony's own extensions", async () => {
     const COIN_MACHINE = soliditySha3("CoinMachine");
-    await colony.installExtension(COIN_MACHINE, 2);
+    await colony.installExtension(COIN_MACHINE, 3);
 
     const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
     const coinMachine = await CoinMachine.at(coinMachineAddress);


### PR DESCRIPTION
In light of [colonyDapp#2995](https://github.com/JoinColony/colonyDapp/issues/2995), the behaviour we understood was desired to be implemented was not actually desired.

The user limit is now enforced against the total number of tokens already sold plus those that are still to be sold that have already been given to coinmachine. This means that a user can, if the max sold per period allows, buy their entire allowance in one transaction at the start of the sale.

This means that, if a sale is terminated early, some users may have more than their allowance. This has been deemed acceptable.