### PR TITLE
Work with updated colonyToken repo

### DIFF
--- a/scripts/provision-token-contracts.sh
+++ b/scripts/provision-token-contracts.sh
@@ -5,8 +5,8 @@ cd ..
 
 test ! -d ./build/contracts/ && mkdir -p ./build/contracts/
 
-cp lib/colonyToken/build/contracts/Token.json ./build/contracts/Token.json
-cp lib/colonyToken/build/contracts/TokenAuthority.json ./build/contracts/TokenAuthority.json
-cp lib/colonyToken/build/contracts/MultiSigWallet.json ./build/contracts/MultiSigWallet.json
+cp lib/colonyToken/build/contracts/PinnedToken.json ./build/contracts/Token.json
+cp lib/colonyToken/build/contracts/PinnedTokenAuthority.json ./build/contracts/TokenAuthority.json
+cp lib/colonyToken/build/contracts/PinnedMultiSigWallet.json ./build/contracts/MultiSigWallet.json
 # Provision the openzeppelin Mintable ERC20 token contract used in integration testing
 cp node_modules/openzeppelin-solidity/build/contracts/ERC20PresetMinterPauser.json ./build/contracts/ERC20PresetMinterPauser.json


### PR DESCRIPTION
Working out the kinks w.r.t. having bumped colonyToken to a new version, specifically how we import the pinned build files.

Merging into master to fix that build, which we can then back-merge into develop.