### PR TITLE
Delegated mining

### DIFF
--- a/contracts/colonyNetwork/ColonyNetworkMining.sol
+++ b/contracts/colonyNetwork/ColonyNetworkMining.sol
@@ -34,6 +34,22 @@ contract ColonyNetworkMining is ColonyNetworkStorage, MultiChain {
     _;
   }
 
+  function setMiningDelegate(address _delegate, bool _allowed) public {
+    if (miningDelegator[_delegate] != address(0x00)){
+      require(msg.sender == miningDelegator[_delegate], "colony-reputation-mining-not-your-delegate");
+    }
+
+    if (_allowed){
+      miningDelegator[_delegate] = msg.sender;
+    } else {
+      miningDelegator[_delegate] = address(0x00);
+    }
+  }
+
+  function getMiningDelegator(address _delegate) external view returns (address) {
+    return miningDelegator[_delegate];
+  }
+
   function setReplacementReputationUpdateLogEntry(
     address _reputationMiningCycle,
     uint256 _id,

--- a/contracts/colonyNetwork/ColonyNetworkMining.sol
+++ b/contracts/colonyNetwork/ColonyNetworkMining.sol
@@ -34,7 +34,7 @@ contract ColonyNetworkMining is ColonyNetworkStorage, MultiChain {
     _;
   }
 
-  function setMiningDelegate(address _delegate, bool _allowed) public {
+  function setMiningDelegate(address _delegate, bool _allowed) public stoppable {
     if (miningDelegator[_delegate] != address(0x00)){
       require(msg.sender == miningDelegator[_delegate], "colony-reputation-mining-not-your-delegate");
     }

--- a/contracts/colonyNetwork/ColonyNetworkMining.sol
+++ b/contracts/colonyNetwork/ColonyNetworkMining.sol
@@ -35,19 +35,19 @@ contract ColonyNetworkMining is ColonyNetworkStorage, MultiChain {
   }
 
   function setMiningDelegate(address _delegate, bool _allowed) public stoppable {
-    if (miningDelegator[_delegate] != address(0x00)){
-      require(msg.sender == miningDelegator[_delegate], "colony-reputation-mining-not-your-delegate");
+    if (miningDelegators[_delegate] != address(0x00)){
+      require(miningDelegators[_delegate] == msg.sender, "colony-reputation-mining-not-your-delegate");
     }
 
     if (_allowed){
-      miningDelegator[_delegate] = msg.sender;
+      miningDelegators[_delegate] = msg.sender;
     } else {
-      miningDelegator[_delegate] = address(0x00);
+      miningDelegators[_delegate] = address(0x00);
     }
   }
 
   function getMiningDelegator(address _delegate) external view returns (address) {
-    return miningDelegator[_delegate];
+    return miningDelegators[_delegate];
   }
 
   function setReplacementReputationUpdateLogEntry(

--- a/contracts/colonyNetwork/ColonyNetworkStorage.sol
+++ b/contracts/colonyNetwork/ColonyNetworkStorage.sol
@@ -100,6 +100,9 @@ contract ColonyNetworkStorage is CommonStorage, ColonyNetworkDataTypes, DSMath {
   // Used for whitelisting payout tokens
   mapping (address => bool) payoutWhitelist; // Storage slot 40
 
+  // Mining delegation mapping
+  mapping(address => address) miningDelegator; // Storage slot 41
+
   modifier calledByColony() {
     require(_isColony[msg.sender], "colony-caller-must-be-colony");
     _;

--- a/contracts/colonyNetwork/ColonyNetworkStorage.sol
+++ b/contracts/colonyNetwork/ColonyNetworkStorage.sol
@@ -101,7 +101,7 @@ contract ColonyNetworkStorage is CommonStorage, ColonyNetworkDataTypes, DSMath {
   mapping (address => bool) payoutWhitelist; // Storage slot 40
 
   // Mining delegation mapping
-  mapping(address => address) miningDelegator; // Storage slot 41
+  mapping(address => address) miningDelegators; // Storage slot 41
 
   modifier calledByColony() {
     require(_isColony[msg.sender], "colony-caller-must-be-colony");

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -403,4 +403,15 @@ interface IColonyNetwork is ColonyNetworkDataTypes, IRecovery {
   /// @notice Called to get the total per-cycle reputation mining reward.
   /// @return The CLNY awarded per mining cycle to the miners.
   function getReputationMiningCycleReward() external view returns (uint256);
+
+  /// @notice Called to give or remove another address's permission to mine on your behalf
+  /// @param _delegate The address you're giving or removing permission from
+  /// @param _allowed Whether they are allowed (true) or not (false) to mine on your behalf
+  function setMiningDelegate(address _delegate, bool _allowed) external;
+
+  /// @notice Called to get the address _delegate is allowed to mine for
+  /// @param _delegate The address that wants to mine
+  /// @return The address they are allowed to mine on behalf of
+  function getMiningDelegator(address _delegate) external view returns (address);
+
 }

--- a/contracts/reputationMiningCycle/ReputationMiningCycle.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycle.sol
@@ -156,7 +156,7 @@ contract ReputationMiningCycle is ReputationMiningCycleCommon {
   function submitRootHash(bytes32 _newHash, uint256 _nLeaves, bytes32 _jrh, uint256 _entryIndex) public
   submissionPossible()
   {
-    address minerAddress = getMinerAddress();
+    address minerAddress = getMinerAddressIfStaked();
     checkEntryQualifies(minerAddress, _newHash, _nLeaves, _jrh, _entryIndex);
     checkWithinTarget(minerAddress, _newHash, _entryIndex);
 
@@ -332,7 +332,7 @@ contract ReputationMiningCycle is ReputationMiningCycleCommon {
 
       emit HashInvalidated(submission.proposedNewRootHash, submission.nLeaves, submission.jrh);
     }
-    rewardResponder(getMinerAddress());
+    rewardResponder(getMinerAddressIfStaked());
     //TODO: Can we do some deleting to make calling this as cheap as possible for people?
   }
 
@@ -386,7 +386,7 @@ contract ReputationMiningCycle is ReputationMiningCycleCommon {
     // Set bounds for first binary search if it's going to be needed
     disputeRounds[_round][_index].upperBound = submission.jrhNLeaves - 1;
 
-    rewardResponder(getMinerAddress());
+    rewardResponder(getMinerAddressIfStaked());
 
     emit JustificationRootHashConfirmed(submission.proposedNewRootHash, submission.nLeaves, submission.jrh);
   }

--- a/contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol
@@ -66,7 +66,7 @@ contract ReputationMiningCycleBinarySearch is ReputationMiningCycleCommon {
     // Process the consequences
     processBinaryChallengeSearchResponse(_round, _idx, _jhIntermediateValue, lastSiblings);
     // Reward the user
-    rewardResponder(msg.sender);
+    rewardResponder(getMinerAddress());
 
     emit BinarySearchStep(submission.proposedNewRootHash, submission.nLeaves, submission.jrh);
   }
@@ -108,7 +108,7 @@ contract ReputationMiningCycleBinarySearch is ReputationMiningCycleCommon {
     }
     disputeRounds[_round][_idx].lastResponseTimestamp = block.timestamp;
 
-    rewardResponder(msg.sender);
+    rewardResponder(getMinerAddress());
 
     emit BinarySearchConfirmed(submission.proposedNewRootHash, submission.nLeaves, submission.jrh, disputeRounds[_round][_idx].lowerBound);
   }

--- a/contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol
@@ -66,7 +66,7 @@ contract ReputationMiningCycleBinarySearch is ReputationMiningCycleCommon {
     // Process the consequences
     processBinaryChallengeSearchResponse(_round, _idx, _jhIntermediateValue, lastSiblings);
     // Reward the user
-    rewardResponder(getMinerAddress());
+    rewardResponder(getMinerAddressIfStaked());
 
     emit BinarySearchStep(submission.proposedNewRootHash, submission.nLeaves, submission.jrh);
   }
@@ -108,7 +108,7 @@ contract ReputationMiningCycleBinarySearch is ReputationMiningCycleCommon {
     }
     disputeRounds[_round][_idx].lastResponseTimestamp = block.timestamp;
 
-    rewardResponder(getMinerAddress());
+    rewardResponder(getMinerAddressIfStaked());
 
     emit BinarySearchConfirmed(submission.proposedNewRootHash, submission.nLeaves, submission.jrh, disputeRounds[_round][_idx].lowerBound);
   }

--- a/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
@@ -32,7 +32,7 @@ contract ReputationMiningCycleCommon is ReputationMiningCycleStorage, PatriciaTr
   // in reputationMiningCycleRespond. If you change one, you should change the other.
   uint256 constant MINING_WINDOW_SIZE = 60 * 60 * 1; // 1 hour
 
-  function getMinerAddress() internal view returns (address) {
+  function getMinerAddressIfStaked() internal view returns (address) {
     // Is msg.sender a miner themselves? See if they have stake.
     uint256 lockBalance = ITokenLocking(tokenLockingAddress).getObligation(msg.sender, clnyTokenAddress, colonyNetworkAddress);
     if (lockBalance > 0) {
@@ -150,7 +150,7 @@ contract ReputationMiningCycleCommon is ReputationMiningCycleStorage, PatriciaTr
       return false;
     }
 
-    address minerAddress = getMinerAddress();
+    address minerAddress = getMinerAddressIfStaked();
 
     uint256 windowOpenFor = block.timestamp - _responseWindowOpened;
 

--- a/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
@@ -32,10 +32,10 @@ contract ReputationMiningCycleCommon is ReputationMiningCycleStorage, PatriciaTr
   // in reputationMiningCycleRespond. If you change one, you should change the other.
   uint256 constant MINING_WINDOW_SIZE = 60 * 60 * 1; // 1 hour
 
-  function getMinerAddress() internal view returns(address){
+  function getMinerAddress() internal view returns (address) {
     // Is msg.sender a miner themselves? See if they have stake.
     uint256 lockBalance = ITokenLocking(tokenLockingAddress).getObligation(msg.sender, clnyTokenAddress, colonyNetworkAddress);
-    if (lockBalance > 0){
+    if (lockBalance > 0) {
       // If so, they we don't let them mine on someone else's behalf
       return msg.sender;
     }

--- a/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
@@ -42,7 +42,7 @@ contract ReputationMiningCycleCommon is ReputationMiningCycleStorage, PatriciaTr
 
     // Return any delegator they are acting on behalf of
     address delegator = IColonyNetwork(colonyNetworkAddress).getMiningDelegator(msg.sender);
-    require(delegator != address(0x00), 'colony-reputation-mining-no-stake-or-delegator');
+    require(delegator != address(0x00), "colony-reputation-mining-no-stake-or-delegator");
     return delegator;
   }
 

--- a/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
@@ -338,7 +338,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleCommon {
     Submission storage submission = reputationHashSubmissions[disputeRounds[_u[U_ROUND]][_u[U_IDX]].firstSubmitter];
 
     // And reward the user
-    rewardResponder(getMinerAddress());
+    rewardResponder(getMinerAddressIfStaked());
 
     emit ChallengeCompleted(submission.proposedNewRootHash, submission.nLeaves, submission.jrh);
   }

--- a/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
@@ -338,7 +338,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleCommon {
     Submission storage submission = reputationHashSubmissions[disputeRounds[_u[U_ROUND]][_u[U_IDX]].firstSubmitter];
 
     // And reward the user
-    rewardResponder(msg.sender);
+    rewardResponder(getMinerAddress());
 
     emit ChallengeCompleted(submission.proposedNewRootHash, submission.nLeaves, submission.jrh);
   }

--- a/docs/_Interface_IColonyNetwork.md
+++ b/docs/_Interface_IColonyNetwork.md
@@ -394,6 +394,23 @@ Get the Meta Colony address.
 |---|---|---|
 |colonyAddress|address|The Meta colony address, if no colony was found, returns 0x0
 
+### `getMiningDelegator`
+
+Called to get the address _delegate is allowed to mine for
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_delegate|address|The address that wants to mine
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|address|address|
+
 ### `getMiningResolver`
 
 Get the resolver to be used by new instances of ReputationMiningCycle.
@@ -762,6 +779,19 @@ Set the colony network fee to pay. e.g. if the fee is 1% (or 0.01), pass 100 as 
 |Name|Type|Description|
 |---|---|---|
 |_feeInverse|uint256|The inverse of the network fee to set
+
+
+### `setMiningDelegate`
+
+Called to give or remove another address's permission to mine on your behalf
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_delegate|address|The address you're giving or removing permission from
+|_allowed|bool|Whether they are allowed (true) or not (false) to mine on your behalf
 
 
 ### `setMiningResolver`

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -621,7 +621,7 @@ export async function advanceMiningCycleNoContest({ colonyNetwork, client, miner
   if (client !== undefined) {
     await client.addLogContentsToReputationTree();
     await client.submitRootHash();
-    await client.confirmEntry();
+    await client.confirmNewHash();
   } else {
     const accounts = await web3GetAccounts();
     minerAddress = minerAddress || accounts[5]; // eslint-disable-line no-param-reassign

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -621,6 +621,7 @@ export async function advanceMiningCycleNoContest({ colonyNetwork, client, miner
   if (client !== undefined) {
     await client.addLogContentsToReputationTree();
     await client.submitRootHash();
+    await client.confirmEntry();
   } else {
     const accounts = await web3GetAccounts();
     minerAddress = minerAddress || accounts[5]; // eslint-disable-line no-param-reassign
@@ -629,8 +630,8 @@ export async function advanceMiningCycleNoContest({ colonyNetwork, client, miner
     } catch (err) {
       console.log("advanceMiningCycleNoContest error thrown by .submitRootHash", err);
     }
+    await repCycle.confirmNewHash(0, { from: minerAddress });
   }
-  await repCycle.confirmNewHash(0, { from: minerAddress });
 }
 
 export async function accommodateChallengeAndInvalidateHashViaTimeout(colonyNetwork, test, client1) {
@@ -652,8 +653,10 @@ export async function accommodateChallengeAndInvalidateHashViaTimeout(colonyNetw
   await forwardTime(SUBMITTER_ONLY_WINDOW + 600, this);
 
   const toInvalidateIdx = idx1.mod(2).eq(1) ? idx1.sub(1) : idx1.add(1);
+  const accounts = await web3GetAccounts();
+  const minerAddress = accounts[5];
 
-  return repCycle.invalidateHash(round1, toInvalidateIdx);
+  return repCycle.invalidateHash(round1, toInvalidateIdx, { from: minerAddress });
 }
 
 export async function accommodateChallengeAndInvalidateHash(colonyNetwork, test, client1, client2, _errors) {
@@ -703,7 +706,8 @@ export async function accommodateChallengeAndInvalidateHash(colonyNetwork, test,
   }
   await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
 
-  return repCycle.invalidateHash(round1, toInvalidateIdx);
+  const signingAddress = await client1.realWallet.getAddress();
+  return repCycle.invalidateHash(round1, toInvalidateIdx, { from: signingAddress });
 }
 
 async function navigateChallenge(colonyNetwork, client1, client2, errors) {
@@ -825,7 +829,11 @@ export async function finishReputationMiningCycle(colonyNetwork, test) {
       const disputeRound = await repCycle.getDisputeRound(roundNumber);
       const timestamp = disputeRound[0].lastResponseTimestamp;
       await forwardTimeTo(parseInt(timestamp, 10) + MINING_CYCLE_DURATION, test);
-      await repCycle.confirmNewHash(roundNumber);
+
+      const accounts = await web3GetAccounts();
+      const minerAddress = accounts[5];
+
+      await repCycle.confirmNewHash(roundNumber, { from: minerAddress });
       // But for now, that's okay.
     } else {
       // We shouldn't get here. If this fires during a test, you haven't finished writing the test.

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -630,7 +630,7 @@ export async function advanceMiningCycleNoContest({ colonyNetwork, client, miner
       console.log("advanceMiningCycleNoContest error thrown by .submitRootHash", err);
     }
   }
-  await repCycle.confirmNewHash(0);
+  await repCycle.confirmNewHash(0, { from: minerAddress });
 }
 
 export async function accommodateChallengeAndInvalidateHashViaTimeout(colonyNetwork, test, client1) {

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -1070,6 +1070,24 @@ class ReputationMiner {
     );
   }
 
+  /**
+   * Confirm the new reputation hash after all dispute resolution (if any) has occurred.
+   * @return {Promise} Resolves to tx hash of the response
+   */
+  async confirmNewHash() {
+    const repCycle = await this.getActiveRepCycle();
+    const [round] = await this.getMySubmissionRoundAndIndex();
+
+    let gasEstimate = ethers.BigNumber.from(4000000);
+    try {
+      gasEstimate = await repCycle.estimateGas.confirmNewHash(round);
+    } catch (err){ // eslint-disable-line no-empty
+
+    }
+    return repCycle.confirmNewHash(round, { gasLimit: gasEstimate, gasPrice: this.gasPrice });
+  }
+
+
   async updatePeriodLength(repCycle) {
     const { numerator, denominator } = await repCycle.getDecayConstant();
 

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -57,13 +57,9 @@ class ReputationMiner {
     }
 
     if (minerAddress) {
-      this.minerAddress = minerAddress;
       this.realWallet = this.realProvider.getSigner(minerAddress);
     } else {
       this.realWallet = new ethers.Wallet(privateKey, this.realProvider);
-      this.minerAddress = this.realWallet.address;
-      // TODO: Check that this wallet can stake?
-      this.minerAddress = this.realWallet.address;
       console.log("Transactions will be signed from ", this.realWallet.address);
     }
   }
@@ -106,6 +102,18 @@ class ReputationMiner {
     this.gasPrice = ethers.utils.hexlify(20000000000);
     const repCycle = await this.getActiveRepCycle();
     await this.updatePeriodLength(repCycle);
+
+    // NB some technical debt here with names. The minerAddress arg passed in on the command line, which
+    // has been used for realWallet and is where transactions will be signed from may or may not be acting
+    // on behalf of another address via delegate mining. So check which address we're actually mining for.
+    const signingAddress = await this.realWallet.getAddress();
+    const delegator = await this.colonyNetwork.getMiningDelegator(signingAddress);
+    if (delegator === ethers.constants.AddressZero){
+      this.minerAddress = signingAddress;
+    } else {
+      this.minerAddress = delegator;
+    }
+    console.log("Mining on behalf of ", this.minerAddress)
   }
 
   /**

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -113,7 +113,7 @@ class ReputationMiner {
     } else {
       this.minerAddress = delegator;
     }
-    console.log("Mining on behalf of ", this.minerAddress)
+    console.log(`Mining on behalf of ${this.minerAddress}`)
   }
 
   /**

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -612,16 +612,11 @@ class ReputationMinerClient {
   }
 
   async confirmEntry() {
-    const addr = await this._miner.colonyNetwork.getReputationMiningCycle(true);
-    const repCycle = new ethers.Contract(addr, this._miner.repCycleContractDef.abi, this._miner.realWallet);
-
     this._adapter.log("⏰ Looks like it's time to confirm the new hash");
-    // Confirm hash
+    // Confirm hash if possible
     const [round] = await this._miner.getMySubmissionRoundAndIndex();
     if (round && round.gte(0)) {
-      const gasEstimate = await repCycle.estimateGas.confirmNewHash(round);
-
-      const confirmNewHashTx = await repCycle.confirmNewHash(round, { gasLimit: gasEstimate, gasPrice: this._miner.gasPrice });
+      const confirmNewHashTx = await this._miner.confirmNewHash();
       this._adapter.log(`⛏️ Transaction waiting to be mined ${confirmNewHashTx.hash}`);
       await confirmNewHashTx.wait();
       this._adapter.log("✅ New reputation hash confirmed");

--- a/packages/reputation-miner/test/ReputationMinerTestWrapper.js
+++ b/packages/reputation-miner/test/ReputationMinerTestWrapper.js
@@ -25,6 +25,11 @@ class ReputationMinerTestWrapper extends ReputationMiner {
     const tx = await super.respondToChallenge();
     return tx.wait();
   }
+
+  async confirmNewHash() {
+    const tx = await super.confirmNewHash();
+    return tx.wait();
+  }
 }
 
 export default ReputationMinerTestWrapper;

--- a/test-chainid/chainid-dependent-behaviour.js
+++ b/test-chainid/chainid-dependent-behaviour.js
@@ -113,12 +113,12 @@ contract("Contract Storage", (accounts) => {
 
       await forwardTime(MINING_CYCLE_DURATION / 2 + SUBMITTER_ONLY_WINDOW + MINING_CYCLE_TIMEOUT + 1, this);
 
-      await repCycle.invalidateHash(0, 0);
-      await repCycle.invalidateHash(0, 3);
+      await repCycle.invalidateHash(0, 0, { from: MINER1 });
+      await repCycle.invalidateHash(0, 3, { from: MINER1 });
 
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
       const networkBalanceBefore = await clnyToken.balanceOf(colonyNetwork.address);
-      const tx = await repCycle.confirmNewHash(1);
+      const tx = await repCycle.confirmNewHash(1, { from: MINER1 });
 
       if (chainId === XDAI || chainId === FORKED_XDAI) {
         // tokens should be paid from the network balance
@@ -155,7 +155,7 @@ contract("Contract Storage", (accounts) => {
       await repCycle.submitRootHash("0x12345678", 10, "0x00", 1, { from: MINER1 });
 
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      const tx = await repCycle.confirmNewHash(0);
+      const tx = await repCycle.confirmNewHash(0, { from: MINER1 });
       await expectNoEvent(tx, "Transfer(address indexed,address indexed,uint256)", [colonyNetwork.address, metaColony.address, 0]);
       await expectNoEvent(tx, "Burn(address indexed,uint256)", [colonyNetwork.address, 0]);
     });

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -268,7 +268,7 @@ contract("All", function (accounts) {
       });
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(2);
+      await repCycle.confirmNewHash(2, { from: STAKER1 });
 
       // withdraw
       const clnyToken = await metaColony.getToken();

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,11 +154,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("fc7809af9cad84e37d62979891ca554c54e9625b4b5b59b0e9e20c287eeaa70e");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("d8e895aa214956a2543325209231d4502c6c241027df357ce9bcf065215c4632");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("78294685a492256887e3159e26071ba06d62883c72ccb26fd323a883eefc30fd");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("e105190bcd647989da1579ac209ae54ed63e08224fbb2469bad9f596773fe558");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("8bab6ab2024de44a08765ee14ec3d6bdc0fa5ae2a5ee221c9f928345a3710658");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("4efedc6f265bd8d13c7a67a5c3ff125a7114bc919aac73fec093e814c277e6e5");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("0c791498486116907a8a439b835e530548aca26516ba9507c6adfe1b5fc4b394");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("1b04043fa94e5e38ac48c136906b1a55ad8fe9a451be68a49e8fcbfdd666c6b0");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("f05ad68eea03d3865a339b8e9665c142bfe0d9abdf1023adb91a033b7e2f677e");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("ac8572b568eceedcbfe8735d5e801b34232f09e7143a793c69908b25f3eaee50");
     });
   });
 });

--- a/test/contracts-network/reputation-basic-functionality.js
+++ b/test/contracts-network/reputation-basic-functionality.js
@@ -126,7 +126,22 @@ contract("Reputation mining - basic functionality", (accounts) => {
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION, this);
 
-      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, "0x00", 0), "colony-reputation-mining-zero-entry-index-passed");
+      await checkErrorRevert(repCycle.submitRootHash("0x12345678", 10, "0x00", 0), "colony-reputation-mining-no-stake-or-delegator");
+
+      const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
+      expect(nUniqueSubmittedHashes).to.be.zero;
+    });
+
+    it("should not allow someone to submit a new reputation hash with an entry index of 0, even if they're mining", async () => {
+      await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, 9000);
+
+      const repCycle = await getActiveRepCycle(colonyNetwork);
+      await forwardTime(MINING_CYCLE_DURATION, this);
+
+      await checkErrorRevert(
+        repCycle.submitRootHash("0x12345678", 10, "0x00", 0, { from: MINER2 }),
+        "colony-reputation-mining-zero-entry-index-passed"
+      );
 
       const nUniqueSubmittedHashes = await repCycle.getNUniqueSubmittedHashes();
       expect(nUniqueSubmittedHashes).to.be.zero;

--- a/test/contracts-network/reputation-basic-functionality.js
+++ b/test/contracts-network/reputation-basic-functionality.js
@@ -175,7 +175,7 @@ contract("Reputation mining - basic functionality", (accounts) => {
 
       // Cleanup
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(0);
+      await repCycle.confirmNewHash(0, { from: MINER1 });
     });
   });
 

--- a/test/extensions/funding-queue.js
+++ b/test/extensions/funding-queue.js
@@ -178,7 +178,7 @@ contract("Funding Queues", (accounts) => {
     const repCycle = await getActiveRepCycle(colonyNetwork);
     await forwardTime(MINING_CYCLE_DURATION + SUBMITTER_ONLY_WINDOW + 1, this);
     await repCycle.submitRootHash(rootHash, 0, "0x00", 10, { from: MINER });
-    await repCycle.confirmNewHash(0);
+    await repCycle.confirmNewHash(0, { from: MINER });
   });
 
   describe("managing the extension", async () => {

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -243,7 +243,7 @@ contract("Voting Reputation", (accounts) => {
     await forwardTime(MINING_CYCLE_DURATION, this);
     await repCycle.submitRootHash(rootHash, 0, "0x00", 10, { from: MINER });
     await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-    await repCycle.confirmNewHash(0);
+    await repCycle.confirmNewHash(0, { from: MINER });
   });
 
   function hashExpenditureSlot(action) {
@@ -1063,7 +1063,7 @@ contract("Voting Reputation", (accounts) => {
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await repCycle.submitRootHash(rootHash, 0, "0x00", 10, { from: MINER });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(0);
+      await repCycle.confirmNewHash(0, { from: MINER });
 
       // Create new motion with new reputation state
       const action = await encodeTxData(colony, "mintTokens", [WAD]);

--- a/test/reputation-system/disputes-over-child-reputation.js
+++ b/test/reputation-system/disputes-over-child-reputation.js
@@ -166,7 +166,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-adjacent-origin-not-adjacent-or-already-exists" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
       const acceptedHash = await colonyNetwork.getReputationRootHash();
 
       const righthash = await goodClient.getRootHash();
@@ -234,7 +234,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
       });
 
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
       const acceptedHash = await colonyNetwork.getReputationRootHash();
       const righthash = await goodClient.getRootHash();
 
@@ -302,7 +302,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
       });
 
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
       const acceptedHash = await colonyNetwork.getReputationRootHash();
       const righthash = await goodClient.getRootHash();
 
@@ -371,9 +371,9 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
       // Cleanup
       await goodClient.respondToChallenge();
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
-      await repCycle.invalidateHash(0, 1);
+      await repCycle.invalidateHash(0, 1, { from: MINER1 });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
       const acceptedHash = await colonyNetwork.getReputationRootHash();
       const righthash = await goodClient.getRootHash();
 
@@ -457,9 +457,9 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
       // Cleanup
       await goodClient.respondToChallenge();
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
-      await repCycle.invalidateHash(0, 1);
+      await repCycle.invalidateHash(0, 1, { from: MINER1 });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
       const acceptedHash = await colonyNetwork.getReputationRootHash();
       const righthash = await goodClient.getRootHash();
 
@@ -563,9 +563,9 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
       // Cleanup
       await goodClient.respondToChallenge();
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
-      await repCycle.invalidateHash(0, 1);
+      await repCycle.invalidateHash(0, 1, { from: MINER1 });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("if origin skill reputation calculation underflows and is wrong", async () => {
@@ -625,7 +625,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
   });
 
@@ -697,7 +697,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-origin-user-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("if child skill reputation calculation is wrong", async () => {
@@ -755,7 +755,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("if a child skill reputation calculation (in a negative update) is wrong", async () => {
@@ -812,7 +812,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("if a child skill reputation calculation is wrong and that user has never had that reputation before", async () => {
@@ -857,7 +857,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
   });
 
@@ -916,7 +916,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("if a colony-wide calculation (for a child skill) is wrong", async () => {
@@ -974,7 +974,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("if a colony-wide child skill is wrong, and the log .amount is larger than the colony total, but the correct change is not", async () => {
@@ -1047,7 +1047,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it.skip("if one person lies about what the child skill is", async () => {
@@ -1146,9 +1146,9 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
       // Cleanup
       await goodClient.respondToChallenge();
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
-      await repCycle.invalidateHash(0, 1);
+      await repCycle.invalidateHash(0, 1, { from: MINER1 });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("if a colony-wide child skill reputation amount calculation underflows and is wrong", async () => {
@@ -1205,7 +1205,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
   });
 
@@ -1281,12 +1281,12 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient, {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" },
       });
-      await repCycle.invalidateHash(0, 3);
+      await repCycle.invalidateHash(0, 3, { from: MINER1 });
       await accommodateChallengeAndInvalidateHash(colonyNetwork, this, goodClient, badClient2, {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(2);
+      await repCycle.confirmNewHash(2, { from: MINER1 });
     });
   });
 });

--- a/test/reputation-system/happy-paths.js
+++ b/test/reputation-system/happy-paths.js
@@ -965,7 +965,6 @@ contract("Reputation Mining - happy paths", (accounts) => {
       const delegatedClient = new ReputationMinerTestWrapper({ loader, realProviderPort, useJsTree, minerAddress: WORKER });
       await colonyNetwork.setMiningDelegate(WORKER, true, { from: MINER1 });
       await delegatedClient.initialise(colonyNetwork.address);
-
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       const addr = await colonyNetwork.getReputationMiningCycle(true);
@@ -986,6 +985,8 @@ contract("Reputation Mining - happy paths", (accounts) => {
 
       await delegatedClient.confirmJustificationRootHash();
       await badClient.confirmJustificationRootHash();
+
+      await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
 
       await delegatedClient.respondToBinarySearchForChallenge();
       await badClient.respondToBinarySearchForChallenge();

--- a/test/reputation-system/happy-paths.js
+++ b/test/reputation-system/happy-paths.js
@@ -199,7 +199,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
 
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(3);
+      await repCycle.confirmNewHash(3, { from: MINER1 });
     });
 
     it("should be able to process a large reputation update log", async function largeReputationLogTest() {
@@ -280,9 +280,9 @@ contract("Reputation Mining - happy paths", (accounts) => {
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
       await goodClient.respondToChallenge();
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.invalidateHash(0, 1);
+      await repCycle.invalidateHash(0, 1, { from: MINER1 });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("should cope if someone's existing reputation would go negative, setting it to zero instead", async function noNegativeRep() {
@@ -317,7 +317,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("should cope if someone's new reputation would be negative, setting it to zero instead", async function newRepToZeroTest() {
@@ -351,7 +351,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-decreased-reputation-value-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("should cope if someone's reputation would overflow, setting it to the maximum value instead", async () => {
@@ -397,7 +397,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
       await forwardTime(MINING_CYCLE_DURATION + SUBMITTER_ONLY_WINDOW + 1, this);
       await repCycle.submitRootHash(rootHash, 2, "0x00", 10, { from: MINER1 });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(0);
+      await repCycle.confirmNewHash(0, { from: MINER1 });
 
       repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -405,7 +405,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-reputation-not-max-int128" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("should calculate reputation decays correctly if they are large", async () => {
@@ -428,7 +428,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
       let repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION + SUBMITTER_ONLY_WINDOW + 1, this);
       await repCycle.submitRootHash(rootHash, 2, "0x00", 10, { from: MINER1 });
-      await repCycle.confirmNewHash(0);
+      await repCycle.confirmNewHash(0, { from: MINER1 });
 
       repCycle = await getActiveRepCycle(colonyNetwork);
       await submitAndForwardTimeToDispute([goodClient, badClient], this);
@@ -436,7 +436,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-decay-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
 
       const largeCalculationResult = INT128_MAX.subn(1).mul(DECAY_RATE.NUMERATOR).div(DECAY_RATE.DENOMINATOR);
       const decayKey = ReputationMinerTestWrapper.getKey(metaColony.address, skillId, MINER1);
@@ -831,7 +831,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-increased-reputation-value-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("should allow a user to prove their reputation", async () => {
@@ -844,7 +844,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
       const repCycle = await getActiveRepCycle(colonyNetwork);
 
       await repCycle.submitRootHash(newRootHash, 10, "0x00", 10, { from: MINER1 });
-      await repCycle.confirmNewHash(0);
+      await repCycle.confirmNewHash(0, { from: MINER1 });
 
       const key = makeReputationKey(metaColony.address, new BN("2"), MINER1);
       const value = goodClient.reputations[key];
@@ -904,7 +904,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
       let repCycle = await getActiveRepCycle(colonyNetwork);
       await repCycle.submitRootHash(rootHash, 2, "0x00", 10, { from: MINER1 });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(0);
+      await repCycle.confirmNewHash(0, { from: MINER1 });
 
       // Check we have exactly one reputation.
       expect(
@@ -923,7 +923,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-decay-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
 
       await giveUserCLNYTokensAndStake(colonyNetwork, MINER2, DEFAULT_STAKE);
 
@@ -951,7 +951,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
 
       repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
 
       // Check it 'decayed' from 0 to 0
       expect(
@@ -971,7 +971,7 @@ contract("Reputation Mining - happy paths", (accounts) => {
       let repCycle = await IReputationMiningCycle.at(addr);
       await forwardTime(MINING_CYCLE_DURATION + SUBMITTER_ONLY_WINDOW + 1, this);
       await repCycle.submitRootHash("0x00", 0, "0x00", 10, { from: WORKER });
-      await repCycle.confirmNewHash(0);
+      await repCycle.confirmNewHash(0, { from: MINER1 });
 
       repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(MINING_CYCLE_DURATION / 2, this);
@@ -1001,9 +1001,9 @@ contract("Reputation Mining - happy paths", (accounts) => {
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
       await delegatedClient.respondToChallenge();
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.invalidateHash(0, 1);
+      await repCycle.invalidateHash(0, 1, { from: MINER1 });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
   });
 });

--- a/test/reputation-system/types-of-disagreement.js
+++ b/test/reputation-system/types-of-disagreement.js
@@ -109,7 +109,7 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-adjacent-disagree-state-disagreement" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("should allow a user to confirm a submitted JRH with proofs for a submission", async () => {
@@ -160,7 +160,7 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-increased-reputation-value-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("should cope if the wrong reputation transition is the first transition", async () => {
@@ -182,7 +182,7 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-decay-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("should allow a binary search between opponents to take place to find their first disagreement", async () => {
@@ -311,7 +311,7 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
       // checks that challengeStepCompleted is one more for the good submission than the bad one.
 
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.invalidateHash(0, 1);
+      await repCycle.invalidateHash(0, 1, { from: MINER1 });
     });
 
     it("if respondToChallenge is attempted to be called multiple times, it should fail", async () => {
@@ -348,13 +348,13 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
       await checkErrorRevertEthers(goodClient.respondToChallenge(), "colony-reputation-mining-challenge-already-responded");
       await checkErrorRevertEthers(badClient.respondToChallenge(), "colony-reputation-mining-increased-reputation-value-incorrect");
 
-      await checkErrorRevert(repCycle.invalidateHash(0, 0), "colony-reputation-mining-less-challenge-rounds-completed", { from: MINER1 });
+      await checkErrorRevert(repCycle.invalidateHash(0, 0, { from: MINER1 }), "colony-reputation-mining-less-challenge-rounds-completed");
 
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
-      await repCycle.invalidateHash(0, 1);
+      await repCycle.invalidateHash(0, 1, { from: MINER1 });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
 
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
 
       const rightHash = await goodClient.getRootHash();
       const confirmedHash = await colonyNetwork.getReputationRootHash();
@@ -384,7 +384,7 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
 
       // Cleanup
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
   });
 
@@ -410,7 +410,7 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
 
       // Cleanup
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("where the number of leaves has been incremented incorrectly when adding a new reputation", async () => {
@@ -427,7 +427,7 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
       });
       const repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("where the number of leaves has been incremented during an update of an existing reputation", async () => {
@@ -450,7 +450,7 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
       });
 
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
   });
 
@@ -476,7 +476,7 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
 
       // Cleanup
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("with an extra leaf causing proof 1 to be too long", async () => {
@@ -501,9 +501,9 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
 
       // Cleanup
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
-      await repCycle.invalidateHash(0, 1);
+      await repCycle.invalidateHash(0, 1, { from: MINER1 });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("with an extra leaf inserted and a leaf removed causing proof lengths to be right, but JT wrong", async () => {
@@ -532,9 +532,9 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
 
       // Cleanup
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
-      await repCycle.invalidateHash(0, 1);
+      await repCycle.invalidateHash(0, 1, { from: MINER1 });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("with an extra leaf causing proof 2 to be too long", async () => {
@@ -603,9 +603,9 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
       expect(delta).to.eq.BN(1);
 
       await forwardTime(MINING_CYCLE_DURATION / 6, this);
-      await repCycle.invalidateHash(0, 1);
+      await repCycle.invalidateHash(0, 1, { from: MINER1 });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("if a new reputation's uniqueID is wrong", async () => {
@@ -648,7 +648,7 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-increased-reputation-value-incorrect" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
 
       await badClient.resetDB();
       await badClient.initialise(colonyNetwork.address);
@@ -668,7 +668,7 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
       });
       repCycle = await getActiveRepCycle(colonyNetwork);
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
 
     it("if an update makes reputation amount go over the max, in a dispute, it should be limited to the max value", async () => {
@@ -731,7 +731,7 @@ contract("Reputation Mining - types of disagreement", (accounts) => {
         client2: { respondToChallenge: "colony-reputation-mining-reputation-not-max-int128" },
       });
       await forwardTime(SUBMITTER_ONLY_WINDOW + 1, this);
-      await repCycle.confirmNewHash(1);
+      await repCycle.confirmNewHash(1, { from: MINER1 });
     });
   });
 });


### PR DESCRIPTION
Closes #1002 

Draft status, as not ready to merge, but after feedback.

Implements what Daniel and I vaguely talked about a while ago. Basically, everything stays the same, but instead of using `msg.sender` during mining, we instead call a function that either returns `msg.sender` (i.e. the fallback case should be the existing functionality) or, if a delegation has been awarded to `msg.sender`, returns the address they are allowed to mine on behalf of.