### PR TITLE
Miner (hopefully) faster sync, faster startup if submission made

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ reputations.json
 reputationStates.sqlite
 reputationStates.sqlite-shm
 reputationStates.sqlite-wal
+justificationTreeCache.json
 truffle-security-output.json
 .coverage_contracts
 etherrouter-address.json

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -1442,7 +1442,7 @@ class ReputationMiner {
     }
 
     const currentJRH = await this.justificationTree.getRootHash();
-    if (currentJRH !== justificationRootHash) {
+    if (justificationRootHash && currentJRH !== justificationRootHash) {
       console.log("WARNING: The supplied JRH failed to be recreated successfully. Are you sure it was saved?");
     }
   }

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -7,6 +7,9 @@ import Database from "better-sqlite3";
 import PatriciaTreeNoHash from "./patriciaNoHashKey";
 import PatriciaTree from "./patricia";
 
+const fs = require('fs').promises;
+const path = require('path');
+
 // We don't need the account address right now for this secret key, but I'm leaving it in in case we
 // do in the future.
 // const accountAddress = "0xbb46703786c2049d4d6dd43f5b4edf52a20fefe4";
@@ -24,6 +27,8 @@ class ReputationMiner {
   constructor({ loader, minerAddress, privateKey, provider, realProviderPort = 8545, useJsTree = false, dbPath = "./reputationStates.sqlite" }) {
     this.loader = loader;
     this.dbPath = dbPath;
+    this.justificationCachePath = `${path.dirname(dbPath)}/justificationTreeCache.json`
+    this.justificationHashes = {}
 
     this.useJsTree = useJsTree;
     if (!this.useJsTree) {
@@ -192,25 +197,35 @@ class ReputationMiner {
   }
 
   /**
-   * When called, adds the entire contents of the current (active) log to its reputation tree. It also builds a Justification Tree as it does so
-   * in case a dispute is called which would require it.
+   * When called, adds the entire contents of the current (active) log to its reputation tree. It also optionally
+   * builds a Justification Tree as it does so in case a dispute is called which would require it.
    * @return {Promise}
    */
-  async addLogContentsToReputationTree(blockNumber = "latest") {
-    if (this.useJsTree) {
-      this.justificationTree = new PatriciaTreeNoHash();
+  async addLogContentsToReputationTree(blockNumber = "latest", buildJustificationTree = true) {
+    if (buildJustificationTree){
+      if (this.useJsTree) {
+        this.justificationTree = new PatriciaTreeNoHash();
+      } else {
+        const contractFactory = new ethers.ContractFactory(
+          this.patriciaTreeNoHashContractDef.abi,
+          this.patriciaTreeNoHashContractDef.bytecode,
+          this.ganacheWallet
+        );
+
+        const contract = await contractFactory.deploy();
+        await contract.deployed();
+
+        this.justificationTree = new ethers.Contract(contract.address, this.patriciaTreeNoHashContractDef.abi, this.ganacheWallet);
+      }
     } else {
-      const contractFactory = new ethers.ContractFactory(
-        this.patriciaTreeNoHashContractDef.abi,
-        this.patriciaTreeNoHashContractDef.bytecode,
-        this.ganacheWallet
-      );
-
-      const contract = await contractFactory.deploy();
-      await contract.deployed();
-
-      this.justificationTree = new ethers.Contract(contract.address, this.patriciaTreeNoHashContractDef.abi, this.ganacheWallet);
+      this.justificationTree = {
+        insert: () => {return { wait: () => {}}},
+        getRootHash: () => {},
+        getImpliedRoot: () => {},
+        getProof: () => {},
+      }
     }
+
     this.justificationHashes = {};
     this.reverseReputationHashLookup = {};
     const repCycle = await this.getActiveRepCycle(blockNumber);
@@ -1289,7 +1304,7 @@ class ReputationMiner {
       if (applyLogs) {
         const nLeaves = ethers.BigNumber.from(`0x${event.data.slice(66, 130)}`);
         const previousBlock = event.blockNumber - 1;
-        await this.addLogContentsToReputationTree(previousBlock);
+        await this.addLogContentsToReputationTree(previousBlock, false);
         localHash = await this.reputationTree.getRootHash();
         const localNLeaves = this.nReputations;
         if (localHash !== hash || !localNLeaves.eq(nLeaves)) {
@@ -1386,6 +1401,54 @@ class ReputationMiner {
     if (currentStateHash !== reputationRootHash) {
       console.log("WARNING: The supplied state failed to be recreated successfully. Are you sure it was saved?");
     }
+  }
+
+  async loadJustificationTree(justificationRootHash) {
+    this.justificationHashes = {};
+
+    if (this.useJsTree) {
+      this.justificationTree = new PatriciaTreeNoHash();
+    } else {
+      const contractFactory = new ethers.ContractFactory(
+        this.patriciaTreeNoHashContractDef.abi,
+        this.patriciaTreeNoHashContractDef.bytecode,
+        this.ganacheWallet
+      );
+
+      const contract = await contractFactory.deploy();
+      await contract.deployed();
+
+      this.justificationTree = new ethers.Contract(contract.address, this.patriciaTreeNoHashContractDef.abi, this.ganacheWallet);
+    }
+
+    try {
+
+      const justificationHashFile = await fs.readFile(this.justificationCachePath, 'utf8')
+      this.justificationHashes = JSON.parse(justificationHashFile);
+
+      for (let i = 0; i < Object.keys(this.justificationHashes).length; i += 1) {
+        const hash = Object.keys(this.justificationHashes)[i];
+        const tx = await this.justificationTree.insert(
+          hash,
+          this.justificationHashes[hash].jhLeafValue,
+          { gasLimit: 4000000 }
+        );
+        if (!this.useJsTree) {
+          await tx.wait();
+        }
+      }
+    } catch (err) {
+      console.log(err);
+    }
+
+    const currentJRH = await this.justificationTree.getRootHash();
+    if (currentJRH !== justificationRootHash) {
+      console.log("WARNING: The supplied JRH failed to be recreated successfully. Are you sure it was saved?");
+    }
+  }
+
+  async saveJustificationTree(){
+    await fs.writeFile(this.justificationCachePath, JSON.stringify(this.justificationHashes));
   }
 
   async getAddressesWithReputation(reputationRootHash, colonyAddress, skillId) {

--- a/test/reputation-system/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-system/reputation-mining-client/client-auto-functionality.js
@@ -511,6 +511,45 @@ process.env.SOLIDITY_COVERAGE
           assert.equal(acceptedRootHash, rootHash);
         });
 
+        it("should load the reputation state and JRH from disk if available", async function () {
+          const rootHash = await reputationMinerClient._miner.getRootHash();
+          const nLeaves = await reputationMinerClient._miner.getRootHashNLeaves();
+          const jrh = await reputationMinerClient._miner.justificationTree.getRootHash();
+
+          const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
+          const receive2Submissions = getWaitForNSubmissionsPromise(repCycleEthers, rootHash, nLeaves, jrh, 2);
+
+          // Forward through half of the cycle duration and wait for the client to submit some entries
+          await forwardTime(MINING_CYCLE_DURATION / 2, this);
+          await receive2Submissions; // It might submit a couple more, but that's fine for the purposes of this test.
+          await reputationMinerClient.close();
+
+          class TestAdapter {
+            constructor() {
+              this.outputs = [];
+            }
+
+            log(line) {
+              this.outputs.push(line);
+            }
+          }
+
+          const adapter = new TestAdapter();
+
+          // start up another one.
+          const reputationMinerClient2 = new ReputationMinerClient({
+            loader,
+            realProviderPort,
+            minerAddress: MINER1,
+            useJsTree: true,
+            auto: true,
+            adapter,
+          });
+          await reputationMinerClient2.initialise(colonyNetwork.address, startingBlockNumber);
+          expect(adapter.outputs[0]).to.equal("Successfully resumed mid-submission", "The client didn't resume mid-submission");
+          await reputationMinerClient2.close();
+        });
+
         function noEventSeen(contract, event) {
           return new Promise(function (resolve, reject) {
             contract.on(event, async () => {


### PR DESCRIPTION
Two (mostly) unrelated improvements:

* When syncing past cycles, no need to make the justification tree - they're historical, the time for disputes has passed, so no need to prepare for how we might respond to a dispute. This could be better; some of the lifting to work out keys/values is still done, it's just that the tree that the values are added to performs no-ops and returns nothing, rather than actually building the tree, and so will return quicker than generating the tree and associated proofs. I did is this way because it was easier than picking apart all the bits that generate the justification tree, which are a bit scattered.

* Fast-resume if we've made a submission to the cycle. When we generate the next reputation state and save it to the DB, I also save the data required to recreate the justification tree to a json file (not the database, as this is only needed temporarily and does not need to be queried by the oracle). If we've submitted and the miner restarts, it can see that it submitted, and load that state out of the DB and the Justification Tree out of the temporary file, rather than loading the previous state and (re-)applying the reputation update log. This should be a lot quicker, which is good if a restart happens during a dispute, for example.