### PR TITLE
Fix further wrinkles in the mining client

### DIFF
--- a/contracts/extensions/CoinMachine.sol
+++ b/contracts/extensions/CoinMachine.sol
@@ -91,7 +91,7 @@ contract CoinMachine is ColonyExtension, BasicMetaTransaction {
 
   /// @notice Returns the version of the extension
   function version() public override pure returns (uint256) {
-    return 4;
+    return 5;
   }
 
   /// @notice Configures the extension

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -271,7 +271,7 @@ export async function currentBlock() {
   return p;
 }
 
-export async function getBlockTime(blockNumber) {
+export async function getBlockTime(blockNumber = "latest") {
   const p = new Promise((resolve, reject) => {
     web3.eth.getBlock(blockNumber, (err, res) => {
       if (err) {

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -1364,6 +1364,19 @@ class ReputationMiner {
     }
   }
 
+  // Gas price should be a hex string
+  async setGasPrice(_gasPrice){
+    if (!ethers.utils.isHexString(_gasPrice)){
+      throw new Error("Passed gas price was not a hex string")
+    }
+    const passedPrice = ethers.BigNumber.from(_gasPrice);
+    const minimumPrice = ethers.BigNumber.from("1100000000");
+    if (passedPrice.lt(minimumPrice)){
+      this.gasPrice = minimumPrice.toHexString();
+    } else {
+      this.gasPrice = _gasPrice;
+    }
+  }
 
   async saveCurrentState() {
 

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -1445,6 +1445,9 @@ class ReputationMiner {
         if (!this.useJsTree) {
           await tx.wait();
         }
+        if (i === 0){
+          this.nReputationsBeforeLatestLog = this.justificationHashes[hash].nLeaves
+        }
       }
     } catch (err) {
       console.log(err);
@@ -1453,6 +1456,7 @@ class ReputationMiner {
     const currentJRH = await this.justificationTree.getRootHash();
     if (justificationRootHash && currentJRH !== justificationRootHash) {
       console.log("WARNING: The supplied JRH failed to be recreated successfully. Are you sure it was saved?");
+      this.nReputationsBeforeLatestLog = undefined;
     }
   }
 

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -347,7 +347,7 @@ class ReputationMinerClient {
       factor = 10;
     } else {
       this._adapter.error(`Error during gas estimation: unknown chainid ${this.chainId}`);
-      this._miner.gasPrice = ethers.utils.hexlify(20000000000);
+      this._miner.setGasPrice(ethers.utils.hexlify(20000000000));
       return;
     }
 
@@ -356,13 +356,13 @@ class ReputationMinerClient {
       const gasEstimates = await request(options);
 
       if (gasEstimates[type]){
-        this._miner.gasPrice = ethers.utils.hexlify(gasEstimates[type] / factor * 1e9);
+        this._miner.setGasPrice(ethers.utils.hexlify(gasEstimates[type] / factor * 1e9));
       } else {
-        this._miner.gasPrice = defaultGasPrice;
+        this._miner.setGasPrice(defaultGasPrice);
       }
     } catch (err) {
       this._adapter.error(`Error during gas estimation: ${err}`);
-      this._miner.gasPrice = defaultGasPrice;
+      this._miner.setGasPrice(defaultGasPrice);
     }
   }
 

--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -610,7 +610,8 @@ class ReputationMinerClient {
       // If it's out-of-ether...
       if (err.toString().indexOf('does not have enough funds') >= 0 ) {
         // This could obviously be much better in the future, but for now, we'll settle for this not triggering a restart loop.
-        this._adapter.error(`Block checks suspended due to not enough Ether. Send ether to \`${this._miner.minerAddress}\`, then restart the miner`);
+        const signingAddress = await this._miner.realWallet.getAddress()
+        this._adapter.error(`Block checks suspended due to not enough Ether. Send ether to \`${signingAddress}\`, then restart the miner`);
         return;
       }
       if (repCycleCode === "0x") {

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,7 +154,7 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("2fc4ca2bc026596911efe7d856f35872f404991cc0a431062583bee2412fea26");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("4b33c6ecc4cdb85217bb207c5fe83f315947716edc9e69ca4f825b271a73fa66");
       expect(colonyAccount.stateRoot.toString("hex")).to.equal("f76b564446d2c023cf887feb6bf0d3a09e6659f12f7f86a896affac7fc03fcfd");
       expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("114b65e001ab37d07caf85521f32707401b67ca490333207b31e313567333176");
       expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("8882b29a20fbfc26fc4840ddb02d6e996d7feeb96331179bd6c828f93ce9bcf4");


### PR DESCRIPTION
~_NB based on #1020 so cannot be merged until that is. Can be reviewed, however_~

A variety of fixes here:

* The message to refill an address with Ether was not taking in to account delegated mining.
* The mysterious-errors-overnight error, I think, is because by default Nethermind refuses transactions with a gas price lower than 1.1Gwei; I think this is a consequence of EIP1559, but not 100% sure. When gas is higher, it's not seen, but I _think_ that overnight, gas drops below 1.1Gwei according to the Blockscout oracle, which we then use and our node rejects. Didn't want to overly tinker with the node to change it, given it's in production, and accommodating the defaults seems reasonable, anyway.
* If we had been delayed replying to a challenge, we'd invalidate our opponent before confirming our JRH, which could result in us both getting invalidated. We now always respond to a challenge if it's appropriate to do so, and only once it's not possible is invalidating our opponents considered.
* If a challenge needed to be navigated, and we'd loaded the state from disk, `this.nReputationsBeforeLatestLog` was left uninitialized which causes the challenge navigation process to fail.