### PR TITLE
Two new events to support frontend

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -384,7 +384,7 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
   function unlockToken() public stoppable auth {
     ERC20Extended(token).unlock();
 
-    emit TokenUnlocked();
+    emit TokenUnlocked(msgSender());
   }
 
   function getTokenApproval(address _token, address _spender) public view returns (uint256) {

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -316,7 +316,8 @@ interface ColonyDataTypes {
 
   /// @notice Event emitted when the colony unlocks its native token through the
   /// provided function
-  event TokenUnlocked();
+  /// @param agent The address that is responsible for triggering this event
+  event TokenUnlocked(address agent);
 
   /// @notice Event logged when a manual reputation reward/penalty is made
   /// @param agent The address that is responsible for triggering this event

--- a/contracts/extensions/CoinMachine.sol
+++ b/contracts/extensions/CoinMachine.sol
@@ -30,7 +30,7 @@ contract CoinMachine is ColonyExtension, BasicMetaTransaction {
 
   // Events
 
-  event TokensBought(address indexed buyer, address indexed token, uint256 numTokens, uint256 totalCost);
+  event TokensBought(address indexed buyer, address token, uint256 numTokens, uint256 totalCost);
   event PeriodUpdated(uint256 activePeriod, uint256 currentPeriod);
   event PriceEvolutionSet(bool evolvePrice);
   event WhitelistSet(address whitelist);

--- a/contracts/extensions/CoinMachine.sol
+++ b/contracts/extensions/CoinMachine.sol
@@ -30,7 +30,7 @@ contract CoinMachine is ColonyExtension, BasicMetaTransaction {
 
   // Events
 
-  event TokensBought(address buyer, uint256 numTokens, uint256 totalCost);
+  event TokensBought(address indexed buyer, address indexed token, uint256 numTokens, uint256 totalCost);
   event PeriodUpdated(uint256 activePeriod, uint256 currentPeriod);
   event PriceEvolutionSet(bool evolvePrice);
   event WhitelistSet(address whitelist);
@@ -243,7 +243,7 @@ contract CoinMachine is ColonyExtension, BasicMetaTransaction {
 
     require(ERC20(token).transfer(msgSender(), numTokens), "coin-machine-transfer-failed");
 
-    emit TokensBought(msgSender(), numTokens, totalCost);
+    emit TokensBought(msgSender(), token, numTokens, totalCost);
   }
 
   /// @notice Bring the token accounting current


### PR DESCRIPTION
Updating CoinMachine's `TokensBought` event to emit the token address, and the `TokenUnlocked` event to include the agent. Also bumping CoinMachine's version to 5.