### PR TITLE
Fix miner sync and improve oracle performance

### DIFF
--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -1028,3 +1028,18 @@ export function bn2bytes32(x, size = 64) {
 export function rolesToBytes32(roles) {
   return `0x${new BN(roles.map((role) => new BN(1).shln(role)).reduce((a, b) => a.or(b), new BN(0))).toString(16, 64)}`;
 }
+
+export class TestAdapter {
+  constructor() {
+    this.outputs = [];
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  error(line) {
+    console.log(line);
+  }
+
+  log(line) {
+    this.outputs.push(line);
+  }
+}

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -1335,6 +1335,15 @@ class ReputationMiner {
       }
     }
 
+    // Some more cycles might have completed since we started syncing
+    const lastEventBlock = events[events.length - 1].blockNumber
+    filter.fromBlock = lastEventBlock;
+    const sinceEvents = await this.realProvider.getLogs(filter);
+    if (sinceEvents.length > 1){
+      console.log("Some more cycles have completed during the sync process. Continuing to sync...")
+      await this.sync(lastEventBlock, saveHistoricalStates);
+    }
+
     // Check final state
     const currentHash = await this.colonyNetwork.getReputationRootHash();
     // TODO: Once getReputationRootHashNLeaves exists, use it

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -367,7 +367,7 @@ class ReputationMiner {
       // Then the user-specifc sums in the order children, parents, skill.
       if (amount.lt(0)) {
         const nUpdates = ethers.BigNumber.from(logEntry.nUpdates);
-        const [nParents] = await this.colonyNetwork.getSkill(logEntry.skillId);
+        const [nParents] = await this.colonyNetwork.getSkill(logEntry.skillId, {blockTag: blockNumber});
         const nChildUpdates = nUpdates.div(2).sub(1).sub(nParents);
         const relativeUpdateNumber = updateNumber.sub(logEntry.nPreviousUpdates).sub(this.nReputationsBeforeLatestLog);
         // Child updates are two sets: colonywide sums for children - located in the first nChildUpdates,
@@ -375,7 +375,7 @@ class ReputationMiner {
 
         // Get current reputation amount of the origin skill, which is positioned at the end of the current logEntry nUpdates.
         const originSkillUpdateNumber = updateNumber.sub(relativeUpdateNumber).add(nUpdates).sub(1);
-        const originSkillKey = await this.getKeyForUpdateNumber(originSkillUpdateNumber);
+        const originSkillKey = await this.getKeyForUpdateNumber(originSkillUpdateNumber, blockNumber);
         originReputationProof = await this.getReputationProofObject(originSkillKey);
         const originSkillKeyExists = this.reputations[originSkillKey] !== undefined;
 
@@ -400,9 +400,9 @@ class ReputationMiner {
           let keyUsedInCalculations;
           if (relativeUpdateNumber.lt(nChildUpdates)) {
             const childSkillUpdateNumber = updateNumber.add(nUpdates.div(2));
-            keyUsedInCalculations = await this.getKeyForUpdateNumber(childSkillUpdateNumber);
+            keyUsedInCalculations = await this.getKeyForUpdateNumber(childSkillUpdateNumber, blockNumber);
           } else {
-            keyUsedInCalculations = await this.getKeyForUpdateNumber(updateNumber);
+            keyUsedInCalculations = await this.getKeyForUpdateNumber(updateNumber, blockNumber);
           }
           childReputationProof = await this.getReputationProofObject(keyUsedInCalculations);
 

--- a/test/reputation-system/client-sync-functionality.js
+++ b/test/reputation-system/client-sync-functionality.js
@@ -5,7 +5,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 
 import TruffleLoader from "../../packages/reputation-miner/TruffleLoader";
-import { DEFAULT_STAKE, INITIAL_FUNDING } from "../../helpers/constants";
+import { DEFAULT_STAKE, INITIAL_FUNDING, UINT256_MAX } from "../../helpers/constants";
 import { forwardTime, currentBlock, advanceMiningCycleNoContest, getActiveRepCycle } from "../../helpers/test-helper";
 import { giveUserCLNYTokensAndStake, setupFinalizedTask, fundColonyWithTokens } from "../../helpers/test-data-generator";
 import ReputationMinerTestWrapper from "../../packages/reputation-miner/test/ReputationMinerTestWrapper";
@@ -133,6 +133,7 @@ process.env.SOLIDITY_COVERAGE
           for (let i = 0; i < 5; i += 1) {
             await setupFinalizedTask({ colonyNetwork, colony: metaColony });
           }
+          await metaColony.emitDomainReputationPenalty(1, UINT256_MAX, 1, accounts[2], -100, { from: accounts[0] });
 
           await advanceMiningCycleNoContest({ colonyNetwork, client: reputationMiner1, test: this });
 

--- a/test/reputation-system/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-system/reputation-mining-client/client-auto-functionality.js
@@ -18,6 +18,7 @@ import {
   finishReputationMiningCycle,
   currentBlock,
   getWaitForNSubmissionsPromise,
+  TestAdapter,
 } from "../../../helpers/test-helper";
 import {
   setupColonyNetwork,
@@ -517,21 +518,6 @@ process.env.SOLIDITY_COVERAGE
           const jrh = await reputationMinerClient._miner.justificationTree.getRootHash();
 
           const repCycleEthers = await reputationMinerClient._miner.getActiveRepCycle();
-
-          class TestAdapter {
-            constructor() {
-              this.outputs = [];
-            }
-
-            // eslint-disable-next-line class-methods-use-this
-            error(line) {
-              console.log(line);
-            }
-
-            log(line) {
-              this.outputs.push(line);
-            }
-          }
 
           // start up another one - does it quick-load pre submission?
           let adapter = new TestAdapter();


### PR DESCRIPTION
Several improvements here:

###  Sync issues

We tried syncing from scratch on QA and ran in to difficulty; I wasn't confident I hadn't just done a load of messing around on QA at some point, so assumed that the sync was good.

When trying to sync up production from scratch, where I was confident that we didn't have such issues, we ran in to problems again. I've tracked them down to a negative reputation update, and the origin skill key being incorrectly worked out against the _latest_ reputation update log, rather than the _historical_ reputation update log that we're trying to sync against.

~~Leaving this as a draft for now, as I've not successfully sync'd production yet, so we might need further changes, but it's looking promising:~~
![screenshot-2022-02-18_14-47-39](https://user-images.githubusercontent.com/311812/154705091-9f982b49-168d-48a5-9c62-34a116febc9b.png)

Production sync'd from scratch successfully, so will be taking this out of draft

Strictly, the call the `getSkill` to work out nParents doesn't need a blockTag, as `nParents` can never change, but just in case we do something that renders that not true in the future, I decided to add the blockNumber tag there.

This PR also incorporates improvements made to the reputation oracle so that it's more performant. 


### Improve sync experience

By recursively calling `sync` if necessary, we allow sync to complete successfully even if more cycles complete during the syncing process (which will certainly be the case while syncing from scratch).

### Improve queries for last confirmed state
Keep most recently confirmed state in memory for oracle. Previously, only the _next_ state was kept in memory, and any other reputation queries (i.e. all of them) had to hit the DB. By keeping the most recently confirmed state in memory, the majority of queries are easier to serve (as the majority of reputation queries are for reputation in the most recently confirmed state) and we hit the database much, much less.

### Improve saving the current state to DB
I also changed the schema of the `reputations` table, adding a composite primary key across roothash/colony/skillid/user. This combination was already unique (as the schema upgrade on the existing table proved), and so arguably should have been a key already (though is not free, it comes with a significant storage overhead). By making this composite primary key, the 'insert reputation' query can now be an 'INSERT OR IGNORE' - this should be fine, as such a value should never need to be updated (even if a sync goes wrong, which will result in wrong root hashes). This means we don't have to read the database to see if we need to add the reputation or not, and can simply fire off all of the write requests and let the database deal with any unexpected duplicates. This resulted in the time for `saveCurrentState` on production dropping from 15 minutes to a few seconds.

### Improve test coverage for client
With changes to the client and more branches, our coverage dropped below our (very arbitrary) mark, so had to bulk out the tests to compensate (without feeling bad about lowering the mark!)