### PR TITLE
Update expenditure functionality

### DIFF
--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -1015,7 +1015,7 @@ contract("Colony Expenditure", (accounts) => {
       expect(expenditureSlot.skills[0]).to.eq.BN(GLOBAL_SKILL_ID);
     });
 
-    it("should allow arbitration users to update expenditure slot payouts", async () => {
+    it.only("should allow arbitration users to update expenditure slot payouts", async () => {
       const mask = [MAPPING, MAPPING];
       const keys = ["0x0", bn2bytes32(new BN(token.address.slice(2), 16))];
       const value = bn2bytes32(new BN(100));
@@ -1024,6 +1024,13 @@ contract("Colony Expenditure", (accounts) => {
 
       const expenditureSlotPayout = await colony.getExpenditureSlotPayout(expenditureId, 0, token.address);
       expect(expenditureSlotPayout).to.eq.BN(100);
+
+      // Should have also updated the funding pot's payoutsWeCannotMake
+      const expenditure = await colony.getExpenditure(expenditureId);
+      const fundingPotId = await expenditure.fundingPotId;
+      const fundingPot = await colony.getFundingPot(fundingPotId);
+
+      expect(fundingPot.payoutsWeCannotMake).to.eq.BN(1);
     });
 
     it("should not allow arbitration users to pass invalid slots", async () => {

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -869,6 +869,77 @@ contract("Voting Reputation", (accounts) => {
       expect(expenditureSlot.claimDelay).to.be.zero;
     });
 
+    it.only("globalClaimDelay on an expenditure is accurately reset after motions have completed", async () => {
+      await colony.setDefaultGlobalClaimDelay(SECONDS_PER_DAY, { from: USER0 });
+      await colony.makeExpenditure(1, UINT256_MAX, 1);
+      const expenditureId = await colony.getExpenditureCount();
+
+      // Set finalizedTimestamp to WAD
+      const action = await encodeTxData(colony, "setExpenditureState", [1, UINT256_MAX, expenditureId, 25, [true], [bn2bytes32(new BN(3))], WAD32]);
+
+      await voting.createMotion(1, UINT256_MAX, ADDRESS_ZERO, action, domain1Key, domain1Value, domain1Mask, domain1Siblings);
+      motionId = await voting.getMotionCount();
+
+      let expenditureMotionCount;
+      expenditureMotionCount = await voting.getExpenditureMotionCount(soliditySha3(expenditureId));
+      expect(expenditureMotionCount).to.be.zero;
+
+      let expenditure;
+      expenditure = await colony.getExpenditure(expenditureId);
+      expect(expenditure.globalClaimDelay).to.eq.BN(SECONDS_PER_DAY);
+
+      await voting.stakeMotion(motionId, 1, UINT256_MAX, YAY, REQUIRED_STAKE, user0Key, user0Value, user0Mask, user0Siblings, { from: USER0 });
+
+      expenditureMotionCount = await voting.getExpenditureMotionCount(soliditySha3(expenditureId));
+      expect(expenditureMotionCount).to.eq.BN(1);
+
+      // expenditure = await colony.getExpenditure(expenditureId);
+      // expect(expenditure.globalClaimDelay).to.eq.BN(UINT256_MAX.divn(3));
+
+      await forwardTime(STAKE_PERIOD, this);
+      await voting.finalizeMotion(motionId);
+
+      expenditure = await colony.getExpenditure(expenditureId);
+      expect(expenditure.globalClaimDelay).to.eq.BN(SECONDS_PER_DAY);
+    });
+
+    it.only("claimdelay on an expenditure slot accurately reset after motions have completed", async () => {
+      await colony.makeExpenditure(1, UINT256_MAX, 1);
+      const expenditureId = await colony.getExpenditureCount();
+      await colony.setExpenditureClaimDelay(expenditureId, 0, SECONDS_PER_DAY, { from: USER0 });
+      await colony.finalizeExpenditure(expenditureId);
+
+      // Set payoutModifier to 1 for expenditure slot 0
+      const action = await encodeTxData(colony, "setExpenditureState", [
+        1,
+        UINT256_MAX,
+        expenditureId,
+        26,
+        [false, true],
+        ["0x0", bn2bytes32(new BN(2))],
+        WAD32,
+      ]);
+
+      await voting.createMotion(1, UINT256_MAX, ADDRESS_ZERO, action, domain1Key, domain1Value, domain1Mask, domain1Siblings);
+      motionId = await voting.getMotionCount();
+
+      let expenditureSlot;
+      expenditureSlot = await colony.getExpenditureSlot(expenditureId, 0);
+      expect(expenditureSlot.claimDelay).to.be.eq.BN(SECONDS_PER_DAY);
+
+      await voting.stakeMotion(motionId, 1, UINT256_MAX, YAY, REQUIRED_STAKE, user0Key, user0Value, user0Mask, user0Siblings, { from: USER0 });
+
+      const expenditureMotionCount = await voting.getExpenditureMotionCount(soliditySha3(expenditureId, 0));
+      expect(expenditureMotionCount).to.eq.BN(1);
+
+      // expenditureSlot = await colony.getExpenditureSlot(expenditureId, 0);
+      // expect(expenditureSlot.claimDelay).to.eq.BN(UINT256_MAX.divn(3));
+      await forwardTime(STAKE_PERIOD, this);
+      await voting.finalizeMotion(motionId);
+      expenditureSlot = await colony.getExpenditureSlot(expenditureId, 0);
+      expect(expenditureSlot.claimDelay).to.be.eq.BN(SECONDS_PER_DAY);
+    });
+
     it("cannot stake with someone else's reputation", async () => {
       await checkErrorRevert(
         voting.stakeMotion(motionId, 1, UINT256_MAX, YAY, REQUIRED_STAKE, user0Key, user0Value, user0Mask, user0Siblings, { from: USER1 }),


### PR DESCRIPTION
After a call with Raul and Arren yesterday, discussion how expenditures wished to be used, three issues raised themselves. The first commit adds tests demonstrating two:

* When voting is conducted on an expenditure, the claim delay is reset once all disputes are resolved, whereas clearly the original claim delay should be left (if appropriate). This should also, presumably, apply to motions *about* the claim delay (which I have not included a test for)
* When arbitration mode is used to change the payout for a motion (which is currently done via the general-purpose `setExpenditureState`), the `payoutsWeCannotMake` value for the associated funding pot is not updated.

I think it's clear both of the above should be resolved. The third issue is less clear on how to resolve. It currently takes a lot of motions to make a complicated expenditure, and there's some indication that the ability to make a motion to e.g. set a lot of slots simultaneously, and possibly fund them, would be attractive - but the issue there is the only reasonable approach to such an implementation would want to use `makeArbitraryTransactions`, which forbids self-targeting for security reasons.

I think the best solution to this third issue is an extension built on top of expenditures akin to OneTxPayment with whatever batched functionality the front-end requires.