### PR TITLE
Add MetadataDelta event and function

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -91,6 +91,12 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
     emit ColonyMetadata(msgSender(), _metadata);
   }
 
+  function editColonyByDelta(string memory _metadataDelta) public
+  stoppable
+  auth {
+    emit ColonyMetadataDelta(msgSender(), _metadataDelta);
+  }
+
   function bootstrapColony(address[] memory _users, int[] memory _amounts) public
   stoppable
   auth
@@ -315,6 +321,9 @@ contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
 
     sig = bytes4(keccak256("deprecateDomain(uint256,uint256,uint256,bool)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Architecture), address(this), sig, true);
+
+    sig = bytes4(keccak256("editColonyByDelta(string)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
 
     delete rootLocalSkill; // In case the colony has set this slot in recovery mode
     IColony(address(this)).initialiseRootLocalSkill();

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -123,6 +123,7 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ROOT_ROLE, "addLocalSkill()");
     addRoleCapability(ROOT_ROLE, "deprecateLocalSkill(uint256,bool)");
     addRoleCapability(ARCHITECTURE_ROLE, "deprecateDomain(uint256,uint256,uint256,bool)");
+    addRoleCapability(ROOT_ROLE, "editColonyByDelta(string)");
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -274,6 +274,11 @@ interface ColonyDataTypes {
   /// @param metadata IPFS hash of the metadata
   event ColonyMetadata(address agent, string metadata);
 
+  /// @notice Event logged when Colony metadata is updated via a delta
+  /// @param agent The address that is responsible for triggering this event
+  /// @param metadata IPFS hash of the delta
+  event ColonyMetadataDelta(address agent, string metadata);
+
   /// @notice Event logged when a new FundingPot is added
   /// @param fundingPotId Id of the newly-created FundingPot
   event FundingPotAdded(uint256 fundingPotId);

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -228,6 +228,11 @@ interface IColony is ColonyDataTypes, IRecovery, IBasicMetaTransaction {
   /// @param _metadata IPFS hash of the metadata
   function editColony(string memory _metadata) external;
 
+  /// @notice Called to change the metadata associated with a colony. Expected to be a IPFS hash of a
+  /// delta to a JSON blob, but not enforced to any degree by the contracts
+  /// @param _metadataDelta IPFS hash of the metadata delta
+  function editColonyByDelta(string memory _metadataDelta) external;
+
   /// @notice Allows the colony to bootstrap itself by having initial reputation and token `_amount` assigned to `_users`.
   /// This reputation is assigned in the colony-wide domain. Secured function to authorised members.
   /// @dev Only allowed to be called when `taskCount` is `0` by authorized addresses.

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -154,11 +154,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleAccount.stateRoot.toString("hex"));
       console.log("tokenLockingStateHash:", tokenLockingAccount.stateRoot.toString("hex"));
 
-      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("e70625d050c702331a52664add39e5ac64fded6a11bb8836143280c1a887de1a");
-      expect(colonyAccount.stateRoot.toString("hex")).to.equal("8f7bd7254265034b3830cb19335160ca2b74d7ac74aab7151baefbfab64d0ff2");
-      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("bbe095b668f3de3991ffe03a8d2eb8688374a598d9922e28eb04f3977826309c");
-      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("9ee0d346e2a597ee9083711e9c7f6f414bff6b9f0ae7f88f7db534a2280964c0");
-      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("9484aed2f25183c3d88967bb90ef988c5d83a2813aa7cf931a89a741f4a845c0");
+      expect(colonyNetworkAccount.stateRoot.toString("hex")).to.equal("abc691df82610adc362fc162293bb1151a7869039b145bbd925d3c760a22778d");
+      expect(colonyAccount.stateRoot.toString("hex")).to.equal("db3561898fd52285f65cf27eecfdfb556838f7626f5f425d9b293dcf703fae84");
+      expect(metaColonyAccount.stateRoot.toString("hex")).to.equal("58f1833f0b94c47c028c91ededb70d6697624ecf98bc2cc7930bf55f40d2d931");
+      expect(miningCycleAccount.stateRoot.toString("hex")).to.equal("1f3909ac9098d953ec1d197e6d7924384e96209770f445466ea2f0c0c39f4834");
+      expect(tokenLockingAccount.stateRoot.toString("hex")).to.equal("7ec700a44aef86af735adcb205136940a73bd0507d07d88e93e629dee06f05c3");
     });
   });
 });

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -376,6 +376,18 @@ contract("Colony", (accounts) => {
     });
   });
 
+  describe("when editing colony data", () => {
+    it("should be able to emit the event we expect to contain an entire blob", async () => {
+      const tx = await colony.editColony("ipfsContainingBlob");
+      await expectEvent(tx, "ColonyMetadata", [USER0, "ipfsContainingBlob"]);
+    });
+
+    it("should be able to emit the event we expect to contain a delta", async () => {
+      const tx = await colony.editColonyByDelta("ipfsContainingDelta");
+      await expectEvent(tx, "ColonyMetadataDelta", [USER0, "ipfsContainingDelta"]);
+    });
+  });
+
   describe("when executing metatransactions", () => {
     it("should allow a metatransaction to occur", async () => {
       const txData = await colony.contract.methods.mintTokens(100).encodeABI();


### PR DESCRIPTION
Based on conversations around [this issue](https://github.com/JoinColony/colonyDapp/issues/3335) I've added a new function that can be used by the dapp and expected to emit (the IPFS hash of) a delta, rather than a complete blob, when interacting with the colony metadata. The structure is entirely up to the dapp team, we're totally agnostic here (as we are with the existing colony metadata event).

Another option would be to keep using the existing event, but for deltas and whole blobs, but by adding this event it's much easier for the dapp team to develop against. 

By having both, we allow essentially a 'checkpointing' system to be used if the list of changes gets very long (resulting in long load times as the entire edit history is loaded from IPFS). We expect the rough flow in the dapp to be load the latest blob, and then load all changes since that latest blob. In that way, someone with admin permissions can 'checkpoint' by emitting the current state as a whole blob with the existing function (yes, they could edit stuff as well, but they can already do that if they have that permission).