### PR TITLE
Add dev script to easily start reputation oracle

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "clean:ganache": "rimraf ./ganache-chain-db/",
     "provision:token:contracts": "truffle compile && truffle compile --contracts_directory 'lib/dappsys/[!note][!stop][!proxy][!thing][!token]*.sol' && bash ./scripts/provision-token-contracts.sh",
     "start:blockchain:client": "bash ./scripts/start-blockchain-client.sh",
+    "start:reputation:oracle": "./scripts/start-reputation-oracle.js",
     "stop:blockchain:client": "bash ./scripts/stop-blockchain-client.sh",
     "fork:goerli": "yarn run ganache-cli --fork https://goerli.infura.io/v3/e21146aa267845a2b7b4da025178196d --port 8605",
     "fork:mainnet": "yarn run ganache-cli --fork https://mainnet.infura.io/v3/e21146aa267845a2b7b4da025178196d --port 8601",

--- a/scripts/start-reputation-oracle.js
+++ b/scripts/start-reputation-oracle.js
@@ -5,44 +5,50 @@
  * DO NOT USE IN PRODUCTION
  */
 
-const fs = require("fs");
 const path = require("path");
 const { exec } = require("child_process");
 const http = require("http");
 
-const { etherRouterAddress } = require('../etherrouter-address.json');
-const reputationOraclePath = path.resolve(__dirname, '../packages/reputation-miner');
+const { etherRouterAddress } = require("../etherrouter-address.json"); // eslint-disable-line import/no-unresolved
+
+const reputationOraclePath = path.resolve(__dirname, "../packages/reputation-miner");
 
 async function start() {
-    const ganacheAccounts = await getGanacheAccounts();
-    const command = `node ./bin/index.js --minerAddress="${ganacheAccounts[5]}" --colonyNetworkAddress="${etherRouterAddress}" --syncFrom=1 --dbPath ./reputations.sqlite`;
-    const proc = exec(command, { cwd: reputationOraclePath });
-    proc.stdout.pipe(process.stdout);
-    proc.stderr.pipe(process.stderr);
+  const ganacheAccounts = await getGanacheAccounts();
+  const command =
+    `node ./bin/index.js --minerAddress="${ganacheAccounts[5]}" ` +
+    `--colonyNetworkAddress="${etherRouterAddress}" --syncFrom=1 --dbPath ./reputations.sqlite`;
+  const proc = exec(command, { cwd: reputationOraclePath });
+  proc.stdout.pipe(process.stdout);
+  proc.stderr.pipe(process.stderr);
 }
 
 async function getGanacheAccounts() {
-    const requestAccounts = JSON.stringify({
-        "jsonrpc":"2.0",
-        "method":"eth_accounts",
-        "params":[],
-        "id": 1
-    });
-    const response = await new Promise((resolve, reject) => {
-        const req = http.request('http://127.0.0.1:8545', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            }
-        }, (res) => {
-            res.setEncoding('utf8');
-            res.on('error', () => reject('Could not connect to RPC endpoint'));
-            res.on('data', (chunk) => resolve(JSON.parse(chunk)));
-        });
-        req.write(requestAccounts);
-        req.end();
-    });
-    return response.result;
+  const requestAccounts = JSON.stringify({
+    jsonrpc: "2.0",
+    method: "eth_accounts",
+    params: [],
+    id: 1,
+  });
+  const response = await new Promise((resolve, reject) => {
+    const req = http.request(
+      "http://127.0.0.1:8545",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+      (res) => {
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => resolve(JSON.parse(chunk)));
+      }
+    );
+    req.on("error", () => reject(new Error("Could not connect to RPC endpoint")));
+    req.write(requestAccounts);
+    req.end();
+  });
+  return response.result;
 }
 
 start();

--- a/scripts/start-reputation-oracle.js
+++ b/scripts/start-reputation-oracle.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+/*
+ * Start the Reputation Miner/Oracle for local development
+ * DO NOT USE IN PRODUCTION
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { exec } = require("child_process");
+const http = require("http");
+
+const { etherRouterAddress } = require('../etherrouter-address.json');
+const reputationOraclePath = path.resolve(__dirname, '../packages/reputation-miner');
+
+async function start() {
+    const ganacheAccounts = await getGanacheAccounts();
+    const command = `node ./bin/index.js --minerAddress="${ganacheAccounts[5]}" --colonyNetworkAddress="${etherRouterAddress}" --syncFrom=1 --dbPath ./reputations.sqlite`;
+    const proc = exec(command, { cwd: reputationOraclePath });
+    proc.stdout.pipe(process.stdout);
+    proc.stderr.pipe(process.stderr);
+}
+
+async function getGanacheAccounts() {
+    const requestAccounts = JSON.stringify({
+        "jsonrpc":"2.0",
+        "method":"eth_accounts",
+        "params":[],
+        "id": 1
+    });
+    const response = await new Promise((resolve, reject) => {
+        const req = http.request('http://127.0.0.1:8545', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        }, (res) => {
+            res.setEncoding('utf8');
+            res.on('error', () => reject('Could not connect to RPC endpoint'));
+            res.on('data', (chunk) => resolve(JSON.parse(chunk)));
+        });
+        req.write(requestAccounts);
+        req.end();
+    });
+    return response.result;
+}
+
+start();


### PR DESCRIPTION
I added this script to make it easier to start the reputation oracle for development purposes.

It gets the ganache accounts from the RPC node and the `etherrouter-address` from the corresponding json file.

