### PR TITLE
Move checkReputation to ColonyExtension

### DIFF
--- a/contracts/extensions/ColonyExtension.sol
+++ b/contracts/extensions/ColonyExtension.sol
@@ -22,9 +22,11 @@ import "./../../lib/dappsys/math.sol";
 import "./../common/EtherRouter.sol";
 import "./../colony/IColony.sol";
 import "./../colony/ColonyDataTypes.sol";
+import "./../colonyNetwork/IColonyNetwork.sol";
+import "./../patriciaTree/PatriciaTreeProofs.sol";
 
 
-abstract contract ColonyExtension is DSAuth, DSMath {
+abstract contract ColonyExtension is DSAuth, DSMath, PatriciaTreeProofs {
 
   uint256 constant UINT256_MAX = 2**256 - 1;
 
@@ -59,4 +61,39 @@ abstract contract ColonyExtension is DSAuth, DSMath {
     return address(colony);
   }
 
+  function checkReputation(
+    bytes32 _rootHash,
+    uint256 _skillId,
+    address _user,
+    bytes memory _key,
+    bytes memory _value,
+    uint256 _branchMask,
+    bytes32[] memory _siblings
+  )
+    internal
+    view
+    returns (uint256)
+  {
+    bytes32 impliedRoot = getImpliedRootHashKey(_key, _value, _branchMask, _siblings);
+    require(_rootHash == impliedRoot, "colony-extension-invalid-root-hash");
+
+    uint256 reputationValue;
+    address keyColonyAddress;
+    uint256 keySkillId;
+    address keyUserAddress;
+
+    assembly {
+      reputationValue := mload(add(_value, 32))
+      keyColonyAddress := mload(add(_key, 20))
+      keySkillId := mload(add(_key, 52))
+      keyUserAddress := mload(add(_key, 72))
+    }
+
+    require(keyColonyAddress == address(colony), "colony-extension-invalid-colony-address");
+    // slither-disable-next-line incorrect-equality
+    require(keySkillId == _skillId, "colony-extension-invalid-skill-id");
+    require(keyUserAddress == _user, "colony-extension-invalid-user-address");
+
+    return reputationValue;
+  }
 }

--- a/contracts/extensions/StakedExpenditure.sol
+++ b/contracts/extensions/StakedExpenditure.sol
@@ -20,13 +20,12 @@ pragma experimental ABIEncoderV2;
 
 import "./../colony/ColonyDataTypes.sol";
 import "./../colonyNetwork/IColonyNetwork.sol";
-import "./../patriciaTree/PatriciaTreeProofs.sol";
 import "./ColonyExtensionMeta.sol";
 
 // ignore-file-swc-108
 
 
-contract StakedExpenditure is ColonyExtensionMeta, PatriciaTreeProofs {
+contract StakedExpenditure is ColonyExtensionMeta {
 
   // Events
 
@@ -122,7 +121,9 @@ contract StakedExpenditure is ColonyExtensionMeta, PatriciaTreeProofs {
     public
     notDeprecated
   {
-    uint256 domainRep = getReputationFromProof(_domainId, _key, _value, _branchMask, _siblings);
+    bytes32 rootHash = IColonyNetwork(colony.getColonyNetwork()).getReputationRootHash();
+    uint256 domainSkillId = colony.getDomain(_domainId).skillId;
+    uint256 domainRep = checkReputation(rootHash, domainSkillId, address(0x0), _key, _value, _branchMask, _siblings);
     uint256 stakeAmount = wmul(domainRep, stakeFraction);
 
     colony.obligateStake(msgSender(), _domainId, stakeAmount);
@@ -304,40 +305,5 @@ contract StakedExpenditure is ColonyExtensionMeta, PatriciaTreeProofs {
     );
 
     emit ExpenditureCancelled(_expenditureId);
-  }
-
-  function getReputationFromProof(
-    uint256 _domainId,
-    bytes memory _key,
-    bytes memory _value,
-    uint256 _branchMask,
-    bytes32[] memory _siblings
-  )
-    internal
-    view
-    returns (uint256)
-  {
-    bytes32 rootHash = IColonyNetwork(colony.getColonyNetwork()).getReputationRootHash();
-    bytes32 impliedRoot = getImpliedRootHashKey(_key, _value, _branchMask, _siblings);
-    require(rootHash == impliedRoot, "staked-expenditure-invalid-root-hash");
-
-
-    uint256 reputationValue;
-    address keyColonyAddress;
-    uint256 keySkillId;
-    address keyUserAddress;
-
-    assembly {
-      reputationValue := mload(add(_value, 32))
-      keyColonyAddress := mload(add(_key, 20))
-      keySkillId := mload(add(_key, 52))
-      keyUserAddress := mload(add(_key, 72))
-    }
-
-    require(keyColonyAddress == address(colony), "staked-expenditure-invalid-colony-address");
-    require(keySkillId == colony.getDomain(_domainId).skillId, "staked-expenditure-invalid-skill-id");
-    require(keyUserAddress == address(0x0), "staked-expenditure-invalid-user-address");
-
-    return reputationValue;
   }
 }

--- a/contracts/extensions/StakedExpenditure.sol
+++ b/contracts/extensions/StakedExpenditure.sol
@@ -65,7 +65,7 @@ contract StakedExpenditure is ColonyExtensionMeta {
   /// @notice Returns the version of the extension
   /// @return _version The extension's version number
   function version() public override pure returns (uint256 _version) {
-    return 1;
+    return 2;
   }
 
   /// @notice Configures the extension

--- a/contracts/extensions/votingReputation/VotingReputation.sol
+++ b/contracts/extensions/votingReputation/VotingReputation.sol
@@ -22,13 +22,13 @@ import "./../../colonyNetwork/IColonyNetwork.sol";
 import "./../../colony/ColonyRoles.sol";
 import "./../../common/BasicMetaTransaction.sol";
 import "./../../common/ERC20Extended.sol";
-import "./../../patriciaTree/PatriciaTreeProofs.sol";
 import "./../../tokenLocking/ITokenLocking.sol";
 import "./../ColonyExtension.sol";
 import "./VotingReputationDataTypes.sol";
 
+contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputationDataTypes {
 
-contract VotingReputation is ColonyExtension, PatriciaTreeProofs, BasicMetaTransaction, VotingReputationDataTypes {
+  // Constants
   uint256 constant UINT128_MAX = 2**128 - 1;
 
   uint256 constant NAY = 0;
@@ -250,7 +250,7 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs, BasicMetaTrans
     motion.domainId = _domainId;
     motion.skillId = skillId;
 
-    motion.skillRep = getReputationFromProof(motionCount, address(0x0), _key, _value, _branchMask, _siblings);
+    motion.skillRep = checkReputation(motion.rootHash, skillId, address(0x0), _key, _value, _branchMask, _siblings);
     motion.altTarget = _altTarget;
     motion.action = _action;
 
@@ -308,7 +308,7 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs, BasicMetaTrans
     uint256 stakerTotalAmount = add(stakes[_motionId][msgSender()][_vote], amount);
 
     require(
-      stakerTotalAmount <= getReputationFromProof(_motionId, msgSender(), _key, _value, _branchMask, _siblings),
+      stakerTotalAmount <= checkReputation(motion.rootHash, motion.skillId, msgSender(), _key, _value, _branchMask, _siblings),
       "voting-rep-insufficient-rep"
     );
     require(
@@ -383,7 +383,7 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs, BasicMetaTrans
     require(getMotionState(_motionId) == MotionState.Submit, "voting-rep-motion-not-open");
     require(_voteSecret != bytes32(0), "voting-rep-invalid-secret");
 
-    uint256 userRep = getReputationFromProof(_motionId, msgSender(), _key, _value, _branchMask, _siblings);
+    uint256 userRep = checkReputation(motion.rootHash, motion.skillId, msgSender(), _key, _value, _branchMask, _siblings);
 
     // Count reputation if first submission
     if (voteSecrets[_motionId][msgSender()] == bytes32(0)) {
@@ -417,7 +417,7 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs, BasicMetaTrans
     require(getMotionState(_motionId) == MotionState.Reveal, "voting-rep-motion-not-reveal");
     require(_vote <= 1, "voting-rep-bad-vote");
 
-    uint256 userRep = getReputationFromProof(_motionId, msgSender(), _key, _value, _branchMask, _siblings);
+    uint256 userRep = checkReputation(motion.rootHash, motion.skillId, msgSender(), _key, _value, _branchMask, _siblings);
     motion.votes[_vote] = add(motion.votes[_vote], userRep);
 
     bytes32 voteSecret = voteSecrets[_motionId][msgSender()];
@@ -460,7 +460,7 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs, BasicMetaTrans
     uint256 domainId = motion.domainId;
     motion.domainId = _newDomainId;
     motion.skillId = newDomainSkillId;
-    motion.skillRep = getReputationFromProof(_motionId, address(0x0), _key, _value, _branchMask, _siblings);
+    motion.skillRep = checkReputation(motion.rootHash, motion.skillId, address(0x0), _key, _value, _branchMask, _siblings);
 
     uint256 loser = (motion.votes[NAY] < motion.votes[YAY]) ? NAY : YAY;
     motion.stakes[loser] = sub(motion.stakes[loser], motion.paidVoterComp);
@@ -818,38 +818,6 @@ contract VotingReputation is ColonyExtension, PatriciaTreeProofs, BasicMetaTrans
 
   function flip(uint256 _vote) internal pure returns (uint256) {
     return sub(1, _vote);
-  }
-
-  function getReputationFromProof(
-    uint256 _motionId,
-    address _who,
-    bytes memory _key,
-    bytes memory _value,
-    uint256 _branchMask,
-    bytes32[] memory _siblings
-  )
-    internal view returns (uint256)
-  {
-    bytes32 impliedRoot = getImpliedRootHashKey(_key, _value, _branchMask, _siblings);
-    require(motions[_motionId].rootHash == impliedRoot, "voting-rep-invalid-root-hash");
-
-    uint256 reputationValue;
-    address keyColonyAddress;
-    uint256 keySkill;
-    address keyUserAddress;
-
-    assembly {
-      reputationValue := mload(add(_value, 32))
-      keyColonyAddress := mload(add(_key, 20))
-      keySkill := mload(add(_key, 52))
-      keyUserAddress := mload(add(_key, 72))
-    }
-
-    require(keyColonyAddress == address(colony), "voting-rep-invalid-colony-address");
-    require(keySkill == motions[_motionId].skillId, "voting-rep-invalid-skill-id");
-    require(keyUserAddress == _who, "voting-rep-invalid-user-address");
-
-    return reputationValue;
   }
 
   function getActionDomainSkillId(bytes memory _action) internal view returns (uint256) {

--- a/contracts/extensions/votingReputation/VotingReputation.sol
+++ b/contracts/extensions/votingReputation/VotingReputation.sol
@@ -120,7 +120,7 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
   }
 
   function version() public pure override returns (uint256 _version) {
-    return 7;
+    return 8;
   }
 
   function install(address _colony) public override {

--- a/contracts/testHelpers/VotingReputationMisaligned.sol
+++ b/contracts/testHelpers/VotingReputationMisaligned.sol
@@ -22,12 +22,11 @@ import "./../colonyNetwork/IColonyNetwork.sol";
 import "./../colony/ColonyRoles.sol";
 import "./../common/BasicMetaTransaction.sol";
 import "./../common/ERC20Extended.sol";
-import "./../patriciaTree/PatriciaTreeProofs.sol";
 import "./../tokenLocking/ITokenLocking.sol";
 import "./../extensions/ColonyExtension.sol";
 
 
-contract VotingReputationMisaligned is ColonyExtension, PatriciaTreeProofs, BasicMetaTransaction {
+contract VotingReputationMisaligned is ColonyExtension, BasicMetaTransaction {
 
   // Events
   event MotionCreated(uint256 indexed motionId, address creator, uint256 indexed domainId);

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -149,7 +149,7 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleStateHash);
       console.log("tokenLockingStateHash:", tokenLockingStateHash);
 
-      expect(colonyNetworkStateHash).to.equal("0xf0e5f8367ae0df3e0c77fded953186e7068fe089ec5a3d57703525075b1a8feb");
+      expect(colonyNetworkStateHash).to.equal("0x4dd3b98782ed065f4b03a08f31ea62f9ad57c66a80dea0c48d9cc17402bc566b");
       expect(colonyStateHash).to.equal("0xa49d332bbdd1951f062b1ffc40bbeb7b3a0a16fd2cd1879fca8348eda7b5b587");
       expect(metaColonyStateHash).to.equal("0xff23657f917385e6a94f328907443fef625f08b8b3224e065a53b690f91be0bb");
       expect(miningCycleStateHash).to.equal("0x264d4a83e21fef92f687f9fabacae9370966b0b30ebc15307653c4c3d33a0035");

--- a/test/extensions/funding-queue.js
+++ b/test/extensions/funding-queue.js
@@ -375,14 +375,14 @@ contract("Funding Queues", (accounts) => {
     it("cannot back a basic proposal with a bad reputation proof", async () => {
       await checkErrorRevert(
         fundingQueue.backProposal(proposalId, WAD, proposalId, HEAD, "0x0", "0x0", "0x0", [], { from: USER0 }),
-        "funding-queue-invalid-root-hash"
+        "colony-extension-invalid-root-hash"
       );
     });
 
     it("cannot back a basic proposal with the wrong user address", async () => {
       await checkErrorRevert(
         fundingQueue.backProposal(proposalId, WAD, proposalId, HEAD, user0Key, user0Value, user0Mask, user0Siblings, { from: USER1 }),
-        "funding-queue-invalid-user-address"
+        "colony-extension-invalid-user-address"
       );
     });
 
@@ -393,7 +393,7 @@ contract("Funding Queues", (accounts) => {
 
       await checkErrorRevert(
         fundingQueue.backProposal(proposalId, WAD, proposalId, HEAD, key, value, mask, siblings, { from: USER0 }),
-        "funding-queue-invalid-skill-id"
+        "colony-extension-invalid-skill-id"
       );
     });
 
@@ -404,7 +404,7 @@ contract("Funding Queues", (accounts) => {
 
       await checkErrorRevert(
         fundingQueue.backProposal(proposalId, WAD, proposalId, HEAD, key, value, mask, siblings, { from: USER0 }),
-        "funding-queue-invalid-colony-address"
+        "colony-extension-invalid-colony-address"
       );
     });
 

--- a/test/extensions/staked-expenditure.js
+++ b/test/extensions/staked-expenditure.js
@@ -201,7 +201,7 @@ contract("StakedExpenditure", (accounts) => {
       [mask, siblings] = await reputationTree.getProof(key);
       await checkErrorRevert(
         stakedExpenditure.makeExpenditureWithStake(1, UINT256_MAX, 1, key, value, mask, siblings),
-        "staked-expenditure-invalid-root-hash"
+        "colony-extension-invalid-root-hash"
       );
 
       key = makeReputationKey(ADDRESS_ZERO, domain1.skillId);
@@ -209,7 +209,7 @@ contract("StakedExpenditure", (accounts) => {
       [mask, siblings] = await reputationTree.getProof(key);
       await checkErrorRevert(
         stakedExpenditure.makeExpenditureWithStake(1, UINT256_MAX, 1, key, value, mask, siblings),
-        "staked-expenditure-invalid-colony-address"
+        "colony-extension-invalid-colony-address"
       );
 
       key = makeReputationKey(colony.address, 100);
@@ -217,7 +217,7 @@ contract("StakedExpenditure", (accounts) => {
       [mask, siblings] = await reputationTree.getProof(key);
       await checkErrorRevert(
         stakedExpenditure.makeExpenditureWithStake(1, UINT256_MAX, 1, key, value, mask, siblings),
-        "staked-expenditure-invalid-skill-id"
+        "colony-extension-invalid-skill-id"
       );
 
       key = makeReputationKey(colony.address, domain1.skillId, USER0);
@@ -225,7 +225,7 @@ contract("StakedExpenditure", (accounts) => {
       [mask, siblings] = await reputationTree.getProof(key);
       await checkErrorRevert(
         stakedExpenditure.makeExpenditureWithStake(1, UINT256_MAX, 1, key, value, mask, siblings),
-        "staked-expenditure-invalid-user-address"
+        "colony-extension-invalid-user-address"
       );
     });
 

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -972,7 +972,7 @@ contract("Voting Reputation", (accounts) => {
     it("cannot stake with someone else's reputation", async () => {
       await checkErrorRevert(
         voting.stakeMotion(motionId, 1, UINT256_MAX, YAY, REQUIRED_STAKE, user0Key, user0Value, user0Mask, user0Siblings, { from: USER1 }),
-        "voting-rep-invalid-user-address"
+        "colony-extension-invalid-user-address"
       );
     });
 
@@ -1151,14 +1151,14 @@ contract("Voting Reputation", (accounts) => {
       const [user0Mask2, user0Siblings2] = await reputationTree.getProof(user0Key);
       const [user1Mask2, user1Siblings2] = await reputationTree.getProof(user1Key);
 
-      // Set new rootHash
-      const rootHash = await reputationTree.getRootHash();
-      expect(oldRootHash).to.not.equal(rootHash);
+      const newRootHash = await reputationTree.getRootHash();
+      expect(oldRootHash).to.not.equal(newRootHash);
 
       await forwardTime(MINING_CYCLE_DURATION, this);
 
+      // Set newRootHash
       const repCycle = await getActiveRepCycle(colonyNetwork);
-      await repCycle.submitRootHash(rootHash, 0, "0x00", 10, { from: MINER });
+      await repCycle.submitRootHash(newRootHash, 0, "0x00", 10, { from: MINER });
       await forwardTime(CHALLENGE_RESPONSE_WINDOW_DURATION + 1, this);
       await repCycle.confirmNewHash(0, { from: MINER });
 
@@ -1240,7 +1240,7 @@ contract("Voting Reputation", (accounts) => {
       await forwardTime(SUBMIT_PERIOD, this);
 
       // Invalid proof (wrong root hash)
-      await checkErrorRevert(voting.revealVote(motionId, SALT, NAY, FAKE, FAKE, 0, [], { from: USER0 }), "voting-rep-invalid-root-hash");
+      await checkErrorRevert(voting.revealVote(motionId, SALT, NAY, FAKE, FAKE, 0, [], { from: USER0 }), "colony-extension-invalid-root-hash");
 
       // Invalid colony address
       let key, value, mask, siblings; // eslint-disable-line one-var
@@ -1250,19 +1250,23 @@ contract("Voting Reputation", (accounts) => {
 
       await checkErrorRevert(
         voting.revealVote(motionId, SALT, NAY, key, value, mask, siblings, { from: USER0 }),
-        "voting-rep-invalid-colony-address"
+        "colony-extension-invalid-colony-address"
       );
 
       // Invalid skill id
       key = makeReputationKey(colony.address, 1234, USER0);
       value = makeReputationValue(WAD, 4);
       [mask, siblings] = await reputationTree.getProof(key);
-      await checkErrorRevert(voting.revealVote(motionId, SALT, NAY, key, value, mask, siblings, { from: USER0 }), "voting-rep-invalid-skill-id");
+
+      await checkErrorRevert(
+        voting.revealVote(motionId, SALT, NAY, key, value, mask, siblings, { from: USER0 }),
+        "colony-extension-invalid-skill-id"
+      );
 
       // Invalid user address
       await checkErrorRevert(
         voting.revealVote(motionId, SALT, NAY, user1Key, user1Value, user1Mask, user1Siblings, { from: USER0 }),
-        "voting-rep-invalid-user-address"
+        "colony-extension-invalid-user-address"
       );
     });
   });
@@ -2103,7 +2107,7 @@ contract("Voting Reputation", (accounts) => {
     });
 
     it("cannot internally escalate a domain motion with an invalid reputation proof", async () => {
-      await checkErrorRevert(voting.escalateMotion(motionId, 1, 0, "0x0", "0x0", "0x0", [], { from: USER0 }), "voting-rep-invalid-root-hash");
+      await checkErrorRevert(voting.escalateMotion(motionId, 1, 0, "0x0", "0x0", "0x0", [], { from: USER0 }), "colony-extension-invalid-root-hash");
     });
 
     it("can stake after internally escalating a domain motion", async () => {


### PR DESCRIPTION
Checking reputation proofs is generally useful functionality. Rather than have extensions re-implement, let's provide a common function.

