### PR TITLE
Add missing await to miner sync test

### DIFF
--- a/test/reputation-system/client-sync-functionality.js
+++ b/test/reputation-system/client-sync-functionality.js
@@ -132,7 +132,7 @@ process.env.SOLIDITY_COVERAGE
           // Do some additional updates.
           await advanceMiningCycleNoContest({ colonyNetwork, client: reputationMiner1, test: this });
 
-          fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(5));
+          await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(5));
           for (let i = 0; i < 5; i += 1) {
             await setupFinalizedTask({ colonyNetwork, colony: metaColony });
           }


### PR DESCRIPTION
For whatever reason, we've started seeing [this](https://app.circleci.com/pipelines/github/JoinColony/colonyNetwork/4637/workflows/71d7a592-2dd8-4538-b05c-1f7703cd66fd/jobs/24656) error on multiple builds; this missing await is the culprit.