### PR TITLE
Make miner slightly more cautious about state

### DIFF
--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -993,6 +993,9 @@ exports.getWaitForNSubmissionsPromise = async function getWaitForNSubmissionsPro
   return new Promise(function (resolve, reject) {
     repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nLeaves, _jrh, _entryIndex, event) => {
       let nSubmissions;
+      // If we've passed in a hash, we check how many submissions that hash in particular has
+      // If not, and we're just waiting for N submissions from any hash, we lookup the number of
+      // submissions the hash in the emitted event that triggered this function has
       if (rootHash === _hash) {
         nSubmissions = await repCycleEthers.getNSubmissionsForHash(rootHash, nLeaves, jrh);
       } else {

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -993,7 +993,7 @@ exports.getWaitForNSubmissionsPromise = async function getWaitForNSubmissionsPro
   return new Promise(function (resolve, reject) {
     repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nLeaves, _jrh, _entryIndex, event) => {
       let nSubmissions;
-      if (rootHash) {
+      if (rootHash === _hash) {
         nSubmissions = await repCycleEthers.getNSubmissionsForHash(rootHash, nLeaves, jrh);
       } else {
         nSubmissions = await repCycleEthers.getNSubmissionsForHash(_hash, _nLeaves, _jrh);

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -993,10 +993,10 @@ exports.getWaitForNSubmissionsPromise = async function getWaitForNSubmissionsPro
   return new Promise(function (resolve, reject) {
     repCycleEthers.on("ReputationRootHashSubmitted", async (_miner, _hash, _nLeaves, _jrh, _entryIndex, event) => {
       let nSubmissions;
-      // If we've passed in a hash, we check how many submissions that hash in particular has
-      // If not, and we're just waiting for N submissions from any hash, we lookup the number of
-      // submissions the hash in the emitted event that triggered this function has
-      if (rootHash === _hash) {
+      // We want to see when our hash hits N submissions
+      // If we've passed in our hash, we check how many submissions that hash has
+      // If not, we're waiting for N submissions from any hash
+      if (rootHash) {
         nSubmissions = await repCycleEthers.getNSubmissionsForHash(rootHash, nLeaves, jrh);
       } else {
         nSubmissions = await repCycleEthers.getNSubmissionsForHash(_hash, _nLeaves, _jrh);

--- a/packages/reputation-miner/test/ReputationMinerLongTransactionMined.js
+++ b/packages/reputation-miner/test/ReputationMinerLongTransactionMined.js
@@ -1,0 +1,37 @@
+const ethers = require("ethers");
+const ReputationMinerTestWrapper = require("./ReputationMinerTestWrapper");
+
+class ReputationMinerLongTransactionMined extends ReputationMinerTestWrapper {
+  // Only difference between this and the 'real' client should be that submitRootHash
+  // doesn't resolve until we tell it to, via resolveSubmission()
+
+  async submitRootHash(entryIndex) {
+    const hash = await this.getRootHash();
+    const nLeaves = await this.getRootHashNLeaves();
+    const jrh = await this.justificationTree.getRootHash();
+    const repCycle = await this.getActiveRepCycle();
+
+    if (!entryIndex) {
+      entryIndex = await this.getEntryIndex(); // eslint-disable-line no-param-reassign
+    }
+    let gasEstimate = ethers.BigNumber.from(1000000);
+    try {
+      gasEstimate = await repCycle.estimate.submitRootHash(hash, nLeaves, jrh, entryIndex);
+    } catch (err) { // eslint-disable-line no-empty
+
+    }
+
+    // Submit that entry
+    this.p = new Promise((resolve) => {
+      this.result = repCycle.submitRootHash(hash, nLeaves, jrh, entryIndex, { gasLimit: gasEstimate, gasPrice: this.gasPrice });
+      this.resolve = resolve;
+    })
+    return this.p;
+  }
+
+  async resolveSubmission() {
+    this.resolve(this.result);
+  }
+}
+
+module.exports = ReputationMinerLongTransactionMined;


### PR DESCRIPTION
A recent incident revealed the reputation miner was a bit brittle. It submitted a new reputation hash, but the account being submitted from had (very nearly) run out of xdai, so the transaction was not able to be mined, and just sat pending in the pool with the client `await`ing it. When I topped up the miner, the transaction was mined, and the miner continued, but had missed several cycles and so ended up out-of-sync. This PR is intended to fix that issue, by having the miner check that the on-chain accepted state is the one it expects before applying a reputation update log and continuing to mine.

While I was in there, I took the opportunity to abstract some test logic that was repeated in the relevant tests.