### PR TITLE
`npm` migration hotfixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
           command: npm run solhint
       - run:
           name: "Check git hooks run"
-          command: yarn run check:gitchanges
+          command: npm run check:gitchanges
       - run:
           name: "Checking contract storage variables"
           command: npm run check:storagevars
@@ -191,7 +191,7 @@ jobs:
       - <<: *step_setup_global_packages
       - run:
           name: "Running upgrade tests with coverage"
-          command: yarn run test:contracts:upgrade:coverage
+          command: npm run test:contracts:upgrade:coverage
           environment:
             NODE_OPTIONS: --max_old_space_size=4096
       - persist_to_workspace:

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ coverage-miner
 lib/*
 ganache-accounts.json
 .vscode/
-yarn-error.log
 reputations.json
 reputationStates.sqlite
 reputationStates.sqlite-shm

--- a/packages/metatransaction-broadcaster/Dockerfile
+++ b/packages/metatransaction-broadcaster/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:14-bullseye
 COPY ./packages ./packages
 COPY ./package.json ./
-COPY ./yarn.lock ./
+COPY ./package-lock.json ./
 COPY ./build ./build
-RUN yarn
+RUN npm ci
 EXPOSE 3000
 CMD node $NODE_ARGS packages/metatransaction-broadcaster/bin/index.js --colonyNetworkAddress $COLONYNETWORK_ADDRESS --privateKey $PRIVATE_KEY --gasLimit $GASLIMIT $ARGS


### PR DESCRIPTION
I found some forgotten `yarn` references that sneaked in between two rebase cycles. Here's the fix for them.

