### PR TITLE
Use self-consistent coverage configurations for separate runs

### DIFF
--- a/.solcover.extensions.js
+++ b/.solcover.extensions.js
@@ -1,33 +1,5 @@
-const { execSync } = require("child_process");
-const log = console.log;
+const config = require("./.solcover.js")
 
-// Copies pre-built token artifacts to .coverage_artifacts/contracts
-function provisionTokenContracts(config){
-  let output;
-  const provisionColonyToken = `bash ./scripts/provision-token-contracts.sh`;
+config.istanbulFolder = "./coverage-extensions"
 
-  log('Provisioning ColonyToken contracts...')
-  output = execSync(provisionColonyToken);
-  log(output.toString())
-}
-
-module.exports = {
-    skipFiles: [
-      'Migrations.sol',
-      'common/EtherRouter.sol',
-      'patriciaTree',
-      'testHelpers',
-      'ens'
-    ],
-    providerOptions: {
-      port: 8555,
-      network_id: 1999,
-      account_keys_path: "./ganache-accounts.json",
-      vmErrorsOnRPCResponse: false,
-      total_accounts: 18
-    },
-    onCompileComplete: provisionTokenContracts,
-    istanbulFolder: "./coverage-extensions",
-    modifierWhitelist: ["always"],
-}
-
+module.exports = config

--- a/.solcover.reputation.js
+++ b/.solcover.reputation.js
@@ -1,33 +1,5 @@
-const { execSync } = require("child_process");
-const log = console.log;
+const config = require("./.solcover.js")
 
-// Copies pre-built token artifacts to .coverage_artifacts/contracts
-function provisionTokenContracts(config){
-  let output;
-  const provisionColonyToken = `bash ./scripts/provision-token-contracts.sh`;
+config.istanbulFolder = "./coverage-reputation"
 
-  log('Provisioning ColonyToken contracts...')
-  output = execSync(provisionColonyToken);
-  log(output.toString())
-}
-
-module.exports = {
-    skipFiles: [
-      'Migrations.sol',
-      'common/EtherRouter.sol',
-      'patriciaTree',
-      'testHelpers',
-      'ens',
-    ],
-    providerOptions: {
-      port: 8555,
-      network_id: 1999,
-      account_keys_path: "./ganache-accounts.json",
-      vmErrorsOnRPCResponse: false,
-      total_accounts: 18
-    },
-    onCompileComplete: provisionTokenContracts,
-    istanbulFolder: "./coverage-reputation",
-    modifierWhitelist: ["always"],
-}
-
+module.exports = config

--- a/.solcover.upgrade.js
+++ b/.solcover.upgrade.js
@@ -1,15 +1,5 @@
 const { execSync } = require("child_process");
-const log = console.log;
-
-// Copies pre-built token artifacts to .coverage_artifacts/contracts
-function provisionTokenContracts(config){
-  let output;
-  const provisionColonyToken = `bash ./scripts/provision-token-contracts.sh`;
-
-  log('Provisioning ColonyToken contracts...')
-  output = execSync(provisionColonyToken);
-  log(output.toString())
-}
+const config = require("./.solcover.js")
 
 function getFilesToSkip(){
   const array = [
@@ -24,16 +14,7 @@ function getFilesToSkip(){
   return array.concat(output.toString().split('\n').slice(0,-1))
 }
 
-module.exports = {
-    skipFiles: getFilesToSkip(),
-    providerOptions: {
-      port: 8555,
-      network_id: 1999,
-      account_keys_path: "./ganache-accounts.json",
-      vmErrorsOnRPCResponse: false,
-      total_accounts: 18
-    },
-    onCompileComplete: provisionTokenContracts,
-    istanbulFolder: "./coverage-upgrade"
-}
+config.istanbulFolder = "./coverage-upgrade"
+config.skipFiles = getFilesToSkip();
 
+module.exports = config


### PR DESCRIPTION
We've seen [this issue](https://app.circleci.com/pipelines/github/JoinColony/colonyNetwork/4931/workflows/7cd8361c-b366-4c33-ac6f-5bf6b809a315/jobs/27125) in a [lot of builds](https://app.circleci.com/pipelines/github/JoinColony/colonyNetwork/4921/workflows/2487d6f6-097f-434e-8eba-4f62c470529d/jobs/26996) lately. It was intermittent, though, and so tough to pin down. ~~I was also unable to reproduce locally. It ended up being due to [this issue](https://github.com/gotwarlost/istanbul/pull/940) now that we're on Node 14 (and I'm attributing the inablility to reproduce locally due to `node`/`npm` version weirdness I've got going on locally).~~

~~I ended up forking `istanbul-combine` to use a fixed `istanbul` under the hood, which seems to solve the issue.~~

~~Unfortunately, the resulting `package-lock.json` [threw an error](https://app.circleci.com/pipelines/github/JoinColony/colonyNetwork/4937/workflows/16500303-2a9a-4ff1-8f24-86282d9be670/jobs/27135) when using `npm ci` (though not `npm i`, weirdly). Updating `npm` for the `check-coverage` stage of the build fixes that.~~