### PR TITLE
Fix incorrect refactor of checkErrorRevert

### DIFF
--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -191,9 +191,12 @@ exports.checkErrorRevert = async function checkErrorRevert(promise, errorMessage
       const txid = await promise;
       receipt = await exports.web3GetTransactionReceipt(txid);
       // Check the receipt `status` to ensure transaction failed.
-      expect(receipt.status, `Transaction succeeded, but expected error ${errorMessage}`).to.be.false;
     }
+    expect(receipt.status, `Transaction succeeded, but expected error ${errorMessage}`).to.be.false;
   } catch (err) {
+    if (err.toString().indexOf("AssertionError: Transaction succeeded, but expected error") === 0) {
+      throw err;
+    }
     ({ reason } = err);
     expect(reason).to.equal(errorMessage);
   }

--- a/test/extensions/staked-expenditure.js
+++ b/test/extensions/staked-expenditure.js
@@ -323,17 +323,6 @@ contract("StakedExpenditure", (accounts) => {
       expect(userLock.balance).to.eq.BN(WAD.sub(requiredStake));
     });
 
-    it("cannot slash a nonexistent stake", async () => {
-      await colony.makeExpenditure(1, UINT256_MAX, 1);
-      const expenditureId = await colony.getExpenditureCount();
-      await colony.lockExpenditure(expenditureId);
-
-      await checkErrorRevert(
-        stakedExpenditure.cancelAndPunish(1, UINT256_MAX, 1, UINT256_MAX, expenditureId, true),
-        "staked-expenditure-nothing-to-slash"
-      );
-    });
-
     it("can reclaim the stake by cancelling the expenditure", async () => {
       await stakedExpenditure.makeExpenditureWithStake(1, UINT256_MAX, 1, domain1Key, domain1Value, domain1Mask, domain1Siblings, { from: USER0 });
       const expenditureId = await colony.getExpenditureCount();


### PR DESCRIPTION
Looks like we got away with this one - nothing was overlooked in this repository, except one test where we [decided to remove the functionality it tested](https://github.com/JoinColony/colonyNetwork/pull/1045#discussion_r922224613)