### PR TITLE
Fix streaming payment extension

### DIFF
--- a/contracts/extensions/StreamingPayments.sol
+++ b/contracts/extensions/StreamingPayments.sol
@@ -189,7 +189,7 @@ contract StreamingPayments is ColonyExtensionMeta {
 
       uint256 amountEntitledFromStart = getAmountEntitledFromStart(_id, _tokens[i]);
       uint256 amountSinceLastClaim = sub(amountEntitledFromStart, paymentToken.pseudoAmountClaimedFromStart);
-      amountsToClaim[i] = getAmountClaimable(_id, _tokens[i], amountSinceLastClaim);
+      amountsToClaim[i] = getAmountClaimable(domainFundingPotId, _tokens[i], amountSinceLastClaim);
       paymentToken.pseudoAmountClaimedFromStart = add(paymentToken.pseudoAmountClaimedFromStart, amountsToClaim[i]);
       anythingToClaim = anythingToClaim || amountsToClaim[i] > 0;
     }


### PR DESCRIPTION
There's a bug in Streaming Payments that my multicall work uncovered. This PR fixes it.

EDIT: I think that function really should be expecting the expenditure id, but it's much more gas efficient like this.