### PR TITLE
Update versioning check script

### DIFF
--- a/scripts/versioningCheck.sh
+++ b/scripts/versioningCheck.sh
@@ -8,12 +8,9 @@ git checkout $LATEST_RELEASE
 
 # Compile release
 
-npm i --force && npx truffle compile
+npm ci --force && npx truffle compile
 rm -rf build-$LATEST_RELEASE || true
 mv build build-$LATEST_RELEASE
-
-git checkout yarn.lock
-rm package-lock.json
 
 # Compile current commit
 git checkout $CURRENT_BRANCH


### PR DESCRIPTION
The latest release now uses `npm` not yarn, so we don't have dance around quite so many houses with the version check script (and, indeed, trying to do so broke the builds).