### PR TITLE
Add event for arbitrary transactions

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -26,10 +26,10 @@ import "./ColonyStorage.sol";
 
 contract Colony is BasicMetaTransaction, ColonyStorage, PatriciaTreeProofs {
 
-  // V10: G Lightweight Spaceship
+  // V11: G Lightweight Spaceship 2
   // This function, exactly as defined, is used in build scripts. Take care when updating.
   // Version number should be upped with every change in Colony or its dependency contracts or libraries.
-  function version() public pure returns (uint256 colonyVersion) { return 10; }
+  function version() public pure returns (uint256 colonyVersion) { return 11; }
 
   function getColonyNetwork() public view returns (address) {
     return colonyNetworkAddress;

--- a/contracts/colony/ColonyArbitraryTransaction.sol
+++ b/contracts/colony/ColonyArbitraryTransaction.sol
@@ -94,6 +94,8 @@ contract ColonyArbitraryTransaction is ColonyStorage {
 
     if (sig == APPROVE_SIG) { approveTransactionCleanup(_to, _action); }
 
+    emit ArbitraryTransaction(_to, _action, res);
+
     return res;
   }
 

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -347,6 +347,8 @@ interface ColonyDataTypes {
   /// @param amount The (maximum) amount the address is having its reputation changed by
   event ArbitraryReputationUpdate(address agent, address user, uint256 skillId, int256 amount);
 
+  event ArbitraryTransaction(address target, bytes data, bool success);
+
   struct RewardPayoutCycle {
     // Reputation root hash at the time of reward payout creation
     bytes32 reputationState;

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -13,7 +13,7 @@ const INT256_MIN = new BN(2).pow(new BN(255)).mul(new BN(-1));
 const INT128_MAX = new BN(2).pow(new BN(127)).sub(new BN(1));
 const INT128_MIN = new BN(2).pow(new BN(127)).mul(new BN(-1));
 
-const CURR_VERSION = 10;
+const CURR_VERSION = 11;
 
 const RECOVERY_ROLE = 0;
 const ROOT_ROLE = 1;

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -385,7 +385,15 @@ async function eventMatchArgs(event, args) {
       if (arg !== event.args[i]) {
         return false;
       }
-    } else if (hexlifyAndPad(arg) !== hexlifyAndPad(event.args[i])) {
+    } else if (typeof arg === "number") {
+      if (hexlifyAndPad(arg) !== hexlifyAndPad(event.args[i])) {
+        return false;
+      }
+    } else if (typeof arg === "string" && arg.length <= 66) {
+      if (hexlifyAndPad(arg) !== hexlifyAndPad(event.args[i])) {
+        return false;
+      }
+    } else if (arg !== event.args[i]) {
       return false;
     }
   }

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -149,7 +149,7 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleStateHash);
       console.log("tokenLockingStateHash:", tokenLockingStateHash);
 
-      expect(colonyNetworkStateHash).to.equal("0x4dd3b98782ed065f4b03a08f31ea62f9ad57c66a80dea0c48d9cc17402bc566b");
+      expect(colonyNetworkStateHash).to.equal("0x570abb3930d7a11071801bb7d43a48fd726722371a49f4f7ec73714f9987c818");
       expect(colonyStateHash).to.equal("0xa49d332bbdd1951f062b1ffc40bbeb7b3a0a16fd2cd1879fca8348eda7b5b587");
       expect(metaColonyStateHash).to.equal("0xff23657f917385e6a94f328907443fef625f08b8b3224e065a53b690f91be0bb");
       expect(miningCycleStateHash).to.equal("0x264d4a83e21fef92f687f9fabacae9370966b0b30ebc15307653c4c3d33a0035");

--- a/test/contracts-network/colony-arbitrary-transactions.js
+++ b/test/contracts-network/colony-arbitrary-transactions.js
@@ -6,7 +6,7 @@ const { ethers } = require("ethers");
 const { soliditySha3 } = require("web3-utils");
 
 const { UINT256_MAX, WAD } = require("../../helpers/constants");
-const { checkErrorRevert, encodeTxData } = require("../../helpers/test-helper");
+const { checkErrorRevert, encodeTxData, expectEvent } = require("../../helpers/test-helper");
 const { setupRandomColony, fundColonyWithTokens } = require("../../helpers/test-data-generator");
 
 const { expect } = chai;
@@ -39,7 +39,9 @@ contract("Colony Arbitrary Transactions", (accounts) => {
     const action = await encodeTxData(token, "mint", [WAD]);
     const balancePre = await token.balanceOf(colony.address);
 
-    await colony.makeArbitraryTransaction(token.address, action);
+    const tx = await colony.makeArbitraryTransaction(token.address, action);
+
+    await expectEvent(tx, "ArbitraryTransaction(address,bytes,bool)", [token.address, action, true]);
 
     const balancePost = await token.balanceOf(colony.address);
     expect(balancePost.sub(balancePre)).to.eq.BN(WAD);
@@ -50,7 +52,10 @@ contract("Colony Arbitrary Transactions", (accounts) => {
     const action2 = await encodeTxData(token, "mint", [WAD.muln(2)]);
     const balancePre = await token.balanceOf(colony.address);
 
-    await colony.makeArbitraryTransactions([token.address, token.address], [action, action2], true);
+    const tx = await colony.makeArbitraryTransactions([token.address, token.address], [action, action2], true);
+
+    await expectEvent(tx, "ArbitraryTransaction(address,bytes,bool)", [token.address, action, true]);
+    await expectEvent(tx, "ArbitraryTransaction(address,bytes,bool)", [token.address, action2, true]);
 
     const balancePost = await token.balanceOf(colony.address);
     expect(balancePost.sub(balancePre)).to.eq.BN(WAD.muln(3));


### PR DESCRIPTION
We try to make sure that every call has an associated event, and arbitrary transactions not having one has finally come up as an issue in the frontend.

Only tricky thing here was improving `eventMatchArgs` to accommodate bytes.