### PR TITLE
Add nonces public getter to MetaTxToken to actually be EIP2612 compliant

### DIFF
--- a/contracts/metaTxToken/MetaTxToken.sol
+++ b/contracts/metaTxToken/MetaTxToken.sol
@@ -37,6 +37,11 @@ contract MetaTxToken is DSTokenBaseMeta(0), DSAuthMeta {
     return metatransactionNonces[_user];
   }
 
+  // EIP2612 function signature
+  function nonces(address _user) external view returns (uint256 nonce){
+    return metatransactionNonces[_user];
+  }
+
   function incrementMetatransactionNonce(address _user) override internal {
     metatransactionNonces[_user]++;
   }

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -440,7 +440,7 @@ exports.getMetaTransactionParameters = async function getMetaTransactionParamete
 
 exports.getPermitParameters = async function getPermitParameters(owner, spender, amount, deadline, targetAddress) {
   const contract = await MetaTxToken.at(targetAddress);
-  const nonce = await contract.getMetatransactionNonce(owner);
+  const nonce = await contract.nonces(owner);
   const multichain = await MultiChain.new();
   const chainId = await multichain.getChainId();
   const name = await contract.name();


### PR DESCRIPTION
Strictly, MetaTxToken was not [EIP 2612 compliant](https://eips.ethereum.org/EIPS/eip-2612) as it did not have the `nonces` getter. This has finally tripped someone up, so adding it so that it can percolate through the stack at some point for new deployments, at least.