### PR TITLE
Add check for ecrecover in ColonyTask

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -27,7 +27,6 @@ import "./ColonyStorage.sol";
 
 contract Colony is BasicMetaTransaction, Multicall, ColonyStorage, PatriciaTreeProofs {
 
-  // V11: Hazel Lightweight Spaceship
   // This function, exactly as defined, is used in build scripts. Take care when updating.
   // Version number should be upped with every change in Colony or its dependency contracts or libraries.
   function version() public pure returns (uint256 colonyVersion) { return 11; }

--- a/contracts/colony/ColonyTask.sol
+++ b/contracts/colony/ColonyTask.sol
@@ -570,6 +570,7 @@ contract ColonyTask is ColonyStorage {
       }
 
       reviewerAddresses[i] = ecrecover(txHash, _sigV[i], _sigR[i], _sigS[i]);
+      require(reviewerAddresses[i] != address(0), "colony-task-invalid-signature");
     }
     return reviewerAddresses;
   }

--- a/test/contracts-network/colony-task.js
+++ b/test/contracts-network/colony-task.js
@@ -1200,6 +1200,22 @@ contract("ColonyTask", (accounts) => {
       await checkErrorRevert(colony.executeTaskChange([sigV[0]], sigR, sigS, [0], 0, txData), "colony-task-change-signatures-count-do-not-match");
     });
 
+    it("should fail to execute task change with a bad signature and only one of the relevant roles set", async () => {
+      const taskId = await makeTask({ colony });
+      const { sigR, sigS, txData } = await getSigsAndTransactionData({
+        colony,
+        taskId,
+        functionName: "setTaskDueDate",
+        signers: [MANAGER],
+        sigTypes: [0],
+        args: [taskId, "1"],
+      });
+
+      // Make the signature bad
+      const sigV = [11];
+      await checkErrorRevert(colony.executeTaskChange(sigV, sigR, sigS, [0], 0, txData), "colony-task-invalid-signature");
+    });
+
     it("should fail to execute task change send for a task role assignment call (which should be using executeTaskRoleAssignment)", async () => {
       const taskId = await makeTask({ colony });
       const { sigV, sigR, sigS, txData } = await getSigsAndTransactionData({


### PR DESCRIPTION
ColonyTask was missing the check on the return from `ecrecover`, which returns 0 for an invalid signature, which, in the case of some roles not being set for a task, allowed an invalid signature to be used to call functions on the task.