### PR TITLE
Fix MTX broadcaster intermittent bug; pay for bridge transactions

### DIFF
--- a/packages/metatransaction-broadcaster/Dockerfile
+++ b/packages/metatransaction-broadcaster/Dockerfile
@@ -3,8 +3,8 @@ COPY ./packages ./packages
 COPY ./package.json ./
 COPY ./package-lock.json ./
 COPY ./build ./build
-RUN npm ci
+RUN yarn
 RUN cd ./packages/metatransaction-broadcaster/ && npm i
 RUN cd ./packages/package-utils/ && npm i
 EXPOSE 3000
-CMD node $NODE_ARGS packages/metatransaction-broadcaster/bin/index.js --colonyNetworkAddress $COLONYNETWORK_ADDRESS --privateKey $PRIVATE_KEY --gasLimit $GASLIMIT $ARGS
+CMD node $NODE_ARGS packages/metatransaction-broadcaster/bin/index.js --colonyNetworkAddress $COLONYNETWORK_ADDRESS --privateKey $PRIVATE_KEY $ARGS

--- a/packages/metatransaction-broadcaster/MetatransactionBroadcaster.js
+++ b/packages/metatransaction-broadcaster/MetatransactionBroadcaster.js
@@ -6,6 +6,9 @@ const queue = require("express-queue");
 const NonceManager = require("./ExtendedNonceManager");
 const { colonyIOCors, ConsoleAdapter, updateGasEstimate } = require("../package-utils");
 
+const ETHEREUM_BRIDGE_ADDRESS = "0x75Df5AF045d91108662D8080fD1FEFAd6aA0bb59";
+const BINANCE_BRIDGE_ADDRESS = "0x162E898bD0aacB578C8D5F8d6ca588c13d2A383F";
+
 class MetatransactionBroadcaster {
   /**
    * Constructor for MetatransactionBroadcaster
@@ -194,14 +197,35 @@ class MetatransactionBroadcaster {
     const possibleColony = new ethers.Contract(target, colonyDef.abi, this.wallet);
     try {
       const tx = possibleColony.interface.parseTransaction({ data: txData });
-      if (tx.signature === "makeArbitraryTransaction(address,bytes)") {
-        return false;
-      }
-      if (tx.signature === "makeArbitraryTransactions(address[],bytes[],bool)") {
-        return false;
-      }
-      if (tx.signature === "makeSingleArbitraryTransaction(address,bytes)") {
-        return false;
+      // If it's an arbitrary transaction...
+      if (
+        tx.signature === "makeArbitraryTransaction(address,bytes)" ||
+        tx.signature === "makeSingleArbitraryTransaction(address,bytes)" ||
+        tx.signature === "makeArbitraryTransactions(address[],bytes[],bool)"
+      ) {
+        // We allow it if these transactions are going only to known bridges.
+        let addresses = tx.args[0];
+        let calls = tx.args[1];
+
+        if (!Array.isArray(addresses)) {
+          addresses = [addresses];
+        }
+        if (!Array.isArray(calls)) {
+          calls = [calls];
+        }
+        if (addresses.length !== calls.length) {
+          // If the arrays don't line up, return false.
+          return false;
+        }
+        for (let i = 0; i < addresses.length; i += 1) {
+          if (
+            !MetatransactionBroadcaster.isBridgeAddress(addresses[i]) || // It's not going to a bridge address
+            // Or it is, but not calling the function we allow
+            calls[i].slice(0, 10) !== ethers.utils.keccak256(ethers.utils.toUtf8Bytes("requireToPassMessage(address,bytes,uint256)")).slice(0, 10)
+          ) {
+            return false;
+          }
+        }
       }
     } catch (err) {
       // Not a colony related transaction (we recognise)
@@ -254,6 +278,19 @@ class MetatransactionBroadcaster {
     }
 
     return true;
+  }
+
+  static isBridgeAddress(targetOrTargets) {
+    if (targetOrTargets === ETHEREUM_BRIDGE_ADDRESS) {
+      return true;
+    }
+    if (targetOrTargets === BINANCE_BRIDGE_ADDRESS) {
+      return true;
+    }
+    if (Array.isArray(targetOrTargets)) {
+      return targetOrTargets.map((x) => MetatransactionBroadcaster.isBridgeAddress(x)).every((x) => x === true);
+    }
+    return false;
   }
 
   async isValidSetAuthorityTransaction(tx, userAddress) {

--- a/packages/metatransaction-broadcaster/MetatransactionBroadcaster.js
+++ b/packages/metatransaction-broadcaster/MetatransactionBroadcaster.js
@@ -8,6 +8,7 @@ const { colonyIOCors, ConsoleAdapter, updateGasEstimate } = require("../package-
 
 const ETHEREUM_BRIDGE_ADDRESS = "0x75Df5AF045d91108662D8080fD1FEFAd6aA0bb59";
 const BINANCE_BRIDGE_ADDRESS = "0x162E898bD0aacB578C8D5F8d6ca588c13d2A383F";
+const REQUIRE_TO_PASS_MESSAGE_SIG = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("requireToPassMessage(address,bytes,uint256)")).slice(0, 10);
 
 class MetatransactionBroadcaster {
   /**
@@ -217,11 +218,11 @@ class MetatransactionBroadcaster {
           // If the arrays don't line up, return false.
           return false;
         }
+
         for (let i = 0; i < addresses.length; i += 1) {
           if (
             !MetatransactionBroadcaster.isBridgeAddress(addresses[i]) || // It's not going to a bridge address
-            // Or it is, but not calling the function we allow
-            calls[i].slice(0, 10) !== ethers.utils.keccak256(ethers.utils.toUtf8Bytes("requireToPassMessage(address,bytes,uint256)")).slice(0, 10)
+            calls[i].slice(0, 10) !== REQUIRE_TO_PASS_MESSAGE_SIG // Or it is, but not calling the function we allow
           ) {
             return false;
           }

--- a/packages/package-utils/updateGasEstimate.js
+++ b/packages/package-utils/updateGasEstimate.js
@@ -40,7 +40,7 @@ const updateGasEstimate = async function (_type, chainId, adapter) {
     const gasEstimates = await axios.request(options);
     let gasPrice;
     if (gasEstimates[type]) {
-      gasPrice = ethers.utils.hexlify((gasEstimates[type] / factor) * 1e9);
+      gasPrice = ethers.utils.hexlify(ethers.BigNumber.from(gasEstimates[type] * 1e9).div(factor));
     } else {
       gasPrice = defaultGasPrice;
     }


### PR DESCRIPTION
Closes #1111 . We want people using the safe-control feature to not be obliged to pay for the bridging transaction on the Gnosis Chain side, so have whitelisted the two (currently known / cared about) bridge contracts, and allowed calls to the arbitrary transactions functions on a colony to call exactly `requireToPassMessage` on those contracts and still be eligible for using our metatransaction broadcaster.

Also fixes an untracked bug where, if the gas-price oracle used returned certain values, a non-integer would be passed to hexlify which would error. That should now no longer be possible, regardless of what value is returned by the oracle.

Based on #1113 so no merging until that is merged.