### PR TITLE
fix typo

### DIFF
--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -447,7 +447,7 @@ interface IColonyNetwork is ColonyNetworkDataTypes, IRecovery, IBasicMetaTransac
   /// @notice Called to deploy a token authority
   /// @dev This is more expensive than deploying a token directly, but is able to be done via
   /// a metatransaction
-  /// @param _token The address of the otken
+  /// @param _token The address of the token
   /// @param _colony The address of the colony in control of the token
   /// @param _allowedToTransfer An array of addresses that are allowed to transfer the token even if it's locked
   /// @return _tokenAuthority The address of the newly deployed TokenAuthority

--- a/docs/interfaces/icolonynetwork.md
+++ b/docs/interfaces/icolonynetwork.md
@@ -258,7 +258,7 @@ Called to deploy a token authority
 
 |Name|Type|Description|
 |---|---|---|
-|_token|address|The address of the otken
+|_token|address|The address of the token
 |_colony|address|The address of the colony in control of the token
 |_allowedToTransfer|address[]|An array of addresses that are allowed to transfer the token even if it's locked
 


### PR DESCRIPTION
# Description

Fix a typo in the params comment for `deployTokenAuthority`

