### PR TITLE
Make sure colonies have roles associated with functions introduced in v8

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -310,12 +310,18 @@ contract Colony is BasicMetaTransaction, Multicall, ColonyStorage, PatriciaTreeP
     emit ColonyUpgraded(msgSender(), currentVersion, _newVersion);
   }
 
-  // v9 to v10
+  // v11 to v12
   function finishUpgrade() public always {
     ColonyAuthority colonyAuthority = ColonyAuthority(address(authority));
     bytes4 sig;
 
-    sig = bytes4(keccak256("setExpenditurePayout(uint256,uint256,uint256,uint256,address,uint256)"));
+    sig = bytes4(keccak256("makeArbitraryTransactions(address[],bytes[],bool)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
+
+    sig = bytes4(keccak256("setDefaultGlobalClaimDelay(uint256)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, true);
+
+    sig = bytes4(keccak256("setExpenditureMetadata(uint256,uint256,uint256,string)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Arbitration), address(this), sig, true);
   }
 


### PR DESCRIPTION
When we deployed ELWSS, according to my logs, it seems as if did not deploy a new ColonyNetwork. I assume this was because, at first glance, ColonyNetwork had not changed in the `ColonyNetwork*` files and so I didn't think it was necessary. But ColonyAuthority had changed, introducing three functions, which ColonyNetwork deploys.

As far as I can tell, any colonies created from ELWSS to ELWSS3 do not have a role permitted to call these three functions. One of these is required for Safe Control, and so we have to deploy a new version that colonies can upgrade to that fixes this functionality for those missing.

This is a script I've used to investigate the extent of the issue. I believe that this only happened for the ELWSS deployment, and no others, but I would appreciate some sanity checking on that front.

```
web3Utils = require('web3-utils');
fs = require('fs');

// To use from truffle console
// checkArbitraryTransactionPermission = require('../checkArbitraryTransactionsPermission.js').default
// cn = await IColonyNetwork.at("0x78163f593D1Fa151B4B7cacD146586aD2b686294") // Production
// cn = await IColonyNetwork.at("0x6a05DD32860C1b5351B97b4eCAAbFbc60edb102f") // QA
// checkArbitraryTransactionPermission(cn, IColony, ColonyAuthority)

exports.default = async function checkArbitraryTransactionPermission(cn, IColony, ColonyAuthority){
	colonyCount = await cn.getColonyCount()
	// For each colony, get the reputation voting contract
	console.log(colonyCount.toNumber(), "colonies");
	results = []

	for (i =1;i<=colonyCount.toNumber(); i+=1){
		if (i % 50 === 0){
			console.log(i)
		}
		colonyAddress = await cn.getColony(i)

		const c = await IColony.at(colonyAddress);
		const version = await c.version();

		const authorityAddress = await c.authority();
		const a = await ColonyAuthority.at(authorityAddress)
		const functions = [
			"",// 0
			"", // 1
			"", // 2
			"setArbitrationRole(uint256,uint256,address,uint256,bool)",
			"makeExpenditure(uint256,uint256,uint256)",
			"setPayoutWhitelist(address,bool)",
			"", //6
			"moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)",
			"makeArbitraryTransactions(address[],bytes[],bool)",
			"addLocalSkill()",
			"setExpenditurePayout(uint256,uint256,uint256,uint256,address,uint256)"
		]
		for (let idx =0; idx < functions.length; idx += 1){
			const funcName = functions[idx]
			if (funcName === ""){
				continue;
			}
			const sig = web3Utils.soliditySha3(functions[idx]).slice(0,10)
			const res = await a.getCapabilityRoles(c.address, sig)
			if (res === "0x0000000000000000000000000000000000000000000000000000000000000000" && version.toNumber() >= idx){
				const name = await cn.lookupRegisteredENSDomain(colonyAddress)
				console.log('v', version.toNumber(), c.address, name, 'missing', funcName)
			}

		}

	}
}
```