### PR TITLE
Remove uses of add/sub/mul

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -107,8 +107,8 @@ contract Colony is BasicMetaTransaction, Multicall, ColonyStorage, PatriciaTreeP
     for (uint256 i = 0; i < _users.length; i++) {
       require(_amounts[i] >= 0, "colony-bootstrap-bad-amount-input");
       require(uint256(_amounts[i]) <= fundingPots[1].balance[token], "colony-bootstrap-not-enough-tokens");
-      fundingPots[1].balance[token] = sub(fundingPots[1].balance[token], uint256(_amounts[i]));
-      nonRewardPotsTotal[token] = sub(nonRewardPotsTotal[token], uint256(_amounts[i]));
+      fundingPots[1].balance[token] = fundingPots[1].balance[token] - uint256(_amounts[i]);
+      nonRewardPotsTotal[token] = nonRewardPotsTotal[token] - uint256(_amounts[i]);
     }
 
     // After doing all the local storage changes, then do all the external calls
@@ -336,7 +336,7 @@ contract Colony is BasicMetaTransaction, Multicall, ColonyStorage, PatriciaTreeP
     // This mapping is in slot 34 (see ColonyStorage.sol);
     uint256 slot = uint256(keccak256(abi.encode(uint256(uint160(_user)), uint256(METATRANSACTION_NONCES_SLOT))));
     protectSlot(slot);
-    metatransactionNonces[_user] = add(metatransactionNonces[_user], 1);
+    metatransactionNonces[_user] += 1;
   }
 
   function checkNotAdditionalProtectedVariable(uint256 _slot) public view {
@@ -345,20 +345,20 @@ contract Colony is BasicMetaTransaction, Multicall, ColonyStorage, PatriciaTreeP
   }
 
   function approveStake(address _approvee, uint256 _domainId, uint256 _amount) public stoppable {
-    approvals[msgSender()][_approvee][_domainId] = add(approvals[msgSender()][_approvee][_domainId], _amount);
+    approvals[msgSender()][_approvee][_domainId] += _amount;
 
     ITokenLocking(tokenLockingAddress).approveStake(msgSender(), _amount, token);
   }
 
   function obligateStake(address _user, uint256 _domainId, uint256 _amount) public stoppable {
-    approvals[_user][msgSender()][_domainId] = sub(approvals[_user][msgSender()][_domainId], _amount);
-    obligations[_user][msgSender()][_domainId] = add(obligations[_user][msgSender()][_domainId], _amount);
+    approvals[_user][msgSender()][_domainId] -= _amount;
+    obligations[_user][msgSender()][_domainId] += _amount;
 
     ITokenLocking(tokenLockingAddress).obligateStake(_user, _amount, token);
   }
 
   function deobligateStake(address _user, uint256 _domainId, uint256 _amount) public stoppable {
-    obligations[_user][msgSender()][_domainId] = sub(obligations[_user][msgSender()][_domainId], _amount);
+    obligations[_user][msgSender()][_domainId] -= _amount;
 
     ITokenLocking(tokenLockingAddress).deobligateStake(_user, _amount, token);
   }
@@ -373,7 +373,7 @@ contract Colony is BasicMetaTransaction, Multicall, ColonyStorage, PatriciaTreeP
     address _beneficiary
   ) public stoppable authDomain(_permissionDomainId, _childSkillIndex, _domainId)
   {
-    obligations[_user][_obligator][_domainId] = sub(obligations[_user][_obligator][_domainId], _amount);
+    obligations[_user][_obligator][_domainId] -= _amount;
 
     ITokenLocking(tokenLockingAddress).transferStake(_user, _amount, token, _beneficiary);
   }

--- a/contracts/colony/ColonyArbitraryTransaction.sol
+++ b/contracts/colony/ColonyArbitraryTransaction.sol
@@ -155,10 +155,10 @@ contract ColonyArbitraryTransaction is ColonyStorage {
     if (recordedApproval > actualApproval && !_postApproval){
       // They've spend some tokens out of root. Adjust balances accordingly
       // If we are post approval, then they have not spent tokens
-      fundingPots[1].balance[_token] = fundingPots[1].balance[_token] - recordedApproval + actualApproval;
+      fundingPots[1].balance[_token] = (fundingPots[1].balance[_token] - recordedApproval) + actualApproval;
     }
 
-    tokenApprovalTotals[_token] = tokenApprovalTotals[_token] - recordedApproval + actualApproval;
+    tokenApprovalTotals[_token] = (tokenApprovalTotals[_token] - recordedApproval) + actualApproval;
     require(fundingPots[1].balance[_token] >= tokenApprovalTotals[_token], "colony-approval-exceeds-balance");
 
     tokenApprovals[_token][_spender] = actualApproval;

--- a/contracts/colony/ColonyArbitraryTransaction.sol
+++ b/contracts/colony/ColonyArbitraryTransaction.sol
@@ -120,7 +120,7 @@ contract ColonyArbitraryTransaction is ColonyStorage {
     assembly {
       amount := mload(add(_action, 0x24))
     }
-    fundingPots[1].balance[_to] = sub(fundingPots[1].balance[_to], amount);
+    fundingPots[1].balance[_to] -= amount;
     require(fundingPots[1].balance[_to] >= tokenApprovalTotals[_to], "colony-not-enough-tokens");
   }
 
@@ -129,7 +129,7 @@ contract ColonyArbitraryTransaction is ColonyStorage {
     assembly {
       amount := mload(add(_action, 0x44))
     }
-    fundingPots[1].balance[_to] = sub(fundingPots[1].balance[_to], amount);
+    fundingPots[1].balance[_to] -= amount;
     require(fundingPots[1].balance[_to] >= tokenApprovalTotals[_to], "colony-not-enough-tokens");
   }
 
@@ -155,10 +155,10 @@ contract ColonyArbitraryTransaction is ColonyStorage {
     if (recordedApproval > actualApproval && !_postApproval){
       // They've spend some tokens out of root. Adjust balances accordingly
       // If we are post approval, then they have not spent tokens
-      fundingPots[1].balance[_token] = add(sub(fundingPots[1].balance[_token], recordedApproval), actualApproval);
+      fundingPots[1].balance[_token] = fundingPots[1].balance[_token] - recordedApproval + actualApproval;
     }
 
-    tokenApprovalTotals[_token] = add(sub(tokenApprovalTotals[_token], recordedApproval), actualApproval);
+    tokenApprovalTotals[_token] = tokenApprovalTotals[_token] - recordedApproval + actualApproval;
     require(fundingPots[1].balance[_token] >= tokenApprovalTotals[_token], "colony-approval-exceeds-balance");
 
     tokenApprovals[_token][_spender] = actualApproval;

--- a/contracts/colony/ColonyExpenditure.sol
+++ b/contracts/colony/ColonyExpenditure.sol
@@ -400,7 +400,7 @@ contract ColonyExpenditure is ColonyStorage {
       if (_mask[i] == ARRAY) {
         require(uint256(_keys[i]) <= MAX_ARRAY, "colony-expenditure-large-offset");
 
-        slot = bytes32(add(uint256(_keys[i]), uint256(slot)));
+        slot = bytes32(uint256(_keys[i]) + uint256(slot));
         // If we are indexing in to an array, and this was the last entry
         //  in keys, then we have arrived at the storage slot that we want
         //  to set, and so do not hash the slot (which would take us to the

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -417,7 +417,7 @@ contract ColonyFunding is ColonyStorage { // ignore-swc-123
       uint256 currentPayout = expenditureSlotPayouts[_id][_slots[i]][_token];
 
       expenditureSlotPayouts[_id][_slots[i]][_token] = _amounts[i];
-      fundingPot.payouts[_token] = currentTotal - currentPayout + _amounts[i];
+      fundingPot.payouts[_token] = (currentTotal - currentPayout) + _amounts[i];
 
 
       emit ExpenditurePayoutSet(msgSender(), _id, _slots[i], _token, _amounts[i]);
@@ -439,7 +439,7 @@ contract ColonyFunding is ColonyStorage { // ignore-swc-123
     uint currentTaskRolePayout = task.payouts[uint8(_role)][_token];
     task.payouts[uint8(_role)][_token] = _amount;
 
-    fundingPot.payouts[_token] = currentTotalAmount - currentTaskRolePayout + _amount;
+    fundingPot.payouts[_token] = (currentTotalAmount - currentTaskRolePayout) + _amount;
 
     updatePayoutsWeCannotMakeAfterBudgetChange(task.fundingPotId, _token, currentTotalAmount);
   }

--- a/contracts/colony/ColonyRewards.sol
+++ b/contracts/colony/ColonyRewards.sol
@@ -39,11 +39,11 @@ contract ColonyRewards is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
   {
     ITokenLocking tokenLocking = ITokenLocking(tokenLockingAddress);
     uint256 totalLockCount = tokenLocking.lockToken(token);
-    uint256 thisPayoutAmount = sub(fundingPots[0].balance[_token], pendingRewardPayments[_token]);
+    uint256 thisPayoutAmount = fundingPots[0].balance[_token] - pendingRewardPayments[_token];
     require(thisPayoutAmount > 0, "colony-reward-payout-no-rewards");
-    pendingRewardPayments[_token] = add(pendingRewardPayments[_token], thisPayoutAmount);
+    pendingRewardPayments[_token] = pendingRewardPayments[_token] + thisPayoutAmount;
 
-    uint256 totalTokens = sub(ERC20Extended(token).totalSupply(), ERC20Extended(token).balanceOf(address(this)));
+    uint256 totalTokens = ERC20Extended(token).totalSupply() - ERC20Extended(token).balanceOf(address(this));
     require(totalTokens > 0, "colony-reward-payout-invalid-total-tokens");
 
     bytes32 rootHash = IColonyNetwork(colonyNetworkAddress).getReputationRootHash();
@@ -99,14 +99,11 @@ contract ColonyRewards is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     ITokenLocking(tokenLockingAddress).unlockTokenForUser(token, msgSender(), _payoutId);
 
     uint fee = calculateNetworkFeeForPayout(reward);
-    uint remainder = sub(reward, fee);
+    uint remainder = reward - fee;
 
-    fundingPots[0].balance[tokenAddress] = sub(fundingPots[0].balance[tokenAddress], reward);
-    pendingRewardPayments[rewardPayoutCycles[_payoutId].tokenAddress] = sub(
-      pendingRewardPayments[rewardPayoutCycles[_payoutId].tokenAddress],
-      reward
-    );
-    rewardPayoutCycles[_payoutId].amountRemaining = sub(rewardPayoutCycles[_payoutId].amountRemaining, reward);
+    fundingPots[0].balance[tokenAddress] -= reward;
+    pendingRewardPayments[rewardPayoutCycles[_payoutId].tokenAddress] -= reward;
+    rewardPayoutCycles[_payoutId].amountRemaining -= reward;
 
     assert(ERC20Extended(tokenAddress).transfer(msgSender(), remainder));
     assert(ERC20Extended(tokenAddress).transfer(colonyNetworkAddress, fee));
@@ -121,7 +118,7 @@ contract ColonyRewards is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     require(block.timestamp - payout.blockTimestamp > 60 days, "colony-reward-payout-active");
 
     rewardPayoutCycles[_payoutId].finalized = true;
-    pendingRewardPayments[payout.tokenAddress] = sub(pendingRewardPayments[payout.tokenAddress], payout.amountRemaining);
+    pendingRewardPayments[payout.tokenAddress] -= payout.amountRemaining;
 
     emit RewardPayoutCycleEnded(msgSender(), _payoutId);
   }
@@ -190,18 +187,18 @@ contract ColonyRewards is ColonyStorage, PatriciaTreeProofs { // ignore-swc-123
     // squareRoots[5] - square root of denominator
     // squareRoots[6] - square root of payout.amount
 
-    require(mul(squareRoots[0], squareRoots[0]) <= userReputation, "colony-reward-payout-invalid-parameter-user-reputation");
-    require(mul(squareRoots[1], squareRoots[1]) <= userTokens, "colony-reward-payout-invalid-parameter-user-token");
-    require(mul(squareRoots[2], squareRoots[2]) >= payout.colonyWideReputation, "colony-reward-payout-invalid-parameter-total-reputation");
-    require(mul(squareRoots[3], squareRoots[3]) >= payout.totalTokens, "colony-reward-payout-invalid-parameter-total-tokens");
-    require(mul(squareRoots[6], squareRoots[6]) <= payout.amount, "colony-reward-payout-invalid-parameter-amount");
-    uint256 numerator = mul(squareRoots[0], squareRoots[1]);
-    uint256 denominator = mul(squareRoots[2], squareRoots[3]);
+    require(squareRoots[0] * squareRoots[0] <= userReputation, "colony-reward-payout-invalid-parameter-user-reputation");
+    require(squareRoots[1] * squareRoots[1] <= userTokens, "colony-reward-payout-invalid-parameter-user-token");
+    require(squareRoots[2] * squareRoots[2] >= payout.colonyWideReputation, "colony-reward-payout-invalid-parameter-total-reputation");
+    require(squareRoots[3] * squareRoots[3] >= payout.totalTokens, "colony-reward-payout-invalid-parameter-total-tokens");
+    require(squareRoots[6] * squareRoots[6] <= payout.amount, "colony-reward-payout-invalid-parameter-amount");
+    uint256 numerator = squareRoots[0] * squareRoots[1];
+    uint256 denominator = squareRoots[2] * squareRoots[3];
 
-    require(mul(squareRoots[4], squareRoots[4]) <= numerator, "colony-reward-payout-invalid-parameter-numerator");
-    require(mul(squareRoots[5], squareRoots[5]) >= denominator, "colony-reward-payout-invalid-parameter-denominator");
+    require(squareRoots[4] * squareRoots[4] <= numerator, "colony-reward-payout-invalid-parameter-numerator");
+    require(squareRoots[5] * squareRoots[5] >= denominator, "colony-reward-payout-invalid-parameter-denominator");
 
-    uint256 reward = (mul(squareRoots[4], squareRoots[6]) / squareRoots[5]) ** 2;
+    uint256 reward = (squareRoots[4] * squareRoots[6] / squareRoots[5]) ** 2;
 
     return (payout.tokenAddress, reward);
   }

--- a/contracts/colony/ColonyTask.sol
+++ b/contracts/colony/ColonyTask.sol
@@ -59,7 +59,7 @@ contract ColonyTask is ColonyStorage {
     uint taskCompletionTime = tasks[_id].completionTimestamp;
 
     // Check we are within 5 days of the work submission time
-    require(sub(block.timestamp, taskCompletionTime) <= RATING_COMMIT_TIMEOUT, "colony-task-rating-secret-submit-period-closed");
+    require(block.timestamp - taskCompletionTime <= RATING_COMMIT_TIMEOUT, "colony-task-rating-secret-submit-period-closed");
     _;
   }
 
@@ -71,11 +71,11 @@ contract ColonyTask is ColonyStorage {
     // Otherwise start the reveal period after the commit period has expired
     // In both cases, keep reveal period open for 5 days
     if (ratingSecrets.count == 2) {
-      require(sub(block.timestamp, ratingSecrets.timestamp) <= RATING_REVEAL_TIMEOUT, "colony-task-rating-secret-reveal-period-closed");
+      require(block.timestamp - ratingSecrets.timestamp <= RATING_REVEAL_TIMEOUT, "colony-task-rating-secret-reveal-period-closed");
     } else if (ratingSecrets.count < 2) {
       uint taskCompletionTime = tasks[_id].completionTimestamp;
-      require(sub(block.timestamp, taskCompletionTime) > RATING_COMMIT_TIMEOUT, "colony-task-rating-secret-reveal-period-not-open");
-      require(sub(block.timestamp, taskCompletionTime) <= add(RATING_COMMIT_TIMEOUT, RATING_REVEAL_TIMEOUT), "colony-task-rating-secret-reveal-period-closed");
+      require(block.timestamp - taskCompletionTime > RATING_COMMIT_TIMEOUT, "colony-task-rating-secret-reveal-period-not-open");
+      require(block.timestamp - taskCompletionTime <= RATING_COMMIT_TIMEOUT + RATING_REVEAL_TIMEOUT, "colony-task-rating-secret-reveal-period-closed");
     }
     _;
   }
@@ -539,10 +539,10 @@ contract ColonyTask is ColonyStorage {
     assert(rating != TaskRatings.None);
 
     bool negative = (rating == TaskRatings.Unsatisfactory);
-    uint256 reputation = mul(payout, (rating == TaskRatings.Excellent) ? 3 : 2);
+    uint256 reputation = payout * ((rating == TaskRatings.Excellent) ? 3 : 2);
 
     if (rateFail) {
-      reputation = negative ? add(reputation, payout) : sub(reputation, payout);
+      reputation = negative ? reputation + payout : reputation - payout;
     }
 
     // We may lose one atom of reputation here :sad:
@@ -602,7 +602,7 @@ contract ColonyTask is ColonyStorage {
     // More than 10 days from completion have passed
     return (
       tasks[_id].completionTimestamp > 0 && // If this is zero, the task isn't complete yet!
-      sub(block.timestamp, tasks[_id].completionTimestamp) > add(RATING_COMMIT_TIMEOUT, RATING_REVEAL_TIMEOUT)
+      block.timestamp - tasks[_id].completionTimestamp > RATING_COMMIT_TIMEOUT + RATING_REVEAL_TIMEOUT
     );
   }
 

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -176,7 +176,7 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage, Multicall 
   }
 
   function getParentSkillId(uint _skillId, uint _parentSkillIndex) public view returns (uint256) {
-    return ascendSkillTree(_skillId, add(_parentSkillIndex,1));
+    return ascendSkillTree(_skillId, _parentSkillIndex + 1);
   }
 
   function getChildSkillId(uint _skillId, uint _childSkillIndex) public view returns (uint256) {
@@ -276,7 +276,7 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage, Multicall 
     // This mapping is in slot 41 (see ColonyNetworkStorage.sol);
     uint256 slot = uint256(keccak256(abi.encode(uint256(uint160(_user)), uint256(METATRANSACTION_NONCES_SLOT))));
     protectSlot(slot);
-    metatransactionNonces[_user] = add(metatransactionNonces[_user], 1);
+    metatransactionNonces[_user] += 1;
   }
 
   function ascendSkillTree(uint _skillId, uint _parentSkillNumber) internal view returns (uint256) {

--- a/contracts/colonyNetwork/ColonyNetworkAuction.sol
+++ b/contracts/colonyNetwork/ColonyNetworkAuction.sol
@@ -165,6 +165,7 @@ contract DutchAuction is DSMath, MultiChain, BasicMetaTransaction {
     // Total amount to end the auction at the current price
     uint totalToEndAuctionAtCurrentPrice;
     // For low quantity auctions, there are cases where q * p < 1e18 once price has decreased sufficiently
+    // slither-disable-next-line incorrect-equality
     if (quantity < TOKEN_MULTIPLIER && price() == minPrice) {
       totalToEndAuctionAtCurrentPrice = 1;
     } else {
@@ -190,6 +191,9 @@ contract DutchAuction is DSMath, MultiChain, BasicMetaTransaction {
     if (daysOpen > 36) {
       return minPrice;
     }
+    // This isn't a weak pseudo rng, this is a legitimate use of modulo on a timestamp to work out what
+    // fraction of a day has passed (in addition to a whole number of days)
+    //slither-disable-next-line weak-prng
     uint r = duration % 86400;
 
     uint x = 10**(36 - daysOpen) * (864000 - 9 * r) / 864000;
@@ -274,9 +278,10 @@ contract DutchAuction is DSMath, MultiChain, BasicMetaTransaction {
     bids[recipient] = 0;
     uint beforeClaimBalance = token.balanceOf(recipient);
     assert(token.transfer(recipient, tokens));
-    // slither-disable-next-line incorrect-equality
+    // slither-disable-start incorrect-equality
     assert(token.balanceOf(recipient) == beforeClaimBalance + tokens);
     assert(bids[recipient] == 0);
+    // slither-disable-end incorrect-equality
 
     emit AuctionClaim(recipient, tokens);
     return true;

--- a/contracts/colonyNetwork/ColonyNetworkMining.sol
+++ b/contracts/colonyNetwork/ColonyNetworkMining.sol
@@ -151,9 +151,9 @@ contract ColonyNetworkMining is ColonyNetworkStorage, MultiChain {
 
     // (1 - exp{-t_n/T}) * (1 - (n-1)/N), 3rd degree Taylor expansion for exponential term
     uint256 tnDivT = wdiv(timeStakedMax * WAD, T);
-    uint256 expTnDivT = add(add(add(WAD, tnDivT), wmul(tnDivT, tnDivT) / 2), wmul(wmul(tnDivT, tnDivT), tnDivT) / 6);
-    uint256 stakeTerm = sub(WAD, wdiv(WAD, expTnDivT));
-    uint256 submissionTerm = sub(WAD, wdiv(submissonIndex * WAD, N));
+    uint256 expTnDivT = (((WAD + tnDivT) + wmul(tnDivT, tnDivT) / 2) + wmul(wmul(tnDivT, tnDivT), tnDivT) / 6);
+    uint256 stakeTerm = WAD - wdiv(WAD, expTnDivT);
+    uint256 submissionTerm = WAD - wdiv(submissonIndex * WAD, N);
     return wmul(stakeTerm, submissionTerm);
   }
 
@@ -174,7 +174,7 @@ contract ColonyNetworkMining is ColonyNetworkStorage, MultiChain {
     for (i = 0; i < stakers.length; i++) {
       timeStaked = miningStakes[stakers[i]].timestamp;
       minerWeights[i] = calculateMinerWeight(block.timestamp - timeStaked, i);
-      minerWeightsTotal = add(minerWeightsTotal, minerWeights[i]);
+      minerWeightsTotal += minerWeights[i];
     }
 
     uint256 realReward; // Used to prevent dust buildup due to small imprecisions in WAD arithmetic.
@@ -213,7 +213,7 @@ contract ColonyNetworkMining is ColonyNetworkStorage, MultiChain {
     // it in ReputationMiningCycle.invalidateHash;
     for (uint256 i; i < _stakers.length; i++) {
       lostStake = min(miningStakes[_stakers[i]].amount, _amount);
-      miningStakes[_stakers[i]].amount = sub(miningStakes[_stakers[i]].amount, lostStake);
+      miningStakes[_stakers[i]].amount -= lostStake;
     }
 
     ITokenLocking(tokenLocking).deposit(clnyToken, 0, true); // Faux deposit to clear any locks
@@ -227,7 +227,7 @@ contract ColonyNetworkMining is ColonyNetworkStorage, MultiChain {
 
   function reward(address _recipient, uint256 _amount) public stoppable onlyReputationMiningCycle {
     // TODO: Gain rep?
-    pendingMiningRewards[_recipient] = add(pendingMiningRewards[_recipient], _amount);
+    pendingMiningRewards[_recipient] += _amount;
   }
 
   function claimMiningReward(address _recipient) public stoppable {
@@ -244,7 +244,7 @@ contract ColonyNetworkMining is ColonyNetworkStorage, MultiChain {
     ITokenLocking(tokenLocking).obligateStake(msgSender(), _amount, clnyToken);
 
     miningStakes[msgSender()].timestamp = getNewTimestamp(miningStakes[msgSender()].amount, _amount, miningStakes[msgSender()].timestamp, block.timestamp);
-    miningStakes[msgSender()].amount = add(miningStakes[msgSender()].amount, _amount);
+    miningStakes[msgSender()].amount += _amount;
   }
 
   function unstakeForMining(uint256 _amount) public stoppable {
@@ -252,7 +252,7 @@ contract ColonyNetworkMining is ColonyNetworkStorage, MultiChain {
     // Prevent those involved in a mining cycle withdrawing stake during the mining process.
     require(!IReputationMiningCycle(activeReputationMiningCycle).userInvolvedInMiningCycle(msgSender()), "colony-network-hash-submitted");
     ITokenLocking(tokenLocking).deobligateStake(msgSender(), _amount, clnyToken);
-    miningStakes[msgSender()].amount = sub(miningStakes[msgSender()].amount, _amount);
+    miningStakes[msgSender()].amount -= _amount;
   }
 
   function getMiningStake(address _user) public view returns (MiningStake memory) {
@@ -296,7 +296,7 @@ contract ColonyNetworkMining is ColonyNetworkStorage, MultiChain {
       currWeight /= 2;
     }
 
-    return add(mul(prevWeight, _prevTime), mul(currWeight, _currTime)) / add(prevWeight, currWeight);
+    return ((prevWeight * _prevTime) + (currWeight * _currTime)) / (prevWeight + currWeight);
   }
 
   function setMiningResolver(address _miningResolver) public

--- a/contracts/colonyNetwork/ColonyNetworkMining.sol
+++ b/contracts/colonyNetwork/ColonyNetworkMining.sol
@@ -289,7 +289,8 @@ contract ColonyNetworkMining is ColonyNetworkStorage, MultiChain {
   function getNewTimestamp(uint256 _prevWeight, uint256 _currWeight, uint256 _prevTime, uint256 _currTime) internal pure returns (uint256) {
     uint256 prevWeight = _prevWeight;
     uint256 currWeight = _currWeight;
-
+    // This is the exact scenario in the docs they say this might be required - avoiding overflows
+    // slither-disable-start divide-before-multiply
     // Needed to prevent overflows in the timestamp calculation
     while ((prevWeight >= UINT192_MAX) || (currWeight >= UINT192_MAX)) {
       prevWeight /= 2;
@@ -297,6 +298,7 @@ contract ColonyNetworkMining is ColonyNetworkStorage, MultiChain {
     }
 
     return ((prevWeight * _prevTime) + (currWeight * _currTime)) / (prevWeight + currWeight);
+    // slither-disable-end divide-before-multiply
   }
 
   function setMiningResolver(address _miningResolver) public

--- a/contracts/extensions/CoinMachine.sol
+++ b/contracts/extensions/CoinMachine.sol
@@ -226,15 +226,15 @@ contract CoinMachine is ColonyExtension, BasicMetaTransaction {
       return;
     }
 
-    activeIntake = add(activeIntake, totalCost);
-    activeSold = add(activeSold, numTokens);
+    activeIntake += totalCost;
+    activeSold += numTokens;
 
     assert(activeSold <= maxPerPeriod);
 
     // Do userLimitFraction bookkeeping (only if needed)
     if (userLimitFraction < WAD) {
-      soldTotal = add(soldTotal, numTokens);
-      soldUser[msgSender()] = add(soldUser[msgSender()], numTokens);
+      soldTotal += numTokens;
+      soldUser[msgSender()] += numTokens;
     }
 
     // Check if we've sold out
@@ -388,7 +388,7 @@ contract CoinMachine is ColonyExtension, BasicMetaTransaction {
   /// @notice Get the number of remaining tokens for sale this period
   /// @return _remaining Tokens remaining
   function getSellableTokens() public view returns (uint256 _remaining) {
-    return sub(maxPerPeriod, ((activePeriod >= getCurrentPeriod()) ? activeSold : 0));
+    return (maxPerPeriod - ((activePeriod >= getCurrentPeriod()) ? activeSold : 0));
   }
 
   /// @notice Get the maximum amount of tokens a user can purchase in total
@@ -398,7 +398,7 @@ contract CoinMachine is ColonyExtension, BasicMetaTransaction {
     return
       (userLimitFraction == WAD || whitelist == address(0x0)) ?
       UINT256_MAX :
-      sub(wmul(add(getTokenBalance(), soldTotal), userLimitFraction), soldUser[_user])
+      wmul(getTokenBalance() + soldTotal, userLimitFraction) - soldUser[_user]
     ;
   }
 

--- a/contracts/extensions/EvaluatedExpenditure.sol
+++ b/contracts/extensions/EvaluatedExpenditure.sol
@@ -74,7 +74,7 @@ contract EvaluatedExpenditure is ColonyExtension, BasicMetaTransaction {
   }
 
   function incrementMetatransactionNonce(address _user) override internal {
-    metatransactionNonces[_user] = add(metatransactionNonces[_user], 1);
+    metatransactionNonces[_user] += 1;
   }
 
   /// @notice Sets the payout modifiers in given expenditure slots, using the arbitration permission

--- a/contracts/extensions/FundingQueue.sol
+++ b/contracts/extensions/FundingQueue.sol
@@ -268,11 +268,7 @@ contract FundingQueue is ColonyExtension, BasicMetaTransaction {
 
     // Update the user's reputation backing
     uint256 prevBacking = supporters[_id][msgSender()];
-    if (_backing >= prevBacking) {
-      proposal.totalSupport = add(proposal.totalSupport, sub(_backing, prevBacking));
-    } else {
-      proposal.totalSupport = sub(proposal.totalSupport, sub(prevBacking, _backing));
-    }
+    proposal.totalSupport = proposal.totalSupport - prevBacking + _backing;
     supporters[_id][msgSender()] = _backing;
 
     // Remove the proposal from its current position, if exists
@@ -311,20 +307,18 @@ contract FundingQueue is ColonyExtension, BasicMetaTransaction {
     require(queue[HEAD] == _id, "funding-queue-proposal-not-head");
 
     uint256 fundingToTransfer = calculateFundingToTransfer(_id);
-    uint256 remainingRequested = sub(proposal.totalRequested, proposal.totalPaid);
+    uint256 remainingRequested = proposal.totalRequested - proposal.totalPaid;
     uint256 actualFundingToTransfer = min(fundingToTransfer, remainingRequested);
 
     // Infer update time based on actualFundingToTransfer / fundingToTransfer
     //  This is done so, if completed, the timestamp reflects the approximate completion
-    uint256 updateTime = add(
-      proposal.lastUpdated,
+    uint256 updateTime = proposal.lastUpdated +
       wmul(
-        sub(block.timestamp, proposal.lastUpdated),
+        block.timestamp - proposal.lastUpdated,
         wdiv(actualFundingToTransfer, max(fundingToTransfer, 1)) // Avoid divide-by-zero
-      )
-    );
+      );
 
-    proposal.totalPaid = add(proposal.totalPaid, actualFundingToTransfer);
+    proposal.totalPaid += actualFundingToTransfer;
     proposal.lastUpdated = updateTime;
 
     assert(proposal.totalPaid <= proposal.totalRequested);
@@ -433,7 +427,7 @@ contract FundingQueue is ColonyExtension, BasicMetaTransaction {
     uint256 unitsElapsed = (block.timestamp - proposal.lastUpdated) / 10; // 10 second intervals
 
     uint256 newBalance = wmul(balance, wpow(decayRate, unitsElapsed));
-    uint256 fundingToTransfer = sub(balance, newBalance);
+    uint256 fundingToTransfer = balance - newBalance;
 
     return fundingToTransfer;
   }
@@ -451,10 +445,7 @@ contract FundingQueue is ColonyExtension, BasicMetaTransaction {
     uint256 lowerBin = backingPercent / (10 ** 17);
     uint256 lowerPct = (backingPercent - (lowerBin * 10 ** 17)) * 10;
 
-    return add(
-      wmul(getDecayRateFromBin(lowerBin), sub(WAD, lowerPct)),
-      wmul(getDecayRateFromBin(lowerBin + 1), lowerPct)
-    );
+    return wmul(getDecayRateFromBin(lowerBin), WAD - lowerPct) + wmul(getDecayRateFromBin(lowerBin + 1), lowerPct);
   }
 
   function getDecayRateFromBin(uint256 bin) internal pure returns (uint256) {

--- a/contracts/extensions/FundingQueue.sol
+++ b/contracts/extensions/FundingQueue.sol
@@ -268,7 +268,7 @@ contract FundingQueue is ColonyExtension, BasicMetaTransaction {
 
     // Update the user's reputation backing
     uint256 prevBacking = supporters[_id][msgSender()];
-    proposal.totalSupport = proposal.totalSupport - prevBacking + _backing;
+    proposal.totalSupport = (proposal.totalSupport - prevBacking) + _backing;
     supporters[_id][msgSender()] = _backing;
 
     // Remove the proposal from its current position, if exists

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -281,7 +281,7 @@ contract OneTxPayment is ColonyExtension, BasicMetaTransaction {
       while (j < uniqueTokensIdx && !isMatch) {
         if (_tokens[i] == uniqueTokens[j]) {
           isMatch = true;
-          uniqueAmounts[j] = add(uniqueAmounts[j], _amounts[i]);
+          uniqueAmounts[j] += _amounts[i];
         }
         j++;
       }

--- a/contracts/extensions/StreamingPayments.sol
+++ b/contracts/extensions/StreamingPayments.sol
@@ -403,6 +403,7 @@ contract StreamingPayments is ColonyExtensionMeta {
     }
 
     uint256 durationToClaim = min(block.timestamp, streamingPayment.endTime) - streamingPayment.startTime;
+    // slither-disable-next-line incorrect-equality
     if (durationToClaim == 0) {
       return 0;
     }

--- a/contracts/extensions/StreamingPayments.sol
+++ b/contracts/extensions/StreamingPayments.sol
@@ -188,9 +188,9 @@ contract StreamingPayments is ColonyExtensionMeta {
       PaymentToken storage paymentToken = paymentTokens[_id][_tokens[i]];
 
       uint256 amountEntitledFromStart = getAmountEntitledFromStart(_id, _tokens[i]);
-      uint256 amountSinceLastClaim = sub(amountEntitledFromStart, paymentToken.pseudoAmountClaimedFromStart);
+      uint256 amountSinceLastClaim = amountEntitledFromStart - paymentToken.pseudoAmountClaimedFromStart;
       amountsToClaim[i] = getAmountClaimable(domainFundingPotId, _tokens[i], amountSinceLastClaim);
-      paymentToken.pseudoAmountClaimedFromStart = add(paymentToken.pseudoAmountClaimedFromStart, amountsToClaim[i]);
+      paymentToken.pseudoAmountClaimedFromStart = paymentToken.pseudoAmountClaimedFromStart + amountsToClaim[i];
       anythingToClaim = anythingToClaim || amountsToClaim[i] > 0;
     }
 
@@ -402,7 +402,7 @@ contract StreamingPayments is ColonyExtensionMeta {
       return 0;
     }
 
-    uint256 durationToClaim = sub(min(block.timestamp, streamingPayment.endTime), streamingPayment.startTime);
+    uint256 durationToClaim = min(block.timestamp, streamingPayment.endTime) - streamingPayment.startTime;
     if (durationToClaim == 0) {
       return 0;
     }

--- a/contracts/extensions/TokenSupplier.sol
+++ b/contracts/extensions/TokenSupplier.sol
@@ -131,8 +131,8 @@ contract TokenSupplier is ColonyExtension, BasicMetaTransaction {
       isRoot() || (
         isRootFunding() &&
         block.timestamp - lastRateUpdate >= 4 weeks &&
-        _tokenIssuanceRate <= add(tokenIssuanceRate, tokenIssuanceRate / 10) &&
-        _tokenIssuanceRate >= sub(tokenIssuanceRate, tokenIssuanceRate / 10)
+        _tokenIssuanceRate <= tokenIssuanceRate + tokenIssuanceRate / 10 &&
+        _tokenIssuanceRate >= tokenIssuanceRate - tokenIssuanceRate / 10
       ), "token-supplier-caller-not-authorized"
     );
 
@@ -151,11 +151,11 @@ contract TokenSupplier is ColonyExtension, BasicMetaTransaction {
     uint256 tokenSupply = ERC20Extended(token).totalSupply();
 
     uint256 newSupply = min(
-      (tokenSupplyCeiling > tokenSupply) ? sub(tokenSupplyCeiling, tokenSupply) : 0,
+      (tokenSupplyCeiling > tokenSupply) ? (tokenSupplyCeiling - tokenSupply) : 0,
       wmul(tokenIssuanceRate, wdiv((block.timestamp - lastIssue), ISSUANCE_PERIOD))
     );
 
-    assert(newSupply == 0 || add(tokenSupply, newSupply) <= tokenSupplyCeiling);
+    assert(newSupply == 0 || (tokenSupply + newSupply) <= tokenSupplyCeiling);
 
     // Don't update lastIssue if we aren't actually issuing tokens
     if (newSupply > 0) {

--- a/contracts/extensions/votingReputation/VotingReputation.sol
+++ b/contracts/extensions/votingReputation/VotingReputation.sol
@@ -275,10 +275,10 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
     require(getMotionState(_motionId) == MotionState.Staking, "voting-rep-motion-not-staking");
 
     uint256 requiredStake = getRequiredStake(_motionId);
-    uint256 amount = min(_amount, sub(requiredStake, motion.stakes[_vote]));
+    uint256 amount = min(_amount, requiredStake - motion.stakes[_vote]);
     require(amount > 0, "voting-rep-bad-amount");
 
-    uint256 stakerTotalAmount = add(stakes[_motionId][msgSender()][_vote], amount);
+    uint256 stakerTotalAmount = stakes[_motionId][msgSender()][_vote] + amount;
 
     require(
       stakerTotalAmount <= checkReputation(motion.rootHash, motion.skillId, msgSender(), _key, _value, _branchMask, _siblings),
@@ -286,12 +286,12 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
     );
     require(
       stakerTotalAmount >= wmul(requiredStake, userMinStakeFraction) ||
-      add(motion.stakes[_vote], amount) == requiredStake, // To prevent a residual stake from being un-stakable
+      (motion.stakes[_vote] + amount) == requiredStake, // To prevent a residual stake from being un-stakable
       "voting-rep-insufficient-stake"
     );
 
     // Update the stake
-    motion.stakes[_vote] = add(motion.stakes[_vote], amount);
+    motion.stakes[_vote] += amount;
     stakes[_motionId][msgSender()][_vote] = stakerTotalAmount;
 
     // Increment counter & extend claim delay if staking for an expenditure state change
@@ -304,7 +304,7 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
       ) && motion.altTarget == address(0x0)
     ) {
       bytes32 structHash = hashExpenditureActionStruct(motion.action);
-      expenditureMotionCounts[structHash] = add(expenditureMotionCounts[structHash], 1);
+      expenditureMotionCounts[structHash] += 1;
       // Set to UINT256_MAX / 3 to avoid overflow (finalizedTimestamp + globalClaimDelay + claimDelay)
       bytes memory claimDelayAction = createClaimDelayAction(motion.action, UINT256_MAX / 3);
       require(executeCall(_motionId, claimDelayAction), "voting-rep-expenditure-lock-failed");
@@ -360,7 +360,7 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
 
     // Count reputation if first submission
     if (voteSecrets[_motionId][msgSender()] == bytes32(0)) {
-      motion.repSubmitted = add(motion.repSubmitted, userRep);
+      motion.repSubmitted += userRep;
     }
 
     voteSecrets[_motionId][msgSender()] = _voteSecret;
@@ -391,19 +391,19 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
     require(_vote <= 1, "voting-rep-bad-vote");
 
     uint256 userRep = checkReputation(motion.rootHash, motion.skillId, msgSender(), _key, _value, _branchMask, _siblings);
-    motion.votes[_vote] = add(motion.votes[_vote], userRep);
+    motion.votes[_vote] += userRep;
 
     bytes32 voteSecret = voteSecrets[_motionId][msgSender()];
     require(voteSecret == getVoteSecret(_salt, _vote), "voting-rep-secret-no-match");
     delete voteSecrets[_motionId][msgSender()];
 
     uint256 voterReward = getVoterReward(_motionId, userRep);
-    motion.paidVoterComp = add(motion.paidVoterComp, voterReward);
+    motion.paidVoterComp += voterReward;
 
     emit MotionVoteRevealed(_motionId, msgSender(), _vote);
 
     // See if reputation revealed matches reputation submitted
-    if (add(motion.votes[NAY], motion.votes[YAY]) == motion.repSubmitted) {
+    if ((motion.votes[NAY] + motion.votes[YAY]) == motion.repSubmitted) {
       motion.events[REVEAL_END] = uint64(block.timestamp);
 
       emit MotionEventSet(_motionId, REVEAL_END);
@@ -436,8 +436,8 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
     motion.skillRep = checkReputation(motion.rootHash, motion.skillId, address(0x0), _key, _value, _branchMask, _siblings);
 
     uint256 loser = (motion.votes[NAY] < motion.votes[YAY]) ? NAY : YAY;
-    motion.stakes[loser] = sub(motion.stakes[loser], motion.paidVoterComp);
-    motion.pastVoterComp[loser] = add(motion.pastVoterComp[loser], motion.paidVoterComp);
+    motion.stakes[loser] -= motion.paidVoterComp;
+    motion.pastVoterComp[loser] += motion.paidVoterComp;
     delete motion.paidVoterComp;
 
     uint256 requiredStake = getRequiredStake(_motionId);
@@ -462,7 +462,7 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
 
     assert(
       motion.stakes[YAY] == getRequiredStake(_motionId) ||
-      add(motion.votes[NAY], motion.votes[YAY]) > 0
+      (motion.votes[NAY] + motion.votes[YAY]) > 0
     );
 
     motion.finalized = true;
@@ -478,7 +478,7 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
       ) && getTarget(motion.altTarget) == address(colony)
     ) {
       bytes32 structHash = hashExpenditureActionStruct(motion.action);
-      expenditureMotionCounts[structHash] = sub(expenditureMotionCounts[structHash], 1);
+      expenditureMotionCounts[structHash] -= 1;
 
       // Release the claimDelay if this is the last active motion
       if (expenditureMotionCounts[structHash] == 0) {
@@ -488,7 +488,7 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
       }
 
       bytes32 actionHash = hashExpenditureAction(motion.action);
-      uint256 votePower = (add(motion.votes[NAY], motion.votes[YAY]) > 0) ?
+      uint256 votePower = (motion.votes[NAY] + motion.votes[YAY]) > 0 ?
         motion.votes[YAY] : motion.stakes[YAY];
 
       if (expenditurePastVotes[actionHash] < votePower) {
@@ -639,7 +639,7 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
       } else if (motion.stakes[YAY] == requiredStake) {
         return finalizableOrFinalized(motion.action);
       // If not, was there a prior vote we can fall back on?
-      } else if (add(motion.votes[NAY], motion.votes[YAY]) > 0) {
+      } else if (motion.votes[NAY] + motion.votes[YAY] > 0) {
         return finalizableOrFinalized(motion.action);
       // Otherwise, the motion failed
       } else {
@@ -673,7 +673,7 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
   function getVoterReward(uint256 _motionId, uint256 _voterRep) public view returns (uint256 _reward) {
     Motion storage motion = motions[_motionId];
     uint256 fractionUserReputation = wdiv(_voterRep, motion.repSubmitted);
-    uint256 totalStake = add(motion.stakes[YAY], motion.stakes[NAY]);
+    uint256 totalStake = motion.stakes[YAY] + motion.stakes[NAY];
     return wmul(wmul(fractionUserReputation, totalStake), voterRewardFraction);
   }
 
@@ -688,11 +688,11 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
     // Has the user already voted?
     if (voteSecrets[_motionId][_voterAddress] == bytes32(0)) {
       // They have not, so add their rep
-      voteTotal = add(voteTotal, _voterRep);
+      voteTotal += _voterRep;
     }
     uint256 maxFractionUserReputation = wdiv(_voterRep, voteTotal);
 
-    uint256 totalStake = add(motion.stakes[YAY], motion.stakes[NAY]);
+    uint256 totalStake = motion.stakes[YAY] + motion.stakes[NAY];
     return (
       wmul(wmul(minFractionUserReputation, totalStake), voterRewardFraction),
       wmul(wmul(maxFractionUserReputation, totalStake), voterRewardFraction)
@@ -702,7 +702,7 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
   function getStakerReward(uint256 _motionId, address _staker, uint256 _vote) public view returns (uint256 _reward, uint256 _penalty) {
     Motion storage motion = motions[_motionId];
 
-    uint256 totalSideStake = add(motion.stakes[_vote], motion.pastVoterComp[_vote]);
+    uint256 totalSideStake = motion.stakes[_vote] + motion.pastVoterComp[_vote];
     if (totalSideStake == 0) { return (0, 0); }
 
     uint256 stakeFraction = wdiv(stakes[_motionId][_staker][_vote], totalSideStake);
@@ -713,7 +713,7 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
     uint256 repPenalty;
 
     // Went to a vote, use vote to determine reward or penalty
-    if (add(motion.votes[NAY], motion.votes[YAY]) > 0) {
+    if ((motion.votes[NAY] + motion.votes[YAY]) > 0) {
 
       uint256 loserStake;
       uint256 winnerStake;
@@ -725,17 +725,17 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
         winnerStake = motion.stakes[NAY];
       }
 
-      loserStake = sub(loserStake, motion.paidVoterComp);
-      uint256 totalVotes = add(motion.votes[NAY], motion.votes[YAY]);
+      loserStake -= motion.paidVoterComp;
+      uint256 totalVotes = motion.votes[NAY] + motion.votes[YAY];
       uint256 winFraction = wdiv(motion.votes[_vote], totalVotes);
       uint256 winShare = wmul(winFraction, 2 * WAD); // On a scale of 0-2 WAD
 
       if (winShare > WAD || (winShare == WAD && _vote == NAY)) {
         // 50% gets 0% of loser's stake, 100% gets 100% of loser's stake, linear in between
-        stakerReward = wmul(stakeFraction, add(winnerStake, wmul(loserStake, winShare - WAD)));
+        stakerReward = wmul(stakeFraction, (winnerStake + wmul(loserStake, winShare - WAD)));
       } else {
         stakerReward = wmul(stakeFraction, wmul(loserStake, winShare));
-        repPenalty = sub(realStake, stakerReward);
+        repPenalty = realStake - stakerReward;
       }
 
     // Determine rewards based on stakes alone
@@ -751,7 +751,7 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
 
         uint256 loserStake = motion.stakes[flip(_vote)];
         uint256 totalPenalty = wmul(loserStake, WAD / 10);
-        stakerReward = wmul(stakeFraction, add(requiredStake, totalPenalty));
+        stakerReward = wmul(stakeFraction, (requiredStake + totalPenalty));
 
       // Opponent's side fully staked, pay 10% penalty
       } else if (
@@ -761,8 +761,8 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
 
         uint256 loserStake = motion.stakes[_vote];
         uint256 totalPenalty = wmul(loserStake, WAD / 10);
-        stakerReward = wmul(stakeFraction, sub(loserStake, totalPenalty));
-        repPenalty = sub(realStake, stakerReward);
+        stakerReward = wmul(stakeFraction, loserStake - totalPenalty);
+        repPenalty = realStake - stakerReward;
 
       // Neither side fully staked (or no votes were revealed), no reward or penalty
       } else {
@@ -790,7 +790,7 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
   }
 
   function flip(uint256 _vote) internal pure returns (uint256) {
-    return sub(1, _vote);
+    return 1 - _vote;
   }
 
   function getActionDomainSkillId(bytes memory _action) internal view returns (uint256) {

--- a/contracts/metaTxToken/DSTokenBaseMeta.sol
+++ b/contracts/metaTxToken/DSTokenBaseMeta.sol
@@ -53,12 +53,12 @@ abstract contract DSTokenBaseMeta is ERC20, DSMath, BasicMetaTransaction {
     {
         if (src != msgSender()) {
             require(_approvals[src][msgSender()] >= wad, "ds-token-insufficient-approval");
-            _approvals[src][msgSender()] = sub(_approvals[src][msgSender()], wad);
+            _approvals[src][msgSender()] -= wad;
         }
 
         require(_balances[src] >= wad, "ds-token-insufficient-balance");
-        _balances[src] = sub(_balances[src], wad);
-        _balances[dst] = add(_balances[dst], wad);
+        _balances[src] -= wad;
+        _balances[dst] += wad;
 
         emit Transfer(src, dst, wad);
 

--- a/contracts/metaTxToken/MetaTxToken.sol
+++ b/contracts/metaTxToken/MetaTxToken.sol
@@ -95,8 +95,8 @@ contract MetaTxToken is DSTokenBaseMeta(0), DSAuthMeta {
   }
 
   function mint(address guy, uint256 wad) public auth {
-    _balances[guy] = add(_balances[guy], wad);
-    _supply = add(_supply, wad);
+    _balances[guy] += wad;
+    _supply += wad;
 
     emit Mint(guy, wad);
     emit Transfer(address(0x0), guy, wad);
@@ -105,12 +105,12 @@ contract MetaTxToken is DSTokenBaseMeta(0), DSAuthMeta {
   function burn(address guy, uint256 wad) public {
     if (guy != msgSender()) {
       require(_approvals[guy][msgSender()] >= wad, "ds-token-insufficient-approval");
-      _approvals[guy][msgSender()] = sub(_approvals[guy][msgSender()], wad);
+      _approvals[guy][msgSender()] -= wad;
     }
 
     require(_balances[guy] >= wad, "ds-token-insufficient-balance");
-    _balances[guy] = sub(_balances[guy], wad);
-    _supply = sub(_supply, wad);
+    _balances[guy] -=  wad;
+    _supply -= wad;
 
     emit Burn(guy, wad);
   }

--- a/contracts/reputationMiningCycle/ReputationMiningCycle.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycle.sol
@@ -221,7 +221,7 @@ contract ReputationMiningCycle is ReputationMiningCycleCommon {
     );
 
     // Burn tokens that have been slashed, but will not be awarded to others as rewards.
-    IColonyNetwork(colonyNetworkAddress).burnUnneededRewards(sub(stakeLost, rewardsPaidOut));
+    IColonyNetwork(colonyNetworkAddress).burnUnneededRewards(stakeLost - rewardsPaidOut);
 
     DisputedEntry storage winningDisputeEntry = disputeRounds[_roundNumber][0];
     Submission storage submission = reputationHashSubmissions[winningDisputeEntry.firstSubmitter];
@@ -288,11 +288,11 @@ contract ReputationMiningCycle is ReputationMiningCycleCommon {
       require(disputeRounds[_round][opponentIdx].challengeStepCompleted >= disputeRounds[_round][_idx].challengeStepCompleted, "colony-reputation-mining-less-challenge-rounds-completed");
 
       // Require that it has failed a challenge (i.e. failed to respond in time)
-      require(add(disputeRounds[_round][_idx].lastResponseTimestamp, CHALLENGE_RESPONSE_WINDOW_DURATION) <= block.timestamp, "colony-reputation-mining-not-timed-out"); // Timeout is twenty minutes here.
+      require((disputeRounds[_round][_idx].lastResponseTimestamp + CHALLENGE_RESPONSE_WINDOW_DURATION) <= block.timestamp, "colony-reputation-mining-not-timed-out"); // Timeout is twenty minutes here.
 
       // The submission can be invalidated - now check the person invalidating is allowed to
       require(
-        responsePossible(DisputeStages.InvalidateHash, add(disputeRounds[_round][_idx].lastResponseTimestamp, CHALLENGE_RESPONSE_WINDOW_DURATION)),
+        responsePossible(DisputeStages.InvalidateHash, (disputeRounds[_round][_idx].lastResponseTimestamp + CHALLENGE_RESPONSE_WINDOW_DURATION)),
         "colony-reputation-mining-user-ineligible-to-respond"
       );
 

--- a/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol
@@ -50,10 +50,10 @@ contract ReputationMiningCycleCommon is ReputationMiningCycleStorage, PatriciaTr
   function expectedBranchMask(uint256 _nLeaves, uint256 _leaf) public pure returns (uint256) {
     // Gets the expected branchmask for a patricia tree which has nLeaves, with keys from 0 to nLeaves -1
     // i.e. the tree is 'full' - there are no missing leaves
-    uint256 mask = sub(_nLeaves, 1); // Every branchmask in a full tree has at least these 1s set
+    uint256 mask = _nLeaves - 1; // Every branchmask in a full tree has at least these 1s set
     uint256 xored = mask ^ _leaf; // Where do mask and leaf differ?
     // Set every bit in the mask from the first bit where they differ to 1
-    uint256 remainderMask = sub(nextPowerOfTwoInclusive(add(xored, 1)), 1);
+    uint256 remainderMask = nextPowerOfTwoInclusive(xored + 1) - 1;
     return mask | remainderMask;
   }
 
@@ -172,7 +172,7 @@ contract ReputationMiningCycleCommon is ReputationMiningCycleStorage, PatriciaTr
   function nextPowerOfTwoInclusive(uint256 _v) internal pure returns (uint) { // solium-disable-line security/no-assign-params
     // Returns the next power of two, or v if v is already a power of two.
     // Doesn't work for zero.
-    _v = sub(_v, 1);
+    _v -= 1;
     _v |= _v >> 1;
     _v |= _v >> 2;
     _v |= _v >> 4;
@@ -181,7 +181,7 @@ contract ReputationMiningCycleCommon is ReputationMiningCycleStorage, PatriciaTr
     _v |= _v >> 32;
     _v |= _v >> 64;
     _v |= _v >> 128;
-    _v = add(_v, 1);
+    _v += 1;
     return _v;
   }
 

--- a/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
@@ -600,7 +600,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleCommon {
   // e.g. for log entry with 6 updates, the relative update number range is [0 .. 5] (inclusive)
   function getRelativeUpdateNumber(uint256[26] memory u, ReputationLogEntry memory logEntry) internal view returns (uint256) {
     uint256 nLeaves = IColonyNetwork(colonyNetworkAddress).getReputationRootHashNLeaves();
-    uint256 updateNumber = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1 - nLeaves;
+    uint256 updateNumber = (disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1) - nLeaves;
 
     // Check that the supplied log entry corresponds to this update number
     require(updateNumber >= logEntry.nPreviousUpdates, "colony-reputation-mining-update-number-part-of-previous-log-entry-updates");

--- a/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
@@ -600,7 +600,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleCommon {
   // e.g. for log entry with 6 updates, the relative update number range is [0 .. 5] (inclusive)
   function getRelativeUpdateNumber(uint256[26] memory u, ReputationLogEntry memory logEntry) internal view returns (uint256) {
     uint256 nLeaves = IColonyNetwork(colonyNetworkAddress).getReputationRootHashNLeaves();
-    uint256 updateNumber = sub(sub(disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound, 1), nLeaves);
+    uint256 updateNumber = disputeRounds[u[U_ROUND]][u[U_IDX]].lowerBound - 1 - nLeaves;
 
     // Check that the supplied log entry corresponds to this update number
     require(updateNumber >= logEntry.nPreviousUpdates, "colony-reputation-mining-update-number-part-of-previous-log-entry-updates");

--- a/contracts/testHelpers/ToggleableToken.sol
+++ b/contracts/testHelpers/ToggleableToken.sol
@@ -46,12 +46,12 @@ contract ToggleableToken is DSMath, ERC20Events {
 
         if (src != msg.sender) {
             require(_approvals[src][msg.sender] >= wad, "ds-token-insufficient-approval");
-            _approvals[src][msg.sender] = sub(_approvals[src][msg.sender], wad);
+            _approvals[src][msg.sender] -= wad;
         }
 
         require(_balances[src] >= wad, "ds-token-insufficient-balance");
-        _balances[src] = sub(_balances[src], wad);
-        _balances[dst] = add(_balances[dst], wad);
+        _balances[src] -= wad;
+        _balances[dst] += wad;
 
         emit Transfer(src, dst, wad);
 
@@ -67,8 +67,8 @@ contract ToggleableToken is DSMath, ERC20Events {
     }
 
     function mint(address guy, uint wad) public {
-       	_balances[guy] = add(_balances[guy], wad);
-        _supply = add(_supply, wad);
+       	_balances[guy] += wad;
+        _supply += wad;
         emit Mint(guy, wad);
         emit Transfer(address(0x0), guy, wad);
     }

--- a/contracts/tokenLocking/TokenLocking.sol
+++ b/contracts/tokenLocking/TokenLocking.sol
@@ -46,7 +46,7 @@ contract TokenLocking is TokenLockingStorage, DSMath, BasicMetaTransaction { // 
 
   modifier notObligated(address _token, uint256 _amount) {
     require(
-      sub(userLocks[_token][msgSender()].balance, _amount) >= totalObligations[msgSender()][_token],
+      userLocks[_token][msgSender()].balance - _amount >= totalObligations[msgSender()][_token],
       "colony-token-locking-excess-obligation"
     );
     _;
@@ -59,7 +59,7 @@ contract TokenLocking is TokenLockingStorage, DSMath, BasicMetaTransaction { // 
   }
 
   function incrementMetatransactionNonce(address user) override internal {
-    metatransactionNonces[user] = add(metatransactionNonces[user], 1);
+    metatransactionNonces[user] += 1;
   }
 
   function setColonyNetwork(address _colonyNetwork) public auth {
@@ -92,7 +92,7 @@ contract TokenLocking is TokenLockingStorage, DSMath, BasicMetaTransaction { // 
     require(_lockId <= totalLockCount[_token], "colony-token-invalid-lockid");
 
     // These checks should happen in this order, as the second is stricter than the first
-    uint256 lockCountDelta = sub(_lockId, userLocks[_token][_user].lockCount);
+    uint256 lockCountDelta = _lockId - userLocks[_token][_user].lockCount;
     require(lockCountDelta != 0, "colony-token-locking-already-unlocked");
     require(lockCountDelta == 1, "colony-token-locking-has-previous-active-locks");
 
@@ -113,11 +113,11 @@ contract TokenLocking is TokenLockingStorage, DSMath, BasicMetaTransaction { // 
 
   function deposit(address _token, uint256 _amount, bool _force) public tokenNotLocked(_token, _force) {
     Lock storage lock = userLocks[_token][msgSender()];
-    lock.balance = add(lock.balance, _amount);
+    lock.balance += _amount;
 
     // Handle the pendingBalance, if any (idempotent operation)
     if (_force) {
-      lock.balance = add(lock.balance, lock.pendingBalance);
+      lock.balance += lock.pendingBalance;
       delete lock.pendingBalance;
     }
 
@@ -140,7 +140,7 @@ contract TokenLocking is TokenLockingStorage, DSMath, BasicMetaTransaction { // 
   tokenNotLocked(_token, _force)
   {
     Lock storage userLock = userLocks[_token][msgSender()];
-    userLock.balance = sub(userLock.balance, _amount);
+    userLock.balance -= _amount;
 
     makeConditionalDeposit(_token, _amount, _recipient);
 
@@ -157,7 +157,7 @@ contract TokenLocking is TokenLockingStorage, DSMath, BasicMetaTransaction { // 
   tokenNotLocked(_token, _force)
   {
     Lock storage lock = userLocks[_token][msgSender()];
-    lock.balance = sub(lock.balance, _amount);
+    lock.balance -= _amount;
 
     require(ERC20Extended(_token).transfer(msgSender(), _amount), "colony-token-locking-transfer-failed");
 
@@ -165,15 +165,15 @@ contract TokenLocking is TokenLockingStorage, DSMath, BasicMetaTransaction { // 
   }
 
   function approveStake(address _user, uint256 _amount, address _token) public calledByColonyOrNetwork() {
-    approvals[_user][_token][msgSender()] = add(approvals[_user][_token][msgSender()], _amount);
+    approvals[_user][_token][msgSender()] += _amount;
 
     emit UserTokenApproved(_token, _user, msgSender(), _amount);
   }
 
   function obligateStake(address _user, uint256 _amount, address _token) public calledByColonyOrNetwork() {
-    approvals[_user][_token][msgSender()] = sub(approvals[_user][_token][msgSender()], _amount);
-    obligations[_user][_token][msgSender()] = add(obligations[_user][_token][msgSender()], _amount);
-    totalObligations[_user][_token] = add(totalObligations[_user][_token], _amount);
+    approvals[_user][_token][msgSender()] -= _amount;
+    obligations[_user][_token][msgSender()] += _amount;
+    totalObligations[_user][_token] += _amount;
 
     require(userLocks[_token][_user].balance >= totalObligations[_user][_token], "colony-token-locking-insufficient-deposit");
 
@@ -181,19 +181,19 @@ contract TokenLocking is TokenLockingStorage, DSMath, BasicMetaTransaction { // 
   }
 
   function deobligateStake(address _user, uint256 _amount, address _token) public calledByColonyOrNetwork() {
-    obligations[_user][_token][msgSender()] = sub(obligations[_user][_token][msgSender()], _amount);
-    totalObligations[_user][_token] = sub(totalObligations[_user][_token], _amount);
+    obligations[_user][_token][msgSender()] -= _amount;
+    totalObligations[_user][_token] -= _amount;
 
     emit UserTokenDeobligated(_token, _user, msgSender(), _amount);
   }
 
   function transferStake(address _user, uint256 _amount, address _token, address _recipient) public calledByColonyOrNetwork() {
-    obligations[_user][_token][msgSender()] = sub(obligations[_user][_token][msgSender()], _amount);
-    totalObligations[_user][_token] = sub(totalObligations[_user][_token], _amount);
+    obligations[_user][_token][msgSender()] -= _amount;
+    totalObligations[_user][_token] -= _amount;
 
     // Transfer the the tokens
     Lock storage userLock = userLocks[_token][_user];
-    userLock.balance = sub(userLock.balance, _amount);
+    userLock.balance -= _amount;
 
     makeConditionalDeposit(_token, _amount, _recipient);
 
@@ -230,16 +230,16 @@ contract TokenLocking is TokenLockingStorage, DSMath, BasicMetaTransaction { // 
   function makeConditionalDeposit(address _token, uint256 _amount, address _user) internal {
     Lock storage userLock = userLocks[_token][_user];
     if (isTokenUnlocked(_token, _user)) {
-      userLock.balance = add(userLock.balance, _amount);
+      userLock.balance += _amount;
     } else {
       // If the transfer fails (for any reason), add tokens to pendingBalance
       // slither-disable-next-line unchecked-transfer
       try ERC20Extended(_token).transfer(_user, _amount) returns (bool success) {
         if (!success) {
-          userLock.pendingBalance = add(userLock.pendingBalance, _amount);
+          userLock.pendingBalance += _amount;
         }
       } catch {
-        userLock.pendingBalance = add(userLock.pendingBalance, _amount);
+        userLock.pendingBalance += _amount;
       }
     }
   }


### PR DESCRIPTION
These are no longer needed with the Solidity upgrade, and in #1053 we agreed would be removed in a separate PR.

There's a new slither release that flagged a few new things which I've dealt with as I saw appropriate.