### PR TITLE
Introduce StagedPayment

### DIFF
--- a/contracts/extensions/StakedExpenditure.sol
+++ b/contracts/extensions/StakedExpenditure.sol
@@ -143,11 +143,13 @@ contract StakedExpenditure is ColonyExtensionMeta {
   /// @param _childSkillIndex The index that the `_expenditureId` is relative to `_permissionDomainId`,
   /// @param _expenditureId The id of the expenditure
   /// @param _slot The slot being released
+  /// @param _tokens An array of payment tokens associated with the slot
   function releaseStagedPayment(
     uint256 _permissionDomainId,
     uint256 _childSkillIndex,
     uint256 _expenditureId,
-    uint256 _slot
+    uint256 _slot,
+    address[] memory _tokens
   )
     public
   {
@@ -161,6 +163,10 @@ contract StakedExpenditure is ColonyExtensionMeta {
     bool[] memory mask = new bool[](2); mask[0] = false; mask[1] = true;
     bytes32[] memory keys = new bytes32[](2); keys[0] = bytes32(0); keys[1] = bytes32(uint256(1));
     colony.setExpenditureState(_permissionDomainId, _childSkillIndex, _expenditureId, 26, mask, keys, bytes32(0));
+
+    for (uint256 i; i < _tokens.length; i++) {
+      colony.claimExpenditurePayout(_expenditureId, _slot, _tokens[i]);
+    }
 
     emit StagedPaymentReleased(_expenditureId, _slot);
   }

--- a/docs/interfaces/extensions/stakedexpenditure.md
+++ b/docs/interfaces/extensions/stakedexpenditure.md
@@ -112,7 +112,7 @@ Configures the extension
 |_colony|address|The colony in which the extension holds permissions
 
 
-### ▸ `makeExpenditureWithStake(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _domainId, bytes memory _key, bytes memory _value, uint256 _branchMask, bytes32[] memory _siblings)`
+### ▸ `makeExpenditureWithStake(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _domainId, bytes memory _key, bytes memory _value, uint256 _branchMask, bytes32[] memory _siblings, bool _stagedPayment)`
 
 Make an expenditure by putting up a stake
 
@@ -128,6 +128,7 @@ Make an expenditure by putting up a stake
 |_value|bytes|Reputation value indicating the total reputation in _domainId
 |_branchMask|uint256|The branchmask of the proof
 |_siblings|bytes32[]|The siblings of the proof
+|_stagedPayment|bool|Whether the expenditure is a staged payment
 
 
 ### ▸ `reclaimStake(uint256 _expenditureId)`
@@ -140,6 +141,21 @@ Reclaims the stake if the expenditure is finalized or cancelled
 |Name|Type|Description|
 |---|---|---|
 |_expenditureId|uint256|The id of the expenditure
+
+
+### ▸ `releaseStagedPayment(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _expenditureId, uint256 _slot)`
+
+Release a staged payment slot
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_permissionDomainId|uint256|The domainId in which the extension has the arbitration permission
+|_childSkillIndex|uint256|The index that the `_expenditureId` is relative to `_permissionDomainId`,
+|_expenditureId|uint256|The id of the expenditure
+|_slot|uint256|The slot being released
 
 
 ### ▸ `setStakeFraction(uint256 _stakeFraction)`

--- a/docs/interfaces/extensions/stakedexpenditure.md
+++ b/docs/interfaces/extensions/stakedexpenditure.md
@@ -143,7 +143,7 @@ Reclaims the stake if the expenditure is finalized or cancelled
 |_expenditureId|uint256|The id of the expenditure
 
 
-### ▸ `releaseStagedPayment(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _expenditureId, uint256 _slot)`
+### ▸ `releaseStagedPayment(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _expenditureId, uint256 _slot, address[] memory _tokens)`
 
 Release a staged payment slot
 
@@ -156,6 +156,7 @@ Release a staged payment slot
 |_childSkillIndex|uint256|The index that the `_expenditureId` is relative to `_permissionDomainId`,
 |_expenditureId|uint256|The id of the expenditure
 |_slot|uint256|The slot being released
+|_tokens|address[]|An array of payment tokens associated with the slot
 
 
 ### ▸ `setStakeFraction(uint256 _stakeFraction)`

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -149,8 +149,8 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleStateHash);
       console.log("tokenLockingStateHash:", tokenLockingStateHash);
 
-      expect(colonyNetworkStateHash).to.equal("0x711cd2107e1466eee7e531b4abee44853d8ac1a0708f31004a615f57f3de819c");
-      expect(colonyStateHash).to.equal("0x54a0edcb2097270bd95d610dc827869cc827241d131461f58788f7c3257ca151");
+      expect(colonyNetworkStateHash).to.equal("0x75cd8aff0c6e32a21857a1038de8468ee40b977dc144c016a05da80a4e7ab19b");
+      expect(colonyStateHash).to.equal("0x4e90fcbe58b79118b2a2c09dd96c2cefe46f732b18b1d6230a361c0332133dec");
       expect(metaColonyStateHash).to.equal("0x15fab25907cfb6baedeaf1fdabd68678d37584a1817a08dfe77db60db378a508");
       expect(miningCycleStateHash).to.equal("0x632d459a2197708bd2dbde87e8275c47dddcdf16d59e3efd21dcef9acb2a7366");
       expect(tokenLockingStateHash).to.equal("0x30fbcbfbe589329fe20288101faabe1f60a4610ae0c0effb15526c6b390a8e07");

--- a/test/extensions/staked-expenditure.js
+++ b/test/extensions/staked-expenditure.js
@@ -437,7 +437,7 @@ contract("Staked Expenditure", (accounts) => {
 
       // Cannot release stage if not finalized
       await checkErrorRevert(
-        stakedExpenditure.releaseStagedPayment(1, UINT256_MAX, expenditureId, 0, { from: USER0 }),
+        stakedExpenditure.releaseStagedPayment(1, UINT256_MAX, expenditureId, 0, [token.address], { from: USER0 }),
         "staked-expenditure-not-finalized"
       );
 
@@ -448,11 +448,11 @@ contract("Staked Expenditure", (accounts) => {
 
       // Cannot release stage if not creator
       await checkErrorRevert(
-        stakedExpenditure.releaseStagedPayment(1, UINT256_MAX, expenditureId, 0, { from: USER1 }),
+        stakedExpenditure.releaseStagedPayment(1, UINT256_MAX, expenditureId, 0, [token.address], { from: USER1 }),
         "staked-expenditure-not-creator"
       );
 
-      await stakedExpenditure.releaseStagedPayment(1, UINT256_MAX, expenditureId, 0, { from: USER0 });
+      await stakedExpenditure.releaseStagedPayment(1, UINT256_MAX, expenditureId, 0, [token.address], { from: USER0 });
       await colony.claimExpenditurePayout(expenditureId, 0, token.address);
     });
 
@@ -463,7 +463,7 @@ contract("Staked Expenditure", (accounts) => {
       const expenditureId = await colony.getExpenditureCount();
 
       await checkErrorRevert(
-        stakedExpenditure.releaseStagedPayment(1, UINT256_MAX, expenditureId, 0, { from: USER0 }),
+        stakedExpenditure.releaseStagedPayment(1, UINT256_MAX, expenditureId, 0, [token.address], { from: USER0 }),
         "staked-expenditure-not-staged-payment"
       );
     });


### PR DESCRIPTION
Closes #1129 

Implements Staged Payments:

- Add a `_stagedPayment` boolean to the existing `makeExpenditureWithStake` function
- Add a `releaseStagedPayment` to let creator set slot claim delays to 0 once finalized

Otherwise, staged payments are behaviorally identical to advanced expenditures.