### PR TITLE
Prevent creation of motions with 0 reputation in domain

### DIFF
--- a/contracts/extensions/votingReputation/VotingReputation.sol
+++ b/contracts/extensions/votingReputation/VotingReputation.sol
@@ -249,6 +249,7 @@ contract VotingReputation is ColonyExtension, BasicMetaTransaction, VotingReputa
     motion.skillId = skillId;
 
     motion.skillRep = checkReputation(motion.rootHash, skillId, address(0x0), _key, _value, _branchMask, _siblings);
+    require(motion.skillRep > 0, "voting-rep-no-reputation-in-domain");
     motion.altTarget = _altTarget;
     motion.action = _action;
 


### PR DESCRIPTION
Mitigates the bug introduced in #1101, whereby if no reputation was present in a domain, a motion could still be created and would immediately become finalizable (though would not execute, as equal - zero - votes had been revealed for each side). Previously, the motion would go through the usual voting and reveal lifecycle, though without actions being able to be taken (as no reputatation exists).

While it could be argued this is desirable behaviour, it happens in a very non-standard way (with relevant timestamps being 0, and therefore in the past), it's better to prevent such useless motions from being created in the first place, which is what this PR is intending to do.