### PR TITLE
Reorganize ColonyAuthority contract

### DIFF
--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -37,98 +37,88 @@ contract ColonyAuthority is CommonAuthority {
 
     colony = _colony;
 
-    // Add permissions for the Administration role
-    addRoleCapability(ADMINISTRATION_ROLE, "makeTask(uint256,uint256,bytes32,uint256,uint256,uint256)");
-    addRoleCapability(ADMINISTRATION_ROLE, "addPayment(uint256,uint256,address,address,uint256,uint256,uint256)");
-    addRoleCapability(ADMINISTRATION_ROLE, "setPaymentRecipient(uint256,uint256,uint256,address)");
-    addRoleCapability(ADMINISTRATION_ROLE, "setPaymentSkill(uint256,uint256,uint256,uint256)");
-    addRoleCapability(ADMINISTRATION_ROLE, "setPaymentPayout(uint256,uint256,uint256,address,uint256)");
-    addRoleCapability(ADMINISTRATION_ROLE, "finalizePayment(uint256,uint256,uint256)");
-
-    // Add permissions for the Funding role
-    addRoleCapability(FUNDING_ROLE, "moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)");
-
-    // Add permissions for the Architecture role
-    addRoleCapability(ARCHITECTURE_ROLE, "addDomain(uint256,uint256,uint256)");
-    addRoleCapability(ARCHITECTURE_ROLE, "setArchitectureRole(uint256,uint256,address,uint256,bool)");
-    addRoleCapability(ARCHITECTURE_ROLE, "setFundingRole(uint256,uint256,address,uint256,bool)");
-    addRoleCapability(ARCHITECTURE_ROLE, "setAdministrationRole(uint256,uint256,address,uint256,bool)");
-
-    // Add permissions for the Root role
-    addRoleCapability(ROOT_ROLE, "setRootRole(address,bool)");
-    addRoleCapability(ROOT_ROLE, "setArchitectureRole(uint256,uint256,address,uint256,bool)");
-    addRoleCapability(ROOT_ROLE, "setFundingRole(uint256,uint256,address,uint256,bool)");
-    addRoleCapability(ROOT_ROLE, "setAdministrationRole(uint256,uint256,address,uint256,bool)");
-
-    // Managing recovery roles
-    addRoleCapability(ROOT_ROLE, "setRecoveryRole(address)");
-    addRoleCapability(ROOT_ROLE, "removeRecoveryRole(address)");
-
-    // Colony functions
-    addRoleCapability(ROOT_ROLE, "startNextRewardPayout(address,bytes,bytes,uint256,bytes32[])");
-    addRoleCapability(ROOT_ROLE, "bootstrapColony(address[],int256[])");
-    addRoleCapability(ROOT_ROLE, "registerColonyLabel(string,string)");
-    addRoleCapability(ROOT_ROLE, "setRewardInverse(uint256)");
-    addRoleCapability(ROOT_ROLE, "mintTokens(uint256)");
-    addRoleCapability(ROOT_ROLE, "upgrade(uint256)");
-
-    //  Meta Colony functions
+    // Root functions are used to change colony-wide parameters
+    // Managing the meta colony
     addRoleCapability(ROOT_ROLE, "addNetworkColonyVersion(uint256,address)");
     addRoleCapability(ROOT_ROLE, "setNetworkFeeInverse(uint256)");
     addRoleCapability(ROOT_ROLE, "addGlobalSkill()");
     addRoleCapability(ROOT_ROLE, "deprecateGlobalSkill(uint256)");
-
-    // Added in colony v3 (auburn-glider)
-    addRoleCapability(ROOT_ROLE, "updateColonyOrbitDB(string)");
-    addRoleCapability(ROOT_ROLE, "setArbitrationRole(uint256,uint256,address,uint256,bool)");
-    addRoleCapability(ARCHITECTURE_ROLE, "setArbitrationRole(uint256,uint256,address,uint256,bool)");
-
-    // Added in colony v4 (burgundy-glider)
-    addRoleCapability(ADMINISTRATION_ROLE, "makeExpenditure(uint256,uint256,uint256)");
-    addRoleCapability(ARBITRATION_ROLE, "transferExpenditureViaArbitration(uint256,uint256,uint256,address)");
-    addRoleCapability(ARBITRATION_ROLE, "setExpenditurePayoutModifier(uint256,uint256,uint256,uint256,int256)");
-    addRoleCapability(ARBITRATION_ROLE, "setExpenditureClaimDelay(uint256,uint256,uint256,uint256,uint256)");
-
-    // Added in colony v5 (cerulean-lwss)
-    addRoleCapability(ROOT_ROLE, "setPayoutWhitelist(address,bool)");
-    addRoleCapability(ROOT_ROLE, "mintTokensFor(address,uint256)");
     addRoleCapability(ROOT_ROLE, "setReputationMiningCycleReward(uint256)");
     addRoleCapability(ROOT_ROLE, "addExtensionToNetwork(bytes32,address)");
+    // Managing user roles (overlaps with Architecture functionality)
+    addRoleCapability(ROOT_ROLE, "setRecoveryRole(address)");
+    addRoleCapability(ROOT_ROLE, "removeRecoveryRole(address)");
+    addRoleCapability(ROOT_ROLE, "setRootRole(address,bool)");
+    addRoleCapability(ROOT_ROLE, "setArchitectureRole(uint256,uint256,address,uint256,bool)");
+    addRoleCapability(ROOT_ROLE, "setArbitrationRole(uint256,uint256,address,uint256,bool)");
+    addRoleCapability(ROOT_ROLE, "setFundingRole(uint256,uint256,address,uint256,bool)");
+    addRoleCapability(ROOT_ROLE, "setAdministrationRole(uint256,uint256,address,uint256,bool)");
     addRoleCapability(ROOT_ROLE, "setUserRoles(uint256,uint256,address,uint256,bytes32)");
+    // Managing the colony
+    addRoleCapability(ROOT_ROLE, "bootstrapColony(address[],int256[])");
+    addRoleCapability(ROOT_ROLE, "upgrade(uint256)");
+    addRoleCapability(ROOT_ROLE, "registerColonyLabel(string,string)");
+    addRoleCapability(ROOT_ROLE, "editColony(string)");
+    addRoleCapability(ROOT_ROLE, "editColonyByDelta(string)");
+    addRoleCapability(ROOT_ROLE, "updateColonyOrbitDB(string)");
+    addRoleCapability(ROOT_ROLE, "addLocalSkill()");
+    addRoleCapability(ROOT_ROLE, "deprecateLocalSkill(uint256,bool)");
+    addRoleCapability(ROOT_ROLE, "setPayoutWhitelist(address,bool)");
+    addRoleCapability(ROOT_ROLE, "setDefaultGlobalClaimDelay(uint256)");
+    // Managing tokens
+    addRoleCapability(ROOT_ROLE, "unlockToken()");
+    addRoleCapability(ROOT_ROLE, "mintTokens(uint256)");
+    addRoleCapability(ROOT_ROLE, "mintTokensFor(address,uint256)");
+    addRoleCapability(ROOT_ROLE, "burnTokens(address,uint256)");
+    // Managing rewards
+    addRoleCapability(ROOT_ROLE, "startNextRewardPayout(address,bytes,bytes,uint256,bytes32[])");
+    addRoleCapability(ROOT_ROLE, "setRewardInverse(uint256)");
+    // Managing extensions
     addRoleCapability(ROOT_ROLE, "installExtension(bytes32,uint256)");
     addRoleCapability(ROOT_ROLE, "upgradeExtension(bytes32,uint256)");
     addRoleCapability(ROOT_ROLE, "deprecateExtension(bytes32,bool)");
     addRoleCapability(ROOT_ROLE, "uninstallExtension(bytes32)");
+    // Other actions
     addRoleCapability(ROOT_ROLE, "makeArbitraryTransaction(address,bytes)");
+    addRoleCapability(ROOT_ROLE, "makeArbitraryTransactions(address[],bytes[],bool)");
     addRoleCapability(ROOT_ROLE, "emitDomainReputationReward(uint256,address,int256)");
     addRoleCapability(ROOT_ROLE, "emitSkillReputationReward(uint256,address,int256)");
-    addRoleCapability(ARBITRATION_ROLE, "transferStake(uint256,uint256,address,address,uint256,uint256,address)");
-    addRoleCapability(ARBITRATION_ROLE, "emitDomainReputationPenalty(uint256,uint256,uint256,address,int256)");
-    addRoleCapability(ARBITRATION_ROLE, "emitSkillReputationPenalty(uint256,address,int256)");
-    addRoleCapability(ARBITRATION_ROLE, "setExpenditureState(uint256,uint256,uint256,uint256,bool[],bytes32[],bytes32)");
-    addRoleCapability(ARCHITECTURE_ROLE, "setUserRoles(uint256,uint256,address,uint256,bytes32)");
+
+    // Architecture functions are used to create and manage domains & set permissions in domains
+    addRoleCapability(ARCHITECTURE_ROLE, "addDomain(uint256,uint256,uint256)");
     addRoleCapability(ARCHITECTURE_ROLE, "addDomain(uint256,uint256,uint256,string)");
     addRoleCapability(ARCHITECTURE_ROLE, "editDomain(uint256,uint256,uint256,string)");
-    addRoleCapability(ROOT_ROLE, "editColony(string)");
-    addRoleCapability(ROOT_ROLE, "burnTokens(address,uint256)");
-    addRoleCapability(ROOT_ROLE, "unlockToken()");
-
-    // Added in colony v7 (dandelion-lwss)
-    addRoleCapability(FUNDING_ROLE, "moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)");
-
-    // Added in colony v8 (ebony-lwss)
-    addRoleCapability(ROOT_ROLE, "makeArbitraryTransactions(address[],bytes[],bool)");
-    addRoleCapability(ROOT_ROLE, "setDefaultGlobalClaimDelay(uint256)");
-    addRoleCapability(ARBITRATION_ROLE, "setExpenditureMetadata(uint256,uint256,uint256,string)");
-
-    // Added in colony v9 (fuschia-lwss)
-    addRoleCapability(ROOT_ROLE, "addLocalSkill()");
-    addRoleCapability(ROOT_ROLE, "deprecateLocalSkill(uint256,bool)");
     addRoleCapability(ARCHITECTURE_ROLE, "deprecateDomain(uint256,uint256,uint256,bool)");
-    addRoleCapability(ROOT_ROLE, "editColonyByDelta(string)");
+    addRoleCapability(ARCHITECTURE_ROLE, "setUserRoles(uint256,uint256,address,uint256,bytes32)");
+    addRoleCapability(ARCHITECTURE_ROLE, "setArchitectureRole(uint256,uint256,address,uint256,bool)");
+    addRoleCapability(ARCHITECTURE_ROLE, "setArbitrationRole(uint256,uint256,address,uint256,bool)");
+    addRoleCapability(ARCHITECTURE_ROLE, "setFundingRole(uint256,uint256,address,uint256,bool)");
+    addRoleCapability(ARCHITECTURE_ROLE, "setAdministrationRole(uint256,uint256,address,uint256,bool)");
 
-    // Added in colony v10 (ginger-lwss)
+    // Arbitration functions are used to resolve disputes and make exceptional changes to reputation
+    addRoleCapability(ARBITRATION_ROLE, "emitDomainReputationPenalty(uint256,uint256,uint256,address,int256)");
+    addRoleCapability(ARBITRATION_ROLE, "emitSkillReputationPenalty(uint256,address,int256)");
+    addRoleCapability(ARBITRATION_ROLE, "transferStake(uint256,uint256,address,address,uint256,uint256,address)");
+    // NB expenditure owners can also call (some of) these functions, regardless of their permissions
+    addRoleCapability(ARBITRATION_ROLE, "setExpenditureState(uint256,uint256,uint256,uint256,bool[],bytes32[],bytes32)");
     addRoleCapability(ARBITRATION_ROLE, "setExpenditurePayout(uint256,uint256,uint256,uint256,address,uint256)");
+    addRoleCapability(ARBITRATION_ROLE, "setExpenditureMetadata(uint256,uint256,uint256,string)");
+    addRoleCapability(ARBITRATION_ROLE, "transferExpenditureViaArbitration(uint256,uint256,uint256,address)"); // Deprecated
+    addRoleCapability(ARBITRATION_ROLE, "setExpenditureClaimDelay(uint256,uint256,uint256,uint256,uint256)"); // Deprecated
+    addRoleCapability(ARBITRATION_ROLE, "setExpenditurePayoutModifier(uint256,uint256,uint256,uint256,int256)"); // Deprecated
+
+    // Funding functions are used to move resources between domains
+    addRoleCapability(FUNDING_ROLE, "moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)");
+    addRoleCapability(FUNDING_ROLE, "moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)"); // Deprecated
+
+    // Administration functions are used to propose and prepare expenditures for funding
+    addRoleCapability(ADMINISTRATION_ROLE, "makeExpenditure(uint256,uint256,uint256)");
+    addRoleCapability(ADMINISTRATION_ROLE, "makeTask(uint256,uint256,bytes32,uint256,uint256,uint256)"); // Deprecated
+    addRoleCapability(ADMINISTRATION_ROLE, "addPayment(uint256,uint256,address,address,uint256,uint256,uint256)"); // Deprecated
+    addRoleCapability(ADMINISTRATION_ROLE, "setPaymentRecipient(uint256,uint256,uint256,address)"); // Deprecated
+    addRoleCapability(ADMINISTRATION_ROLE, "setPaymentSkill(uint256,uint256,uint256,uint256)"); // Deprecated
+    addRoleCapability(ADMINISTRATION_ROLE, "setPaymentPayout(uint256,uint256,uint256,address,uint256)"); // Deprecated
+    addRoleCapability(ADMINISTRATION_ROLE, "finalizePayment(uint256,uint256,uint256)"); // Deprecated
   }
 
   function addRoleCapability(uint8 role, bytes memory sig) private {


### PR DESCRIPTION
Currently it is difficult for product folks to keep track of the permissions associated with various roles. A reorganization of the `ColonyAuthority` contract will make it easier to understand different roles and how they relate.
