### PR TITLE
Make initialise consistent on extensions

### DIFF
--- a/contracts/extensions/StakedExpenditure.sol
+++ b/contracts/extensions/StakedExpenditure.sol
@@ -95,15 +95,16 @@ contract StakedExpenditure is ColonyExtensionMeta {
   /// @param _stakeFraction WAD-denominated fraction, used to determine stake as fraction of rep in domain
   function initialise(uint256 _stakeFraction) onlyRoot public {
     require(stakeFraction == 0, "staked-expenditure-already-initialised");
-    stakeFraction = _stakeFraction;
-
-    emit ExtensionInitialised();
+    setStakeFraction(_stakeFraction);
   }
 
   /// @notice Sets the stake fraction
   /// @param _stakeFraction WAD-denominated fraction, used to determine stake as fraction of rep in domain
   function setStakeFraction(uint256 _stakeFraction) public onlyRoot {
-    require(stakeFraction > 0, "staked-expenditure-not-initialised");
+    if (stakeFraction == 0) {
+      emit ExtensionInitialised();
+    }
+    require(_stakeFraction > 0, "staked-expenditure-value-too-small");
     require(_stakeFraction <= WAD, "staked-expenditure-value-too-large");
     stakeFraction = _stakeFraction;
 

--- a/contracts/extensions/StakedExpenditure.sol
+++ b/contracts/extensions/StakedExpenditure.sol
@@ -91,10 +91,19 @@ contract StakedExpenditure is ColonyExtensionMeta {
   }
 
   // Public
+  /// @notice Initialise the extension
+  /// @param _stakeFraction WAD-denominated fraction, used to determine stake as fraction of rep in domain
+  function initialise(uint256 _stakeFraction) onlyRoot public {
+    require(stakeFraction == 0, "staked-expenditure-already-initialised");
+    stakeFraction = _stakeFraction;
+
+    emit ExtensionInitialised();
+  }
 
   /// @notice Sets the stake fraction
   /// @param _stakeFraction WAD-denominated fraction, used to determine stake as fraction of rep in domain
   function setStakeFraction(uint256 _stakeFraction) public onlyRoot {
+    require(stakeFraction > 0, "staked-expenditure-not-initialised");
     require(_stakeFraction <= WAD, "staked-expenditure-value-too-large");
     stakeFraction = _stakeFraction;
 
@@ -121,6 +130,8 @@ contract StakedExpenditure is ColonyExtensionMeta {
     public
     notDeprecated
   {
+    require(stakeFraction > 0, "staked-expenditure-not-initialised");
+
     bytes32 rootHash = IColonyNetwork(colony.getColonyNetwork()).getReputationRootHash();
     uint256 domainSkillId = colony.getDomain(_domainId).skillId;
     uint256 domainRep = checkReputation(rootHash, domainSkillId, address(0x0), _key, _value, _branchMask, _siblings);

--- a/docs/interfaces/extensions/stakedexpenditure.md
+++ b/docs/interfaces/extensions/stakedexpenditure.md
@@ -100,6 +100,18 @@ Returns the identifier of the extension
 |---|---|---|
 |_identifier|bytes32|The extension's identifier
 
+### ▸ `initialise(uint256 _stakeFraction)`
+
+Initialise the extension
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_stakeFraction|uint256|WAD-denominated fraction, used to determine stake as fraction of rep in domain
+
+
 ### ▸ `install(address _colony)`
 
 Configures the extension

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -149,8 +149,8 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleStateHash);
       console.log("tokenLockingStateHash:", tokenLockingStateHash);
 
-      expect(colonyNetworkStateHash).to.equal("0xe51250c6e46313bf5fa06375e6cb5db9ac7c7747ea2392f76f49030637a9c212");
-      expect(colonyStateHash).to.equal("0x54a0edcb2097270bd95d610dc827869cc827241d131461f58788f7c3257ca151");
+      expect(colonyNetworkStateHash).to.equal("0xcdfbc62e10498217faebf0b967968c8210111e034f97eeaf70fd2274ebef065b");
+      expect(colonyStateHash).to.equal("0x4e90fcbe58b79118b2a2c09dd96c2cefe46f732b18b1d6230a361c0332133dec");
       expect(metaColonyStateHash).to.equal("0x15fab25907cfb6baedeaf1fdabd68678d37584a1817a08dfe77db60db378a508");
       expect(miningCycleStateHash).to.equal("0x632d459a2197708bd2dbde87e8275c47dddcdf16d59e3efd21dcef9acb2a7366");
       expect(tokenLockingStateHash).to.equal("0x30fbcbfbe589329fe20288101faabe1f60a4610ae0c0effb15526c6b390a8e07");

--- a/test/extensions/staked-expenditure.js
+++ b/test/extensions/staked-expenditure.js
@@ -14,6 +14,8 @@ const {
   makeReputationValue,
   getActiveRepCycle,
   forwardTime,
+  expectEvent,
+  expectNoEvent,
 } = require("../../helpers/test-helper");
 
 const PatriciaTree = require("../../packages/reputation-miner/patricia");
@@ -145,8 +147,13 @@ contract("StakedExpenditure", (accounts) => {
       await colony.uninstallExtension(STAKED_EXPENDITURE, { from: USER0 });
     });
 
-    it("can't call setStakeFraction if not initialized", async () => {
-      await checkErrorRevert(stakedExpenditure.setStakeFraction(WAD, { from: USER0 }), "staked-expenditure-not-initialised");
+    it("setStakeFraction will emit the correct event if stakeFraction == 0", async () => {
+      let tx = await stakedExpenditure.setStakeFraction(WAD, { from: USER0 });
+      await expectEvent(tx, "ExtensionInitialised", []);
+
+      // But not the second time
+      tx = await stakedExpenditure.setStakeFraction(WAD, { from: USER0 });
+      await expectNoEvent(tx, "ExtensionInitialised", []);
     });
 
     it("can't call initialise if initialised", async () => {

--- a/test/extensions/staked-expenditure.js
+++ b/test/extensions/staked-expenditure.js
@@ -144,11 +144,31 @@ contract("StakedExpenditure", (accounts) => {
 
       await colony.uninstallExtension(STAKED_EXPENDITURE, { from: USER0 });
     });
+
+    it("can't call setStakeFraction if not initialized", async () => {
+      await checkErrorRevert(stakedExpenditure.setStakeFraction(WAD, { from: USER0 }), "staked-expenditure-not-initialised");
+    });
+
+    it("can't call initialise if initialised", async () => {
+      await stakedExpenditure.initialise(WAD, { from: USER0 });
+      await checkErrorRevert(stakedExpenditure.initialise(WAD, { from: USER0 }), "staked-expenditure-already-initialised");
+    });
+
+    it("must be root to initialise", async () => {
+      await checkErrorRevert(stakedExpenditure.initialise(WAD, { from: USER1 }), "staked-expenditure-caller-not-root");
+    });
+
+    it("can't call makeExpenditureWithStake if not initialised", async () => {
+      await checkErrorRevert(
+        stakedExpenditure.makeExpenditureWithStake(1, UINT256_MAX, 1, domain1Key, domain1Value, domain1Mask, domain1Siblings, { from: USER0 }),
+        "staked-expenditure-not-initialised"
+      );
+    });
   });
 
   describe("using stakes to manage expenditures", async () => {
     beforeEach(async () => {
-      await stakedExpenditure.setStakeFraction(WAD.divn(10)); // Stake of .3 WADs
+      await stakedExpenditure.initialise(WAD.divn(10)); // Stake of .3 WADs
       requiredStake = WAD.muln(3).divn(10);
 
       await token.mint(USER0, WAD);


### PR DESCRIPTION
The Staked Expenditure extension broke some assumptions that have been made elsewhere in the stack, so bringing it in line. We should try and stick to these going forwards:

* Extensions that need to be initialised should use `initialise`, even if only setting one parameter - and this should emit the `ExtensionInitialised` event.
* `initialise` should be callable exactly once (and therefore `extensionInitialised` emitted exactly once).
* Other functions can then be used to adjust parameters 'in flight'.

I checked other extensions, and they seem to follow these restrictions, so just this one that needed updating.
