### PR TITLE
Add ExpenditurePayoutClaimed event

### DIFF
--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -350,13 +350,14 @@ interface ColonyDataTypes {
   event ArbitraryTransaction(address target, bytes data, bool success);
 
   /// @notice Event logged when an expenditure payout is claimed.
-  /// @dev This is emitted in addition to PayoutClaimed event
+  /// @dev This is emitted in addition to the other PayoutClaimed
+  /// event. The other will be removed soon.
   /// @param agent The address that is responsible for triggering this event
   /// @param id Id of the expenditure
   /// @param slot Expenditure slot of the payout claimed
   /// @param token Token of the payout claim
   /// @param tokenPayout Amount of the payout claimed, after network fee was deducted
-  event ExpenditurePayoutClaimed(address agent, uint256 id, uint256 slot, address token, uint256 tokenPayout);
+  event PayoutClaimed(address agent, uint256 id, uint256 slot, address token, uint256 tokenPayout);
 
   // Structs
 

--- a/contracts/colony/ColonyDataTypes.sol
+++ b/contracts/colony/ColonyDataTypes.sol
@@ -349,6 +349,17 @@ interface ColonyDataTypes {
 
   event ArbitraryTransaction(address target, bytes data, bool success);
 
+  /// @notice Event logged when an expenditure payout is claimed.
+  /// @dev This is emitted in addition to PayoutClaimed event
+  /// @param agent The address that is responsible for triggering this event
+  /// @param id Id of the expenditure
+  /// @param slot Expenditure slot of the payout claimed
+  /// @param token Token of the payout claim
+  /// @param tokenPayout Amount of the payout claimed, after network fee was deducted
+  event ExpenditurePayoutClaimed(address agent, uint256 id, uint256 slot, address token, uint256 tokenPayout);
+
+  // Structs
+
   struct RewardPayoutCycle {
     // Reputation root hash at the time of reward payout creation
     bytes32 reputationState;

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -233,6 +233,7 @@ contract ColonyFunding is ColonyStorage { // ignore-swc-123
 
     // Finish the payout
     processPayout(expenditure.fundingPotId, _token, tokenPayout, slot.recipient);
+    emit ExpenditurePayoutClaimed(msgSender(), _id, _slot, _token, tokenPayout);
   }
 
   function setPaymentPayout(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, address _token, uint256 _amount) public

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -233,7 +233,8 @@ contract ColonyFunding is ColonyStorage { // ignore-swc-123
 
     // Finish the payout
     processPayout(expenditure.fundingPotId, _token, tokenPayout, slot.recipient);
-    emit ExpenditurePayoutClaimed(msgSender(), _id, _slot, _token, tokenPayout);
+    
+    emit PayoutClaimed(msgSender(), _id, _slot, _token, tokenPayout);
   }
 
   function setPaymentPayout(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, address _token, uint256 _amount) public

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -232,9 +232,9 @@ contract ColonyFunding is ColonyStorage { // ignore-swc-123
     }
 
     // Finish the payout
-    processPayout(expenditure.fundingPotId, _token, tokenPayout, slot.recipient);
+    uint256 payoutMinusFee = processPayout(expenditure.fundingPotId, _token, tokenPayout, slot.recipient);
     
-    emit PayoutClaimed(msgSender(), _id, _slot, _token, tokenPayout);
+    emit PayoutClaimed(msgSender(), _id, _slot, _token, payoutMinusFee);
   }
 
   function setPaymentPayout(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, address _token, uint256 _amount) public
@@ -447,7 +447,7 @@ contract ColonyFunding is ColonyStorage { // ignore-swc-123
     updatePayoutsWeCannotMakeAfterBudgetChange(task.fundingPotId, _token, currentTotalAmount);
   }
 
-  function processPayout(uint256 _fundingPotId, address _token, uint256 _payout, address payable _user) private {
+  function processPayout(uint256 _fundingPotId, address _token, uint256 _payout, address payable _user) private returns (uint256 payoutToUser) {
     refundDomain(_fundingPotId, _token);
 
     IColonyNetwork colonyNetworkContract = IColonyNetwork(colonyNetworkAddress);
@@ -458,19 +458,19 @@ contract ColonyFunding is ColonyStorage { // ignore-swc-123
     nonRewardPotsTotal[_token] -= _payout;
 
     uint fee = isOwnExtension(_user) ? 0 : calculateNetworkFeeForPayout(_payout);
-    uint remainder = _payout - fee;
+    uint payoutToUser = _payout - fee;
 
     if (_token == address(0x0)) {
       // Payout ether
       // Fee goes directly to Meta Colony
-      _user.transfer(remainder);
+      _user.transfer(payoutToUser);
       metaColonyAddress.transfer(fee);
     } else {
       // Payout token
       // If it's a whitelisted token, it goes straight to the metaColony
       // If it's any other token, goes to the colonyNetwork contract first to be auctioned.
       ERC20Extended payoutToken = ERC20Extended(_token);
-      assert(payoutToken.transfer(_user, remainder));
+      assert(payoutToken.transfer(_user, payoutToUser));
       if (colonyNetworkContract.getPayoutWhitelist(_token)) {
         assert(payoutToken.transfer(metaColonyAddress, fee));
       } else {
@@ -479,7 +479,9 @@ contract ColonyFunding is ColonyStorage { // ignore-swc-123
     }
 
     // slither-disable-next-line reentrancy-unlimited-gas
-    emit PayoutClaimed(msgSender(), _fundingPotId, _token, remainder);
+    emit PayoutClaimed(msgSender(), _fundingPotId, _token, payoutToUser);
+
+    return payoutToUser;
   }
 
   function refundDomain(uint256 _fundingPotId, address _token) private {

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -802,7 +802,7 @@ contract("Colony Expenditure", (accounts) => {
       );
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
       const tx = await colony.claimExpenditurePayout(expenditureId, SLOT0, token.address);
-      await expectEvent(tx, "ExpenditurePayoutClaimed", [accounts[0], expenditureId, SLOT0, token.address, WAD]);
+      await expectEvent(tx, "PayoutClaimed", [accounts[0], expenditureId, SLOT0, token.address, WAD]);
       await expectEvent(tx, "PayoutClaimed", [accounts[0], expenditure.fundingPotId, token.address, WAD.divn(100).muln(99).subn(1)]);
     });
 

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -802,7 +802,7 @@ contract("Colony Expenditure", (accounts) => {
       );
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
       const tx = await colony.claimExpenditurePayout(expenditureId, SLOT0, token.address);
-      await expectEvent(tx, "PayoutClaimed", [accounts[0], expenditureId, SLOT0, token.address, WAD]);
+      await expectEvent(tx, "PayoutClaimed", [accounts[0], expenditureId, SLOT0, token.address, WAD.divn(100).muln(99).subn(1)]);
       await expectEvent(tx, "PayoutClaimed", [accounts[0], expenditure.fundingPotId, token.address, WAD.divn(100).muln(99).subn(1)]);
     });
 

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -784,6 +784,28 @@ contract("Colony Expenditure", (accounts) => {
       expect(networkBalanceAfter.sub(networkBalanceBefore)).to.eq.BN(WAD.divn(100).addn(1)); // eslint-disable-line prettier/prettier
     });
 
+    it("when claiming a payout, the appropriate events are emitted", async () => {
+      await colony.setExpenditureRecipient(expenditureId, SLOT0, RECIPIENT, { from: ADMIN });
+      await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
+
+      const expenditure = await colony.getExpenditure(expenditureId);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD,
+        token.address
+      );
+      await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
+      const tx = await colony.claimExpenditurePayout(expenditureId, SLOT0, token.address);
+      await expectEvent(tx, "ExpenditurePayoutClaimed", [accounts[0], expenditureId, SLOT0, token.address, WAD]);
+      await expectEvent(tx, "PayoutClaimed", [accounts[0], expenditure.fundingPotId, token.address, WAD.divn(100).muln(99).subn(1)]);
+    });
+
     it("should allow anyone to claim on behalf of the slot, in multiple tokens", async () => {
       await colony.setExpenditureRecipient(expenditureId, SLOT0, RECIPIENT, { from: ADMIN });
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });


### PR DESCRIPTION
From @jakubcolony 

> I think I'll need to store whether a payout has been already claimed or not, to be able to determine whether there's any more payouts to claim from the UI. I thought about listening to the PayoutClaimed event in block-ingestor and then checking whether the funding pot ID belongs to an expenditure. However, this event doesn't contain information on which slot has been claimed, just the token address and the amount, which I don't think is enough to uniquely identify the claimed payout.
>
> I suppose I could call the getExpenditureSlotPayout every time I want to check their claimed status but caching it is a more preferable solution. Do you have any ideas on how that could be done? Could we possibly have another expenditure specific event, say ExpenditurePayoutClaimed, that would contain the slot info?

I agreed with Jakub's conclusion that there is no way to uniquely identify a claimed payout (especially if there are multiple payouts for the same amount / destination), short of tracing the transaction which we _really_ don't want to expect people to to, and agree that the easiest way to solve this is to add the `ExpenditurePayoutClaimed` event.

There's some crossover here with #1150; when that is complete there will only be one type of payout on the core contracts, so perhaps with this merged, the even there could go back to `PayoutClaimed` with an adjusted signature; alternatively, we could start this event named PayoutClaimed which would be a little confusing to begin with but correct moving forward.