### PR TITLE
Fix flickery test when run with other tests

### DIFF
--- a/test/reputation-system/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-system/reputation-mining-client/client-auto-functionality.js
@@ -82,14 +82,14 @@ process.env.SOLIDITY_COVERAGE
         goodClient = new ReputationMinerTestWrapper({
           loader,
           realProviderPort,
-          minerAddress: MINER2,
+          minerAddress: _MINER2,
           useJsTree: true,
           // dbPath: "./reputationStates_good.sqlite"
         });
         reputationMinerClient = new ReputationMinerClient({
           loader,
           realProviderPort,
-          minerAddress: MINER1,
+          minerAddress: _MINER1,
           useJsTree: true,
           auto: true,
           oracle: false,


### PR DESCRIPTION
So after #1156, we were meant to be done with the flickery 'losing a race shouldn't prevent a miner from continuing' test. But it turns out, that there [are still dragons out there](https://app.circleci.com/pipelines/github/JoinColony/colonyNetwork/5686/workflows/87900da6-0395-481a-9366-84b658575004/jobs/34341). So, what's going on here? Prior to that PR being merged, I ran that test repeatedly for 12 hours, continuously, and had it pass every time, having had failures within 10 minutes prior to my changes.

While there were issues with the test itself that were fixed in that PR, on CI it is never run alone, but as part of a suite. And what I think I've pinned down was happening here is as follows:

* The previous test completes, and the `afterEach` runs. This is meant to `.close` the client, and then make sure the network is in a sane state for the next test - specifically, that the reputation mining cycle is ready to receive new submissions.
* This (sometimes) happens when `.doBlockChecks` is running  for the client. Even though the `.close` has removed the block handlers, if a block is seen while `doBlockChecks` is running, when `endDoBlockChecks` is called, `doBlockChecks` will be called again.
* When that call is made, because the same network is used between tests, the client will sometimes (correctly) decide to make a submission for the next reputation mining cycle after the checking of the network state has been completed. That messes up this test, which makes 11 submissions with the intention of two clients racing for the 12th (and final) one. Instead, with that first submission and the 11 that the test itself makes, all hash submissions have been made for the cycle and the test times out, as neither of the clients make any further submissions.

Despite the fact that, in the real world, for someone running the client, I do not think this would have ever manifested itself as an issue, I think this represents an issue in the client - when `.close` is called, we are meant to be shutting down, and so we should finish whatever block we are currently processing, and then end there. As a result, it is the client, and not the tests that have been changed in this PR to give (hopefully) the intended behaviour (though I have fixed one thing I found that was technically wrong in passing in the tests).

