### PR TITLE
Add punish flag to StakedExpenditure cancel event

### DIFF
--- a/contracts/extensions/StakedExpenditure.sol
+++ b/contracts/extensions/StakedExpenditure.sol
@@ -30,7 +30,7 @@ contract StakedExpenditure is ColonyExtensionMeta {
   // Events
 
   event ExpenditureMadeViaStake(address indexed creator, uint256 expenditureId, uint256 stake);
-  event ExpenditureCancelled(uint256 expenditureId);
+  event ExpenditureCancelled(uint256 expenditureId, bool punished);
   event StakeReclaimed(uint256 expenditureId);
   event StakeFractionSet(uint256 stakeFraction);
 
@@ -264,6 +264,8 @@ contract StakedExpenditure is ColonyExtensionMeta {
     }
 
     cancelExpenditure(_permissionDomainId, _childSkillIndex, _expenditureId, expenditure.owner);
+
+    emit ExpenditureCancelled(_expenditureId, _punish);
   }
 
   // View
@@ -315,7 +317,5 @@ contract StakedExpenditure is ColonyExtensionMeta {
       keys,
       value
     );
-
-    emit ExpenditureCancelled(_expenditureId);
   }
 }

--- a/test/extensions/staked-expenditure.js
+++ b/test/extensions/staked-expenditure.js
@@ -270,7 +270,9 @@ contract("StakedExpenditure", (accounts) => {
       const expenditureId = await colony.getExpenditureCount();
       await colony.lockExpenditure(expenditureId);
 
-      await stakedExpenditure.cancelAndPunish(1, UINT256_MAX, 1, UINT256_MAX, expenditureId, true);
+      const tx = await stakedExpenditure.cancelAndPunish(1, UINT256_MAX, 1, UINT256_MAX, expenditureId, true);
+
+      await expectEvent(tx, "ExpenditureCancelled", [expenditureId, true]);
 
       const obligation = await tokenLocking.getObligation(USER0, token.address, colony.address);
       expect(obligation).to.be.zero;
@@ -310,7 +312,9 @@ contract("StakedExpenditure", (accounts) => {
       const expenditureId = await colony.getExpenditureCount();
       await colony.lockExpenditure(expenditureId);
 
-      await stakedExpenditure.cancelAndPunish(1, UINT256_MAX, 1, UINT256_MAX, expenditureId, false);
+      const tx = await stakedExpenditure.cancelAndPunish(1, UINT256_MAX, 1, UINT256_MAX, expenditureId, false);
+
+      await expectEvent(tx, "ExpenditureCancelled", [expenditureId, false]);
 
       let obligation;
       let userLock;


### PR DESCRIPTION
This is something that the block ingestor wants to be able to track, and I think adding the flag to the event is the only way to do it infallibly. 