### PR TITLE
Reputation Miner Improvements

### DIFF
--- a/test/reputation-system/client-sync-functionality.js
+++ b/test/reputation-system/client-sync-functionality.js
@@ -262,8 +262,10 @@ process.env.SOLIDITY_COVERAGE
             useJsTree: true,
             dbPath: fileName,
           });
+
           await reputationMiner3.initialise(colonyNetwork.address);
-          await reputationMiner3.sync("latest");
+          const latestBlock = await currentBlock();
+          await reputationMiner3.sync(parseInt(latestBlock.number, 10));
 
           const loadedState = await reputationMiner3.getRootHash();
           expect(loadedState).to.equal(currentState);


### PR DESCRIPTION
@chmanie is working on mining documentation and aids for people who wish to reputation mine. This PR is going to capture changes to the miner that are revealed by that work. Currently there is one change:

* Page the previous mining cycles on syncing. This is exactly the same issue that we were facing in the frontend in a few different areas that Raul fixed. The same solution is done here - instead of asking for all events in one big request, we split it up in to multiple requests and join all the responses together.