### PR TITLE
Remove global skills

### DIFF
--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -329,6 +329,7 @@ contract Colony is BasicMetaTransaction, Multicall, ColonyStorage, PatriciaTreeP
     sig = bytes4(keccak256("setPaymentPayout(uint256,uint256,uint256,address,uint256)"));
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Administration), address(this), sig, false);
     sig = bytes4(keccak256("finalizePayment(uint256,uint256,uint256)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Administration), address(this), sig, false);
 
     // Remove Global Skills functions
     sig = bytes4(keccak256("addGlobalSkill()"));

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -330,6 +330,12 @@ contract Colony is BasicMetaTransaction, Multicall, ColonyStorage, PatriciaTreeP
     colonyAuthority.setRoleCapability(uint8(ColonyRole.Administration), address(this), sig, false);
     sig = bytes4(keccak256("finalizePayment(uint256,uint256,uint256)"));
 
+    // Remove Global Skills functions
+    sig = bytes4(keccak256("addGlobalSkill()"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, false);
+    sig = bytes4(keccak256("deprecateGlobalSkill(uint256)"));
+    colonyAuthority.setRoleCapability(uint8(ColonyRole.Root), address(this), sig, false);
+
     // If OneTxPayment extension is installed, add the new role and upgrade it
     bytes32 ONE_TX_PAYMENT = keccak256("OneTxPayment");
     IColonyNetwork network = IColonyNetwork(colonyNetworkAddress);

--- a/contracts/colony/Colony.sol
+++ b/contracts/colony/Colony.sol
@@ -68,7 +68,7 @@ contract Colony is BasicMetaTransaction, Multicall, ColonyStorage, PatriciaTreeP
     uint256 _skillId,
     address _user,
     int256 _amount
-  ) public stoppable auth validGlobalOrLocalSkill(_skillId) {
+  ) public stoppable auth validLocalSkill(_skillId) {
     require(_amount > 0, "colony-reward-must-be-positive");
     IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, _skillId);
 
@@ -96,7 +96,7 @@ contract Colony is BasicMetaTransaction, Multicall, ColonyStorage, PatriciaTreeP
     uint256 _skillId,
     address _user,
     int256 _amount
-  ) public stoppable auth validGlobalOrLocalSkill(_skillId) {
+  ) public stoppable auth validLocalSkill(_skillId) {
     require(_amount <= 0, "colony-penalty-cannot-be-positive");
     IColonyNetwork(colonyNetworkAddress).appendReputationUpdateLog(_user, _amount, _skillId);
 
@@ -192,15 +192,6 @@ contract Colony is BasicMetaTransaction, Multicall, ColonyStorage, PatriciaTreeP
 
   function updateColonyOrbitDB(string memory orbitdb) public stoppable auth {
     IColonyNetwork(colonyNetworkAddress).updateColonyOrbitDB(orbitdb);
-  }
-
-  function addGlobalSkill() public stoppable auth returns (uint256) {
-    return IColonyNetwork(colonyNetworkAddress).addSkill(0); // ignore-swc-107
-  }
-
-  // slither-disable-next-line unused-return
-  function deprecateGlobalSkill(uint256 _skillId) public stoppable auth {
-    IColonyNetwork(colonyNetworkAddress).deprecateSkill(_skillId, true);
   }
 
   function setNetworkFeeInverse(uint256 _feeInverse) public stoppable auth {

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -76,8 +76,6 @@ contract ColonyAuthority is CommonAuthority {
     //  Meta Colony functions
     addRoleCapability(ROOT_ROLE, "addNetworkColonyVersion(uint256,address)");
     addRoleCapability(ROOT_ROLE, "setNetworkFeeInverse(uint256)");
-    addRoleCapability(ROOT_ROLE, "addGlobalSkill()");
-    addRoleCapability(ROOT_ROLE, "deprecateGlobalSkill(uint256)");
 
     // Added in colony v3 (auburn-glider)
     addRoleCapability(ROOT_ROLE, "updateColonyOrbitDB(string)");

--- a/contracts/colony/ColonyAuthority.sol
+++ b/contracts/colony/ColonyAuthority.sol
@@ -45,7 +45,7 @@ contract ColonyAuthority is CommonAuthority {
     addRoleCapability(ADMINISTRATION_ROLE, "setPaymentSkill(uint256,uint256,uint256,uint256)"); // Only for versions < 14
     addRoleCapability(ADMINISTRATION_ROLE, "setPaymentPayout(uint256,uint256,uint256,address,uint256)"); // Only for versions < 14
     addRoleCapability(ADMINISTRATION_ROLE, "finalizePayment(uint256,uint256,uint256)"); // Only for versions < 14
-    
+
     // Add permissions for the Funding role
     addRoleCapability(FUNDING_ROLE, "moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)");
 

--- a/contracts/colony/ColonyDomains.sol
+++ b/contracts/colony/ColonyDomains.sol
@@ -108,6 +108,7 @@ contract ColonyDomains is ColonyStorage {
     }
   }
 
+  // NOTE: We intentionally avoid adding rootLocalSkill to the local skills mapping
   function initialiseRootLocalSkill() public stoppable {
     require(rootLocalSkill == 0, "colony-root-local-skill-initialised");
     rootLocalSkill = IColonyNetwork(colonyNetworkAddress).initialiseRootLocalSkill();

--- a/contracts/colony/ColonyExpenditure.sol
+++ b/contracts/colony/ColonyExpenditure.sol
@@ -162,7 +162,7 @@ contract ColonyExpenditure is ColonyStorage {
     require(_slots.length == _skillIds.length, "colony-expenditure-bad-slots");
 
     for (uint256 i; i < _slots.length; i++) {
-      require(isValidGlobalOrLocalSkill(_skillIds[i]), "colony-not-valid-global-or-local-skill");
+      require(isValidLocalSkill(_skillIds[i]), "colony-not-valid-local-skill");
 
       // We only allow setting of the first skill here.
       // If we allow more in the future, make sure to have a hard limit that

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -166,8 +166,8 @@ contract ColonyStorage is ColonyDataTypes, ColonyNetworkDataTypes, DSMath, Commo
     _;
   }
 
-  modifier validGlobalOrLocalSkill(uint256 _skillId) {
-    require(isValidGlobalOrLocalSkill(_skillId), "colony-not-valid-global-or-local-skill");
+  modifier validLocalSkill(uint256 _skillId) {
+    require(isValidLocalSkill(_skillId), "colony-not-valid-local-skill");
     _;
   }
 
@@ -301,9 +301,9 @@ contract ColonyStorage is ColonyDataTypes, ColonyNetworkDataTypes, DSMath, Commo
     }
   }
 
-  function isValidGlobalOrLocalSkill(uint256 skillId) internal view returns (bool) {
-    Skill memory skill = IColonyNetwork(colonyNetworkAddress).getSkill(skillId);
-    return (skill.globalSkill || localSkills[skillId]) && !skill.deprecated;
+  function isValidLocalSkill(uint256 skillId) internal view returns (bool) {
+    bool deprecated = IColonyNetwork(colonyNetworkAddress).getSkill(skillId).deprecated;
+    return localSkills[skillId] && !deprecated;
   }
 
   function domainExists(uint256 domainId) internal view returns (bool) {

--- a/contracts/colony/ColonyStorage.sol
+++ b/contracts/colony/ColonyStorage.sol
@@ -302,8 +302,8 @@ contract ColonyStorage is ColonyDataTypes, ColonyNetworkDataTypes, DSMath, Commo
   }
 
   function isValidLocalSkill(uint256 skillId) internal view returns (bool) {
-    bool deprecated = IColonyNetwork(colonyNetworkAddress).getSkill(skillId).deprecated;
-    return localSkills[skillId] && !deprecated;
+    Skill memory skill = IColonyNetwork(colonyNetworkAddress).getSkill(skillId);
+    return localSkills[skillId] && !skill.deprecated && !skill.DEPRECATED_globalSkill;
   }
 
   function domainExists(uint256 domainId) internal view returns (bool) {

--- a/contracts/colony/IMetaColony.sol
+++ b/contracts/colony/IMetaColony.sol
@@ -27,16 +27,6 @@ interface IMetaColony is IColony {
   /// @param _wad Amount to mint and transfer to the colony network
   function mintTokensForColonyNetwork(uint256 _wad) external;
 
-  /// @notice Add a new global skill.
-  /// @dev Calls `IColonyNetwork.addSkill`.
-  /// @return skillId Id of the added skill
-  function addGlobalSkill() external returns (uint256 skillId);
-
-  /// @notice Mark a global skill as deprecated which stops new tasks and payments from using it.
-  /// @dev Calls `IColonyNetwork.deprecateSkill`.
-  /// @param _skillId Id of the added skill
-  function deprecateGlobalSkill(uint256 _skillId) external;
-
   /// @notice Set the Colony Network fee inverse amount.
   /// @dev Calls `IColonyNetwork.setFeeInverse`.
   /// @param _feeInverse Nonzero amount for the fee inverse

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -117,16 +117,11 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage, Multicall 
     allowedToAddSkill(_parentSkillId == 0)
     returns (uint256)
   {
-    skillCount += 1;
-
     Skill storage parentSkill = skills[_parentSkillId];
-    // Global and local skill trees are kept separate
-    require(
-      _parentSkillId == 0 || !parentSkill.globalSkill,
-      "colony-global-and-local-skill-trees-are-separate"
-    );
 
+    skillCount += 1;
     Skill memory s;
+
     if (_parentSkillId != 0) {
       s.nParents = parentSkill.nParents + 1;
       skills[skillCount] = s;
@@ -162,9 +157,7 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage, Multicall 
         treeWalkingCounter += 1;
       }
     } else {
-      // Add a global skill
-      s.globalSkill = true;
-      skills[skillCount] = s;
+      require(false, "colony-global-skills-are-deprecated");
     }
 
     emit SkillAdded(skillCount, _parentSkillId);
@@ -207,7 +200,8 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage, Multicall 
   }
 
   function initialiseRootLocalSkill() public stoppable calledByColony returns (uint256) {
-    return skillCount++;
+    skillCount++;
+    return skillCount;
   }
 
   function appendReputationUpdateLog(

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -156,8 +156,6 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage, Multicall 
 
         treeWalkingCounter += 1;
       }
-    } else {
-      require(false, "colony-global-skills-are-deprecated");
     }
 
     emit SkillAdded(skillCount, _parentSkillId);

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -114,7 +114,10 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage, Multicall 
     require(_parentSkillId > 0, "colony-network-invalid-parent-skill");
 
     Skill storage parentSkill = skills[_parentSkillId];
-
+    require(
+      !parentSkill.DEPRECATED_globalSkill,
+      "colony-deprecated-global-and-local-skill-trees-are-separate"
+    );
     skillCount += 1;
     Skill memory s;
 

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -114,10 +114,8 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage, Multicall 
     require(_parentSkillId > 0, "colony-network-invalid-parent-skill");
 
     Skill storage parentSkill = skills[_parentSkillId];
-    require(
-      !parentSkill.DEPRECATED_globalSkill,
-      "colony-deprecated-global-and-local-skill-trees-are-separate"
-    );
+    require(!parentSkill.DEPRECATED_globalSkill, "colony-network-no-global-skills");
+
     skillCount += 1;
     Skill memory s;
 

--- a/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
+++ b/contracts/colonyNetwork/ColonyNetworkDataTypes.sol
@@ -157,7 +157,7 @@ interface ColonyNetworkDataTypes {
     // array of `skill_id`s of all child skills
     uint256[] children;
     // `true` for a global skill reused across colonies or `false` for a skill mapped to a single colony's domain
-    bool globalSkill;
+    bool DEPRECATED_globalSkill;
     // `true` for a global skill that is deprecated
     bool deprecated;
   }

--- a/contracts/colonyNetwork/ColonyNetworkDeployer.sol
+++ b/contracts/colonyNetwork/ColonyNetworkDeployer.sol
@@ -33,7 +33,7 @@ contract ColonyNetworkDeployer is ColonyNetworkStorage {
 
     metaColony = createColony(_tokenAddress, currentColonyVersion, "", "");
 
-    // Add the special mining skill
+    // Add the special mining skill, parent is the root domain
     reputationMiningSkillId = IColonyNetwork(address(this)).addSkill(skillCount - 1);
 
     emit MetaColonyCreated(metaColony, _tokenAddress, skillCount);

--- a/contracts/colonyNetwork/ColonyNetworkStorage.sol
+++ b/contracts/colonyNetwork/ColonyNetworkStorage.sol
@@ -123,17 +123,8 @@ contract ColonyNetworkStorage is ColonyNetworkDataTypes, DSMath, CommonStorage {
     _;
   }
 
-  // Meta Colony allowed to manage Global skills
-  // All colonies are able to manage their Local (domain associated) skills
-  modifier allowedToAddSkill(bool globalSkill) {
-    if (globalSkill) {
-      require(msgSender() == metaColony, "colony-must-be-meta-colony");
-    } else {
-      require(
-        _isColony[msgSender()] || msgSender() == address(this),
-        "colony-caller-must-be-colony"
-      );
-    }
+  modifier allowedToAddSkill() {
+    require(_isColony[msgSender()] || msgSender() == address(this), "colony-caller-must-be-colony");
     _;
   }
 

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -85,8 +85,7 @@ interface IColonyNetwork is ColonyNetworkDataTypes, IRecovery, IBasicMetaTransac
   /// @return _addressIsColony true if specified address is a colony, otherwise false
   function isColony(address _colony) external view returns (bool _addressIsColony);
 
-  /// @notice Adds a new skill to the global or local skills tree, under skill `_parentSkillId`.
-  /// Only the Meta Colony is allowed to add a global skill, called via `IColony.addGlobalSkill`.
+  /// @notice Adds a new skill to the domain or local skills tree, under skill `_parentSkillId`.
   /// Any colony is allowed to add a local skill and which is associated with a new domain via `IColony.addDomain`.
   /// @dev Errors if the parent skill does not exist or if this is called by an unauthorised sender.
   /// @param _parentSkillId Id of the skill under which the new skill will be added. If 0, a global skill is added with no parent.

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -376,6 +376,7 @@ contract OneTxPayment is ColonyExtension, BasicMetaTransaction {
     mask[0] = ARRAY;
     bytes32[] memory keys = new bytes32[](1);
     keys[0] = CLAIM_DELAY_OFFSET;
+
     colony.setExpenditureState(
       _permissionDomainId,
       _childSkillIndex,

--- a/docs/interfaces/icolonynetwork.md
+++ b/docs/interfaces/icolonynetwork.md
@@ -38,7 +38,7 @@ Add a new extension resolver to the Extensions repository.
 
 ### ▸ `addSkill(uint256 _parentSkillId):uint256 _skillId`
 
-Adds a new skill to the global or local skills tree, under skill `_parentSkillId`. Only the Meta Colony is allowed to add a global skill, called via `IColony.addGlobalSkill`. Any colony is allowed to add a local skill and which is associated with a new domain via `IColony.addDomain`.
+Adds a new skill to the domain or local skills tree, under skill `_parentSkillId`. Any colony is allowed to add a local skill and which is associated with a new domain via `IColony.addDomain`.
 
 *Note: Errors if the parent skill does not exist or if this is called by an unauthorised sender.*
 

--- a/docs/interfaces/imetacolony.md
+++ b/docs/interfaces/imetacolony.md
@@ -21,19 +21,6 @@ Add a new extension/version to the Extensions repository.
 |_resolver|address|The deployed resolver containing the extension contract logic
 
 
-### ▸ `addGlobalSkill():uint256 skillId`
-
-Add a new global skill.
-
-*Note: Calls `IColonyNetwork.addSkill`.*
-
-
-**Return Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|skillId|uint256|Id of the added skill
-
 ### ▸ `addNetworkColonyVersion(uint256 _version, address _resolver)`
 
 Adds a new Colony contract version and the address of associated `_resolver` contract. Secured function to authorised members.
@@ -46,19 +33,6 @@ Adds a new Colony contract version and the address of associated `_resolver` con
 |---|---|---|
 |_version|uint256|The new Colony contract version
 |_resolver|address|Address of the `Resolver` contract which will be used with the underlying `EtherRouter` contract
-
-
-### ▸ `deprecateGlobalSkill(uint256 _skillId)`
-
-Mark a global skill as deprecated which stops new tasks and payments from using it.
-
-*Note: Calls `IColonyNetwork.deprecateSkill`.*
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_skillId|uint256|Id of the added skill
 
 
 ### ▸ `mintTokensForColonyNetwork(uint256 _wad)`

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -71,8 +71,6 @@ const DECAY_RATE = {
   DENOMINATOR: new BN("1000000000000000"),
 };
 
-const GLOBAL_SKILL_ID = new BN("4"); // Not a root global skill ID or anything, just the first global skill's ID
-
 const SLOT0 = 0;
 const SLOT1 = 1;
 const SLOT2 = 2;
@@ -122,7 +120,6 @@ module.exports = {
   CHALLENGE_RESPONSE_WINDOW_DURATION,
   ALL_ENTRIES_ALLOWED_END_OF_WINDOW,
   DECAY_RATE,
-  GLOBAL_SKILL_ID,
   IPFS_HASH,
   HASHZERO,
   ADDRESS_ZERO,

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -24,8 +24,14 @@ exports.makeExpenditure = async function makeExpenditure({ colonyNetwork, colony
   }
 
   if (skillId === undefined) {
-    await colony.addLocalSkill();
-    skillId = await colonyNetwork.getSkillCount(); // eslint-disable-line no-param-reassign
+    const rootLocalSkillId = await colony.getRootLocalSkill();
+    const rootLocalSkill = await colonyNetwork.getSkill(rootLocalSkillId);
+    if (rootLocalSkill.children.length > 0) {
+      [skillId] = rootLocalSkill.children; // eslint-disable-line no-param-reassign
+    } else {
+      await colony.addLocalSkill();
+      skillId = await colonyNetwork.getSkillCount(); // eslint-disable-line no-param-reassign
+    }
   }
 
   const accounts = await web3GetAccounts();

--- a/helpers/test-data-generator.js
+++ b/helpers/test-data-generator.js
@@ -1,17 +1,7 @@
 /* globals artifacts */
 const BN = require("bn.js");
 
-const {
-  UINT256_MAX,
-  MANAGER_PAYOUT,
-  EVALUATOR_PAYOUT,
-  WORKER_PAYOUT,
-  INITIAL_FUNDING,
-  SLOT0,
-  SLOT1,
-  SLOT2,
-  ADDRESS_ZERO,
-} = require("./constants");
+const { UINT256_MAX, MANAGER_PAYOUT, EVALUATOR_PAYOUT, WORKER_PAYOUT, INITIAL_FUNDING, SLOT0, SLOT1, SLOT2, ADDRESS_ZERO } = require("./constants");
 
 const { getTokenArgs, web3GetAccounts, getChildSkillIndex, web3SignTypedData } = require("./test-helper");
 

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -18,6 +18,7 @@ const NoLimitSubdomains = artifacts.require("NoLimitSubdomains");
 const Resolver = artifacts.require("Resolver");
 const ContractEditing = artifacts.require("ContractEditing");
 const ColonyDomains = artifacts.require("ColonyDomains");
+const EtherRouter = artifacts.require("EtherRouter");
 
 const { expect } = chai;
 
@@ -1063,6 +1064,16 @@ exports.getColonyEditable = async function getColonyEditable(colony, colonyNetwo
   await colonyResolver.register("setStorageSlot(uint256,bytes32)", contractEditing.address);
   const colonyUnderRecovery = await ContractEditing.at(colony.address);
   return colonyUnderRecovery;
+};
+
+exports.getColonyNetworkEditable = async function getColonyNetworkEditable(colonyNetwork) {
+  const networkAsEtherRouter = await EtherRouter.at(colonyNetwork.address);
+  const resolverAddress = await networkAsEtherRouter.resolver();
+  const colonyNetworkResolver = await Resolver.at(resolverAddress);
+  const contractEditing = await ContractEditing.new();
+  await colonyNetworkResolver.register("setStorageSlot(uint256,bytes32)", contractEditing.address);
+  const colonyNetworkEditable = await ContractEditing.at(colonyNetwork.address);
+  return colonyNetworkEditable;
 };
 
 exports.getWaitForNSubmissionsPromise = async function getWaitForNSubmissionsPromise(repCycleEthers, rootHash, nLeaves, jrh, n) {

--- a/migrations/8_setup_meta_colony.js
+++ b/migrations/8_setup_meta_colony.js
@@ -52,7 +52,6 @@ module.exports = async function (deployer, network, accounts) {
   const tokenLocking = await ITokenLocking.at(tokenLockingAddress);
   await tokenLocking.methods["deposit(address,uint256,bool)"](clnyToken.address, DEFAULT_STAKE, true, { from: MAIN_ACCOUNT });
   await colonyNetwork.stakeForMining(DEFAULT_STAKE, { from: MAIN_ACCOUNT });
-  await metaColony.addGlobalSkill();
 
   // Set up functional resolvers that identify correctly as previous versions.
   const Colony = artifacts.require("./Colony");
@@ -109,7 +108,7 @@ module.exports = async function (deployer, network, accounts) {
   await colonyNetwork.startNextCycle();
 
   const skillCount = await colonyNetwork.getSkillCount();
-  assert.equal(skillCount.toNumber(), 4);
+  assert.equal(skillCount.toNumber(), 3); // Root domain, root local skill, mining skill
 
   console.log("### Meta Colony created at", metaColony.address);
 };

--- a/scripts/deployOldUpgradeableVersion.js
+++ b/scripts/deployOldUpgradeableVersion.js
@@ -46,6 +46,28 @@ module.exports.deployOldExtensionVersion = async (contractName, interfaceName, i
   }
 };
 
+module.exports.deployColonyVersionGLWSS4 = (colonyNetwork) => {
+  return module.exports.deployOldColonyVersion(
+    "Colony",
+    "IMetaColony",
+    [
+      // eslint-disable-next-line max-len
+      "Colony,ColonyDomains,ColonyExpenditure,ColonyFunding,ColonyPayment,ColonyRewards,ColonyRoles,ColonyTask,ContractRecovery,ColonyArbitraryTransaction",
+    ],
+    "glwss4",
+    colonyNetwork,
+  );
+};
+
+module.exports.deployColonyNetworkVersionGLWSS4 = () => {
+  return module.exports.deployOldColonyNetworkVersion(
+    "",
+    "IColonyNetwork",
+    ["ColonyNetwork,ColonyNetworkAuction,ColonyNetworkDeployer,ColonyNetworkENS,ColonyNetworkExtensions,ColonyNetworkMining,ContractRecovery"],
+    "glwss4",
+  );
+};
+
 module.exports.deployOldColonyVersion = async (contractName, interfaceName, implementationNames, versionTag, colonyNetwork) => {
   if (versionTag.indexOf(" ") !== -1) {
     throw new Error("Version tag cannot contain spaces");

--- a/scripts/deployOldUpgradeableVersion.js
+++ b/scripts/deployOldUpgradeableVersion.js
@@ -8,7 +8,7 @@ const Promise = require("bluebird");
 const exec = Promise.promisify(require("child_process").exec);
 const contract = require("@truffle/contract");
 const { getColonyEditable, getColonyNetworkEditable } = require("../helpers/test-helper");
-const { ROOT_ROLE } = require("../helpers/constants");
+const { ROOT_ROLE, RECOVERY_ROLE, ADMINISTRATION_ROLE, ARCHITECTURE_ROLE } = require("../helpers/constants");
 
 const colonyDeployed = {};
 const colonyNetworkDeployed = {};
@@ -100,6 +100,9 @@ module.exports.downgradeColony = async (colonyNetwork, colony, version) => {
   const oldAuthority = await colonyDeployed.IMetaColony[version].OldAuthority.new(colony.address, { from: accounts[0] });
   const owner = await oldAuthority.owner();
   await oldAuthority.setUserRole(accounts[0], ROOT_ROLE, true, { from: owner });
+  await oldAuthority.setUserRole(accounts[0], RECOVERY_ROLE, true, { from: owner });
+  await oldAuthority.setUserRole(accounts[0], ADMINISTRATION_ROLE, true, { from: owner });
+  await oldAuthority.setUserRole(accounts[0], ARCHITECTURE_ROLE, true, { from: owner });
   await oldAuthority.setOwner(colony.address, { from: accounts[0] });
   await editableColony.setStorageSlot(0, `0x${"0".repeat(24)}${oldAuthority.address.slice(2)}`);
   const oldVersionResolver = colonyDeployed.IMetaColony[version].resolverAddress;

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -12,7 +12,6 @@ const {
   SECONDS_PER_DAY,
   DEFAULT_STAKE,
   INITIAL_FUNDING,
-  GLOBAL_SKILL_ID,
   MINING_CYCLE_DURATION,
   CHALLENGE_RESPONSE_WINDOW_DURATION,
 } = require("../helpers/constants");
@@ -64,6 +63,7 @@ contract("All", function (accounts) {
 
   let colony;
   let token;
+  let localSkillId;
   let otherToken;
   let metaColony;
   let colonyNetwork;
@@ -82,7 +82,7 @@ contract("All", function (accounts) {
   });
 
   beforeEach(async function () {
-    ({ colony, token } = await setupRandomColony(colonyNetwork));
+    ({ colony, token, localSkillId } = await setupRandomColony(colonyNetwork));
 
     const otherTokenArgs = getTokenArgs();
     otherToken = await Token.new(...otherTokenArgs);
@@ -102,10 +102,10 @@ contract("All", function (accounts) {
     });
 
     it("when working with the Meta Colony", async function () {
-      await metaColony.addGlobalSkill();
-      await metaColony.addGlobalSkill();
-      await metaColony.addGlobalSkill();
-      await metaColony.addGlobalSkill();
+      await metaColony.addLocalSkill();
+      await metaColony.addLocalSkill();
+      await metaColony.addLocalSkill();
+      await metaColony.addLocalSkill();
     });
 
     it("when working with a Colony", async function () {
@@ -128,7 +128,7 @@ contract("All", function (accounts) {
       await oneTxExtension.makePayment(1, UINT256_MAX, 1, UINT256_MAX, [WORKER], [otherToken.address], [10], 1, 0);
 
       // 1 tx payment to one recipient, with skill
-      await oneTxExtension.makePayment(1, UINT256_MAX, 1, UINT256_MAX, [WORKER], [token.address], [10], 1, GLOBAL_SKILL_ID);
+      await oneTxExtension.makePayment(1, UINT256_MAX, 1, UINT256_MAX, [WORKER], [token.address], [10], 1, localSkillId);
 
       const firstToken = token.address < otherToken.address ? token.address : otherToken.address;
       const secondToken = token.address < otherToken.address ? otherToken.address : token.address;

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -155,11 +155,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleStateHash);
       console.log("tokenLockingStateHash:", tokenLockingStateHash);
 
-      expect(colonyNetworkStateHash).to.equal("0xeab47609e58f6f4f73a4b93c30a0604bde4b376aaa08938d9cdab11597583e94");
-      expect(colonyStateHash).to.equal("0x85b450aff8efcd28a9ae73a288e66f138ea40d6de9c8e7a308db4395ea23bfa1");
-      expect(metaColonyStateHash).to.equal("0x60b0189dea488416bdeed0de728d7659775d697219137827d84c83e97210e7e9");
-      expect(miningCycleStateHash).to.equal("0xc9c36a48e266c74abc34de1ef3e522c9925d22941c41a307819c4460635bd260");
-      expect(tokenLockingStateHash).to.equal("0x3dc9cdaf6f43272b4d4485689bcd4f42e3e5d46de02ce2b3b5b33bde51cde7ee");
+      expect(colonyNetworkStateHash).to.equal("0xe2a19d28c1a68778bfe793623d1b9f71f43db3e98b46fef29f3ea1040968f26c");
+      expect(colonyStateHash).to.equal("0x58b09676f8fb26ec467b5bb8ea3392b6da0db191acc5ee2f400a0940ee79f4ce");
+      expect(metaColonyStateHash).to.equal("0xa09c107f9a66e313434ba2d6633e09c15fcb365db7678cf4dc4a19ca481a3954");
+      expect(miningCycleStateHash).to.equal("0xfd18a690f69132bd95d32bf3a91cb2b60d0da16993cd60087bf8ccc1fa75b680");
+      expect(tokenLockingStateHash).to.equal("0x0a66e763122dc805a1fcd36aa1f0cc40228ffa53ed050fec4ac78c70cad4d31a");
     });
   });
 });

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -44,7 +44,10 @@ contract("Contract Storage", (accounts) => {
     token = await Token.new("name", "symbol", 18);
     await token.unlock();
 
-    ({ colony, localSkillId } = await setupColony(colonyNetwork, token.address));
+    colony = await setupColony(colonyNetwork, token.address);
+
+    await colony.addLocalSkill();
+    localSkillId = await colonyNetwork.getSkillCount();
 
     tokenLockingAddress = await colonyNetwork.getTokenLocking();
     const tokenAuthority = await TokenAuthority.new(token.address, colony.address, [tokenLockingAddress]);

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -3,7 +3,7 @@ const chai = require("chai");
 const bnChai = require("bn-chai");
 const BN = require("bn.js");
 
-const { UINT256_MAX, WAD, GLOBAL_SKILL_ID } = require("../helpers/constants");
+const { UINT256_MAX, WAD } = require("../helpers/constants");
 const { fundColonyWithTokens, setupColony } = require("../helpers/test-data-generator");
 
 const { expect } = chai;
@@ -26,6 +26,7 @@ contract("Contract Storage", (accounts) => {
 
   let colony;
   let token;
+  let localSkillId;
   let otherToken;
   let colonyNetwork;
   let metaColony;
@@ -42,7 +43,9 @@ contract("Contract Storage", (accounts) => {
 
     token = await Token.new("name", "symbol", 18);
     await token.unlock();
-    colony = await setupColony(colonyNetwork, token.address);
+
+    ({ colony, localSkillId } = await setupColony(colonyNetwork, token.address));
+
     tokenLockingAddress = await colonyNetwork.getTokenLocking();
     const tokenAuthority = await TokenAuthority.new(token.address, colony.address, [tokenLockingAddress]);
     await token.setAuthority(tokenAuthority.address);
@@ -87,7 +90,7 @@ contract("Contract Storage", (accounts) => {
 
       await colony.setExpenditureRecipient(expenditureId, SLOT0, RECIPIENT, { from: ADMIN });
       await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
-      await colony.setExpenditureSkill(expenditureId, SLOT0, GLOBAL_SKILL_ID, { from: ADMIN });
+      await colony.setExpenditureSkills(expenditureId, [SLOT0], [localSkillId], { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
       await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);

--- a/test-system/end-to-end.js
+++ b/test-system/end-to-end.js
@@ -155,7 +155,7 @@ contract("End to end Colony network and Reputation mining testing", function (ac
 
       // Add 500 more skills which won't be used in reputation
       const s = Array.from(Array(500).keys());
-      const skillsSetupPromise = s.map(() => metaColony.addGlobalSkill());
+      const skillsSetupPromise = s.map(() => metaColony.addLocalSkill());
       await Promise.all(skillsSetupPromise);
 
       skillCount = await colonyNetwork.getSkillCount();

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -286,14 +286,6 @@ contract("Colony Expenditure", (accounts) => {
       await checkErrorRevert(colony.setExpenditureSkills(expenditureId, [SLOT0], [100], { from: ADMIN }), "colony-not-valid-local-skill");
     });
 
-    it("should not allow owners to set a deprecated global skill", async () => {
-      await metaColony.addGlobalSkill();
-      const skillId = await colonyNetwork.getSkillCount();
-      await metaColony.deprecateGlobalSkill(skillId);
-
-      await checkErrorRevert(colony.setExpenditureSkill(expenditureId, SLOT0, skillId, { from: ADMIN }), "colony-not-valid-local-skill");
-    });
-
     it("should allow only owners to update a slot claim delay", async () => {
       await checkErrorRevert(colony.setExpenditureClaimDelay(expenditureId, SLOT0, SECONDS_PER_DAY, { from: USER }), "colony-expenditure-not-owner");
 

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -267,6 +267,13 @@ contract("Colony Expenditure", (accounts) => {
       );
     });
 
+    it("should allow owners to update a slot skill with a local skill", async () => {
+      await colony.setExpenditureSkill(expenditureId, SLOT0, localSkillId, { from: ADMIN });
+
+      expenditureSlot = await colony.getExpenditureSlot(expenditureId, SLOT0);
+      expect(expenditureSlot.skills[0]).to.eq.BN(localSkillId);
+    });
+
     it("should not allow owners to update a slot skill with a local skill from a different colony", async () => {
       const { localSkillId: otherLocalSkillId } = await setupRandomColony(colonyNetwork);
 

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -277,8 +277,6 @@ contract("Colony Expenditure", (accounts) => {
     });
 
     it.skip("should not allow owners to update a slot skill with a deprecated local skill", async () => {
-      await colony.addLocalSkill();
-      const localSkillId = await colonyNetwork.getSkillCount();
       await colony.deprecateLocalSkill(localSkillId, true);
 
       await checkErrorRevert(colony.setExpenditureSkills(expenditureId, [SLOT0], [localSkillId], { from: ADMIN }), "colony-not-valid-local-skill");

--- a/test/contracts-network/colony-expenditure.js
+++ b/test/contracts-network/colony-expenditure.js
@@ -395,15 +395,15 @@ contract("Colony Expenditure", (accounts) => {
 
       // Add global skill
       const oldMetaColony = await OldInterface.at(metaColony.address);
-      await oldMetaColony.addGlobalSkill({ from: accounts[0] });
+      await oldMetaColony.addGlobalSkill();
       const globalSkillId = await colonyNetwork.getSkillCount();
-      await oldMetaColony.addGlobalSkill({ from: accounts[0] });
+      await oldMetaColony.addGlobalSkill();
       const globalSkillId2 = await colonyNetwork.getSkillCount();
-      await oldMetaColony.deprecateGlobalSkill(globalSkillId, { from: accounts[0] });
+      await oldMetaColony.deprecateGlobalSkill(globalSkillId);
 
       // Upgrade to current version
       await colonyNetworkAsEtherRouter.setResolver(latestResolver);
-      await metaColony.upgrade(14, { from: accounts[0] });
+      await metaColony.upgrade(14);
 
       await checkErrorRevert(colony.setExpenditureSkill(expenditureId, SLOT0, globalSkillId, { from: ADMIN }), "colony-not-valid-local-skill");
       await checkErrorRevert(colony.setExpenditureSkill(expenditureId, SLOT0, globalSkillId2, { from: ADMIN }), "colony-not-valid-local-skill");

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -338,9 +338,8 @@ contract("Colony Network", (accounts) => {
       const token = await Token.new(...getTokenArgs());
       const colony = await setupColony(colonyNetwork, token.address);
 
-      const skillCount = await colonyNetwork.getSkillCount();
-      const rootLocalSkillId = skillCount.subn(1);
-      const rootDomainSkillId = skillCount.subn(2);
+      const rootLocalSkillId = await colonyNetwork.getSkillCount();
+      const rootDomainSkillId = rootLocalSkillId.subn(1);
 
       const rootLocalSkill = await colonyNetwork.getSkill(rootLocalSkillId);
       expect(parseInt(rootLocalSkill.nParents, 10)).to.be.zero;

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -29,6 +29,7 @@ const { setupENSRegistrar } = require("../../helpers/upgradable-contracts");
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
 
+const ColonyAuthority = artifacts.require("ColonyAuthority");
 const ENSRegistry = artifacts.require("ENSRegistry");
 const EtherRouter = artifacts.require("EtherRouter");
 const Resolver = artifacts.require("Resolver");
@@ -209,6 +210,10 @@ contract("Colony Network", (accounts) => {
 
       // v4 specifically is needed for the deprecated five-parameter test
       await metaColony.addNetworkColonyVersion(4, newResolverAddress);
+    });
+
+    it("cannot deploy an authority without a colony", async () => {
+      await checkErrorRevert(ColonyAuthority.new(ADDRESS_ZERO), "colony-authority-colony-cannot-be-zero");
     });
 
     it("should allow users to create a new colony at a specific older version", async () => {

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -9,6 +9,7 @@ const namehash = require("eth-ens-namehash");
 const {
   setupColonyNetwork,
   setupMetaColonyWithLockedCLNYToken,
+  setupColony,
   setupRandomColony,
   getMetaTransactionParameters,
 } = require("../../helpers/test-data-generator");
@@ -317,6 +318,9 @@ contract("Colony Network", (accounts) => {
       const skillCount = await colonyNetwork.getSkillCount();
       expect(skillCount).to.eq.BN(3);
 
+      const localSkill = await colonyNetwork.getSkill(1);
+      expect(localSkill.DEPRECATED_globalSkill).to.be.false;
+
       const miningSkillId = await colonyNetwork.getReputationMiningSkillId();
       expect(miningSkillId).to.eq.BN(3);
     });
@@ -331,14 +335,16 @@ contract("Colony Network", (accounts) => {
     });
 
     it("when any colony is created, should have the root domain and local skills initialised", async () => {
-      const { colony } = await setupRandomColony(colonyNetwork);
+      const token = await Token.new(...getTokenArgs());
+      const colony = await setupColony(colonyNetwork, token.address);
+
       const skillCount = await colonyNetwork.getSkillCount();
       const rootLocalSkillId = skillCount.subn(1);
       const rootDomainSkillId = skillCount.subn(2);
 
       const rootLocalSkill = await colonyNetwork.getSkill(rootLocalSkillId);
       expect(parseInt(rootLocalSkill.nParents, 10)).to.be.zero;
-      expect(parseInt(rootLocalSkill.nChildren, 10)).to.eq.BN(1); // Created by data generator
+      expect(parseInt(rootLocalSkill.nChildren, 10)).to.be.zero;
 
       const rootDomainSkill = await colonyNetwork.getSkill(rootDomainSkillId);
       expect(parseInt(rootDomainSkill.nParents, 10)).to.be.zero;

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -491,6 +491,10 @@ contract("Colony Network", (accounts) => {
   });
 
   describe("when working with skills", () => {
+    it("should not be able to add a global skill, even when called from metacolony ", async () => {
+      await checkErrorRevert(colonyNetwork.addSkill(0, { from: metaColony.address }), "colony-network-invalid-parent-skill");
+    });
+
     it("should NOT be able to add a local skill, by an address that is not a Colony", async () => {
       await checkErrorRevert(colonyNetwork.addSkill(1), "colony-caller-must-be-colony");
     });

--- a/test/contracts-network/colony-recovery.js
+++ b/test/contracts-network/colony-recovery.js
@@ -139,8 +139,6 @@ contract("Colony Recovery", (accounts) => {
 
       await checkErrorRevert(colony.initialiseColony(ethers.constants.AddressZero, ethers.constants.AddressZero), "colony-in-recovery-mode");
       await checkErrorRevert(colony.mintTokens(1000), "colony-in-recovery-mode");
-      await checkErrorRevert(metaColony.addGlobalSkill(), "colony-in-recovery-mode");
-      await checkErrorRevert(metaColony.deprecateGlobalSkill(0), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.emitDomainReputationReward(0, ADDRESS_ZERO, 0), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.emitDomainReputationPenalty(0, 0, 0, ADDRESS_ZERO, 0), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.emitSkillReputationReward(0, ADDRESS_ZERO, 0), "colony-in-recovery-mode");
@@ -185,7 +183,6 @@ contract("Colony Recovery", (accounts) => {
       await checkErrorRevert(metaColony.setExpenditureClaimDelays(0, [], []), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.setExpenditurePayoutModifiers(0, [], []), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.setExpenditureRecipient(0, 0, ADDRESS_ZERO), "colony-in-recovery-mode");
-      await checkErrorRevert(metaColony.setExpenditureSkill(0, 0, 0), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.setExpenditureClaimDelay(0, 0, 0), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.setExpenditureState(0, 0, 0, 0, [], [], HASHZERO), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.setExpenditureValues(0, [], [], [], [], [], [], [], [], [], [[]], [[]]), "colony-in-recovery-mode");

--- a/test/contracts-network/colony-staking.js
+++ b/test/contracts-network/colony-staking.js
@@ -126,6 +126,25 @@ contract("Colony Staking", (accounts) => {
       expect(deposit.balance).to.eq.BN(WAD.muln(49));
     });
 
+    it("should not let users call stake management functions on tokenLocking directly", async () => {
+      await checkErrorRevert(
+        tokenLocking.approveStake(USER1, WAD, token.address, { from: USER0 }),
+        "colony-token-locking-sender-not-colony-or-network",
+      );
+      await checkErrorRevert(
+        tokenLocking.obligateStake(USER1, WAD, token.address, { from: USER0 }),
+        "colony-token-locking-sender-not-colony-or-network",
+      );
+      await checkErrorRevert(
+        tokenLocking.deobligateStake(USER1, WAD, token.address, { from: USER0 }),
+        "colony-token-locking-sender-not-colony-or-network",
+      );
+      await checkErrorRevert(
+        tokenLocking.transferStake(USER1, WAD, token.address, USER0, { from: USER0 }),
+        "colony-token-locking-sender-not-colony-or-network",
+      );
+    });
+
     it("should not let users obligate more than is approved for obligator", async () => {
       await colony.approveStake(USER0, 1, WAD, { from: USER1 });
 

--- a/test/contracts-network/colony-task.js
+++ b/test/contracts-network/colony-task.js
@@ -2155,12 +2155,12 @@ contract.skip("ColonyTask", (accounts) => {
 
     it("should NOT be able to set nonexistent skill on task", async () => {
       const taskId = await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskSkill(taskId, 100), "colony-not-valid-global-or-local-skill");
+      await checkErrorRevert(colony.setTaskSkill(taskId, 100), "colony-not-valid-local-skill");
     });
 
     it("should NOT be able to set a domain skill on task", async () => {
       const taskId = await makeTask({ colony });
-      await checkErrorRevert(colony.setTaskSkill(taskId, 1), "colony-not-valid-global-or-local-skill");
+      await checkErrorRevert(colony.setTaskSkill(taskId, 1), "colony-not-valid-local-skill");
     });
 
     it("should NOT be able to set a deprecated global skill on task", async () => {
@@ -2169,7 +2169,7 @@ contract.skip("ColonyTask", (accounts) => {
       const skillId = await colonyNetwork.getSkillCount();
       await metaColony.deprecateGlobalSkill(skillId);
 
-      await checkErrorRevert(colony.setTaskSkill(taskId, skillId), "colony-not-valid-global-or-local-skill");
+      await checkErrorRevert(colony.setTaskSkill(taskId, skillId), "colony-not-valid-local-skill");
     });
   });
 });

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -117,7 +117,8 @@ contract("Colony", (accounts) => {
 
       // A domain skill should have been created for the Colony
       const skillCount = await colonyNetwork.getSkillCount();
-      expect(domain.skillId).to.eq.BN(skillCount.subn(2)); // Account for two local skills
+      expect(domain.skillId).to.be.gte.BN(1);
+      expect(domain.skillId).to.be.lte.BN(skillCount);
     });
 
     it("should let funding pot information be read", async () => {

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -447,7 +447,7 @@ contract("Colony", (accounts) => {
     let OldInterface;
     let oldColony;
     before(async () => {
-      OldInterface = await deployOldColonyVersion(
+      ({ OldInterface } = await deployOldColonyVersion(
         "Colony",
         "IMetaColony",
         [
@@ -456,7 +456,7 @@ contract("Colony", (accounts) => {
         ],
         "glwss4",
         colonyNetwork,
-      );
+      ));
     });
 
     beforeEach(async () => {
@@ -467,6 +467,8 @@ contract("Colony", (accounts) => {
       await token.setAuthority(tokenAuthority.address);
 
       oldColony = await OldInterface.at(colony.address);
+      await colony.addLocalSkill();
+      localSkillId = await colonyNetwork.getSkillCount();
     });
 
     it("should be able to query for a task", async () => {

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -13,7 +13,7 @@ const {
   fundColonyWithTokens,
   setupColony,
 } = require("../../helpers/test-data-generator");
-const { deployOldColonyVersion } = require("../../scripts/deployOldUpgradeableVersion");
+const { deployColonyVersionGLWSS4 } = require("../../scripts/deployOldUpgradeableVersion");
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
@@ -447,16 +447,7 @@ contract("Colony", (accounts) => {
     let OldInterface;
     let oldColony;
     before(async () => {
-      ({ OldInterface } = await deployOldColonyVersion(
-        "Colony",
-        "IMetaColony",
-        [
-          // eslint-disable-next-line max-len
-          "Colony,ColonyDomains,ColonyExpenditure,ColonyFunding,ColonyPayment,ColonyRewards,ColonyRoles,ColonyTask,ContractRecovery,ColonyArbitraryTransaction",
-        ],
-        "glwss4",
-        colonyNetwork,
-      ));
+      ({ OldInterface } = await deployColonyVersionGLWSS4(colonyNetwork));
     });
 
     beforeEach(async () => {

--- a/test/contracts-network/colony.js
+++ b/test/contracts-network/colony.js
@@ -4,7 +4,7 @@ const chai = require("chai");
 const bnChai = require("bn-chai");
 const { ethers } = require("ethers");
 
-const { IPFS_HASH, UINT256_MAX, WAD, ADDRESS_ZERO, SPECIFICATION_HASH, GLOBAL_SKILL_ID, HASHZERO } = require("../../helpers/constants");
+const { IPFS_HASH, UINT256_MAX, WAD, ADDRESS_ZERO, SPECIFICATION_HASH, HASHZERO } = require("../../helpers/constants");
 const { getTokenArgs, web3GetBalance, checkErrorRevert, expectNoEvent, expectAllEvents, expectEvent } = require("../../helpers/test-helper");
 const {
   setupRandomColony,
@@ -28,6 +28,7 @@ const Token = artifacts.require("Token");
 contract("Colony", (accounts) => {
   let colony;
   let token;
+  let localSkillId;
   let colonyNetwork;
 
   const USER0 = accounts[0];
@@ -39,7 +40,7 @@ contract("Colony", (accounts) => {
   });
 
   beforeEach(async () => {
-    ({ colony, token } = await setupRandomColony(colonyNetwork));
+    ({ colony, token, localSkillId } = await setupRandomColony(colonyNetwork));
   });
 
   describe("when initialised", () => {
@@ -115,8 +116,8 @@ contract("Colony", (accounts) => {
       expect(domain.fundingPotId).to.eq.BN(1);
 
       // A domain skill should have been created for the Colony
-      const rootLocalSkillId = await colonyNetwork.getSkillCount();
-      expect(domain.skillId).to.eq.BN(rootLocalSkillId.subn(1));
+      const skillCount = await colonyNetwork.getSkillCount();
+      expect(domain.skillId).to.eq.BN(skillCount.subn(2)); // Account for two local skills
     });
 
     it("should let funding pot information be read", async () => {
@@ -239,20 +240,22 @@ contract("Colony", (accounts) => {
     const INITIAL_ADDRESSES = accounts.slice(0, 4);
 
     it("should assign reputation correctly", async () => {
-      const skillCount = await colonyNetwork.getSkillCount();
-      const rootDomainSkillId = skillCount.subn(1);
+      const domain = await colony.getDomain(1);
 
       await colony.mintTokens(WAD.muln(14));
       await colony.claimColonyFunds(token.address);
       await colony.bootstrapColony(INITIAL_ADDRESSES, INITIAL_REPUTATIONS);
+
       const inactiveReputationMiningCycleAddress = await colonyNetwork.getReputationMiningCycle(false);
       const inactiveReputationMiningCycle = await IReputationMiningCycle.at(inactiveReputationMiningCycleAddress);
+
       const numberOfReputationLogs = await inactiveReputationMiningCycle.getReputationUpdateLogLength();
       expect(numberOfReputationLogs).to.eq.BN(INITIAL_ADDRESSES.length);
+
       const updateLog = await inactiveReputationMiningCycle.getReputationUpdateLogEntry(0);
       expect(updateLog.user).to.eq.BN(INITIAL_ADDRESSES[0]);
       expect(updateLog.amount).to.eq.BN(INITIAL_REPUTATIONS[0]);
-      expect(updateLog.skillId).to.eq.BN(rootDomainSkillId);
+      expect(updateLog.skillId).to.eq.BN(domain.skillId);
     });
 
     it("should assign tokens correctly", async () => {
@@ -466,7 +469,7 @@ contract("Colony", (accounts) => {
     });
 
     it("should be able to query for a task", async () => {
-      await oldColony.makeTask(1, UINT256_MAX, SPECIFICATION_HASH, 1, GLOBAL_SKILL_ID, 0, { from: USER0 });
+      await oldColony.makeTask(1, UINT256_MAX, SPECIFICATION_HASH, 1, localSkillId, 0, { from: USER0 });
       await colony.upgrade(14);
       const taskId = await colony.getTaskCount();
       const task = await colony.getTask(taskId);
@@ -487,7 +490,7 @@ contract("Colony", (accounts) => {
     });
 
     it("should be able to query for a payment", async () => {
-      await oldColony.addPayment(1, UINT256_MAX, USER1, token.address, WAD, 1, GLOBAL_SKILL_ID, { from: USER0 });
+      await oldColony.addPayment(1, UINT256_MAX, USER1, token.address, WAD, 1, localSkillId, { from: USER0 });
       await colony.upgrade(14);
 
       const paymentId = await colony.getPaymentCount();
@@ -500,7 +503,7 @@ contract("Colony", (accounts) => {
     it("should be able to transfer funds allocated to a task back to the domain", async () => {
       await fundColonyWithTokens(colony, token, WAD);
 
-      await oldColony.makeTask(1, UINT256_MAX, SPECIFICATION_HASH, 1, GLOBAL_SKILL_ID, 0, { from: USER0 });
+      await oldColony.makeTask(1, UINT256_MAX, SPECIFICATION_HASH, 1, localSkillId, 0, { from: USER0 });
       const taskId = await colony.getTaskCount();
       const { fundingPotId, status } = await colony.getTask(taskId);
 
@@ -516,7 +519,7 @@ contract("Colony", (accounts) => {
     it("should be able to transfer funds allocated to a payment back to the domain", async () => {
       await fundColonyWithTokens(colony, token, WAD);
 
-      await oldColony.addPayment(1, UINT256_MAX, USER1, token.address, WAD, 1, GLOBAL_SKILL_ID, { from: USER0 });
+      await oldColony.addPayment(1, UINT256_MAX, USER1, token.address, WAD, 1, localSkillId, { from: USER0 });
       const paymentId = await colony.getPaymentCount();
       const { fundingPotId, finalized } = await colony.getPayment(paymentId);
 

--- a/test/contracts-network/meta-colony.js
+++ b/test/contracts-network/meta-colony.js
@@ -8,10 +8,10 @@ const { UINT256_MAX, WAD, ADDRESS_ZERO, HASHZERO } = require("../../helpers/cons
 const { checkErrorRevert, removeSubdomainLimit, restoreSubdomainLimit, bn2bytes32 } = require("../../helpers/test-helper");
 const { setupColonyNetwork, setupMetaColonyWithLockedCLNYToken, setupRandomColony } = require("../../helpers/test-data-generator");
 const {
-  deployOldColonyVersion,
   downgradeColony,
-  deployOldColonyNetworkVersion,
   downgradeColonyNetwork,
+  deployColonyVersionGLWSS4,
+  deployColonyNetworkVersionGLWSS4,
 } = require("../../scripts/deployOldUpgradeableVersion");
 
 const IMetaColony = artifacts.require("IMetaColony");
@@ -420,26 +420,11 @@ contract("Meta Colony", (accounts) => {
   describe("when interacting with (now removed) global skills", () => {
     let globalSkillId;
     beforeEach(async () => {
-      const { OldInterface } = await deployOldColonyVersion(
-        "Colony",
-        "IMetaColony",
-        [
-          // eslint-disable-next-line max-len
-          "Colony,ColonyDomains,ColonyExpenditure,ColonyFunding,ColonyPayment,ColonyRewards,ColonyRoles,ColonyTask,ContractRecovery,ColonyArbitraryTransaction",
-        ],
-        "glwss4",
-        colonyNetwork,
-      );
-
+      const { OldInterface } = await deployColonyVersionGLWSS4(colonyNetwork);
       await downgradeColony(colonyNetwork, metaColony, "glwss4");
 
       // Make the colonyNetwork the old version
-      await deployOldColonyNetworkVersion(
-        "",
-        "IColonyNetwork",
-        ["ColonyNetwork,ColonyNetworkAuction,ColonyNetworkDeployer,ColonyNetworkENS,ColonyNetworkExtensions,ColonyNetworkMining,ContractRecovery"],
-        "glwss4",
-      );
+      await deployColonyNetworkVersionGLWSS4();
 
       const colonyNetworkAsEtherRouter = await EtherRouter.at(colonyNetwork.address);
       const latestResolver = await colonyNetworkAsEtherRouter.resolver();

--- a/test/contracts-network/meta-colony.js
+++ b/test/contracts-network/meta-colony.js
@@ -433,12 +433,12 @@ contract("Meta Colony", (accounts) => {
 
       // Add global skill
       const oldMetaColony = await OldInterface.at(metaColony.address);
-      await oldMetaColony.addGlobalSkill({ from: accounts[0] });
+      await oldMetaColony.addGlobalSkill();
       globalSkillId = await colonyNetwork.getSkillCount();
 
       // Upgrade to current version
       await colonyNetworkAsEtherRouter.setResolver(latestResolver);
-      await metaColony.upgrade(14, { from: accounts[0] });
+      await metaColony.upgrade(14);
     });
 
     describe("when getting a skill", () => {

--- a/test/contracts-network/meta-colony.js
+++ b/test/contracts-network/meta-colony.js
@@ -469,8 +469,9 @@ contract("Meta Colony", (accounts) => {
       // Leave recovery mode
       await metaColony.approveExitRecovery();
       await metaColony.exitRecoveryMode();
+
       // Try to add a child to what the network thinks is a global skill
-      await checkErrorRevert(metaColony.addDomain(1, UINT256_MAX, 1), "colony-deprecated-global-and-local-skill-trees-are-separate");
+      await checkErrorRevert(metaColony.addDomain(1, UINT256_MAX, 1), "colony-network-no-global-skills");
       const skillCountAfter = await colonyNetwork.getSkillCount();
       expect(skillCountBefore).to.eq.BN(skillCountAfter);
     });

--- a/test/contracts-network/token-locking.js
+++ b/test/contracts-network/token-locking.js
@@ -413,7 +413,7 @@ contract("Token Locking", (addresses) => {
       const extensionAddress = await colonyNetwork.getExtensionInstallation(TEST_VOTING_TOKEN, colony.address);
       const votingToken = await TestVotingToken.at(extensionAddress);
 
-      await checkErrorRevert(votingToken.unlockTokenForUser(userAddress, 100), "colony-token-invalid-lockid");
+      await checkErrorRevert(votingToken.unlockTokenForUser(userAddress, 100), "colony-bad-lock-id");
     });
   });
 

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -272,15 +272,15 @@ contract("One transaction payments", (accounts) => {
 
       // Add global skill
       const oldMetaColony = await OldInterface.at(metaColony.address);
-      await oldMetaColony.addGlobalSkill({ from: accounts[0] });
+      await oldMetaColony.addGlobalSkill();
       const globalSkillId = await colonyNetwork.getSkillCount();
-      await oldMetaColony.addGlobalSkill({ from: accounts[0] });
+      await oldMetaColony.addGlobalSkill();
       const globalSkillId2 = await colonyNetwork.getSkillCount();
-      await oldMetaColony.deprecateGlobalSkill(globalSkillId, { from: accounts[0] });
+      await oldMetaColony.deprecateGlobalSkill(globalSkillId);
 
       // Upgrade to current version
       await colonyNetworkAsEtherRouter.setResolver(latestResolver);
-      await metaColony.upgrade(14, { from: accounts[0] });
+      await metaColony.upgrade(14);
 
       await checkErrorRevert(
         oneTxPayment.makePaymentFundedFromDomain(1, UINT256_MAX, 1, UINT256_MAX, [USER1], [token.address], [10], 1, globalSkillId),

--- a/test/extensions/staged-expenditure.js
+++ b/test/extensions/staged-expenditure.js
@@ -196,7 +196,7 @@ contract("Staged Expenditure", (accounts) => {
       await colony.finalizeExpenditure(expenditureId);
 
       // Cannot claim until the slot is released
-      await checkErrorRevert(colony.claimExpenditurePayout(expenditureId, 0, token.address), "colony-expenditure-cannot-claim");
+      await checkErrorRevert(colony.claimExpenditurePayout(expenditureId, SLOT0, token.address), "colony-expenditure-cannot-claim");
 
       // Cannot release stage if no arbitration permission
       await checkErrorRevert(

--- a/test/reputation-system/client-calculations.js
+++ b/test/reputation-system/client-calculations.js
@@ -37,8 +37,9 @@ const setupNewNetworkInstance = async (MINER1, MINER2) => {
 
   await removeSubdomainLimit(colonyNetwork); // Temporary for tests until we allow subdomain depth > 1
 
-  // Initialise global skill: 3. Set up local skills tree 1 -> 4 -> 5
+  // Initialise local skill: 3. Set up local skills tree 1 -> 4 -> 5
   //                                                       \-> 2
+  await metaColony.addLocalSkill();
   await metaColony.addDomain(1, UINT256_MAX, 1);
   await metaColony.addDomain(1, 1, 2);
   // 1 -> M

--- a/test/reputation-system/client-core-functionality.js
+++ b/test/reputation-system/client-core-functionality.js
@@ -328,7 +328,11 @@ process.env.SOLIDITY_COVERAGE
 
         it("should correctly respond to a request for all reputation a single user has in a colony", async () => {
           await fundColonyWithTokens(metaColony, clnyToken, INITIAL_FUNDING.muln(100));
-          await setupClaimedExpenditure({ colonyNetwork, colony: metaColony, worker: MINER1, manager: accounts[6] });
+
+          await metaColony.addLocalSkill();
+          const localSkillId = await colonyNetwork.getSkillCount();
+
+          await setupClaimedExpenditure({ colonyNetwork, colony: metaColony, skillId: localSkillId, worker: MINER1, manager: accounts[6] });
 
           await advanceMiningCycleNoContest({ colonyNetwork, client: reputationMiner, test: this });
           await advanceMiningCycleNoContest({ colonyNetwork, client: reputationMiner, test: this });
@@ -340,10 +344,10 @@ process.env.SOLIDITY_COVERAGE
           let res = await request(url);
           expect(res.statusCode).to.equal(200);
           let { reputations } = JSON.parse(res.body);
-          expect(reputations.length).to.equal(3);
+          expect(reputations.length).to.equal(4);
 
           // More people get reputation doesn't change anything
-          await setupClaimedExpenditure({ colonyNetwork, colony: metaColony, worker: accounts[6], manager: accounts[6] });
+          await setupClaimedExpenditure({ colonyNetwork, colony: metaColony, skillId: localSkillId, worker: accounts[6], manager: accounts[6] });
           await advanceMiningCycleNoContest({ colonyNetwork, client: reputationMiner, test: this });
           await advanceMiningCycleNoContest({ colonyNetwork, client: reputationMiner, test: this });
           rootHash = await reputationMiner.reputationTree.getRootHash();
@@ -353,7 +357,7 @@ process.env.SOLIDITY_COVERAGE
           expect(res.statusCode).to.equal(200);
 
           ({ reputations } = JSON.parse(res.body));
-          expect(reputations.length).to.equal(3);
+          expect(reputations.length).to.equal(4);
         });
 
         it("should correctly respond to a request for all reputation a single user has in a colony that has an invalid address", async () => {

--- a/test/reputation-system/dispute-resolution-misbehaviour.js
+++ b/test/reputation-system/dispute-resolution-misbehaviour.js
@@ -550,7 +550,6 @@ contract("Reputation Mining - disputes resolution misbehaviour", (accounts) => {
       const nUpdates = new BN(lastLogEntry.nUpdates).add(new BN(lastLogEntry.nPreviousUpdates)).add(currentHashNLeaves);
       // The total number of updates we expect is the nPreviousUpdates in the last entry of the log plus the number
       // of updates that log entry implies by itself, plus the number of decays (the number of leaves in current state)
-      console.log(nUpdates.toString());
       if (nUpdates.toNumber() !== 64) {
         throw Error("Should be a power of two");
       }

--- a/test/reputation-system/disputes-over-child-reputation.js
+++ b/test/reputation-system/disputes-over-child-reputation.js
@@ -144,7 +144,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
 
       const badClient = new MaliciousReputationMinerClaimNoOriginReputation(
         { loader, realProviderPort, useJsTree, minerAddress: MINER2 },
-        42, // Passing in update number for colony wide skillId: 5, user: 0
+        50, // Passing in update number for colony wide skillId: 5, user: 0
         1,
       );
 
@@ -199,7 +199,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
 
       const badClient = new MaliciousReputationMinerClaimNoUserChildReputation(
         { loader, realProviderPort, useJsTree, minerAddress: MINER2 },
-        42, // Passing in update number for colony wide skillId: 5, user: 0
+        46, // Passing in update number for colony wide skillId: 5, user: 0
         1,
       );
 
@@ -223,8 +223,8 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
     });
 
     it("if the dispute involves a child skill that doesn't exist, should resolve correctly", async () => {
-      await setupClaimedExpenditure({ colonyNetwork, colony: metaColony, skillId: localSkillId });
-      await setupClaimedExpenditure({ colonyNetwork, colony: metaColony, skillId: localSkillId });
+      await setupClaimedExpenditure({ colonyNetwork, colony: metaColony });
+      await setupClaimedExpenditure({ colonyNetwork, colony: metaColony });
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
 
       // We make two tasks, which guarantees that the origin reputation actually exists if we disagree about
@@ -376,7 +376,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
 
       const badClient = new MaliciousReputationMinerExtraRep(
         { loader, realProviderPort, useJsTree, minerAddress: MINER2 },
-        36, // Passing in update number for colony wide skillId: 5, user: 0
+        40, // Passing in update number for colony wide skillId: 5, user: 0
         "0xfffffffffffffffffffffff",
       );
 
@@ -538,7 +538,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
 
       const badClient = new MaliciousReputationMinerExtraRep(
         { loader, minerAddress: MINER2, realProviderPort, useJsTree },
-        32, // Passing in colony wide update number for skillId: 4, user: 0
+        34, // Passing in colony wide update number for skillId: 4, user: 0
         "0xfffffffffffffffffffffff",
       );
       // Moving the state to the bad client
@@ -833,7 +833,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
 
       const badClient = new MaliciousReputationMinerExtraRep(
         { loader, minerAddress: MINER2, realProviderPort, useJsTree },
-        28, // Passing in update number for skillId: 5, user: 0
+        30, // Passing in update number for skillId: 5, user: 0
         "0xfffffffffff",
       );
       // Moving the state to the bad client
@@ -885,7 +885,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
 
       const badClient = new MaliciousReputationMinerExtraRep(
         { loader, minerAddress: MINER2, realProviderPort, useJsTree },
-        31, // Passing in update number for skillId: 5, user: 0
+        37, // Passing in update number for skillId: 5, user: 0
         "0xfffffffffffffffffffffff",
       );
       // Moving the state to the bad client
@@ -1021,7 +1021,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
 
       const badClient = new MaliciousReputationMinerExtraRep(
         { loader, minerAddress: MINER2, realProviderPort, useJsTree },
-        28, // Passing in colony wide update number for skillId: 5, user: 0
+        32, // Passing in colony wide update number for skillId: 5, user: 0
         "0xfffffffff",
       );
       // Moving the state to the bad client

--- a/test/reputation-system/disputes-over-child-reputation.js
+++ b/test/reputation-system/disputes-over-child-reputation.js
@@ -255,7 +255,7 @@ contract("Reputation Mining - disputes over child reputation", (accounts) => {
 
       const badClient = new MaliciousReputationMinerExtraRep(
         { loader, realProviderPort, useJsTree, minerAddress: MINER2 },
-        36, // Passing in update number for colony wide skillId: 5, user: 0
+        35, // Passing in update number for colony wide skillId: 5, user: 0
         "0xfffffffffffffffffffffff",
       );
 


### PR DESCRIPTION
Closes #1130

This PR affects our tests as follows:

Previously, we would create a global skill upon Metacolony creation, leading to the following initial skills: `Metacolony domain root, Metacolony local skill root, mining skill, global skill`

This global skill was used throughout the tests as the default skill, and resulted in a single reputation update whenever it was given. This PR removes the global skill, and replaces it with a local skill in the tests. Unlike global skills, however, all local skills have exactly one parent: the colony's root local skill. This necessitated some changes in the reputation tests which assert specific numbers of entries in the reputation tree, as every positive local skill update creates two updates, unlike the one update which occurred before.