### PR TITLE
createColonyForFrontend should allow activating locked tokens

### DIFF
--- a/contracts/colonyNetwork/ColonyNetworkDeployer.sol
+++ b/contracts/colonyNetwork/ColonyNetworkDeployer.sol
@@ -111,7 +111,8 @@ contract ColonyNetworkDeployer is ColonyNetworkStorage {
     // Extra token bookkeeping if we deployed it
     if (_tokenAddress == address(0x0)) {
       // Deploy Authority
-      address[] memory allowedToTransfer;
+      address[] memory allowedToTransfer = new address[](1);
+      allowedToTransfer[0] = tokenLocking;
       address tokenAuthorityAddress = IColonyNetwork(address(this)).deployTokenAuthority(
         address(token),
         colonyAddress,


### PR DESCRIPTION
`createColonyForFrontend` is finally being used, but doesn't allow tokens that are locked to be activated. This fixes that oversight on our part.