### PR TITLE
Fix spotty upgrade test setup

### DIFF
--- a/scripts/deployOldUpgradeableVersionTruffle.js
+++ b/scripts/deployOldUpgradeableVersionTruffle.js
@@ -11,7 +11,12 @@ module.exports = async (callback) => {
   const implementationNames = process.argv[implementationNameArgPost + 1].split(",");
   const implementations = implementationNames.map((x) => artifacts.require(x));
 
-  const deployments = await Promise.all(implementations.map((x) => x.new()));
+  const deployments = [];
+  for (let idx = 0; idx < implementations.length; idx += 1) {
+    const res = await implementations[idx].new();
+    deployments.push(res);
+  }
+
   const resolver = await Resolver.new();
 
   const deployedImplementations = {};


### PR DESCRIPTION
Somehow when I wrote this I let myself use a `Promise.all` which we can't do with transactions, as they all get fired approximately at once, which means some might get the same nonce as each other and fail.

This obviously only touches the test suite, so happy to merge these even with the freeze for the upcoming release.