### PR TITLE
Do not trust ethers getFeeData completely

### DIFF
--- a/packages/package-utils/getFeeData.js
+++ b/packages/package-utils/getFeeData.js
@@ -41,7 +41,9 @@ const getFeeData = async function (_type, chainId, adapter, provider) {
     delete feeData.lastBaseFeePerGas;
     if (feeData.maxFeePerGas) {
       delete feeData.gasPrice;
+      feeData.maxFeePerGas = feeData.maxFeePerGas.mul(5).add(feeData.maxPriorityFeePerGas);
     }
+
     return feeData;
   }
 


### PR DESCRIPTION
Seems like there are still scenarios where the values returned by  `getFeeData` from Ethers was not sufficient to allow a transaction to be broadcast, so upping the `maxFeePerGas` to accommodate for large jumps in the base fee when blocks are full.

Non-contracts, so happy for this to be merged even with the freeze for the release.