### PR TITLE
Remove deprecated functions

### DIFF
--- a/contracts/colony/ColonyArbitraryTransaction.sol
+++ b/contracts/colony/ColonyArbitraryTransaction.sol
@@ -95,9 +95,9 @@ contract ColonyArbitraryTransaction is ColonyStorage {
     } catch {}
 
     bool res = executeCall(_to, 0, _action);
-
+    assert(res);
     if (sig == APPROVE_SIG) {
-      approveTransactionCleanup(_to, _action);
+      approveTransactionCheck(_to, _action);
     }
 
     emit ArbitraryTransaction(_to, _action, res);
@@ -105,20 +105,38 @@ contract ColonyArbitraryTransaction is ColonyStorage {
     return res;
   }
 
-  function approveTransactionPreparation(address _to, bytes memory _action) internal {
+  function approveTransactionPreparation(address _token, bytes memory _action) internal {
     address spender;
+    uint256 amount;
     assembly {
       spender := mload(add(_action, 0x24))
+      amount := mload(add(_action, 0x44))
     }
-    updateApprovalAmountInternal(_to, spender, false);
+    updateApprovalAmountInternal(_token, spender);
+
+    // Calculate and set the approval we expect to have after the approve is made
+    tokenApprovalTotals[_token] =
+      (tokenApprovalTotals[_token] - tokenApprovals[_token][spender]) +
+      amount;
+    require(
+      fundingPots[1].balance[_token] >= tokenApprovalTotals[_token],
+      "colony-approval-exceeds-balance"
+    );
+
+    tokenApprovals[_token][spender] = amount;
   }
 
-  function approveTransactionCleanup(address _to, bytes memory _action) internal {
+  function approveTransactionCheck(address _token, bytes memory _action) internal view {
     address spender;
+    uint256 amount;
     assembly {
       spender := mload(add(_action, 0x24))
+      amount := mload(add(_action, 0x44))
     }
-    updateApprovalAmountInternal(_to, spender, true);
+
+    uint256 recordedApproval = tokenApprovals[_token][spender];
+    uint256 actualApproval = ERC20Extended(_token).allowance(address(this), spender);
+    require(recordedApproval == actualApproval, "colony-approval-amount-mismatch");
   }
 
   function burnTransactionPreparation(address _to, bytes memory _action) internal {
@@ -148,21 +166,17 @@ contract ColonyArbitraryTransaction is ColonyStorage {
   }
 
   function updateApprovalAmount(address _token, address _spender) public stoppable {
-    updateApprovalAmountInternal(_token, _spender, false);
+    updateApprovalAmountInternal(_token, _spender);
   }
 
-  function updateApprovalAmountInternal(
-    address _token,
-    address _spender,
-    bool _postApproval
-  ) internal {
+  function updateApprovalAmountInternal(address _token, address _spender) internal {
     uint256 recordedApproval = tokenApprovals[_token][_spender];
     uint256 actualApproval = ERC20Extended(_token).allowance(address(this), _spender);
     if (recordedApproval == actualApproval) {
       return;
     }
 
-    if (recordedApproval > actualApproval && !_postApproval) {
+    if (recordedApproval > actualApproval) {
       // They've spend some tokens out of root. Adjust balances accordingly
       // If we are post approval, then they have not spent tokens
       fundingPots[1].balance[_token] =

--- a/contracts/colony/ColonyArbitraryTransaction.sol
+++ b/contracts/colony/ColonyArbitraryTransaction.sol
@@ -34,13 +34,6 @@ contract ColonyArbitraryTransaction is ColonyStorage {
   bytes4 constant BURN_SIG = bytes4(keccak256("burn(uint256)"));
   bytes4 constant BURN_GUY_SIG = bytes4(keccak256("burn(address,uint256)"));
 
-  function makeArbitraryTransaction(
-    address _to,
-    bytes memory _action
-  ) public stoppable auth returns (bool) {
-    return this.makeSingleArbitraryTransaction(_to, _action);
-  }
-
   function makeArbitraryTransactions(
     address[] memory _targets,
     bytes[] memory _actions,
@@ -54,10 +47,10 @@ contract ColonyArbitraryTransaction is ColonyStorage {
         if (_strict) {
           success = ret;
         }
-      } catch {
+      } catch Error(string memory _err) {
         // We failed in a require, which is only okay if we're not in strict mode
         if (_strict) {
-          success = false;
+          revert(_err);
         }
       }
       require(success, "colony-arbitrary-transaction-failed");

--- a/contracts/colony/ColonyExpenditure.sol
+++ b/contracts/colony/ColonyExpenditure.sol
@@ -74,23 +74,6 @@ contract ColonyExpenditure is ColonyStorage {
     emit ExpenditureTransferred(msgSender(), _id, _newOwner);
   }
 
-  // Deprecated
-  function transferExpenditureViaArbitration(
-    uint256 _permissionDomainId,
-    uint256 _childSkillIndex,
-    uint256 _id,
-    address _newOwner
-  )
-    public
-    stoppable
-    expenditureDraftOrLocked(_id)
-    authDomain(_permissionDomainId, _childSkillIndex, expenditures[_id].domainId)
-  {
-    expenditures[_id].owner = _newOwner;
-
-    emit ExpenditureTransferred(msgSender(), _id, _newOwner);
-  }
-
   function cancelExpenditure(
     uint256 _id
   ) public stoppable expenditureDraft(_id) expenditureOnlyOwner(_id) {
@@ -231,41 +214,6 @@ contract ColonyExpenditure is ColonyStorage {
     if (_payoutTokens.length > 0) {
       setExpenditurePayouts(_id, _payoutTokens, _payoutSlots, _payoutValues);
     }
-  }
-
-  // Deprecated
-  function setExpenditureRecipient(
-    uint256 _id,
-    uint256 _slot,
-    address payable _recipient
-  ) public stoppable {
-    uint256[] memory slots = new uint256[](1);
-    slots[0] = _slot;
-    address payable[] memory recipients = new address payable[](1);
-    recipients[0] = _recipient;
-    setExpenditureRecipients(_id, slots, recipients);
-  }
-
-  // Deprecated
-  function setExpenditureSkill(uint256 _id, uint256 _slot, uint256 _skillId) public stoppable {
-    uint256[] memory slots = new uint256[](1);
-    slots[0] = _slot;
-    uint256[] memory skillIds = new uint256[](1);
-    skillIds[0] = _skillId;
-    setExpenditureSkills(_id, slots, skillIds);
-  }
-
-  // Deprecated
-  function setExpenditureClaimDelay(
-    uint256 _id,
-    uint256 _slot,
-    uint256 _claimDelay
-  ) public stoppable {
-    uint256[] memory slots = new uint256[](1);
-    slots[0] = _slot;
-    uint256[] memory claimDelays = new uint256[](1);
-    claimDelays[0] = _claimDelay;
-    setExpenditureClaimDelays(_id, slots, claimDelays);
   }
 
   uint256 constant EXPENDITURES_SLOT = 25;

--- a/contracts/colony/ColonyFunding.sol
+++ b/contracts/colony/ColonyFunding.sol
@@ -58,25 +58,6 @@ contract ColonyFunding is
     moveFundsBetweenPotsFunctionality(_fromPot, _toPot, _amount, _token);
   }
 
-  function moveFundsBetweenPots(
-    uint256 _permissionDomainId,
-    uint256 _fromChildSkillIndex,
-    uint256 _toChildSkillIndex,
-    uint256 _fromPot,
-    uint256 _toPot,
-    uint256 _amount,
-    address _token
-  )
-    public
-    stoppable
-    domainNotDeprecated(getDomainFromFundingPot(_toPot))
-    authDomain(_permissionDomainId, _fromChildSkillIndex, getDomainFromFundingPot(_fromPot))
-    authDomain(_permissionDomainId, _toChildSkillIndex, getDomainFromFundingPot(_toPot))
-    validFundingTransfer(_fromPot, _toPot)
-  {
-    moveFundsBetweenPotsFunctionality(_fromPot, _toPot, _amount, _token);
-  }
-
   function claimColonyFunds(address _token) public stoppable {
     uint256 toClaim;
     uint256 feeToPay;
@@ -134,20 +115,6 @@ contract ColonyFunding is
     validExpenditure(_id)
     authDomain(_permissionDomainId, _childSkillIndex, expenditures[_id].domainId)
   {
-    uint256[] memory slots = new uint256[](1);
-    slots[0] = _slot;
-    uint256[] memory amounts = new uint256[](1);
-    amounts[0] = _amount;
-    setExpenditurePayoutsInternal(_id, slots, _token, amounts);
-  }
-
-  /// @notice For owners to update payouts with one token and one slot
-  function setExpenditurePayout(
-    uint256 _id,
-    uint256 _slot,
-    address _token,
-    uint256 _amount
-  ) public stoppable expenditureDraft(_id) expenditureOnlyOwner(_id) {
     uint256[] memory slots = new uint256[](1);
     slots[0] = _slot;
     uint256[] memory amounts = new uint256[](1);

--- a/contracts/colony/IColony.sol
+++ b/contracts/colony/IColony.sol
@@ -60,16 +60,6 @@ interface IColony is ColonyDataTypes, IRecovery, IBasicMetaTransaction, IMultica
   /// @return tokenAddress Address of the token contract
   function getToken() external view returns (address tokenAddress);
 
-  /// @notice @deprecated
-  /// @notice Execute arbitrary transaction on behalf of the Colony
-  /// @param _to Contract to receive the function call (cannot be this contract, network or token locking)
-  /// @param _action Bytes array encoding the function call and arguments
-  /// @return success Boolean indicating whether the transaction succeeded
-  function makeArbitraryTransaction(
-    address _to,
-    bytes memory _action
-  ) external returns (bool success);
-
   /// @notice Execute arbitrary transactions on behalf of the Colony in series
   /// @param _targets Array of addressed to be targeted
   /// @param _actions Array of Bytes arrays encoding the function calls and arguments
@@ -450,21 +440,6 @@ interface IColony is ColonyDataTypes, IRecovery, IBasicMetaTransaction, IMultica
   /// @param _newOwner New owner of expenditure
   function transferExpenditure(uint256 _id, address _newOwner) external;
 
-  /// @notice @deprecated
-  /// @notice Updates the expenditure owner. Can only be called by Arbitration role.
-  /// @dev This is now deprecated and will be removed in a future version
-  /// @param _permissionDomainId The domainId in which I have the permission to take this action
-  /// @param _childSkillIndex The index that the `_domainId` is relative to `_permissionDomainId`,
-  /// (only used if `_permissionDomainId` is different to `_domainId`)
-  /// @param _id Expenditure identifier
-  /// @param _newOwner New owner of expenditure
-  function transferExpenditureViaArbitration(
-    uint256 _permissionDomainId,
-    uint256 _childSkillIndex,
-    uint256 _id,
-    address _newOwner
-  ) external;
-
   /// @notice Cancels the expenditure and prevents further editing. Can only be called by expenditure owner.
   /// @param _id Expenditure identifier
   function cancelExpenditure(uint256 _id) external;
@@ -495,14 +470,6 @@ interface IColony is ColonyDataTypes, IRecovery, IBasicMetaTransaction, IMultica
     string memory _metadata
   ) external;
 
-  /// @notice @deprecated
-  /// @notice Sets the recipient on an expenditure slot. Can only be called by expenditure owner.
-  /// @dev Can only be called while expenditure is in draft state.
-  /// @param _id Id of the expenditure
-  /// @param _slot Slot for the recipient address
-  /// @param _recipient Address of the recipient
-  function setExpenditureRecipient(uint256 _id, uint256 _slot, address payable _recipient) external;
-
   /// @notice Sets the recipients in given expenditure slots. Can only be called by expenditure owner.
   /// @dev Can only be called while expenditure is in draft state.
   /// @param _id Id of the expenditure
@@ -512,20 +479,6 @@ interface IColony is ColonyDataTypes, IRecovery, IBasicMetaTransaction, IMultica
     uint256 _id,
     uint256[] memory _slots,
     address payable[] memory _recipients
-  ) external;
-
-  /// @notice @deprecated
-  /// @notice Set the token payout on an expenditure slot. Can only be called by expenditure owner.
-  /// @dev Can only be called while expenditure is in draft state.
-  /// @param _id Id of the expenditure
-  /// @param _slot Number of the slot
-  /// @param _token Address of the token, `0x0` value indicates Ether
-  /// @param _amount Payout amount
-  function setExpenditurePayout(
-    uint256 _id,
-    uint256 _slot,
-    address _token,
-    uint256 _amount
   ) external;
 
   /// @notice Set the token payouts in given expenditure slots. Can only be called by expenditure owner.
@@ -557,13 +510,6 @@ interface IColony is ColonyDataTypes, IRecovery, IBasicMetaTransaction, IMultica
     uint256 _amount
   ) external;
 
-  /// @notice @deprecated
-  /// @notice Sets the skill on an expenditure slot. Can only be called by expenditure owner.
-  /// @param _id Expenditure identifier
-  /// @param _slot Number of the slot
-  /// @param _skillId Id of the new skill to set
-  function setExpenditureSkill(uint256 _id, uint256 _slot, uint256 _skillId) external;
-
   /// @notice Sets the skill on an expenditure slot. Can only be called by expenditure owner.
   /// @param _id Expenditure identifier
   /// @param _slots Array of slots to set skills
@@ -573,13 +519,6 @@ interface IColony is ColonyDataTypes, IRecovery, IBasicMetaTransaction, IMultica
     uint256[] memory _slots,
     uint256[] memory _skillIds
   ) external;
-
-  /// @notice @deprecated
-  /// @notice Sets the claim delay on an expenditure slot. Can only be called by expenditure owner.
-  /// @param _id Expenditure identifier
-  /// @param _slot Number of the slot
-  /// @param _claimDelay Duration of time (in seconds) to delay
-  function setExpenditureClaimDelay(uint256 _id, uint256 _slot, uint256 _claimDelay) external;
 
   /// @notice Sets the claim delays in given expenditure slots. Can only be called by expenditure owner.
   /// @param _id Expenditure identifier
@@ -805,25 +744,6 @@ interface IColony is ColonyDataTypes, IRecovery, IBasicMetaTransaction, IMultica
     uint256 _permissionDomainId,
     uint256 _childSkillIndex,
     uint256 _domainId,
-    uint256 _fromChildSkillIndex,
-    uint256 _toChildSkillIndex,
-    uint256 _fromPot,
-    uint256 _toPot,
-    uint256 _amount,
-    address _token
-  ) external;
-
-  /// @notice @deprecated
-  /// @notice Move a given amount: `_amount` of `_token` funds from funding pot with id `_fromPot` to one with id `_toPot`.
-  /// @param _permissionDomainId The domainId in which I have the permission to take this action
-  /// @param _fromChildSkillIndex The child index in `_permissionDomainId` where we can find the domain for `_fromPotId`
-  /// @param _toChildSkillIndex The child index in `_permissionDomainId` where we can find the domain for `_toPotId`
-  /// @param _fromPot Funding pot id providing the funds
-  /// @param _toPot Funding pot id receiving the funds
-  /// @param _amount Amount of funds
-  /// @param _token Address of the token, `0x0` value indicates Ether
-  function moveFundsBetweenPots(
-    uint256 _permissionDomainId,
     uint256 _fromChildSkillIndex,
     uint256 _toChildSkillIndex,
     uint256 _fromPot,

--- a/contracts/colonyNetwork/ColonyNetwork.sol
+++ b/contracts/colonyNetwork/ColonyNetwork.sol
@@ -187,11 +187,6 @@ contract ColonyNetwork is BasicMetaTransaction, ColonyNetworkStorage, Multicall 
     return changed;
   }
 
-  /// @notice @deprecated
-  function deprecateSkill(uint256 _skillId) public stoppable {
-    deprecateSkill(_skillId, true);
-  }
-
   function initialiseRootLocalSkill() public stoppable calledByColony returns (uint256) {
     skillCount++;
     return skillCount;

--- a/contracts/colonyNetwork/ColonyNetworkDeployer.sol
+++ b/contracts/colonyNetwork/ColonyNetworkDeployer.sol
@@ -39,22 +39,6 @@ contract ColonyNetworkDeployer is ColonyNetworkStorage {
     emit MetaColonyCreated(metaColony, _tokenAddress, skillCount);
   }
 
-  /// @notice @deprecated only deploys version 3 colonies.
-  function createColony(address _tokenAddress) public stoppable returns (address) {
-    return createColony(_tokenAddress, 3, "", "");
-  }
-
-  /// @notice @deprecated only deploys version 4 colonies.
-  function createColony(
-    address _tokenAddress,
-    uint256 _version, // solhint-disable-line no-unused-vars
-    string memory _colonyName,
-    string memory _orbitdb, // solhint-disable-line no-unused-vars
-    bool _useExtensionManager // solhint-disable-line no-unused-vars
-  ) public stoppable returns (address) {
-    return createColony(_tokenAddress, 4, _colonyName, "");
-  }
-
   function createColony(
     address _tokenAddress,
     uint256 _version,

--- a/contracts/colonyNetwork/IColonyNetwork.sol
+++ b/contracts/colonyNetwork/IColonyNetwork.sol
@@ -104,12 +104,6 @@ interface IColonyNetwork is ColonyNetworkDataTypes, IRecovery, IBasicMetaTransac
   /// @return _changed Whether the deprecated state was changed
   function deprecateSkill(uint256 _skillId, bool _deprecated) external returns (bool _changed);
 
-  /// @notice Mark a skill as deprecated which stops new tasks and payments from using it.
-  /// @dev This function is deprecated and will be removed in a future release
-  /// @dev Currently disabled, and will error if called even by a colony
-  /// @param _skillId Id of the skill
-  function deprecateSkill(uint256 _skillId) external;
-
   /// @notice Initialise the local skills tree for a colony
   /// @return _rootLocalSkillId The root local skill
   function initialiseRootLocalSkill() external returns (uint256 _rootLocalSkillId);
@@ -141,30 +135,6 @@ interface IColonyNetwork is ColonyNetworkDataTypes, IRecovery, IBasicMetaTransac
   /// @notice Create the Meta Colony, same as a normal colony plus the root skill.
   /// @param _tokenAddress Address of the CLNY token
   function createMetaColony(address _tokenAddress) external;
-
-  /// @notice Creates a new colony in the network, at version 3
-  /// @dev This is now deprecated and will be removed in a future version
-  /// @dev For the colony to mint tokens, token ownership must be transferred to the new colony
-  /// @param _tokenAddress Address of an ERC20 token to serve as the colony token.
-  /// @return _colonyAddress Address of the newly created colony
-  function createColony(address _tokenAddress) external returns (address _colonyAddress);
-
-  /// @notice Overload of the simpler `createColony` -- creates a new colony in the network with a variety of options, at version 4
-  /// @dev This is now deprecated and will be removed in a future version
-  /// @dev For the colony to mint tokens, token ownership must be transferred to the new colony
-  /// @param _tokenAddress Address of an ERC20 token to serve as the colony token
-  /// @param _version The version of colony to deploy (pass 0 for the current version)
-  /// @param _colonyName The label to register (if null, no label is registered)
-  /// @param _orbitdb DEPRECATED Currently a no-op
-  /// @param _useExtensionManager DEPRECATED Currently a no-op
-  /// @return _colonyAddress Address of the newly created colony
-  function createColony(
-    address _tokenAddress,
-    uint256 _version,
-    string memory _colonyName,
-    string memory _orbitdb,
-    bool _useExtensionManager
-  ) external returns (address _colonyAddress);
 
   /// @notice Creates a new colony in the network, with an optional ENS name
   /// @dev For the colony to mint tokens, token ownership must be transferred to the new colony

--- a/contracts/common/SetExpenditureSingleValues.sol
+++ b/contracts/common/SetExpenditureSingleValues.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity 0.8.23;
+pragma experimental ABIEncoderV2;
+
+import { IColony } from "./../colony/IColony.sol";
+
+contract SetExpenditureSingleValues {
+  struct SetExpenditureValuesCallData {
+    uint256[] slots;
+    uint256[][] wrappedSlots;
+    address payable[] recipients;
+    uint256[] skills;
+    address[] tokens;
+    uint256[][] amounts;
+  }
+
+  function setExpenditureSingleValues(
+    address colony,
+    uint256 _expenditureId,
+    uint256 _slot,
+    address payable _recipient,
+    uint256 _skillId,
+    address _token,
+    uint256 _amount
+  ) internal {
+    SetExpenditureValuesCallData memory data = SetExpenditureValuesCallData(
+      new uint256[](1),
+      new uint256[][](1),
+      new address payable[](1),
+      new uint256[](0),
+      new address[](1),
+      new uint256[][](1)
+    );
+
+    if (_skillId != 0) {
+      data.skills = new uint256[](1);
+      data.skills[0] = _skillId;
+    }
+
+    data.slots[0] = _slot;
+    data.wrappedSlots[0] = new uint256[](1);
+    data.wrappedSlots[0][0] = _slot;
+
+    data.recipients[0] = _recipient;
+    data.tokens[0] = _token;
+    data.amounts[0] = new uint256[](1);
+    data.amounts[0][0] = _amount;
+
+    uint256[] memory emptyUint256Array;
+    int256[] memory emptyInt256Array;
+
+    IColony(colony).setExpenditureValues(
+      _expenditureId,
+      data.slots,
+      data.recipients,
+      data.slots,
+      data.skills,
+      emptyUint256Array,
+      emptyUint256Array,
+      emptyUint256Array,
+      emptyInt256Array,
+      data.tokens,
+      data.wrappedSlots,
+      data.amounts
+    );
+  }
+}

--- a/contracts/extensions/FundingQueue.sol
+++ b/contracts/extensions/FundingQueue.sol
@@ -370,6 +370,8 @@ contract FundingQueue is ColonyExtension, BasicMetaTransaction {
 
     colony.moveFundsBetweenPots(
       proposal.domainId,
+      UINT256_MAX,
+      proposal.domainId,
       proposal.fromChildSkillIndex,
       proposal.toChildSkillIndex,
       proposal.fromPot,

--- a/contracts/extensions/StreamingPayments.sol
+++ b/contracts/extensions/StreamingPayments.sol
@@ -21,10 +21,11 @@ pragma experimental ABIEncoderV2;
 
 import { ColonyExtensionMeta } from "./ColonyExtensionMeta.sol";
 import { IColony, ColonyDataTypes } from "./../colony/IColony.sol";
+import { SetExpenditureSingleValues } from "./../common/SetExpenditureSingleValues.sol";
 
 // ignore-file-swc-108
 
-contract StreamingPayments is ColonyExtensionMeta {
+contract StreamingPayments is ColonyExtensionMeta, SetExpenditureSingleValues {
   // Events
 
   event StreamingPaymentCreated(address agent, uint256 streamingPaymentId);
@@ -522,11 +523,20 @@ contract StreamingPayments is ColonyExtensionMeta {
           _amountsToClaim[i],
           _tokens[i]
         );
-        colony.setExpenditurePayout(expenditureId, SLOT, _tokens[i], _amountsToClaim[i]);
+        setExpenditureSingleValues(
+          address(colony),
+          expenditureId,
+          SLOT,
+          streamingPayments[_id].recipient,
+          0,
+          _tokens[i],
+          _amountsToClaim[i]
+        );
+        // colony.setExpenditurePayout(expenditureId, SLOT, _tokens[i], _amountsToClaim[i]);
       }
     }
 
-    colony.setExpenditureRecipient(expenditureId, SLOT, streamingPayments[_id].recipient);
+    // colony.setExpenditureRecipient(expenditureId, SLOT, streamingPayments[_id].recipient);
     colony.finalizeExpenditure(expenditureId);
     return expenditureId;
   }

--- a/contracts/tokenLocking/ITokenLocking.sol
+++ b/contracts/tokenLocking/ITokenLocking.sol
@@ -49,13 +49,6 @@ interface ITokenLocking is TokenLockingDataTypes, IBasicMetaTransaction {
   /// @param _lockId Id of the lock user wants to increment to
   function incrementLockCounterTo(address _token, uint256 _lockId) external;
 
-  /// @notice @deprecated
-  /// @notice Deposit `_amount` of deposited tokens. Can only be called if user tokens are not locked.
-  /// Before calling this function user has to allow that their tokens can be transferred by token locking contract.
-  /// @param _token Address of the token to deposit
-  /// @param _amount Amount to deposit
-  function deposit(address _token, uint256 _amount) external;
-
   /// @notice Deposit `_amount` of colony tokens.
   /// Before calling this function user has to allow that their tokens can be transferred by token locking contract.
   /// @param _token Address of the token to deposit
@@ -76,23 +69,11 @@ interface ITokenLocking is TokenLockingDataTypes, IBasicMetaTransaction {
   /// @param _force Pass true to forcibly unlock the token
   function transfer(address _token, uint256 _amount, address _recipient, bool _force) external;
 
-  /// @notice @deprecated
-  /// @notice Withdraw `_amount` of deposited tokens. Can only be called if user tokens are not locked.
-  /// @param _token Address of the token to withdraw from
-  /// @param _amount Amount to withdraw
-  function withdraw(address _token, uint256 _amount) external;
-
   /// @notice Withdraw `_amount` of deposited tokens. Set `_force` to `true` to forcibly unlock the token before the withdrawal.
   /// @param _token Address of the token to withdraw from
   /// @param _amount Amount to withdraw
   /// @param _force Pass true to forcibly unlock the token
   function withdraw(address _token, uint256 _amount, bool _force) external;
-
-  /// @notice This function is deprecated and only exists to aid upgrades.
-  /// @param _recipient The address to receive the reward
-  /// @param _amount The amount to reward
-  /// @dev It's a NOOP. You don't need to call this, and if you write a contract that does it will break in the future.
-  function reward(address _recipient, uint256 _amount) external;
 
   /// @notice Allow the colony to obligate some amount of tokens as a stake.
   /// @dev Can only be called by a colony or colonyNetwork

--- a/contracts/tokenLocking/TokenLocking.sol
+++ b/contracts/tokenLocking/TokenLocking.sol
@@ -117,11 +117,6 @@ contract TokenLocking is
     userLocks[_token][msgSender()].lockCount = _lockId;
   }
 
-  // Deprecated interface
-  function deposit(address _token, uint256 _amount) public {
-    deposit(_token, _amount, false);
-  }
-
   function deposit(
     address _token,
     uint256 _amount,
@@ -168,11 +163,6 @@ contract TokenLocking is
     makeConditionalDeposit(_token, _amount, _recipient);
 
     emit UserTokenTransferred(_token, msgSender(), _recipient, _amount);
-  }
-
-  // Deprecated interface
-  function withdraw(address _token, uint256 _amount) public {
-    withdraw(_token, _amount, false);
   }
 
   function withdraw(

--- a/docs/interfaces/icolony.md
+++ b/docs/interfaces/icolony.md
@@ -960,24 +960,6 @@ Lock the colony's token. Can only be called by a network-managed extension.
 |---|---|---|
 |timesLocked|uint256|The amount of times the token was locked
 
-### ▸ `makeArbitraryTransaction(address _to, bytes memory _action):bool success`
-
-Execute arbitrary transaction on behalf of the Colony
-
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_to|address|Contract to receive the function call (cannot be this contract, network or token locking)
-|_action|bytes|Bytes array encoding the function call and arguments
-
-**Return Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|success|bool|Boolean indicating whether the transaction succeeded
-
 ### ▸ `makeArbitraryTransactions(address[] memory _targets, bytes[] memory _actions, bool _strict):bool success`
 
 Execute arbitrary transactions on behalf of the Colony in series
@@ -1074,24 +1056,6 @@ Move a given amount: `_amount` of `_token` funds from funding pot with id `_from
 |_domainId|uint256|The domain where I am taking this action, pointed to by _permissionDomainId and _childSkillIndex
 |_fromChildSkillIndex|uint256|In the array of child skills for the skill associated with the domain pointed to by _permissionDomainId + _childSkillIndex,         the index of the skill associated with the domain that contains _fromPot
 |_toChildSkillIndex|uint256|The same, but for the _toPot which the funds are being moved to
-|_fromPot|uint256|Funding pot id providing the funds
-|_toPot|uint256|Funding pot id receiving the funds
-|_amount|uint256|Amount of funds
-|_token|address|Address of the token, `0x0` value indicates Ether
-
-
-### ▸ `moveFundsBetweenPots(uint256 _permissionDomainId, uint256 _fromChildSkillIndex, uint256 _toChildSkillIndex, uint256 _fromPot, uint256 _toPot, uint256 _amount, address _token)`
-
-Move a given amount: `_amount` of `_token` funds from funding pot with id `_fromPot` to one with id `_toPot`.
-
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_permissionDomainId|uint256|The domainId in which I have the permission to take this action
-|_fromChildSkillIndex|uint256|The child index in `_permissionDomainId` where we can find the domain for `_fromPotId`
-|_toChildSkillIndex|uint256|The child index in `_permissionDomainId` where we can find the domain for `_toPotId`
 |_fromPot|uint256|Funding pot id providing the funds
 |_toPot|uint256|Funding pot id receiving the funds
 |_amount|uint256|Amount of funds
@@ -1198,20 +1162,6 @@ Update the default global claim delay for expenditures
 |_globalClaimDelay|uint256|The new default global claim delay
 
 
-### ▸ `setExpenditureClaimDelay(uint256 _id, uint256 _slot, uint256 _claimDelay)`
-
-Sets the claim delay on an expenditure slot. Can only be called by expenditure owner.
-
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_id|uint256|Expenditure identifier
-|_slot|uint256|Number of the slot
-|_claimDelay|uint256|Duration of time (in seconds) to delay
-
-
 ### ▸ `setExpenditureClaimDelays(uint256 _id, uint256[] memory _slots, uint256[] memory _claimDelays)`
 
 Sets the claim delays in given expenditure slots. Can only be called by expenditure owner.
@@ -1253,22 +1203,6 @@ Sets the metadata for an expenditure. Can only be called by Arbitration role.
 |_childSkillIndex|uint256|The index that the `_domainId` is relative to `_permissionDomainId`,
 |_id|uint256|Id of the expenditure
 |_metadata|string|IPFS hash of the metadata
-
-
-### ▸ `setExpenditurePayout(uint256 _id, uint256 _slot, address _token, uint256 _amount)`
-
-Set the token payout on an expenditure slot. Can only be called by expenditure owner.
-
-*Note: Can only be called while expenditure is in draft state.*
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_id|uint256|Id of the expenditure
-|_slot|uint256|Number of the slot
-|_token|address|Address of the token, `0x0` value indicates Ether
-|_amount|uint256|Payout amount
 
 
 ### ▸ `setExpenditurePayout(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, uint256 _slot, address _token, uint256 _amount)`
@@ -1318,21 +1252,6 @@ Set the token payouts in given expenditure slots. Can only be called by expendit
 |_amounts|uint256[]|Payout amounts
 
 
-### ▸ `setExpenditureRecipient(uint256 _id, uint256 _slot, address _recipient)`
-
-Sets the recipient on an expenditure slot. Can only be called by expenditure owner.
-
-*Note: Can only be called while expenditure is in draft state.*
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_id|uint256|Id of the expenditure
-|_slot|uint256|Slot for the recipient address
-|_recipient|address|Address of the recipient
-
-
 ### ▸ `setExpenditureRecipients(uint256 _id, uint256[] memory _slots, address[] memory _recipients)`
 
 Sets the recipients in given expenditure slots. Can only be called by expenditure owner.
@@ -1346,20 +1265,6 @@ Sets the recipients in given expenditure slots. Can only be called by expenditur
 |_id|uint256|Id of the expenditure
 |_slots|uint256[]|Array of slots to set recipients
 |_recipients|address[]|Addresses of the recipients
-
-
-### ▸ `setExpenditureSkill(uint256 _id, uint256 _slot, uint256 _skillId)`
-
-Sets the skill on an expenditure slot. Can only be called by expenditure owner.
-
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_id|uint256|Expenditure identifier
-|_slot|uint256|Number of the slot
-|_skillId|uint256|Id of the new skill to set
 
 
 ### ▸ `setExpenditureSkills(uint256 _id, uint256[] memory _slots, uint256[] memory _skillIds)`
@@ -1499,22 +1404,6 @@ Updates the expenditure owner. Can only be called by expenditure owner.
 
 |Name|Type|Description|
 |---|---|---|
-|_id|uint256|Expenditure identifier
-|_newOwner|address|New owner of expenditure
-
-
-### ▸ `transferExpenditureViaArbitration(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _id, address _newOwner)`
-
-Updates the expenditure owner. Can only be called by Arbitration role.
-
-*Note: This is now deprecated and will be removed in a future version*
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_permissionDomainId|uint256|The domainId in which I have the permission to take this action
-|_childSkillIndex|uint256|The index that the `_domainId` is relative to `_permissionDomainId`, (only used if `_permissionDomainId` is different to `_domainId`)
 |_id|uint256|Expenditure identifier
 |_newOwner|address|New owner of expenditure
 

--- a/docs/interfaces/icolonynetwork.md
+++ b/docs/interfaces/icolonynetwork.md
@@ -130,24 +130,6 @@ Used by a user to claim any mining rewards due to them. This will place them in 
 |_recipient|address|The user whose rewards to claim
 
 
-### ▸ `createColony(address _tokenAddress):address _colonyAddress`
-
-Creates a new colony in the network, at version 3
-
-*Note: This is now deprecated and will be removed in a future version*
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_tokenAddress|address|Address of an ERC20 token to serve as the colony token.
-
-**Return Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_colonyAddress|address|Address of the newly created colony
-
 ### ▸ `createColony(address _tokenAddress, uint256 _version, string memory _colonyName):address _colonyAddress`
 
 Creates a new colony in the network, with an optional ENS name
@@ -182,28 +164,6 @@ Creates a new colony in the network, with an optional ENS name
 |_version|uint256|The version of colony to deploy (pass 0 for the current version)
 |_colonyName|string|The label to register (if null, no label is registered)
 |_metadata|string|The metadata associated with the new colony
-
-**Return Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_colonyAddress|address|Address of the newly created colony
-
-### ▸ `createColony(address _tokenAddress, uint256 _version, string memory _colonyName, string memory _orbitdb, bool _useExtensionManager):address _colonyAddress`
-
-Overload of the simpler `createColony` -- creates a new colony in the network with a variety of options, at version 4
-
-*Note: This is now deprecated and will be removed in a future version*
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_tokenAddress|address|Address of an ERC20 token to serve as the colony token
-|_version|uint256|The version of colony to deploy (pass 0 for the current version)
-|_colonyName|string|The label to register (if null, no label is registered)
-|_orbitdb|string|DEPRECATED Currently a no-op
-|_useExtensionManager|bool|DEPRECATED Currently a no-op
 
 **Return Parameters**
 
@@ -299,19 +259,6 @@ Set the deprecation of an extension in a colony. Can only be called by a Colony.
 |---|---|---|
 |_extensionId|bytes32|keccak256 hash of the extension name, used as an indentifier
 |_deprecated|bool|Whether to deprecate the extension or not
-
-
-### ▸ `deprecateSkill(uint256 _skillId)`
-
-Mark a skill as deprecated which stops new tasks and payments from using it.
-
-*Note: This function is deprecated and will be removed in a future release*
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_skillId|uint256|Id of the skill
 
 
 ### ▸ `deprecateSkill(uint256 _skillId, bool _deprecated):bool _changed`

--- a/docs/interfaces/itokenlocking.md
+++ b/docs/interfaces/itokenlocking.md
@@ -39,19 +39,6 @@ Deobligate the user some amount of tokens, releasing the stake. Can only be call
 |_token|address|The colony's internal token address
 
 
-### ▸ `deposit(address _token, uint256 _amount)`
-
-Deposit `_amount` of deposited tokens. Can only be called if user tokens are not locked. Before calling this function user has to allow that their tokens can be transferred by token locking contract.
-
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_token|address|Address of the token to deposit
-|_amount|uint256|Amount to deposit
-
-
 ### ▸ `deposit(address _token, uint256 _amount, bool _force)`
 
 Deposit `_amount` of colony tokens. Before calling this function user has to allow that their tokens can be transferred by token locking contract.
@@ -227,20 +214,6 @@ Obligate the user some amount of tokens as a stake. Can only be called by a colo
 |_token|address|The colony's internal token address
 
 
-### ▸ `reward(address _recipient, uint256 _amount)`
-
-This function is deprecated and only exists to aid upgrades.
-
-*Note: It's a NOOP. You don't need to call this, and if you write a contract that does it will break in the future.*
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_recipient|address|The address to receive the reward
-|_amount|uint256|The amount to reward
-
-
 ### ▸ `setColonyNetwork(address _colonyNetwork)`
 
 Set the ColonyNetwork contract address.
@@ -296,19 +269,6 @@ Increments the lock counter to `_lockId` for the `_user` if user's lock count is
 |_token|address|Address of the token we want to unlock
 |_user|address|Address of the user
 |_lockId|uint256|Id of the lock we want to increment to
-
-
-### ▸ `withdraw(address _token, uint256 _amount)`
-
-Withdraw `_amount` of deposited tokens. Can only be called if user tokens are not locked.
-
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_token|address|Address of the token to withdraw from
-|_amount|uint256|Amount to withdraw
 
 
 ### ▸ `withdraw(address _token, uint256 _amount, bool _force)`

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -1140,6 +1140,13 @@ exports.encodeTxData = async function encodeTxData(colony, functionName, args) {
     }
   });
 
+  if (functionName.indexOf("(") !== -1) {
+    // Create an Interface with ethers from the function signature
+    const iFace = new ethers.utils.Interface([`function ${functionName}`]);
+    return iFace.encodeFunctionData(functionName, convertedArgs);
+  }
+
+  // Otherwise, it's a function on the truffle contract that was passed to us
   const txData = await colony.contract.methods[functionName](...convertedArgs).encodeABI();
   return txData;
 };

--- a/packages/metatransaction-broadcaster/MetatransactionBroadcaster.js
+++ b/packages/metatransaction-broadcaster/MetatransactionBroadcaster.js
@@ -195,7 +195,14 @@ class MetatransactionBroadcaster {
 
   async isColonyFamilyTransactionAllowed(target, txData, userAddress) {
     const colonyDef = await this.loader.load({ contractName: "IColony" }, { abi: true, address: false });
-    const possibleColony = new ethers.Contract(target, colonyDef.abi, this.wallet);
+    // Add the old makeArbitraryTransaction to the abi
+    const iface = new ethers.utils.Interface(["function makeArbitraryTransaction(address,bytes)"]);
+    const oldJsonAbi = JSON.parse(iface.format(ethers.utils.FormatTypes.json));
+    oldJsonAbi[0].inputs = oldJsonAbi[0].inputs.map((x) => {
+      return { ...x, internalType: x.type };
+    });
+
+    const possibleColony = new ethers.Contract(target, [...colonyDef.abi, ...oldJsonAbi], this.wallet);
     try {
       const tx = possibleColony.interface.parseTransaction({ data: txData });
       // If it's an arbitrary transaction...

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -247,7 +247,7 @@ contract("All", function (accounts) {
 
       await fundColonyWithTokens(newColony, otherToken, 300);
 
-      await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await newColony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       const tx = await newColony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId = tx.logs[0].args.rewardPayoutId;
@@ -281,7 +281,7 @@ contract("All", function (accounts) {
       await forwardTime(5184001);
       await newColony.finalizeRewardPayout(payoutId);
 
-      await newColony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await newColony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       const tx2 = await newColony.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof);
       const payoutId2 = tx2.logs[0].args.rewardPayoutId;

--- a/test-smoke/colony-storage-consistent.js
+++ b/test-smoke/colony-storage-consistent.js
@@ -91,12 +91,22 @@ contract("Contract Storage", (accounts) => {
       await colony.makeExpenditure(1, UINT256_MAX, 1, { from: ADMIN });
       const expenditureId = await colony.getExpenditureCount();
 
-      await colony.setExpenditureRecipient(expenditureId, SLOT0, RECIPIENT, { from: ADMIN });
-      await colony.setExpenditurePayout(expenditureId, SLOT0, token.address, WAD, { from: ADMIN });
+      await colony.setExpenditureRecipients(expenditureId, [SLOT0], [RECIPIENT], { from: ADMIN });
+      await colony.setExpenditurePayouts(expenditureId, [SLOT0], token.address, [WAD], { from: ADMIN });
       await colony.setExpenditureSkills(expenditureId, [SLOT0], [localSkillId], { from: ADMIN });
 
       const expenditure = await colony.getExpenditure(expenditureId);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, domain1.fundingPotId, expenditure.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD,
+        token.address,
+      );
       await colony.finalizeExpenditure(expenditureId, { from: ADMIN });
       await colony.claimExpenditurePayout(expenditureId, SLOT0, token.address);
 
@@ -155,11 +165,11 @@ contract("Contract Storage", (accounts) => {
       console.log("miningCycleStateHash:", miningCycleStateHash);
       console.log("tokenLockingStateHash:", tokenLockingStateHash);
 
-      expect(colonyNetworkStateHash).to.equal("0xe2a19d28c1a68778bfe793623d1b9f71f43db3e98b46fef29f3ea1040968f26c");
-      expect(colonyStateHash).to.equal("0x58b09676f8fb26ec467b5bb8ea3392b6da0db191acc5ee2f400a0940ee79f4ce");
-      expect(metaColonyStateHash).to.equal("0xa09c107f9a66e313434ba2d6633e09c15fcb365db7678cf4dc4a19ca481a3954");
-      expect(miningCycleStateHash).to.equal("0xfd18a690f69132bd95d32bf3a91cb2b60d0da16993cd60087bf8ccc1fa75b680");
-      expect(tokenLockingStateHash).to.equal("0x0a66e763122dc805a1fcd36aa1f0cc40228ffa53ed050fec4ac78c70cad4d31a");
+      expect(colonyNetworkStateHash).to.equal("0x7c394f57b45ff6fd37a512c33427d9a9bb31bc393dee3316ec9076c1b477100c");
+      expect(colonyStateHash).to.equal("0x97af08abf31d5320c2ef7d118ca25ce42b6ea874bfaccc17bee28132314d6a30");
+      expect(metaColonyStateHash).to.equal("0x4e2dc36a06a282d10673d50908bfab9e7f56ae28e8a318286426b3c67eced2e9");
+      expect(miningCycleStateHash).to.equal("0xff6aae2cdd6dbb74ca9cb2e5fd625d80679538f0f95d35b4616b5e2df82df622");
+      expect(tokenLockingStateHash).to.equal("0xf3ba80967cecfdb7d1f6f9d92e3f1484dcb81557911efe5135b0315f915c5294");
     });
   });
 });

--- a/test/contracts-network/colony-arbitrary-transactions.js
+++ b/test/contracts-network/colony-arbitrary-transactions.js
@@ -5,15 +5,15 @@ const bnChai = require("bn-chai");
 const { ethers } = require("ethers");
 const { soliditySha3 } = require("web3-utils");
 
-const { UINT256_MAX, WAD } = require("../../helpers/constants");
-const { checkErrorRevert, encodeTxData, expectEvent } = require("../../helpers/test-helper");
+const { UINT256_MAX, WAD, ARBITRATION_ROLE, FUNDING_ROLE, ADMINISTRATION_ROLE } = require("../../helpers/constants");
+const { checkErrorRevert, encodeTxData, expectEvent, rolesToBytes32 } = require("../../helpers/test-helper");
 const { setupRandomColony, fundColonyWithTokens } = require("../../helpers/test-data-generator");
 
 const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
 const ADDRESS_ZERO = ethers.constants.AddressZero;
 
-const CoinMachine = artifacts.require("CoinMachine");
+const OneTxPayment = artifacts.require("OneTxPayment");
 const EtherRouter = artifacts.require("EtherRouter");
 const IColonyNetwork = artifacts.require("IColonyNetwork");
 const ITokenLocking = artifacts.require("ITokenLocking");
@@ -39,7 +39,7 @@ contract("Colony Arbitrary Transactions", (accounts) => {
     const action = await encodeTxData(token, "mint", [WAD]);
     const balancePre = await token.balanceOf(colony.address);
 
-    const tx = await colony.makeArbitraryTransaction(token.address, action);
+    const tx = await colony.makeArbitraryTransactions([token.address], [action], true);
 
     await expectEvent(tx, "ArbitraryTransaction(address,bytes,bool)", [token.address, action, true]);
 
@@ -66,10 +66,7 @@ contract("Colony Arbitrary Transactions", (accounts) => {
     const action2 = await encodeTxData(token, "mint", [WAD.muln(2)]);
     const balancePre = await token.balanceOf(colony.address);
 
-    await checkErrorRevert(
-      colony.makeArbitraryTransactions([token.address, ADDRESS_ZERO], [action, action2], true),
-      "colony-arbitrary-transaction-failed",
-    );
+    await checkErrorRevert(colony.makeArbitraryTransactions([token.address, colony.address], [action, action2], true), "colony-cannot-target-self");
 
     const balancePost = await token.balanceOf(colony.address);
     expect(balancePost).to.eq.BN(balancePre);
@@ -100,15 +97,15 @@ contract("Colony Arbitrary Transactions", (accounts) => {
   it("should not be able to make arbitrary transactions if not root", async () => {
     const action = await encodeTxData(token, "mint", [WAD]);
 
-    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action, { from: USER1 }), "ds-auth-unauthorized");
+    await checkErrorRevert(colony.makeArbitraryTransactions([token.address], [action], true, { from: USER1 }), "ds-auth-unauthorized");
   });
 
   it("should not be able to make arbitrary transactions to a colony itself", async () => {
-    await checkErrorRevert(colony.makeArbitraryTransaction(colony.address, "0x0"), "colony-cannot-target-self");
+    await checkErrorRevert(colony.makeArbitraryTransactions([colony.address], ["0x0"], true), "colony-cannot-target-self");
   });
 
   it("should not be able to make arbitrary transactions to a user address", async () => {
-    await checkErrorRevert(colony.makeArbitraryTransaction(accounts[0], "0x0"), "colony-to-must-be-contract");
+    await checkErrorRevert(colony.makeArbitraryTransactions([accounts[0]], ["0x0"], true), "colony-to-must-be-contract");
   });
 
   it("should not be able to make arbitrary transactions to network or token locking", async () => {
@@ -118,14 +115,14 @@ contract("Colony Arbitrary Transactions", (accounts) => {
     const action1 = await encodeTxData(colonyNetwork, "addSkill", [0]);
     const action2 = await encodeTxData(tokenLocking, "lockToken", [token.address]);
 
-    await checkErrorRevert(colony.makeArbitraryTransaction(colonyNetwork.address, action1), "colony-cannot-target-network");
-    await checkErrorRevert(colony.makeArbitraryTransaction(tokenLocking.address, action2), "colony-cannot-target-token-locking");
+    await checkErrorRevert(colony.makeArbitraryTransactions([colonyNetwork.address], [action1], true), "colony-cannot-target-network");
+    await checkErrorRevert(colony.makeArbitraryTransactions([tokenLocking.address], [action2], true), "colony-cannot-target-token-locking");
   });
 
   it("if an arbitrary transaction is made to approve tokens, then tokens needed for approval cannot be moved out of the main pot", async () => {
     await fundColonyWithTokens(colony, token, 100);
     const action1 = await encodeTxData(token, "approve", [USER0, 50]);
-    await colony.makeArbitraryTransaction(token.address, action1);
+    await colony.makeArbitraryTransactions([token.address], [action1], true);
     await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 50, token.address);
     await checkErrorRevert(
       colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 50, token.address),
@@ -141,7 +138,7 @@ contract("Colony Arbitrary Transactions", (accounts) => {
    tokens can only be moved from main pot that weren't part of the allowance`, async () => {
     await fundColonyWithTokens(colony, token, 100);
     const action1 = await encodeTxData(token, "approve", [USER0, 20]);
-    await colony.makeArbitraryTransaction(token.address, action1);
+    await colony.makeArbitraryTransactions([token.address], [action1], true);
     // Use allowance
     await token.transferFrom(colony.address, USER0, 20, { from: USER0 });
     // Approval tracking still thinks it has to reserve 20
@@ -173,9 +170,9 @@ contract("Colony Arbitrary Transactions", (accounts) => {
     await fundColonyWithTokens(colony, token, 100);
     const action1 = await encodeTxData(token, "approve", [USER0, 300]);
     // Not enough tokens at all
-    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action1), "colony-approval-exceeds-balance");
+    await checkErrorRevert(colony.makeArbitraryTransactions([token.address], [action1], true), "colony-approval-exceeds-balance");
     await fundColonyWithTokens(colony, token, 1000);
-    await colony.makeArbitraryTransaction(token.address, action1);
+    await colony.makeArbitraryTransactions([token.address], [action1], true);
     // They are now approved for 300.
     let approval = await colony.getTokenApproval(token.address, USER0);
     expect(approval).to.be.eq.BN(300);
@@ -184,14 +181,14 @@ contract("Colony Arbitrary Transactions", (accounts) => {
 
     const action2 = await encodeTxData(token, "approve", [USER0, 900]);
     // User was approved for 300, we now approve them for 900. There are enough tokens to cover this, even though 900 + 300 > 1100, the balance of the pot
-    await colony.makeArbitraryTransaction(token.address, action2);
+    await colony.makeArbitraryTransactions([token.address], [action2], true);
     approval = await colony.getTokenApproval(token.address, USER0);
     expect(approval).to.be.eq.BN(900);
     allApprovals = await colony.getTotalTokenApproval(token.address);
     expect(allApprovals).to.be.eq.BN(900);
 
     // Set them back to 300
-    await colony.makeArbitraryTransaction(token.address, action1);
+    await colony.makeArbitraryTransactions([token.address], [action1], true);
     approval = await colony.getTokenApproval(token.address, USER0);
     expect(approval).to.be.eq.BN(300);
     allApprovals = await colony.getTotalTokenApproval(token.address);
@@ -199,10 +196,10 @@ contract("Colony Arbitrary Transactions", (accounts) => {
 
     // Cannot approve someone else for 900
     const action3 = await encodeTxData(token, "approve", [USER1, 900]);
-    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action3), "colony-approval-exceeds-balance");
+    await checkErrorRevert(colony.makeArbitraryTransactions([token.address], [action3], true), "colony-approval-exceeds-balance");
     // But can for 800
     const action4 = await encodeTxData(token, "approve", [USER1, 800]);
-    await colony.makeArbitraryTransaction(token.address, action4);
+    await colony.makeArbitraryTransactions([token.address], [action4], true);
     approval = await colony.getTokenApproval(token.address, USER1);
     expect(approval).to.be.eq.BN(800);
     allApprovals = await colony.getTotalTokenApproval(token.address);
@@ -210,45 +207,63 @@ contract("Colony Arbitrary Transactions", (accounts) => {
   });
 
   it("should not be able to make arbitrary transactions to the colony's own extensions", async () => {
-    const COIN_MACHINE = soliditySha3("CoinMachine");
+    const ONE_TX_PAYMENT = soliditySha3("OneTxPayment");
 
     const ethersProvider = new ethers.providers.JsonRpcProvider(web3.currentProvider.host);
     const ethersColonyNetwork = new ethers.Contract(colonyNetwork.address, colonyNetwork.abi, ethersProvider);
 
-    const eventFilter = ethersColonyNetwork.filters.ExtensionAddedToNetwork(COIN_MACHINE);
+    const eventFilter = ethersColonyNetwork.filters.ExtensionAddedToNetwork(ONE_TX_PAYMENT);
     const events = await ethersColonyNetwork.queryFilter(eventFilter, 0);
-    const log = await ethersColonyNetwork.interface.parseLog(events[0]);
+    const log = ethersColonyNetwork.interface.parseLog(events[0]);
 
-    await colony.installExtension(COIN_MACHINE, log.args.version);
+    await colony.installExtension(ONE_TX_PAYMENT, log.args.version);
 
-    const coinMachineAddress = await colonyNetwork.getExtensionInstallation(COIN_MACHINE, colony.address);
-    const coinMachine = await CoinMachine.at(coinMachineAddress);
-    await coinMachine.initialise(token.address, ethers.constants.AddressZero, 60 * 60, 10, WAD, WAD, WAD, WAD, ADDRESS_ZERO);
-    await token.mint(coinMachine.address, WAD);
+    const oneTxPaymentAddress = await colonyNetwork.getExtensionInstallation(ONE_TX_PAYMENT, colony.address);
+    const oneTxPayment = await OneTxPayment.at(oneTxPaymentAddress);
+    const ROLES = rolesToBytes32([ARBITRATION_ROLE, FUNDING_ROLE, ADMINISTRATION_ROLE]);
 
-    const action = await encodeTxData(coinMachine, "buyTokens", [WAD]);
+    // Give extension funding and administration rights
+    await colony.setUserRoles(1, UINT256_MAX, oneTxPayment.address, 1, ROLES);
+    await colony.setUserRoles(1, UINT256_MAX, colony.address, 1, ROLES);
 
-    await checkErrorRevert(colony.makeArbitraryTransaction(coinMachine.address, action), "colony-cannot-target-extensions");
+    await colony.send(10); // NB 10 wei, not ten ether!
+    await colony.claimColonyFunds(ADDRESS_ZERO);
+
+    const action = await encodeTxData(oneTxPayment, "makePaymentFundedFromDomain", [
+      1,
+      UINT256_MAX,
+      1,
+      UINT256_MAX,
+      [USER1],
+      [ADDRESS_ZERO],
+      [10],
+      1,
+      0,
+    ]);
+
+    await checkErrorRevert(colony.makeArbitraryTransactions([oneTxPayment.address], [action], true), "colony-cannot-target-extensions");
 
     // But other colonies can
     const { colony: otherColony } = await setupRandomColony(colonyNetwork);
-    await otherColony.makeArbitraryTransaction(coinMachine.address, action);
+    await colony.setUserRoles(1, UINT256_MAX, otherColony.address, 1, ROLES);
+
+    await otherColony.makeArbitraryTransactions([oneTxPayment.address], [action], true);
   });
 
   it("when burning tokens, can burn own tokens with burn(amount) up to the amount unspoken for in root pot", async () => {
     await fundColonyWithTokens(colony, token, 100);
     const action1 = await encodeTxData(token, "approve", [USER0, 60]);
-    await colony.makeArbitraryTransaction(token.address, action1);
+    await colony.makeArbitraryTransactions([token.address], [action1], true);
     let potBalance = await colony.getFundingPotBalance(1, token.address);
     expect(potBalance).to.be.eq.BN(100);
 
     const action2 = await encodeTxData(token, "burn", [100]);
     // Can't  burn 100 as 60 are reserved
-    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action2), "colony-not-enough-tokens");
+    await checkErrorRevert(colony.makeArbitraryTransactions([token.address], [action2], true), "colony-not-enough-tokens");
 
     // Can burn 40
     const action3 = await encodeTxData(token, "burn", [40]);
-    await colony.makeArbitraryTransaction(token.address, action3);
+    await colony.makeArbitraryTransactions([token.address], [action3], true);
     potBalance = await colony.getFundingPotBalance(1, token.address);
     expect(potBalance).to.be.eq.BN(60);
   });
@@ -256,17 +271,17 @@ contract("Colony Arbitrary Transactions", (accounts) => {
   it("when transferring tokens, can transfer own tokens with transfer(dst, amount) up to the amount unspoken for in root pot", async () => {
     await fundColonyWithTokens(colony, token, 100);
     const action1 = await encodeTxData(token, "approve", [USER0, 60]);
-    await colony.makeArbitraryTransaction(token.address, action1);
+    await colony.makeArbitraryTransactions([token.address], [action1], true);
     let potBalance = await colony.getFundingPotBalance(1, token.address);
     expect(potBalance).to.be.eq.BN(100);
 
     const action2 = await encodeTxData(token, "transfer", [USER0, 100]);
     // Can't transfer 100 as 60 are reserved
-    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action2), "colony-not-enough-tokens");
+    await checkErrorRevert(colony.makeArbitraryTransactions([token.address], [action2], true), "colony-not-enough-tokens");
 
     // Can transfer 40
     const action3 = await encodeTxData(token, "transfer", [USER0, 40]);
-    await colony.makeArbitraryTransaction(token.address, action3);
+    await colony.makeArbitraryTransactions([token.address], [action3], true);
     potBalance = await colony.getFundingPotBalance(1, token.address);
     expect(potBalance).to.be.eq.BN(60);
     const userBalance = await token.balanceOf(USER0);
@@ -277,7 +292,7 @@ contract("Colony Arbitrary Transactions", (accounts) => {
     await token.mint(100);
     await token.approve(colony.address, 100);
     const action1 = await encodeTxData(token, "burn", [USER0, 60]);
-    await colony.makeArbitraryTransaction(token.address, action1);
+    await colony.makeArbitraryTransactions([token.address], [action1], true);
 
     const userBalance = await token.balanceOf(USER0);
     expect(userBalance).to.be.eq.BN(40);
@@ -287,7 +302,7 @@ contract("Colony Arbitrary Transactions", (accounts) => {
     await token.mint(100);
     await token.approve(colony.address, 100);
     const action1 = await encodeTxData(token, "transferFrom", [USER0, colony.address, 60]);
-    await colony.makeArbitraryTransaction(token.address, action1);
+    await colony.makeArbitraryTransactions([token.address], [action1], true);
 
     const userBalance = await token.balanceOf(USER0);
     expect(userBalance).to.be.eq.BN(40);
@@ -297,11 +312,11 @@ contract("Colony Arbitrary Transactions", (accounts) => {
 
   it("cannot burn own tokens with burn(guy, amount)", async () => {
     const action = await encodeTxData(token, "burn", [colony.address, 60]);
-    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action), "colony-cannot-spend-own-allowance");
+    await checkErrorRevert(colony.makeArbitraryTransactions([token.address], [action], true), "colony-cannot-spend-own-allowance");
   });
 
   it("cannot transfer own tokens with transferFrom(from, to, amount)", async () => {
     const action = await encodeTxData(token, "transferFrom", [colony.address, USER0, 60]);
-    await checkErrorRevert(colony.makeArbitraryTransaction(token.address, action), "colony-cannot-spend-own-allowance");
+    await checkErrorRevert(colony.makeArbitraryTransactions([token.address], [action], true), "colony-cannot-spend-own-allowance");
   });
 });

--- a/test/contracts-network/colony-funding.js
+++ b/test/contracts-network/colony-funding.js
@@ -167,8 +167,8 @@ contract("Colony Funding", (accounts) => {
       await colony.addDomain(1, UINT256_MAX, 1);
       await colony.addDomain(1, UINT256_MAX, 1);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, 1, 2, 40, otherToken.address);
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 1, 2, 3, 50, otherToken.address), "Panic: Arithmetic overflow");
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, 0, 1, 2, 40, otherToken.address);
+      await checkErrorRevert(colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 1, 2, 3, 50, otherToken.address), "Panic: Arithmetic overflow");
 
       const colonyTokenBalance = await otherToken.balanceOf(colony.address);
       const pot1Balance = await colony.getFundingPotBalance(1, otherToken.address);
@@ -370,14 +370,20 @@ contract("Colony Funding", (accounts) => {
 
     it("should not allow contributions to nonexistent funding pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, UINT256_MAX, 3, 1, 5, 40, otherToken.address), "colony-funding-nonexistent-pot");
+      await checkErrorRevert(
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, 3, 1, 5, 40, otherToken.address),
+        "colony-funding-nonexistent-pot",
+      );
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       expect(colonyPotBalance).to.eq.BN(99);
     });
 
     it("should not allow attempts to move funds from nonexistent funding pots", async () => {
       await fundColonyWithTokens(colony, otherToken, 100);
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 3, UINT256_MAX, 5, 1, 40, otherToken.address), "colony-funding-nonexistent-pot");
+      await checkErrorRevert(
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 3, UINT256_MAX, 5, 1, 40, otherToken.address),
+        "colony-funding-nonexistent-pot",
+      );
       const colonyPotBalance = await colony.getFundingPotBalance(1, otherToken.address);
       expect(colonyPotBalance).to.eq.BN(99);
     });
@@ -475,8 +481,11 @@ contract("Colony Funding", (accounts) => {
       await colony.addDomain(1, UINT256_MAX, 1);
       await colony.addDomain(1, UINT256_MAX, 1);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, 1, 2, 40, ethers.constants.AddressZero);
-      await checkErrorRevert(colony.moveFundsBetweenPots(1, 0, 1, 2, 3, 50, ethers.constants.AddressZero), "Panic: Arithmetic overflow");
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, 0, 1, 2, 40, ethers.constants.AddressZero);
+      await checkErrorRevert(
+        colony.moveFundsBetweenPots(1, UINT256_MAX, 1, 0, 1, 2, 3, 50, ethers.constants.AddressZero),
+        "Panic: Arithmetic overflow",
+      );
 
       const colonyEtherBalance = await web3GetBalance(colony.address);
       const pot1Balance = await colony.getFundingPotBalance(1, ethers.constants.AddressZero);

--- a/test/contracts-network/colony-network-extensions.js
+++ b/test/contracts-network/colony-network-extensions.js
@@ -144,6 +144,10 @@ contract("Colony Network Extensions", (accounts) => {
   });
 
   describe("installing extensions", () => {
+    it("non-colonies cannot call installExtension on ColonyNetwork", async () => {
+      await checkErrorRevert(colonyNetwork.installExtension(TEST_EXTENSION, 1), "colony-caller-must-be-colony");
+    });
+
     it("allows a root user to install an extension with any version", async () => {
       await colony.installExtension(TEST_EXTENSION, 2, { from: ROOT });
 
@@ -205,6 +209,10 @@ contract("Colony Network Extensions", (accounts) => {
   });
 
   describe("upgrading extensions", () => {
+    it("non-colonies cannot call upgradeExtension on ColonyNetwork", async () => {
+      await checkErrorRevert(colonyNetwork.upgradeExtension(TEST_EXTENSION, 1), "colony-caller-must-be-colony");
+    });
+
     it("allows root users to upgrade an extension", async () => {
       await colony.installExtension(TEST_EXTENSION, 1, { from: ROOT });
 
@@ -248,6 +256,10 @@ contract("Colony Network Extensions", (accounts) => {
   });
 
   describe("deprecating extensions", () => {
+    it("non-colonies cannot call deprecateExtension on ColonyNetwork", async () => {
+      await checkErrorRevert(colonyNetwork.deprecateExtension(TEST_EXTENSION, true), "colony-caller-must-be-colony");
+    });
+
     it("allows root users to deprecate and undeprecate an extension", async () => {
       await colony.installExtension(TEST_EXTENSION, 1, { from: ROOT });
 
@@ -273,6 +285,10 @@ contract("Colony Network Extensions", (accounts) => {
   });
 
   describe("uninstalling extensions", () => {
+    it("non-colonies cannot call uninstallExtension on ColonyNetwork", async () => {
+      await checkErrorRevert(colonyNetwork.uninstallExtension(TEST_EXTENSION), "colony-caller-must-be-colony");
+    });
+
     it("allows root users to uninstall an extension and send ether to the beneficiary", async () => {
       await colony.installExtension(TEST_EXTENSION, 1, { from: ROOT });
 

--- a/test/contracts-network/colony-network-recovery.js
+++ b/test/contracts-network/colony-network-recovery.js
@@ -135,14 +135,13 @@ contract("Colony Network Recovery", (accounts) => {
 
     it("should not be able to call normal functions while in recovery", async () => {
       await colonyNetwork.enterRecoveryMode();
-      await checkErrorRevert(colonyNetwork.createColony(clny.address), "colony-in-recovery-mode");
       await checkErrorRevert(colonyNetwork.createMetaColony(clny.address), "colony-in-recovery-mode");
       await checkErrorRevert(colonyNetwork.setTokenLocking(ADDRESS_ZERO), "colony-in-recovery-mode");
       await checkErrorRevert(colonyNetwork.initialiseRootLocalSkill(), "colony-in-recovery-mode");
       await checkErrorRevert(colonyNetwork.appendReputationUpdateLog(ADDRESS_ZERO, 0, 0), "colony-in-recovery-mode");
-      await checkErrorRevert(colonyNetwork.createColony(clny.address, 4, "", "", true), "colony-in-recovery-mode");
       await checkErrorRevert(colonyNetwork.createColony(clny.address, 4, ""), "colony-in-recovery-mode");
       await checkErrorRevert(colonyNetwork.createColony(clny.address, 4, "", ""), "colony-in-recovery-mode");
+      await checkErrorRevert(colonyNetwork.createColonyForFrontend(clny.address, "", "", 18, 10, "", ""), "colony-in-recovery-mode");
       await checkErrorRevert(colonyNetwork.setupRegistrar(clny.address, HASHZERO), "colony-in-recovery-mode");
       await checkErrorRevert(colonyNetwork.registerUserLabel("", ""), "colony-in-recovery-mode");
       await checkErrorRevertEstimateGas(
@@ -187,7 +186,6 @@ contract("Colony Network Recovery", (accounts) => {
       await checkErrorRevert(colonyNetwork.initialise(ADDRESS_ZERO, 1), "colony-in-recovery-mode");
       await checkErrorRevert(colonyNetwork.addSkill(1), "colony-in-recovery-mode");
       await checkErrorRevert(colonyNetwork.deprecateSkill(1, true), "colony-in-recovery-mode");
-      await checkErrorRevert(colonyNetwork.deprecateSkill(1), "colony-in-recovery-mode");
       await checkErrorRevert(colonyNetwork.setFeeInverse(1), "colony-in-recovery-mode");
       await checkErrorRevert(colonyNetwork.setPayoutWhitelist(ADDRESS_ZERO, true), "colony-in-recovery-mode");
       await checkErrorRevert(colonyNetwork.claimMiningReward(ADDRESS_ZERO), "colony-in-recovery-mode");

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -240,25 +240,6 @@ contract("Colony Network", (accounts) => {
       await checkErrorRevert(colonyNetwork.createColony(token.address, nonexistentVersion, "", ""), "colony-network-invalid-version");
     });
 
-    it("should allow use of the deprecated one-parameter createColony", async () => {
-      const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
-      const oldVersion = currentColonyVersion.subn(1);
-      await metaColony.addNetworkColonyVersion(oldVersion, newResolverAddress);
-      // Add version 3 if necessary, required to test the deprecated createColony
-      if (!oldVersion.eq(3)) {
-        await metaColony.addNetworkColonyVersion(3, newResolverAddress);
-      }
-      const token = await Token.new(...getTokenArgs());
-
-      await colonyNetwork.createColony(token.address);
-    });
-
-    it("should allow use of the deprecated five-parameter createColony", async () => {
-      const token = await Token.new(...getTokenArgs());
-
-      await colonyNetwork.createColony(token.address, 5, "", "", "");
-    });
-
     it("should allow users to create a colony for the frontend in one transaction with an existing token", async () => {
       const token = await Token.new(...getTokenArgs());
       await colonyNetwork.createColonyForFrontend(token.address, "", "", 0, version, "", "");

--- a/test/contracts-network/colony-permissions.js
+++ b/test/contracts-network/colony-permissions.js
@@ -369,31 +369,6 @@ contract("ColonyPermissions", (accounts) => {
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
       // Test we can move funds between domain 1 and 2, and also 2 and 3
-      // Deprecated version
-      await colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)"](
-        1,
-        UINT256_MAX,
-        0,
-        domain1.fundingPotId,
-        domain2.fundingPotId,
-        WAD,
-        token.address,
-        {
-          from: USER2,
-        },
-      );
-      await colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)"](
-        1,
-        0,
-        1,
-        domain2.fundingPotId,
-        domain3.fundingPotId,
-        WAD,
-        token.address,
-        { from: USER2 },
-      );
-
-      // Newest version
       await colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,address)"](
         1,
         UINT256_MAX,
@@ -418,34 +393,6 @@ contract("ColonyPermissions", (accounts) => {
         WAD,
         token.address,
         { from: USER2 },
-      );
-
-      // But only with valid proofs. Deprecated version of this function
-      await checkErrorRevert(
-        colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)"](
-          1,
-          1,
-          1,
-          domain2.fundingPotId,
-          domain3.fundingPotId,
-          WAD,
-          token.address,
-          { from: USER2 },
-        ),
-        "ds-auth-invalid-domain-inheritance",
-      );
-      await checkErrorRevert(
-        colony.methods["moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)"](
-          1,
-          0,
-          0,
-          domain2.fundingPotId,
-          domain3.fundingPotId,
-          WAD,
-          token.address,
-          { from: USER2 },
-        ),
-        "ds-auth-invalid-domain-inheritance",
       );
 
       // The newest version

--- a/test/contracts-network/colony-recovery.js
+++ b/test/contracts-network/colony-recovery.js
@@ -172,7 +172,6 @@ contract("Colony Recovery", (accounts) => {
       await checkErrorRevert(metaColony.setDefaultGlobalClaimDelay(0), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.makeExpenditure(0, 0, 0), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.transferExpenditure(0, ADDRESS_ZERO), "colony-in-recovery-mode");
-      await checkErrorRevert(metaColony.transferExpenditureViaArbitration(0, 0, 0, ADDRESS_ZERO), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.cancelExpenditure(0), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.lockExpenditure(0), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.finalizeExpenditure(0), "colony-in-recovery-mode");
@@ -182,8 +181,6 @@ contract("Colony Recovery", (accounts) => {
       await checkErrorRevert(metaColony.setExpenditureSkills(0, [], []), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.setExpenditureClaimDelays(0, [], []), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.setExpenditurePayoutModifiers(0, [], []), "colony-in-recovery-mode");
-      await checkErrorRevert(metaColony.setExpenditureRecipient(0, 0, ADDRESS_ZERO), "colony-in-recovery-mode");
-      await checkErrorRevert(metaColony.setExpenditureClaimDelay(0, 0, 0), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.setExpenditureState(0, 0, 0, 0, [], [], HASHZERO), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.setExpenditureValues(0, [], [], [], [], [], [], [], [], [], [[]], [[]]), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.setArbitrationRole(0, 0, ADDRESS_ZERO, 0, true), "colony-in-recovery-mode");
@@ -195,19 +192,16 @@ contract("Colony Recovery", (accounts) => {
       await checkErrorRevert(metaColony.unlockTokenForUser(ADDRESS_ZERO, 0), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.claimExpenditurePayout(0, 0, ADDRESS_ZERO), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.moveFundsBetweenPots(0, 0, 0, 0, 0, 0, 0, 0, ADDRESS_ZERO), "colony-in-recovery-mode");
-      await checkErrorRevert(metaColony.moveFundsBetweenPots(0, 0, 0, 0, 0, 0, ADDRESS_ZERO), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.claimColonyFunds(ADDRESS_ZERO), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.startNextRewardPayout(ADDRESS_ZERO, HASHZERO, HASHZERO, 0, []), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.claimRewardPayout(0, [0, 0, 0, 0, 0, 0, 0], HASHZERO, HASHZERO, 0, []), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.setRewardInverse(0), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.setExpenditurePayouts(0, [], ADDRESS_ZERO, []), "colony-in-recovery-mode");
-      await checkErrorRevert(metaColony.setExpenditurePayout(0, 0, ADDRESS_ZERO, 0), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.setExpenditurePayout(1, UINT256_MAX, 0, 0, ADDRESS_ZERO, 0), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.enterRecoveryMode(), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.burnTokens(ADDRESS_ZERO, 0), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.registerColonyLabel("", ""), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.updateColonyOrbitDB(""), "colony-in-recovery-mode");
-      await checkErrorRevert(metaColony.makeArbitraryTransaction(ADDRESS_ZERO, HASHZERO), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.makeArbitraryTransactions([], [], true), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.makeSingleArbitraryTransaction(ADDRESS_ZERO, HASHZERO), "colony-in-recovery-mode");
       await checkErrorRevert(metaColony.updateApprovalAmount(ADDRESS_ZERO, ADDRESS_ZERO), "colony-in-recovery-mode");

--- a/test/contracts-network/colony-reward-payouts.js
+++ b/test/contracts-network/colony-reward-payouts.js
@@ -775,8 +775,8 @@ contract("Colony Reward Payouts", (accounts) => {
       await newToken.approve(tokenLocking.address, userReputation, { from: userAddress1 });
       await tokenLocking.methods["deposit(address,uint256,bool)"](newToken.address, userReputation, true, { from: userAddress1 });
 
-      await colony1.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
-      await colony2.moveFundsBetweenPots(1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony1.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
+      await colony2.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 0, 100, otherToken.address);
 
       ({ logs } = await colony1.startNextRewardPayout(otherToken.address, ...colonyWideReputationProof1));
       const payoutId1 = logs[0].args.rewardPayoutId;

--- a/test/contracts-network/colony-staking.js
+++ b/test/contracts-network/colony-staking.js
@@ -38,13 +38,11 @@ contract("Colony Staking", (accounts) => {
     await colony.setArbitrationRole(1, UINT256_MAX, USER2, 1, true);
 
     await colony.makeExpenditure(1, UINT256_MAX, 1);
-    await colony.setExpenditureRecipient(1, SLOT0, USER0);
-    await colony.setExpenditureRecipient(1, SLOT1, USER1);
+    await colony.setExpenditureRecipients(1, [SLOT0, SLOT1], [USER0, USER1]);
 
     await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
     await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, UINT256_MAX, 1, 3, WAD.muln(200), token.address);
-    await colony.setExpenditurePayout(1, SLOT0, token.address, WAD.muln(100));
-    await colony.setExpenditurePayout(1, SLOT1, token.address, WAD.muln(100));
+    await colony.setExpenditurePayouts(1, [SLOT0, SLOT1], token.address, [WAD.muln(100), WAD.muln(100)]);
 
     await colony.finalizeExpenditure(1);
     await colony.claimExpenditurePayout(1, SLOT0, token.address);

--- a/test/contracts-network/reputation-basic-functionality.js
+++ b/test/contracts-network/reputation-basic-functionality.js
@@ -256,6 +256,11 @@ contract("Reputation mining - basic functionality", (accounts) => {
 
       await checkErrorRevert(inactiveRepCycle.initialise(MINER1, MINER2), "colony-reputation-mining-cycle-already-initialised");
     });
+
+    it("should not allow mining-only functions to network to be called by someone not reputationMiningCycle", async () => {
+      await checkErrorRevert(colonyNetwork.burnUnneededRewards(0), "colony-reputation-mining-sender-not-active-reputation-cycle");
+      await checkErrorRevert(colonyNetwork.reward(colonyNetwork.address, 1), "colony-reputation-mining-sender-not-active-reputation-cycle");
+    });
   });
 
   describe("when reading reputation mining constant properties", async () => {

--- a/test/contracts-network/reputation-update.js
+++ b/test/contracts-network/reputation-update.js
@@ -180,8 +180,8 @@ contract("Reputation Updates", (accounts) => {
 
       const SLOT0 = 0;
 
-      await metaColony.setExpenditureRecipient(expenditureId, SLOT0, RECIPIENT);
-      await metaColony.setExpenditurePayout(expenditureId, SLOT0, clnyToken.address, WAD);
+      await metaColony.setExpenditureRecipients(expenditureId, [SLOT0], [RECIPIENT]);
+      await metaColony.setExpenditurePayouts(expenditureId, [SLOT0], clnyToken.address, [WAD]);
 
       const domain1 = await metaColony.getDomain(1);
 

--- a/test/contracts-network/token-locking.js
+++ b/test/contracts-network/token-locking.js
@@ -114,16 +114,6 @@ contract("Token Locking", (addresses) => {
       expect(tokenLockingContractBalance).to.eq.BN(usersTokens);
     });
 
-    it("should correctly deposit tokens using the deprecated interface", async () => {
-      await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
-      await tokenLocking.methods["deposit(address,uint256)"](token.address, usersTokens, { from: userAddress });
-      const info = await tokenLocking.getUserLock(token.address, userAddress);
-      expect(info.balance).to.eq.BN(usersTokens);
-
-      const tokenLockingContractBalance = await token.balanceOf(tokenLocking.address);
-      expect(tokenLockingContractBalance).to.eq.BN(usersTokens);
-    });
-
     it("should correctly deposit large amounts of tokens", async () => {
       await otherToken.mint(userAddress, UINT256_MAX);
       await otherToken.approve(tokenLocking.address, UINT256_MAX, { from: userAddress });
@@ -229,17 +219,6 @@ contract("Token Locking", (addresses) => {
       await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
       await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
       await tokenLocking.methods["withdraw(address,uint256,bool)"](token.address, usersTokens, false, { from: userAddress });
-
-      const info = await tokenLocking.getUserLock(token.address, userAddress);
-      expect(info.balance).to.be.zero;
-      const userBalance = await token.balanceOf(userAddress);
-      expect(userBalance).to.eq.BN(usersTokens);
-    });
-
-    it("should correctly withdraw tokens via the deprecated interface", async () => {
-      await token.approve(tokenLocking.address, usersTokens, { from: userAddress });
-      await tokenLocking.methods["deposit(address,uint256,bool)"](token.address, usersTokens, true, { from: userAddress });
-      await tokenLocking.methods["withdraw(address,uint256)"](token.address, usersTokens, { from: userAddress });
 
       const info = await tokenLocking.getUserLock(token.address, userAddress);
       expect(info.balance).to.be.zero;

--- a/test/cross-chain/cross-chain.js
+++ b/test/cross-chain/cross-chain.js
@@ -138,7 +138,7 @@ contract("Cross-chain", () => {
 
       console.log("tx to home bridge address:", homeBridge.address);
 
-      const tx = await colony.makeArbitraryTransaction(homeBridge.address, txDataToBeSentToAMB);
+      const tx = await colony.makeArbitraryTransactions([homeBridge.address], [txDataToBeSentToAMB], true);
       await tx.wait();
       await p;
       // Check balances

--- a/test/extensions/funding-queue.js
+++ b/test/extensions/funding-queue.js
@@ -866,7 +866,7 @@ contract("Funding Queues", (accounts) => {
       await colony.setFundingRole(1, 0, fundingQueue.address, 2, true);
       await colony.addDomain(1, 0, 2);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, 1, 2, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, 0, 1, 2, WAD, token.address);
 
       await fundingQueue.createProposal(2, UINT256_MAX, 0, 2, 4, WAD, token.address, { from: USER0 });
       proposalId = await fundingQueue.getProposalCount();

--- a/test/extensions/one-tx-payment.js
+++ b/test/extensions/one-tx-payment.js
@@ -176,7 +176,8 @@ contract("One transaction payments", (accounts) => {
       const d2 = await colony.getDomain(2);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
+
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
       await oneTxPayment.makePaymentFundedFromDomain(1, 0, 1, 0, [USER1], [token.address], [10], 2, localSkillId);
     });
 
@@ -224,7 +225,7 @@ contract("One transaction payments", (accounts) => {
       const d2 = await colony.getDomain(2);
 
       await fundColonyWithTokens(colony, token, INITIAL_FUNDING);
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
 
       await colony.setAdministrationRole(1, 0, USER1, 2, true);
       await colony.setFundingRole(1, 0, USER1, 2, true);
@@ -537,7 +538,7 @@ contract("One transaction payments", (accounts) => {
       const d1 = await colony.getDomain(1);
       const d2 = await colony.getDomain(2);
 
-      await colony.moveFundsBetweenPots(1, UINT256_MAX, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
+      await colony.moveFundsBetweenPots(1, UINT256_MAX, 1, UINT256_MAX, 0, d1.fundingPotId, d2.fundingPotId, WAD, token.address);
 
       await oneTxPayment.makePaymentFundedFromDomain(2, UINT256_MAX, 1, 0, [USER1], [token.address], [10], 2, localSkillId);
 

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -519,7 +519,15 @@ contract("Voting Reputation", (accounts) => {
       // Move funds between domain 2 and domain 3 pots using the old deprecated function
       // This should not be allowed - it doesn't conform to the standard permission proofs, and so can't
       // be checked
-      let action = await encodeTxData(colony, "moveFundsBetweenPots", [1, 0, 1, domain2.fundingPotId, domain3.fundingPotId, WAD, token.address]);
+      let action = await encodeTxData(colony, "moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)", [
+        1,
+        0,
+        1,
+        domain2.fundingPotId,
+        domain3.fundingPotId,
+        WAD,
+        token.address,
+      ]);
       const key = makeReputationKey(colony.address, domain2.skillId);
       const value = makeReputationValue(WAD, 6);
       const [mask, siblings] = await reputationTree.getProof(key);
@@ -2093,7 +2101,7 @@ contract("Voting Reputation", (accounts) => {
     });
 
     it("transactions that try to execute a forbidden method on Reputation Voting extension are rejected by the MTX broadcaster", async function () {
-      const action = await encodeTxData(colony, "makeArbitraryTransaction", [colony.address, "0x00"]);
+      const action = await encodeTxData(colony, "makeArbitraryTransactions", [[colony.address], ["0x00"], true]);
 
       await voting.createMotion(1, UINT256_MAX, ADDRESS_ZERO, action, domain1Key, domain1Value, domain1Mask, domain1Siblings);
       motionId = await voting.getMotionCount();
@@ -3080,7 +3088,15 @@ contract("Voting Reputation", (accounts) => {
     });
 
     it("cannot let an invalid motion involving multicalling OLD_MOVE_FUNDS be finalized", async () => {
-      const action1 = await encodeTxData(colony, "moveFundsBetweenPots", [1, 0, 2, 0, 0, 0, ADDRESS_ZERO]);
+      const action1 = await encodeTxData(colony, "moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)", [
+        1,
+        0,
+        2,
+        0,
+        0,
+        0,
+        ADDRESS_ZERO,
+      ]);
       const multicall = await encodeTxData(colony, "multicall", [[action1]]);
 
       await voting.createMotion(1, UINT256_MAX, ADDRESS_ZERO, multicall, domain1Key, domain1Value, domain1Mask, domain1Siblings);


### PR DESCRIPTION
For a while, we've been marking functions as deprecated, and not doing anything further.

The crows have come home to roost.

Ready for review, I reckon, but not to merge - both because of the upcoming release, and because this will need testing against the dapp and the cdapp to make sure they're not using anything that we're removing, and then having those updated accordingly.