### PR TITLE
Extra tests and extra gas for the metatransaction broadcaster

### DIFF
--- a/packages/metatransaction-broadcaster/MetatransactionBroadcaster.js
+++ b/packages/metatransaction-broadcaster/MetatransactionBroadcaster.js
@@ -301,6 +301,7 @@ class MetatransactionBroadcaster {
     let toBlock = await this.provider.getBlockNumber();
     let fromBlock = toBlock - stepSize;
     let data = [];
+    // TODO: avoid endless loop here if user never sent a metatx
     while (data.length === 0) {
       logs = await this.provider.getLogs({
         address: this.colonyNetwork.address,

--- a/packages/package-utils/getFeeData.js
+++ b/packages/package-utils/getFeeData.js
@@ -52,6 +52,7 @@ const getFeeData = async function (_type, chainId, adapter, provider) {
     delete feeData.lastBaseFeePerGas;
     if (feeData.maxFeePerGas) {
       delete feeData.gasPrice;
+      feeData.maxFeePerGas = feeData.maxFeePerGas.mul(5).add(feeData.maxPriorityFeePerGas);
     }
     // Update gas prices from whichever oracle
     try {


### PR DESCRIPTION
While running down a bug that turned out to be an issue with which transactions were being sent by the front-end, I wrote some more tests. Seemed like a waste to not include them after writing them.

My additions in #1192 only affected unknown chains, which doesn't actually help with production. Added the same 'wiggle room' to when we are on a known chain.