### PR TITLE
Bump docker version for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - checkout
       - <<: *step_restore_cache
       - setup_remote_docker:
-          version: 19.03.13
+          version: docker23
       - <<: *step_pull_solc_docker
       - <<: *step_setup_global_packages
       - run:
@@ -91,7 +91,7 @@ jobs:
       - checkout
       - <<: *step_restore_cache
       - setup_remote_docker:
-          version: 19.03.13
+          version: docker23
       - <<: *step_pull_solc_docker
       - <<: *step_setup_global_packages
       - run:
@@ -198,7 +198,7 @@ jobs:
       - checkout
       - <<: *step_restore_cache
       - setup_remote_docker:
-          version: 19.03.13
+          version: docker23
       - <<: *step_pull_solc_docker
       - <<: *step_setup_global_packages
       - run:
@@ -216,7 +216,7 @@ jobs:
       - checkout
       - <<: *step_restore_cache
       - setup_remote_docker:
-          version: 19.03.13
+          version: docker23
       - <<: *step_pull_solc_docker
       - <<: *step_setup_global_packages
       - run:
@@ -234,7 +234,7 @@ jobs:
       - checkout
       - <<: *step_restore_cache
       - setup_remote_docker:
-          version: 19.03.13
+          version: docker23
       - <<: *step_pull_solc_docker
       - <<: *step_setup_global_packages
       - run:
@@ -252,7 +252,7 @@ jobs:
       - checkout
       - <<: *step_restore_cache
       - setup_remote_docker:
-          version: 19.03.13
+          version: docker23
       - <<: *step_pull_solc_docker
       - <<: *step_setup_global_packages
       - run:
@@ -270,7 +270,7 @@ jobs:
       - checkout
       - <<: *step_restore_cache
       - setup_remote_docker:
-          version: 19.03.13
+          version: docker23
       - <<: *step_pull_solc_docker
       - <<: *step_setup_global_packages
       - run:
@@ -306,7 +306,7 @@ jobs:
       - checkout
       - <<: *step_restore_cache
       - setup_remote_docker:
-          version: 19.03.13
+          version: docker23
       - <<: *step_pull_solc_docker
       - <<: *step_setup_global_packages
       - run:
@@ -354,7 +354,7 @@ jobs:
       - checkout
       - <<: *step_restore_cache
       - setup_remote_docker:
-          version: 19.03.13
+          version: docker23
       - <<: *step_pull_solc_docker
       - <<: *step_setup_global_packages
       - <<: *step_setup_slither
@@ -369,7 +369,7 @@ jobs:
       - checkout
       - <<: *step_restore_cache
       - setup_remote_docker:
-          version: 19.03.13
+          version: docker23
       - <<: *step_pull_solc_docker
       - <<: *step_setup_global_packages
       - run:


### PR DESCRIPTION
The version of docker we use on Circle has [been deprecated](https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176), so to avoid our builds intermittently failing over the next year, and then failing permanently before the end of it, we need to bump the version.