### PR TITLE
Delete username/password if not set for miner

### DIFF
--- a/packages/reputation-miner/bin/index.js
+++ b/packages/reputation-miner/bin/index.js
@@ -95,6 +95,12 @@ if (network) {
       user: decodeURI(username),
       password: decodeURI(password.replace(/%23/, '#')),
     }
+    if (connectionInfo.user === "") {
+      delete connectionInfo.user;
+    }
+    if (connectionInfo.password === "") {
+      delete connectionInfo.password;
+    }
     return new RetryProvider(connectionInfo, adapterObject);
   })
   // This is, at best, a huge hack...


### PR DESCRIPTION
These being (presumably) set in the headers in ethers requests to empty strings, rather than not being present, was causing 401 errors when making requests to Chainstack.