### PR TITLE
Streaming payments only support a single stream

### DIFF
--- a/.storage-layouts-normalized/contracts/extensions/StreamingPayments.sol:StreamingPayments.json
+++ b/.storage-layouts-normalized/contracts/extensions/StreamingPayments.sol:StreamingPayments.json
@@ -511,64 +511,42 @@
                 "label": "uint256",
                 "numberOfBytes": "32"
               }
+            },
+            {
+              "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
+              "label": "token",
+              "offset": 0,
+              "slot": "5",
+              "type": {
+                "encoding": "inplace",
+                "label": "address",
+                "numberOfBytes": "20"
+              }
+            },
+            {
+              "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
+              "label": "amount",
+              "offset": 0,
+              "slot": "6",
+              "type": {
+                "encoding": "inplace",
+                "label": "uint256",
+                "numberOfBytes": "32"
+              }
+            },
+            {
+              "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
+              "label": "pseudoAmountClaimedFromStart",
+              "offset": 0,
+              "slot": "7",
+              "type": {
+                "encoding": "inplace",
+                "label": "uint256",
+                "numberOfBytes": "32"
+              }
             }
           ],
-          "numberOfBytes": "160"
-        }
-      }
-    },
-    {
-      "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
-      "label": "paymentTokens",
-      "offset": 0,
-      "slot": "39",
-      "type": {
-        "encoding": "mapping",
-        "key": {
-          "encoding": "inplace",
-          "label": "uint256",
-          "numberOfBytes": "32"
-        },
-        "label": "mapping(uint256 => mapping(address => struct StreamingPayments.PaymentToken))",
-        "numberOfBytes": "32",
-        "value": {
-          "encoding": "mapping",
-          "key": {
-            "encoding": "inplace",
-            "label": "address",
-            "numberOfBytes": "20"
-          },
-          "label": "mapping(address => struct StreamingPayments.PaymentToken)",
-          "numberOfBytes": "32",
-          "value": {
-            "encoding": "inplace",
-            "label": "struct StreamingPayments.PaymentToken",
-            "members": [
-              {
-                "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
-                "label": "amount",
-                "offset": 0,
-                "slot": "0",
-                "type": {
-                  "encoding": "inplace",
-                  "label": "uint256",
-                  "numberOfBytes": "32"
-                }
-              },
-              {
-                "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
-                "label": "pseudoAmountClaimedFromStart",
-                "offset": 0,
-                "slot": "1",
-                "type": {
-                  "encoding": "inplace",
-                  "label": "uint256",
-                  "numberOfBytes": "32"
-                }
-              }
-            ],
-            "numberOfBytes": "64"
-          }
+          "numberOfBytes": "256"
         }
       }
     }

--- a/.storage-layouts/contracts/bridging/WormholeBridgeForColony.sol:WormholeBridgeForColony.json
+++ b/.storage-layouts/contracts/bridging/WormholeBridgeForColony.sol:WormholeBridgeForColony.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/bridging/WormholeBridgeForColony.sol:WormholeBridgeForColony",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/bridging/WormholeBridgeForColony.sol:WormholeBridgeForColony",
       "label": "owner",
       "offset": 0,
@@ -30,7 +30,7 @@
       "label": "wormhole",
       "offset": 0,
       "slot": "3",
-      "type": "t_contract(IWormhole)54429"
+      "type": "t_contract(IWormhole)54240"
     },
     {
       "astId": 2588,
@@ -55,12 +55,12 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
     },
-    "t_contract(IWormhole)54429": {
+    "t_contract(IWormhole)54240": {
       "encoding": "inplace",
       "label": "contract IWormhole",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/Colony.sol:Colony.json
+++ b/.storage-layouts/contracts/colony/Colony.sol:Colony.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colony/Colony.sol:Colony",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colony/Colony.sol:Colony",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyArbitraryTransaction.sol:ColonyArbitraryTransaction.json
+++ b/.storage-layouts/contracts/colony/ColonyArbitraryTransaction.sol:ColonyArbitraryTransaction.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colony/ColonyArbitraryTransaction.sol:ColonyArbitraryTransaction",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colony/ColonyArbitraryTransaction.sol:ColonyArbitraryTransaction",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyAuthority.sol:ColonyAuthority.json
+++ b/.storage-layouts/contracts/colony/ColonyAuthority.sol:ColonyAuthority.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colony/ColonyAuthority.sol:ColonyAuthority",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colony/ColonyAuthority.sol:ColonyAuthority",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 51037,
+      "astId": 50848,
       "contract": "contracts/colony/ColonyAuthority.sol:ColonyAuthority",
       "label": "_root_users",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 51041,
+      "astId": 50852,
       "contract": "contracts/colony/ColonyAuthority.sol:ColonyAuthority",
       "label": "_user_roles",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_mapping(t_address,t_bytes32)"
     },
     {
-      "astId": 51047,
+      "astId": 50858,
       "contract": "contracts/colony/ColonyAuthority.sol:ColonyAuthority",
       "label": "_capability_roles",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_mapping(t_address,t_mapping(t_bytes4,t_bytes32))"
     },
     {
-      "astId": 51053,
+      "astId": 50864,
       "contract": "contracts/colony/ColonyAuthority.sol:ColonyAuthority",
       "label": "_public_capabilities",
       "offset": 0,
@@ -86,7 +86,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyDomains.sol:ColonyDomains.json
+++ b/.storage-layouts/contracts/colony/ColonyDomains.sol:ColonyDomains.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colony/ColonyDomains.sol:ColonyDomains",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colony/ColonyDomains.sol:ColonyDomains",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyExpenditure.sol:ColonyExpenditure.json
+++ b/.storage-layouts/contracts/colony/ColonyExpenditure.sol:ColonyExpenditure.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colony/ColonyExpenditure.sol:ColonyExpenditure",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colony/ColonyExpenditure.sol:ColonyExpenditure",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyFunding.sol:ColonyFunding.json
+++ b/.storage-layouts/contracts/colony/ColonyFunding.sol:ColonyFunding.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colony/ColonyFunding.sol:ColonyFunding",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colony/ColonyFunding.sol:ColonyFunding",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyRewards.sol:ColonyRewards.json
+++ b/.storage-layouts/contracts/colony/ColonyRewards.sol:ColonyRewards.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colony/ColonyRewards.sol:ColonyRewards",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colony/ColonyRewards.sol:ColonyRewards",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyRoles.sol:ColonyRoles.json
+++ b/.storage-layouts/contracts/colony/ColonyRoles.sol:ColonyRoles.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colony/ColonyRoles.sol:ColonyRoles",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colony/ColonyRoles.sol:ColonyRoles",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyStorage.sol:ColonyStorage.json
+++ b/.storage-layouts/contracts/colony/ColonyStorage.sol:ColonyStorage.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colony/ColonyStorage.sol:ColonyStorage",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colony/ColonyStorage.sol:ColonyStorage",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetwork.sol:ColonyNetwork.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetwork.sol:ColonyNetwork.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colonyNetwork/ColonyNetwork.sol:ColonyNetwork",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colonyNetwork/ColonyNetwork.sol:ColonyNetwork",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkAuction.sol:ColonyNetworkAuction.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkAuction.sol:ColonyNetworkAuction.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuction.sol:ColonyNetworkAuction",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuction.sol:ColonyNetworkAuction",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 51037,
+      "astId": 50848,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority",
       "label": "_root_users",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 51041,
+      "astId": 50852,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority",
       "label": "_user_roles",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_mapping(t_address,t_bytes32)"
     },
     {
-      "astId": 51047,
+      "astId": 50858,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority",
       "label": "_capability_roles",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_mapping(t_address,t_mapping(t_bytes4,t_bytes32))"
     },
     {
-      "astId": 51053,
+      "astId": 50864,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority",
       "label": "_public_capabilities",
       "offset": 0,
@@ -78,7 +78,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkDeployer.sol:ColonyNetworkDeployer.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkDeployer.sol:ColonyNetworkDeployer.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colonyNetwork/ColonyNetworkDeployer.sol:ColonyNetworkDeployer",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colonyNetwork/ColonyNetworkDeployer.sol:ColonyNetworkDeployer",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkENS.sol:ColonyNetworkENS.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkENS.sol:ColonyNetworkENS.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colonyNetwork/ColonyNetworkENS.sol:ColonyNetworkENS",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colonyNetwork/ColonyNetworkENS.sol:ColonyNetworkENS",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkExtensions.sol:ColonyNetworkExtensions.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkExtensions.sol:ColonyNetworkExtensions.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colonyNetwork/ColonyNetworkExtensions.sol:ColonyNetworkExtensions",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colonyNetwork/ColonyNetworkExtensions.sol:ColonyNetworkExtensions",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkMining.sol:ColonyNetworkMining.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkMining.sol:ColonyNetworkMining.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colonyNetwork/ColonyNetworkMining.sol:ColonyNetworkMining",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colonyNetwork/ColonyNetworkMining.sol:ColonyNetworkMining",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkSkills.sol:ColonyNetworkSkills.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkSkills.sol:ColonyNetworkSkills.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colonyNetwork/ColonyNetworkSkills.sol:ColonyNetworkSkills",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colonyNetwork/ColonyNetworkSkills.sol:ColonyNetworkSkills",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkStorage.sol:ColonyNetworkStorage.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkStorage.sol:ColonyNetworkStorage.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/colonyNetwork/ColonyNetworkStorage.sol:ColonyNetworkStorage",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/colonyNetwork/ColonyNetworkStorage.sol:ColonyNetworkStorage",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/common/CommonAuthority.sol:CommonAuthority.json
+++ b/.storage-layouts/contracts/common/CommonAuthority.sol:CommonAuthority.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/common/CommonAuthority.sol:CommonAuthority",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/common/CommonAuthority.sol:CommonAuthority",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 51037,
+      "astId": 50848,
       "contract": "contracts/common/CommonAuthority.sol:CommonAuthority",
       "label": "_root_users",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 51041,
+      "astId": 50852,
       "contract": "contracts/common/CommonAuthority.sol:CommonAuthority",
       "label": "_user_roles",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_mapping(t_address,t_bytes32)"
     },
     {
-      "astId": 51047,
+      "astId": 50858,
       "contract": "contracts/common/CommonAuthority.sol:CommonAuthority",
       "label": "_capability_roles",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_mapping(t_address,t_mapping(t_bytes4,t_bytes32))"
     },
     {
-      "astId": 51053,
+      "astId": 50864,
       "contract": "contracts/common/CommonAuthority.sol:CommonAuthority",
       "label": "_public_capabilities",
       "offset": 0,
@@ -78,7 +78,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/common/CommonStorage.sol:CommonStorage.json
+++ b/.storage-layouts/contracts/common/CommonStorage.sol:CommonStorage.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/common/CommonStorage.sol:CommonStorage",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/common/CommonStorage.sol:CommonStorage",
       "label": "owner",
       "offset": 0,
@@ -76,7 +76,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/common/ContractRecovery.sol:ContractRecovery.json
+++ b/.storage-layouts/contracts/common/ContractRecovery.sol:ContractRecovery.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/common/ContractRecovery.sol:ContractRecovery",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/common/ContractRecovery.sol:ContractRecovery",
       "label": "owner",
       "offset": 0,
@@ -76,7 +76,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/common/DomainRoles.sol:DomainRoles.json
+++ b/.storage-layouts/contracts/common/DomainRoles.sol:DomainRoles.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/common/DomainRoles.sol:DomainRoles",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/common/DomainRoles.sol:DomainRoles",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 51037,
+      "astId": 50848,
       "contract": "contracts/common/DomainRoles.sol:DomainRoles",
       "label": "_root_users",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 51041,
+      "astId": 50852,
       "contract": "contracts/common/DomainRoles.sol:DomainRoles",
       "label": "_user_roles",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_mapping(t_address,t_bytes32)"
     },
     {
-      "astId": 51047,
+      "astId": 50858,
       "contract": "contracts/common/DomainRoles.sol:DomainRoles",
       "label": "_capability_roles",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_mapping(t_address,t_mapping(t_bytes4,t_bytes32))"
     },
     {
-      "astId": 51053,
+      "astId": 50864,
       "contract": "contracts/common/DomainRoles.sol:DomainRoles",
       "label": "_public_capabilities",
       "offset": 0,
@@ -78,7 +78,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/common/EtherRouter.sol:EtherRouter.json
+++ b/.storage-layouts/contracts/common/EtherRouter.sol:EtherRouter.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/common/EtherRouter.sol:EtherRouter",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/common/EtherRouter.sol:EtherRouter",
       "label": "owner",
       "offset": 0,
@@ -31,7 +31,7 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/common/EtherRouterCreate3.sol:EtherRouterCreate3.json
+++ b/.storage-layouts/contracts/common/EtherRouterCreate3.sol:EtherRouterCreate3.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/common/EtherRouterCreate3.sol:EtherRouterCreate3",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/common/EtherRouterCreate3.sol:EtherRouterCreate3",
       "label": "owner",
       "offset": 0,
@@ -31,7 +31,7 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/common/Resolver.sol:Resolver.json
+++ b/.storage-layouts/contracts/common/Resolver.sol:Resolver.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/common/Resolver.sol:Resolver",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/common/Resolver.sol:Resolver",
       "label": "owner",
       "offset": 0,
@@ -36,7 +36,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/CoinMachine.sol:CoinMachine.json
+++ b/.storage-layouts/contracts/extensions/CoinMachine.sol:CoinMachine.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/CoinMachine.sol:CoinMachine",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/CoinMachine.sol:CoinMachine",
       "label": "owner",
       "offset": 0,
@@ -204,7 +204,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/ColonyExtension.sol:ColonyExtension.json
+++ b/.storage-layouts/contracts/extensions/ColonyExtension.sol:ColonyExtension.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/ColonyExtension.sol:ColonyExtension",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/ColonyExtension.sol:ColonyExtension",
       "label": "owner",
       "offset": 0,
@@ -52,7 +52,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/ColonyExtensionMeta.sol:ColonyExtensionMeta.json
+++ b/.storage-layouts/contracts/extensions/ColonyExtensionMeta.sol:ColonyExtensionMeta.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/ColonyExtensionMeta.sol:ColonyExtensionMeta",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/ColonyExtensionMeta.sol:ColonyExtensionMeta",
       "label": "owner",
       "offset": 0,
@@ -316,7 +316,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/EvaluatedExpenditure.sol:EvaluatedExpenditure.json
+++ b/.storage-layouts/contracts/extensions/EvaluatedExpenditure.sol:EvaluatedExpenditure.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/EvaluatedExpenditure.sol:EvaluatedExpenditure",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/EvaluatedExpenditure.sol:EvaluatedExpenditure",
       "label": "owner",
       "offset": 0,
@@ -60,7 +60,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/FundingQueue.sol:FundingQueue.json
+++ b/.storage-layouts/contracts/extensions/FundingQueue.sol:FundingQueue.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/FundingQueue.sol:FundingQueue",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/FundingQueue.sol:FundingQueue",
       "label": "owner",
       "offset": 0,
@@ -54,7 +54,7 @@
       "label": "tokenLocking",
       "offset": 0,
       "slot": "5",
-      "type": "t_contract(ITokenLocking)49117"
+      "type": "t_contract(ITokenLocking)48928"
     },
     {
       "astId": 24013,
@@ -116,7 +116,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -131,7 +131,7 @@
       "label": "contract IColonyNetwork",
       "numberOfBytes": "20"
     },
-    "t_contract(ITokenLocking)49117": {
+    "t_contract(ITokenLocking)48928": {
       "encoding": "inplace",
       "label": "contract ITokenLocking",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/OneTxPayment.sol:OneTxPayment.json
+++ b/.storage-layouts/contracts/extensions/OneTxPayment.sol:OneTxPayment.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/OneTxPayment.sol:OneTxPayment",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/OneTxPayment.sol:OneTxPayment",
       "label": "owner",
       "offset": 0,
@@ -60,7 +60,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/ReputationBootstrapper.sol:ReputationBootstrapper.json
+++ b/.storage-layouts/contracts/extensions/ReputationBootstrapper.sol:ReputationBootstrapper.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/ReputationBootstrapper.sol:ReputationBootstrapper",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/ReputationBootstrapper.sol:ReputationBootstrapper",
       "label": "owner",
       "offset": 0,
@@ -377,7 +377,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/StagedExpenditure.sol:StagedExpenditure.json
+++ b/.storage-layouts/contracts/extensions/StagedExpenditure.sol:StagedExpenditure.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/StagedExpenditure.sol:StagedExpenditure",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/StagedExpenditure.sol:StagedExpenditure",
       "label": "owner",
       "offset": 0,
@@ -324,7 +324,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/StakedExpenditure.sol:StakedExpenditure.json
+++ b/.storage-layouts/contracts/extensions/StakedExpenditure.sol:StakedExpenditure.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/StakedExpenditure.sol:StakedExpenditure",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/StakedExpenditure.sol:StakedExpenditure",
       "label": "owner",
       "offset": 0,
@@ -332,7 +332,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/StreamingPayments.sol:StreamingPayments.json
+++ b/.storage-layouts/contracts/extensions/StreamingPayments.sol:StreamingPayments.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
       "label": "owner",
       "offset": 0,
@@ -305,7 +305,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 28309,
+      "astId": 28330,
       "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
       "label": "numStreamingPayments",
       "offset": 0,
@@ -313,20 +313,12 @@
       "type": "t_uint256"
     },
     {
-      "astId": 28314,
+      "astId": 28335,
       "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
       "label": "streamingPayments",
       "offset": 0,
       "slot": "38",
-      "type": "t_mapping(t_uint256,t_struct(StreamingPayment)28302_storage)"
-    },
-    {
-      "astId": 28321,
-      "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
-      "label": "paymentTokens",
-      "offset": 0,
-      "slot": "39",
-      "type": "t_mapping(t_uint256,t_mapping(t_address,t_struct(PaymentToken)28307_storage))"
+      "type": "t_mapping(t_uint256,t_struct(StreamingPayment)28328_storage)"
     }
   ],
   "types": {
@@ -345,7 +337,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -355,13 +347,6 @@
       "label": "contract IColony",
       "numberOfBytes": "20"
     },
-    "t_mapping(t_address,t_struct(PaymentToken)28307_storage)": {
-      "encoding": "mapping",
-      "key": "t_address",
-      "label": "mapping(address => struct StreamingPayments.PaymentToken)",
-      "numberOfBytes": "32",
-      "value": "t_struct(PaymentToken)28307_storage"
-    },
     "t_mapping(t_address,t_uint256)": {
       "encoding": "mapping",
       "key": "t_address",
@@ -369,49 +354,19 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_mapping(t_uint256,t_mapping(t_address,t_struct(PaymentToken)28307_storage))": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => mapping(address => struct StreamingPayments.PaymentToken))",
-      "numberOfBytes": "32",
-      "value": "t_mapping(t_address,t_struct(PaymentToken)28307_storage)"
-    },
-    "t_mapping(t_uint256,t_struct(StreamingPayment)28302_storage)": {
+    "t_mapping(t_uint256,t_struct(StreamingPayment)28328_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct StreamingPayments.StreamingPayment)",
       "numberOfBytes": "32",
-      "value": "t_struct(StreamingPayment)28302_storage"
+      "value": "t_struct(StreamingPayment)28328_storage"
     },
-    "t_struct(PaymentToken)28307_storage": {
-      "encoding": "inplace",
-      "label": "struct StreamingPayments.PaymentToken",
-      "members": [
-        {
-          "astId": 28304,
-          "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
-          "label": "amount",
-          "offset": 0,
-          "slot": "0",
-          "type": "t_uint256"
-        },
-        {
-          "astId": 28306,
-          "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
-          "label": "pseudoAmountClaimedFromStart",
-          "offset": 0,
-          "slot": "1",
-          "type": "t_uint256"
-        }
-      ],
-      "numberOfBytes": "64"
-    },
-    "t_struct(StreamingPayment)28302_storage": {
+    "t_struct(StreamingPayment)28328_storage": {
       "encoding": "inplace",
       "label": "struct StreamingPayments.StreamingPayment",
       "members": [
         {
-          "astId": 28293,
+          "astId": 28313,
           "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
           "label": "recipient",
           "offset": 0,
@@ -419,7 +374,7 @@
           "type": "t_address_payable"
         },
         {
-          "astId": 28295,
+          "astId": 28315,
           "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
           "label": "domainId",
           "offset": 0,
@@ -427,7 +382,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 28297,
+          "astId": 28317,
           "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
           "label": "startTime",
           "offset": 0,
@@ -435,7 +390,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 28299,
+          "astId": 28319,
           "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
           "label": "endTime",
           "offset": 0,
@@ -443,15 +398,39 @@
           "type": "t_uint256"
         },
         {
-          "astId": 28301,
+          "astId": 28321,
           "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
           "label": "interval",
           "offset": 0,
           "slot": "4",
           "type": "t_uint256"
+        },
+        {
+          "astId": 28323,
+          "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
+          "label": "token",
+          "offset": 0,
+          "slot": "5",
+          "type": "t_address"
+        },
+        {
+          "astId": 28325,
+          "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
+          "label": "amount",
+          "offset": 0,
+          "slot": "6",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 28327,
+          "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
+          "label": "pseudoAmountClaimedFromStart",
+          "offset": 0,
+          "slot": "7",
+          "type": "t_uint256"
         }
       ],
-      "numberOfBytes": "160"
+      "numberOfBytes": "256"
     },
     "t_uint256": {
       "encoding": "inplace",

--- a/.storage-layouts/contracts/extensions/TokenSupplier.sol:TokenSupplier.json
+++ b/.storage-layouts/contracts/extensions/TokenSupplier.sol:TokenSupplier.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "owner",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 29472,
+      "astId": 29283,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "token",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_address"
     },
     {
-      "astId": 29474,
+      "astId": 29285,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "tokenSupplyCeiling",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 29476,
+      "astId": 29287,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "tokenIssuanceRate",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 29478,
+      "astId": 29289,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "lastIssue",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 29480,
+      "astId": 29291,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "lastRateUpdate",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 29484,
+      "astId": 29295,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -100,7 +100,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/Whitelist.sol:Whitelist.json
+++ b/.storage-layouts/contracts/extensions/Whitelist.sol:Whitelist.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/Whitelist.sol:Whitelist",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/Whitelist.sol:Whitelist",
       "label": "owner",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 29936,
+      "astId": 29747,
       "contract": "contracts/extensions/Whitelist.sol:Whitelist",
       "label": "useApprovals",
       "offset": 21,
@@ -49,7 +49,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 29938,
+      "astId": 29749,
       "contract": "contracts/extensions/Whitelist.sol:Whitelist",
       "label": "agreementHash",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_string_storage"
     },
     {
-      "astId": 29942,
+      "astId": 29753,
       "contract": "contracts/extensions/Whitelist.sol:Whitelist",
       "label": "approvals",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 29946,
+      "astId": 29757,
       "contract": "contracts/extensions/Whitelist.sol:Whitelist",
       "label": "signatures",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 29950,
+      "astId": 29761,
       "contract": "contracts/extensions/Whitelist.sol:Whitelist",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -92,7 +92,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation.json
+++ b/.storage-layouts/contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "owner",
       "offset": 0,
@@ -41,15 +41,15 @@
       "type": "t_bool"
     },
     {
-      "astId": 34326,
+      "astId": 34137,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "state",
       "offset": 21,
       "slot": "3",
-      "type": "t_enum(ExtensionState)32574"
+      "type": "t_enum(ExtensionState)32385"
     },
     {
-      "astId": 34329,
+      "astId": 34140,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "colonyNetwork",
       "offset": 0,
@@ -57,15 +57,15 @@
       "type": "t_contract(IColonyNetwork)20072"
     },
     {
-      "astId": 34332,
+      "astId": 34143,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "tokenLocking",
       "offset": 0,
       "slot": "5",
-      "type": "t_contract(ITokenLocking)49117"
+      "type": "t_contract(ITokenLocking)48928"
     },
     {
-      "astId": 34334,
+      "astId": 34145,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "token",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_address"
     },
     {
-      "astId": 34336,
+      "astId": 34147,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "totalStakeFraction",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34338,
+      "astId": 34149,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "voterRewardFraction",
       "offset": 0,
@@ -89,7 +89,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34340,
+      "astId": 34151,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "userMinStakeFraction",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34342,
+      "astId": 34153,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "maxVoteFraction",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34344,
+      "astId": 34155,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "stakePeriod",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34346,
+      "astId": 34157,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "submitPeriod",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34348,
+      "astId": 34159,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "revealPeriod",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34350,
+      "astId": 34161,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "escalationPeriod",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34352,
+      "astId": 34163,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "motionCount",
       "offset": 0,
@@ -145,15 +145,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34357,
+      "astId": 34168,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "motions",
       "offset": 0,
       "slot": "16",
-      "type": "t_mapping(t_uint256,t_struct(Motion)32622_storage)"
+      "type": "t_mapping(t_uint256,t_struct(Motion)32433_storage)"
     },
     {
-      "astId": 34365,
+      "astId": 34176,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "stakes",
       "offset": 0,
@@ -161,7 +161,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))"
     },
     {
-      "astId": 34371,
+      "astId": 34182,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "voteSecrets",
       "offset": 0,
@@ -169,7 +169,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_bytes32))"
     },
     {
-      "astId": 34375,
+      "astId": 34186,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "expenditurePastVotes_DEPRECATED",
       "offset": 0,
@@ -177,7 +177,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 34379,
+      "astId": 34190,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "expenditureMotionCounts_DEPRECATED",
       "offset": 0,
@@ -185,7 +185,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 34383,
+      "astId": 34194,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -193,7 +193,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 34387,
+      "astId": 34198,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "expenditurePastVotes",
       "offset": 0,
@@ -201,7 +201,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 34391,
+      "astId": 34202,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "expenditureMotionLocks",
       "offset": 0,
@@ -209,7 +209,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 34393,
+      "astId": 34204,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "motionCountV10",
       "offset": 0,
@@ -255,7 +255,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -270,12 +270,12 @@
       "label": "contract IColonyNetwork",
       "numberOfBytes": "20"
     },
-    "t_contract(ITokenLocking)49117": {
+    "t_contract(ITokenLocking)48928": {
       "encoding": "inplace",
       "label": "contract ITokenLocking",
       "numberOfBytes": "20"
     },
-    "t_enum(ExtensionState)32574": {
+    "t_enum(ExtensionState)32385": {
       "encoding": "inplace",
       "label": "enum VotingReputationDataTypes.ExtensionState",
       "numberOfBytes": "1"
@@ -322,12 +322,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))"
     },
-    "t_mapping(t_uint256,t_struct(Motion)32622_storage)": {
+    "t_mapping(t_uint256,t_struct(Motion)32433_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct VotingReputationDataTypes.Motion)",
       "numberOfBytes": "32",
-      "value": "t_struct(Motion)32622_storage"
+      "value": "t_struct(Motion)32433_storage"
     },
     "t_mapping(t_uint256,t_uint256)": {
       "encoding": "mapping",
@@ -336,12 +336,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(Motion)32622_storage": {
+    "t_struct(Motion)32433_storage": {
       "encoding": "inplace",
       "label": "struct VotingReputationDataTypes.Motion",
       "members": [
         {
-          "astId": 32587,
+          "astId": 32398,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "events",
           "offset": 0,
@@ -349,7 +349,7 @@
           "type": "t_array(t_uint64)3_storage"
         },
         {
-          "astId": 32589,
+          "astId": 32400,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "rootHash",
           "offset": 0,
@@ -357,7 +357,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 32591,
+          "astId": 32402,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "domainId",
           "offset": 0,
@@ -365,7 +365,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32593,
+          "astId": 32404,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "skillId",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32595,
+          "astId": 32406,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "skillRep",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32597,
+          "astId": 32408,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "repSubmitted",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32599,
+          "astId": 32410,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "paidVoterComp",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32603,
+          "astId": 32414,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "pastVoterComp",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32607,
+          "astId": 32418,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "stakes",
           "offset": 0,
@@ -413,7 +413,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32611,
+          "astId": 32422,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "votes",
           "offset": 0,
@@ -421,7 +421,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32613,
+          "astId": 32424,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "escalated",
           "offset": 0,
@@ -429,7 +429,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32615,
+          "astId": 32426,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "finalized",
           "offset": 1,
@@ -437,7 +437,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32617,
+          "astId": 32428,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "altTarget",
           "offset": 2,
@@ -445,7 +445,7 @@
           "type": "t_address"
         },
         {
-          "astId": 32619,
+          "astId": 32430,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "sig",
           "offset": 22,
@@ -453,7 +453,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 32621,
+          "astId": 32432,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "action",
           "offset": 0,

--- a/.storage-layouts/contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery.json
+++ b/.storage-layouts/contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 32732,
+      "astId": 32543,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 32735,
+      "astId": 32546,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "colony",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_contract(IColony)12697"
     },
     {
-      "astId": 32737,
+      "astId": 32548,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_deprecated",
       "offset": 20,
@@ -41,15 +41,15 @@
       "type": "t_bool"
     },
     {
-      "astId": 32740,
+      "astId": 32551,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_state",
       "offset": 21,
       "slot": "3",
-      "type": "t_enum(ExtensionState)32574"
+      "type": "t_enum(ExtensionState)32385"
     },
     {
-      "astId": 32743,
+      "astId": 32554,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "colonyNetwork",
       "offset": 0,
@@ -57,15 +57,15 @@
       "type": "t_contract(IColonyNetwork)20072"
     },
     {
-      "astId": 32746,
+      "astId": 32557,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "tokenLocking",
       "offset": 0,
       "slot": "5",
-      "type": "t_contract(ITokenLocking)49117"
+      "type": "t_contract(ITokenLocking)48928"
     },
     {
-      "astId": 32748,
+      "astId": 32559,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "token",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_address"
     },
     {
-      "astId": 32750,
+      "astId": 32561,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "totalStakeFraction",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32752,
+      "astId": 32563,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_voterRewardFraction",
       "offset": 0,
@@ -89,7 +89,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32754,
+      "astId": 32565,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_userMinStakeFraction",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32756,
+      "astId": 32567,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_maxVoteFraction",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32758,
+      "astId": 32569,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_stakePeriod",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32760,
+      "astId": 32571,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_submitPeriod",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32762,
+      "astId": 32573,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_revealPeriod",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32764,
+      "astId": 32575,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_escalationPeriod",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32768,
+      "astId": 32579,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_metatransactionNonces",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 32770,
+      "astId": 32581,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_motionCount",
       "offset": 0,
@@ -153,15 +153,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32775,
+      "astId": 32586,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "motions",
       "offset": 0,
       "slot": "17",
-      "type": "t_mapping(t_uint256,t_struct(Motion)32622_storage)"
+      "type": "t_mapping(t_uint256,t_struct(Motion)32433_storage)"
     },
     {
-      "astId": 32783,
+      "astId": 32594,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "stakes",
       "offset": 0,
@@ -169,7 +169,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))"
     },
     {
-      "astId": 32789,
+      "astId": 32600,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_voteSecrets",
       "offset": 0,
@@ -177,7 +177,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_bytes32))"
     },
     {
-      "astId": 32793,
+      "astId": 32604,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_expenditurePastVotes",
       "offset": 0,
@@ -185,7 +185,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 32797,
+      "astId": 32608,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_expenditureMotionCounts",
       "offset": 0,
@@ -231,7 +231,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -246,12 +246,12 @@
       "label": "contract IColonyNetwork",
       "numberOfBytes": "20"
     },
-    "t_contract(ITokenLocking)49117": {
+    "t_contract(ITokenLocking)48928": {
       "encoding": "inplace",
       "label": "contract ITokenLocking",
       "numberOfBytes": "20"
     },
-    "t_enum(ExtensionState)32574": {
+    "t_enum(ExtensionState)32385": {
       "encoding": "inplace",
       "label": "enum VotingReputationDataTypes.ExtensionState",
       "numberOfBytes": "1"
@@ -298,12 +298,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))"
     },
-    "t_mapping(t_uint256,t_struct(Motion)32622_storage)": {
+    "t_mapping(t_uint256,t_struct(Motion)32433_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct VotingReputationDataTypes.Motion)",
       "numberOfBytes": "32",
-      "value": "t_struct(Motion)32622_storage"
+      "value": "t_struct(Motion)32433_storage"
     },
     "t_mapping(t_uint256,t_uint256)": {
       "encoding": "mapping",
@@ -312,12 +312,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(Motion)32622_storage": {
+    "t_struct(Motion)32433_storage": {
       "encoding": "inplace",
       "label": "struct VotingReputationDataTypes.Motion",
       "members": [
         {
-          "astId": 32587,
+          "astId": 32398,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "events",
           "offset": 0,
@@ -325,7 +325,7 @@
           "type": "t_array(t_uint64)3_storage"
         },
         {
-          "astId": 32589,
+          "astId": 32400,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "rootHash",
           "offset": 0,
@@ -333,7 +333,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 32591,
+          "astId": 32402,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "domainId",
           "offset": 0,
@@ -341,7 +341,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32593,
+          "astId": 32404,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "skillId",
           "offset": 0,
@@ -349,7 +349,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32595,
+          "astId": 32406,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "skillRep",
           "offset": 0,
@@ -357,7 +357,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32597,
+          "astId": 32408,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "repSubmitted",
           "offset": 0,
@@ -365,7 +365,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32599,
+          "astId": 32410,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "paidVoterComp",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32603,
+          "astId": 32414,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "pastVoterComp",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32607,
+          "astId": 32418,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "stakes",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32611,
+          "astId": 32422,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "votes",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32613,
+          "astId": 32424,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "escalated",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32615,
+          "astId": 32426,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "finalized",
           "offset": 1,
@@ -413,7 +413,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32617,
+          "astId": 32428,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "altTarget",
           "offset": 2,
@@ -421,7 +421,7 @@
           "type": "t_address"
         },
         {
-          "astId": 32619,
+          "astId": 32430,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "sig",
           "offset": 22,
@@ -429,7 +429,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 32621,
+          "astId": 32432,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "action",
           "offset": 0,

--- a/.storage-layouts/contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking.json
+++ b/.storage-layouts/contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "owner",
       "offset": 0,
@@ -41,15 +41,15 @@
       "type": "t_bool"
     },
     {
-      "astId": 34326,
+      "astId": 34137,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "state",
       "offset": 21,
       "slot": "3",
-      "type": "t_enum(ExtensionState)32574"
+      "type": "t_enum(ExtensionState)32385"
     },
     {
-      "astId": 34329,
+      "astId": 34140,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "colonyNetwork",
       "offset": 0,
@@ -57,15 +57,15 @@
       "type": "t_contract(IColonyNetwork)20072"
     },
     {
-      "astId": 34332,
+      "astId": 34143,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "tokenLocking",
       "offset": 0,
       "slot": "5",
-      "type": "t_contract(ITokenLocking)49117"
+      "type": "t_contract(ITokenLocking)48928"
     },
     {
-      "astId": 34334,
+      "astId": 34145,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "token",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_address"
     },
     {
-      "astId": 34336,
+      "astId": 34147,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "totalStakeFraction",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34338,
+      "astId": 34149,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "voterRewardFraction",
       "offset": 0,
@@ -89,7 +89,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34340,
+      "astId": 34151,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "userMinStakeFraction",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34342,
+      "astId": 34153,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "maxVoteFraction",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34344,
+      "astId": 34155,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "stakePeriod",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34346,
+      "astId": 34157,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "submitPeriod",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34348,
+      "astId": 34159,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "revealPeriod",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34350,
+      "astId": 34161,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "escalationPeriod",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34352,
+      "astId": 34163,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "motionCount",
       "offset": 0,
@@ -145,15 +145,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34357,
+      "astId": 34168,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "motions",
       "offset": 0,
       "slot": "16",
-      "type": "t_mapping(t_uint256,t_struct(Motion)32622_storage)"
+      "type": "t_mapping(t_uint256,t_struct(Motion)32433_storage)"
     },
     {
-      "astId": 34365,
+      "astId": 34176,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "stakes",
       "offset": 0,
@@ -161,7 +161,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))"
     },
     {
-      "astId": 34371,
+      "astId": 34182,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "voteSecrets",
       "offset": 0,
@@ -169,7 +169,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_bytes32))"
     },
     {
-      "astId": 34375,
+      "astId": 34186,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "expenditurePastVotes_DEPRECATED",
       "offset": 0,
@@ -177,7 +177,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 34379,
+      "astId": 34190,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "expenditureMotionCounts_DEPRECATED",
       "offset": 0,
@@ -185,7 +185,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 34383,
+      "astId": 34194,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -193,7 +193,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 34387,
+      "astId": 34198,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "expenditurePastVotes",
       "offset": 0,
@@ -201,7 +201,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 34391,
+      "astId": 34202,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "expenditureMotionLocks",
       "offset": 0,
@@ -209,7 +209,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 34393,
+      "astId": 34204,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "motionCountV10",
       "offset": 0,
@@ -255,7 +255,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -270,12 +270,12 @@
       "label": "contract IColonyNetwork",
       "numberOfBytes": "20"
     },
-    "t_contract(ITokenLocking)49117": {
+    "t_contract(ITokenLocking)48928": {
       "encoding": "inplace",
       "label": "contract ITokenLocking",
       "numberOfBytes": "20"
     },
-    "t_enum(ExtensionState)32574": {
+    "t_enum(ExtensionState)32385": {
       "encoding": "inplace",
       "label": "enum VotingReputationDataTypes.ExtensionState",
       "numberOfBytes": "1"
@@ -322,12 +322,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))"
     },
-    "t_mapping(t_uint256,t_struct(Motion)32622_storage)": {
+    "t_mapping(t_uint256,t_struct(Motion)32433_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct VotingReputationDataTypes.Motion)",
       "numberOfBytes": "32",
-      "value": "t_struct(Motion)32622_storage"
+      "value": "t_struct(Motion)32433_storage"
     },
     "t_mapping(t_uint256,t_uint256)": {
       "encoding": "mapping",
@@ -336,12 +336,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(Motion)32622_storage": {
+    "t_struct(Motion)32433_storage": {
       "encoding": "inplace",
       "label": "struct VotingReputationDataTypes.Motion",
       "members": [
         {
-          "astId": 32587,
+          "astId": 32398,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "events",
           "offset": 0,
@@ -349,7 +349,7 @@
           "type": "t_array(t_uint64)3_storage"
         },
         {
-          "astId": 32589,
+          "astId": 32400,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "rootHash",
           "offset": 0,
@@ -357,7 +357,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 32591,
+          "astId": 32402,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "domainId",
           "offset": 0,
@@ -365,7 +365,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32593,
+          "astId": 32404,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "skillId",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32595,
+          "astId": 32406,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "skillRep",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32597,
+          "astId": 32408,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "repSubmitted",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32599,
+          "astId": 32410,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "paidVoterComp",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32603,
+          "astId": 32414,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "pastVoterComp",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32607,
+          "astId": 32418,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "stakes",
           "offset": 0,
@@ -413,7 +413,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32611,
+          "astId": 32422,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "votes",
           "offset": 0,
@@ -421,7 +421,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32613,
+          "astId": 32424,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "escalated",
           "offset": 0,
@@ -429,7 +429,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32615,
+          "astId": 32426,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "finalized",
           "offset": 1,
@@ -437,7 +437,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32617,
+          "astId": 32428,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "altTarget",
           "offset": 2,
@@ -445,7 +445,7 @@
           "type": "t_address"
         },
         {
-          "astId": 32619,
+          "astId": 32430,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "sig",
           "offset": 22,
@@ -453,7 +453,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 32621,
+          "astId": 32432,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "action",
           "offset": 0,

--- a/.storage-layouts/contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage.json
+++ b/.storage-layouts/contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "owner",
       "offset": 0,
@@ -41,15 +41,15 @@
       "type": "t_bool"
     },
     {
-      "astId": 34326,
+      "astId": 34137,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "state",
       "offset": 21,
       "slot": "3",
-      "type": "t_enum(ExtensionState)32574"
+      "type": "t_enum(ExtensionState)32385"
     },
     {
-      "astId": 34329,
+      "astId": 34140,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "colonyNetwork",
       "offset": 0,
@@ -57,15 +57,15 @@
       "type": "t_contract(IColonyNetwork)20072"
     },
     {
-      "astId": 34332,
+      "astId": 34143,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "tokenLocking",
       "offset": 0,
       "slot": "5",
-      "type": "t_contract(ITokenLocking)49117"
+      "type": "t_contract(ITokenLocking)48928"
     },
     {
-      "astId": 34334,
+      "astId": 34145,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "token",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_address"
     },
     {
-      "astId": 34336,
+      "astId": 34147,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "totalStakeFraction",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34338,
+      "astId": 34149,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "voterRewardFraction",
       "offset": 0,
@@ -89,7 +89,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34340,
+      "astId": 34151,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "userMinStakeFraction",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34342,
+      "astId": 34153,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "maxVoteFraction",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34344,
+      "astId": 34155,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "stakePeriod",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34346,
+      "astId": 34157,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "submitPeriod",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34348,
+      "astId": 34159,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "revealPeriod",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34350,
+      "astId": 34161,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "escalationPeriod",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34352,
+      "astId": 34163,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "motionCount",
       "offset": 0,
@@ -145,15 +145,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34357,
+      "astId": 34168,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "motions",
       "offset": 0,
       "slot": "16",
-      "type": "t_mapping(t_uint256,t_struct(Motion)32622_storage)"
+      "type": "t_mapping(t_uint256,t_struct(Motion)32433_storage)"
     },
     {
-      "astId": 34365,
+      "astId": 34176,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "stakes",
       "offset": 0,
@@ -161,7 +161,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))"
     },
     {
-      "astId": 34371,
+      "astId": 34182,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "voteSecrets",
       "offset": 0,
@@ -169,7 +169,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_bytes32))"
     },
     {
-      "astId": 34375,
+      "astId": 34186,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "expenditurePastVotes_DEPRECATED",
       "offset": 0,
@@ -177,7 +177,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 34379,
+      "astId": 34190,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "expenditureMotionCounts_DEPRECATED",
       "offset": 0,
@@ -185,7 +185,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 34383,
+      "astId": 34194,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -193,7 +193,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 34387,
+      "astId": 34198,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "expenditurePastVotes",
       "offset": 0,
@@ -201,7 +201,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 34391,
+      "astId": 34202,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "expenditureMotionLocks",
       "offset": 0,
@@ -209,7 +209,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 34393,
+      "astId": 34204,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "motionCountV10",
       "offset": 0,
@@ -255,7 +255,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -270,12 +270,12 @@
       "label": "contract IColonyNetwork",
       "numberOfBytes": "20"
     },
-    "t_contract(ITokenLocking)49117": {
+    "t_contract(ITokenLocking)48928": {
       "encoding": "inplace",
       "label": "contract ITokenLocking",
       "numberOfBytes": "20"
     },
-    "t_enum(ExtensionState)32574": {
+    "t_enum(ExtensionState)32385": {
       "encoding": "inplace",
       "label": "enum VotingReputationDataTypes.ExtensionState",
       "numberOfBytes": "1"
@@ -322,12 +322,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))"
     },
-    "t_mapping(t_uint256,t_struct(Motion)32622_storage)": {
+    "t_mapping(t_uint256,t_struct(Motion)32433_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct VotingReputationDataTypes.Motion)",
       "numberOfBytes": "32",
-      "value": "t_struct(Motion)32622_storage"
+      "value": "t_struct(Motion)32433_storage"
     },
     "t_mapping(t_uint256,t_uint256)": {
       "encoding": "mapping",
@@ -336,12 +336,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(Motion)32622_storage": {
+    "t_struct(Motion)32433_storage": {
       "encoding": "inplace",
       "label": "struct VotingReputationDataTypes.Motion",
       "members": [
         {
-          "astId": 32587,
+          "astId": 32398,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "events",
           "offset": 0,
@@ -349,7 +349,7 @@
           "type": "t_array(t_uint64)3_storage"
         },
         {
-          "astId": 32589,
+          "astId": 32400,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "rootHash",
           "offset": 0,
@@ -357,7 +357,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 32591,
+          "astId": 32402,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "domainId",
           "offset": 0,
@@ -365,7 +365,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32593,
+          "astId": 32404,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "skillId",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32595,
+          "astId": 32406,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "skillRep",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32597,
+          "astId": 32408,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "repSubmitted",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32599,
+          "astId": 32410,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "paidVoterComp",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32603,
+          "astId": 32414,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "pastVoterComp",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32607,
+          "astId": 32418,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "stakes",
           "offset": 0,
@@ -413,7 +413,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32611,
+          "astId": 32422,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "votes",
           "offset": 0,
@@ -421,7 +421,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32613,
+          "astId": 32424,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "escalated",
           "offset": 0,
@@ -429,7 +429,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32615,
+          "astId": 32426,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "finalized",
           "offset": 1,
@@ -437,7 +437,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32617,
+          "astId": 32428,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "altTarget",
           "offset": 2,
@@ -445,7 +445,7 @@
           "type": "t_address"
         },
         {
-          "astId": 32619,
+          "astId": 32430,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "sig",
           "offset": 22,
@@ -453,7 +453,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 32621,
+          "astId": 32432,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "action",
           "offset": 0,

--- a/.storage-layouts/contracts/metaTxToken/DSAuthMeta.sol:DSAuthMeta.json
+++ b/.storage-layouts/contracts/metaTxToken/DSAuthMeta.sol:DSAuthMeta.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 35468,
+      "astId": 35279,
       "contract": "contracts/metaTxToken/DSAuthMeta.sol:DSAuthMeta",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 35470,
+      "astId": 35281,
       "contract": "contracts/metaTxToken/DSAuthMeta.sol:DSAuthMeta",
       "label": "owner",
       "offset": 0,
@@ -23,7 +23,7 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/metaTxToken/MetaTxToken.sol:MetaTxToken.json
+++ b/.storage-layouts/contracts/metaTxToken/MetaTxToken.sol:MetaTxToken.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 35601,
+      "astId": 35412,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "_supply",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 35605,
+      "astId": 35416,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "_balances",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 35611,
+      "astId": 35422,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "_approvals",
       "offset": 0,
@@ -25,15 +25,15 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
     },
     {
-      "astId": 35468,
+      "astId": 35279,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "authority",
       "offset": 0,
       "slot": "3",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 35470,
+      "astId": 35281,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "owner",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_address"
     },
     {
-      "astId": 35799,
+      "astId": 35610,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "symbol",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_string_storage"
     },
     {
-      "astId": 35801,
+      "astId": 35612,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "name",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_string_storage"
     },
     {
-      "astId": 35803,
+      "astId": 35614,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "locked",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 35809,
+      "astId": 35620,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -84,7 +84,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/patriciaTree/PatriciaTree.sol:PatriciaTree.json
+++ b/.storage-layouts/contracts/patriciaTree/PatriciaTree.sol:PatriciaTree.json
@@ -1,17 +1,17 @@
 {
   "storage": [
     {
-      "astId": 37226,
+      "astId": 37037,
       "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
       "label": "tree",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(Tree)36335_storage"
+      "type": "t_struct(Tree)36146_storage"
     }
   ],
   "types": {
-    "t_array(t_struct(Edge)36318_storage)2_storage": {
-      "base": "t_struct(Edge)36318_storage",
+    "t_array(t_struct(Edge)36129_storage)2_storage": {
+      "base": "t_struct(Edge)36129_storage",
       "encoding": "inplace",
       "label": "struct Data.Edge[2]",
       "numberOfBytes": "192"
@@ -21,19 +21,19 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_mapping(t_bytes32,t_struct(Node)36324_storage)": {
+    "t_mapping(t_bytes32,t_struct(Node)36135_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Data.Node)",
       "numberOfBytes": "32",
-      "value": "t_struct(Node)36324_storage"
+      "value": "t_struct(Node)36135_storage"
     },
-    "t_struct(Edge)36318_storage": {
+    "t_struct(Edge)36129_storage": {
       "encoding": "inplace",
       "label": "struct Data.Edge",
       "members": [
         {
-          "astId": 36314,
+          "astId": 36125,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "node",
           "offset": 0,
@@ -41,22 +41,22 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36317,
+          "astId": 36128,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "label",
           "offset": 0,
           "slot": "1",
-          "type": "t_struct(Label)36312_storage"
+          "type": "t_struct(Label)36123_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(Label)36312_storage": {
+    "t_struct(Label)36123_storage": {
       "encoding": "inplace",
       "label": "struct Data.Label",
       "members": [
         {
-          "astId": 36309,
+          "astId": 36120,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "data",
           "offset": 0,
@@ -64,7 +64,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36311,
+          "astId": 36122,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "length",
           "offset": 0,
@@ -74,27 +74,27 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Node)36324_storage": {
+    "t_struct(Node)36135_storage": {
       "encoding": "inplace",
       "label": "struct Data.Node",
       "members": [
         {
-          "astId": 36323,
+          "astId": 36134,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "children",
           "offset": 0,
           "slot": "0",
-          "type": "t_array(t_struct(Edge)36318_storage)2_storage"
+          "type": "t_array(t_struct(Edge)36129_storage)2_storage"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(Tree)36335_storage": {
+    "t_struct(Tree)36146_storage": {
       "encoding": "inplace",
       "label": "struct Data.Tree",
       "members": [
         {
-          "astId": 36326,
+          "astId": 36137,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "root",
           "offset": 0,
@@ -102,20 +102,20 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36329,
+          "astId": 36140,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "rootEdge",
           "offset": 0,
           "slot": "1",
-          "type": "t_struct(Edge)36318_storage"
+          "type": "t_struct(Edge)36129_storage"
         },
         {
-          "astId": 36334,
+          "astId": 36145,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "nodes",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_bytes32,t_struct(Node)36324_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Node)36135_storage)"
         }
       ],
       "numberOfBytes": "160"

--- a/.storage-layouts/contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase.json
+++ b/.storage-layouts/contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase.json
@@ -1,17 +1,17 @@
 {
   "storage": [
     {
-      "astId": 37226,
+      "astId": 37037,
       "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
       "label": "tree",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(Tree)36335_storage"
+      "type": "t_struct(Tree)36146_storage"
     }
   ],
   "types": {
-    "t_array(t_struct(Edge)36318_storage)2_storage": {
-      "base": "t_struct(Edge)36318_storage",
+    "t_array(t_struct(Edge)36129_storage)2_storage": {
+      "base": "t_struct(Edge)36129_storage",
       "encoding": "inplace",
       "label": "struct Data.Edge[2]",
       "numberOfBytes": "192"
@@ -21,19 +21,19 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_mapping(t_bytes32,t_struct(Node)36324_storage)": {
+    "t_mapping(t_bytes32,t_struct(Node)36135_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Data.Node)",
       "numberOfBytes": "32",
-      "value": "t_struct(Node)36324_storage"
+      "value": "t_struct(Node)36135_storage"
     },
-    "t_struct(Edge)36318_storage": {
+    "t_struct(Edge)36129_storage": {
       "encoding": "inplace",
       "label": "struct Data.Edge",
       "members": [
         {
-          "astId": 36314,
+          "astId": 36125,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "node",
           "offset": 0,
@@ -41,22 +41,22 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36317,
+          "astId": 36128,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "label",
           "offset": 0,
           "slot": "1",
-          "type": "t_struct(Label)36312_storage"
+          "type": "t_struct(Label)36123_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(Label)36312_storage": {
+    "t_struct(Label)36123_storage": {
       "encoding": "inplace",
       "label": "struct Data.Label",
       "members": [
         {
-          "astId": 36309,
+          "astId": 36120,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "data",
           "offset": 0,
@@ -64,7 +64,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36311,
+          "astId": 36122,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "length",
           "offset": 0,
@@ -74,27 +74,27 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Node)36324_storage": {
+    "t_struct(Node)36135_storage": {
       "encoding": "inplace",
       "label": "struct Data.Node",
       "members": [
         {
-          "astId": 36323,
+          "astId": 36134,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "children",
           "offset": 0,
           "slot": "0",
-          "type": "t_array(t_struct(Edge)36318_storage)2_storage"
+          "type": "t_array(t_struct(Edge)36129_storage)2_storage"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(Tree)36335_storage": {
+    "t_struct(Tree)36146_storage": {
       "encoding": "inplace",
       "label": "struct Data.Tree",
       "members": [
         {
-          "astId": 36326,
+          "astId": 36137,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "root",
           "offset": 0,
@@ -102,20 +102,20 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36329,
+          "astId": 36140,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "rootEdge",
           "offset": 0,
           "slot": "1",
-          "type": "t_struct(Edge)36318_storage"
+          "type": "t_struct(Edge)36129_storage"
         },
         {
-          "astId": 36334,
+          "astId": 36145,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "nodes",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_bytes32,t_struct(Node)36324_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Node)36135_storage)"
         }
       ],
       "numberOfBytes": "160"

--- a/.storage-layouts/contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash.json
+++ b/.storage-layouts/contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash.json
@@ -1,17 +1,17 @@
 {
   "storage": [
     {
-      "astId": 37226,
+      "astId": 37037,
       "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
       "label": "tree",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(Tree)36335_storage"
+      "type": "t_struct(Tree)36146_storage"
     }
   ],
   "types": {
-    "t_array(t_struct(Edge)36318_storage)2_storage": {
-      "base": "t_struct(Edge)36318_storage",
+    "t_array(t_struct(Edge)36129_storage)2_storage": {
+      "base": "t_struct(Edge)36129_storage",
       "encoding": "inplace",
       "label": "struct Data.Edge[2]",
       "numberOfBytes": "192"
@@ -21,19 +21,19 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_mapping(t_bytes32,t_struct(Node)36324_storage)": {
+    "t_mapping(t_bytes32,t_struct(Node)36135_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Data.Node)",
       "numberOfBytes": "32",
-      "value": "t_struct(Node)36324_storage"
+      "value": "t_struct(Node)36135_storage"
     },
-    "t_struct(Edge)36318_storage": {
+    "t_struct(Edge)36129_storage": {
       "encoding": "inplace",
       "label": "struct Data.Edge",
       "members": [
         {
-          "astId": 36314,
+          "astId": 36125,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "node",
           "offset": 0,
@@ -41,22 +41,22 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36317,
+          "astId": 36128,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "label",
           "offset": 0,
           "slot": "1",
-          "type": "t_struct(Label)36312_storage"
+          "type": "t_struct(Label)36123_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(Label)36312_storage": {
+    "t_struct(Label)36123_storage": {
       "encoding": "inplace",
       "label": "struct Data.Label",
       "members": [
         {
-          "astId": 36309,
+          "astId": 36120,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "data",
           "offset": 0,
@@ -64,7 +64,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36311,
+          "astId": 36122,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "length",
           "offset": 0,
@@ -74,27 +74,27 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Node)36324_storage": {
+    "t_struct(Node)36135_storage": {
       "encoding": "inplace",
       "label": "struct Data.Node",
       "members": [
         {
-          "astId": 36323,
+          "astId": 36134,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "children",
           "offset": 0,
           "slot": "0",
-          "type": "t_array(t_struct(Edge)36318_storage)2_storage"
+          "type": "t_array(t_struct(Edge)36129_storage)2_storage"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(Tree)36335_storage": {
+    "t_struct(Tree)36146_storage": {
       "encoding": "inplace",
       "label": "struct Data.Tree",
       "members": [
         {
-          "astId": 36326,
+          "astId": 36137,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "root",
           "offset": 0,
@@ -102,20 +102,20 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36329,
+          "astId": 36140,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "rootEdge",
           "offset": 0,
           "slot": "1",
-          "type": "t_struct(Edge)36318_storage"
+          "type": "t_struct(Edge)36129_storage"
         },
         {
-          "astId": 36334,
+          "astId": 36145,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "nodes",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_bytes32,t_struct(Node)36324_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Node)36135_storage)"
         }
       ],
       "numberOfBytes": "160"

--- a/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle.json
+++ b/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43844,
+      "astId": 43655,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43846,
+      "astId": 43657,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "colonyNetworkAddress",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_address_payable"
     },
     {
-      "astId": 43848,
+      "astId": 43659,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "tokenLockingAddress",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43850,
+      "astId": 43661,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "clnyTokenAddress",
       "offset": 0,
@@ -49,15 +49,15 @@
       "type": "t_address"
     },
     {
-      "astId": 43854,
+      "astId": 43665,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "reputationUpdateLog",
       "offset": 0,
       "slot": "6",
-      "type": "t_array(t_struct(ReputationLogEntry)41361_storage)dyn_storage"
+      "type": "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage"
     },
     {
-      "astId": 43863,
+      "astId": 43674,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "submittedHashes",
       "offset": 0,
@@ -65,15 +65,15 @@
       "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage)))"
     },
     {
-      "astId": 43868,
+      "astId": 43679,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "reputationHashSubmissions",
       "offset": 0,
       "slot": "8",
-      "type": "t_mapping(t_address,t_struct(Submission)41370_storage)"
+      "type": "t_mapping(t_address,t_struct(Submission)41181_storage)"
     },
     {
-      "astId": 43870,
+      "astId": 43681,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "reputationMiningWindowOpenTimestamp",
       "offset": 0,
@@ -81,15 +81,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43876,
+      "astId": 43687,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "disputeRounds",
       "offset": 0,
       "slot": "10",
-      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41391_storage)dyn_storage)"
+      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)"
     },
     {
-      "astId": 43880,
+      "astId": 43691,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "nHashesCompletedChallengeRound",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 43883,
+      "astId": 43694,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "nUniqueSubmittedHashes",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43886,
+      "astId": 43697,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "nInvalidatedHashes",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43892,
+      "astId": 43703,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "submittedEntries",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 43911,
+      "astId": 43722,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "firstIncompleteRound",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43915,
+      "astId": 43726,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "respondedToChallenge",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 43917,
+      "astId": 43728,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "stakeLost",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43919,
+      "astId": 43730,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "rewardsPaidOut",
       "offset": 0,
@@ -153,7 +153,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43921,
+      "astId": 43732,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "cachedDisputeRewardSize",
       "offset": 0,
@@ -178,14 +178,14 @@
       "label": "address[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(DisputedEntry)41391_storage)dyn_storage": {
-      "base": "t_struct(DisputedEntry)41391_storage",
+    "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage": {
+      "base": "t_struct(DisputedEntry)41202_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ReputationLogEntry)41361_storage)dyn_storage": {
-      "base": "t_struct(ReputationLogEntry)41361_storage",
+    "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage": {
+      "base": "t_struct(ReputationLogEntry)41172_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry[]",
       "numberOfBytes": "32"
@@ -200,7 +200,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -224,12 +224,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_bool)"
     },
-    "t_mapping(t_address,t_struct(Submission)41370_storage)": {
+    "t_mapping(t_address,t_struct(Submission)41181_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ReputationMiningCycleDataTypes.Submission)",
       "numberOfBytes": "32",
-      "value": "t_struct(Submission)41370_storage"
+      "value": "t_struct(Submission)41181_storage"
     },
     "t_mapping(t_bytes32,t_array(t_address)dyn_storage)": {
       "encoding": "mapping",
@@ -245,12 +245,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage))"
     },
-    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41391_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ReputationMiningCycleDataTypes.DisputedEntry[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(DisputedEntry)41391_storage)dyn_storage"
+      "value": "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage"
     },
     "t_mapping(t_uint256,t_bool)": {
       "encoding": "mapping",
@@ -273,12 +273,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(DisputedEntry)41391_storage": {
+    "t_struct(DisputedEntry)41202_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry",
       "members": [
         {
-          "astId": 41372,
+          "astId": 41183,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "firstSubmitter",
           "offset": 0,
@@ -286,7 +286,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41374,
+          "astId": 41185,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "lastResponseTimestamp",
           "offset": 0,
@@ -294,7 +294,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41376,
+          "astId": 41187,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "challengeStepCompleted",
           "offset": 0,
@@ -302,7 +302,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41378,
+          "astId": 41189,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "intermediateReputationHash",
           "offset": 0,
@@ -310,7 +310,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41380,
+          "astId": 41191,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "intermediateReputationNLeaves",
           "offset": 0,
@@ -318,7 +318,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41382,
+          "astId": 41193,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "lowerBound",
           "offset": 0,
@@ -326,7 +326,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41384,
+          "astId": 41195,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "upperBound",
           "offset": 0,
@@ -334,7 +334,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41386,
+          "astId": 41197,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "targetHashDuringSearch",
           "offset": 0,
@@ -342,7 +342,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41388,
+          "astId": 41199,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "hash1",
           "offset": 0,
@@ -350,7 +350,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41390,
+          "astId": 41201,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "hash2",
           "offset": 0,
@@ -360,12 +360,12 @@
       ],
       "numberOfBytes": "320"
     },
-    "t_struct(ReputationLogEntry)41361_storage": {
+    "t_struct(ReputationLogEntry)41172_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry",
       "members": [
         {
-          "astId": 41350,
+          "astId": 41161,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "user",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41352,
+          "astId": 41163,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "amount",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_int256"
         },
         {
-          "astId": 41354,
+          "astId": 41165,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "skillId",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41356,
+          "astId": 41167,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "colony",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41358,
+          "astId": 41169,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "nUpdates",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_uint128"
         },
         {
-          "astId": 41360,
+          "astId": 41171,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "nPreviousUpdates",
           "offset": 16,
@@ -415,12 +415,12 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(Submission)41370_storage": {
+    "t_struct(Submission)41181_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.Submission",
       "members": [
         {
-          "astId": 41363,
+          "astId": 41174,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "proposedNewRootHash",
           "offset": 0,
@@ -428,7 +428,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41365,
+          "astId": 41176,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "nLeaves",
           "offset": 0,
@@ -436,7 +436,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41367,
+          "astId": 41178,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "jrh",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41369,
+          "astId": 41180,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "jrhNLeaves",
           "offset": 0,

--- a/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch.json
+++ b/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43844,
+      "astId": 43655,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43846,
+      "astId": 43657,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "colonyNetworkAddress",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_address_payable"
     },
     {
-      "astId": 43848,
+      "astId": 43659,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "tokenLockingAddress",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43850,
+      "astId": 43661,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "clnyTokenAddress",
       "offset": 0,
@@ -49,15 +49,15 @@
       "type": "t_address"
     },
     {
-      "astId": 43854,
+      "astId": 43665,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "reputationUpdateLog",
       "offset": 0,
       "slot": "6",
-      "type": "t_array(t_struct(ReputationLogEntry)41361_storage)dyn_storage"
+      "type": "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage"
     },
     {
-      "astId": 43863,
+      "astId": 43674,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "submittedHashes",
       "offset": 0,
@@ -65,15 +65,15 @@
       "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage)))"
     },
     {
-      "astId": 43868,
+      "astId": 43679,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "reputationHashSubmissions",
       "offset": 0,
       "slot": "8",
-      "type": "t_mapping(t_address,t_struct(Submission)41370_storage)"
+      "type": "t_mapping(t_address,t_struct(Submission)41181_storage)"
     },
     {
-      "astId": 43870,
+      "astId": 43681,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "reputationMiningWindowOpenTimestamp",
       "offset": 0,
@@ -81,15 +81,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43876,
+      "astId": 43687,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "disputeRounds",
       "offset": 0,
       "slot": "10",
-      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41391_storage)dyn_storage)"
+      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)"
     },
     {
-      "astId": 43880,
+      "astId": 43691,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "nHashesCompletedChallengeRound",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 43883,
+      "astId": 43694,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "nUniqueSubmittedHashes",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43886,
+      "astId": 43697,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "nInvalidatedHashes",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43892,
+      "astId": 43703,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "submittedEntries",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 43911,
+      "astId": 43722,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "firstIncompleteRound",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43915,
+      "astId": 43726,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "respondedToChallenge",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 43917,
+      "astId": 43728,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "stakeLost",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43919,
+      "astId": 43730,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "rewardsPaidOut",
       "offset": 0,
@@ -153,7 +153,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43921,
+      "astId": 43732,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "cachedDisputeRewardSize",
       "offset": 0,
@@ -178,14 +178,14 @@
       "label": "address[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(DisputedEntry)41391_storage)dyn_storage": {
-      "base": "t_struct(DisputedEntry)41391_storage",
+    "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage": {
+      "base": "t_struct(DisputedEntry)41202_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ReputationLogEntry)41361_storage)dyn_storage": {
-      "base": "t_struct(ReputationLogEntry)41361_storage",
+    "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage": {
+      "base": "t_struct(ReputationLogEntry)41172_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry[]",
       "numberOfBytes": "32"
@@ -200,7 +200,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -224,12 +224,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_bool)"
     },
-    "t_mapping(t_address,t_struct(Submission)41370_storage)": {
+    "t_mapping(t_address,t_struct(Submission)41181_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ReputationMiningCycleDataTypes.Submission)",
       "numberOfBytes": "32",
-      "value": "t_struct(Submission)41370_storage"
+      "value": "t_struct(Submission)41181_storage"
     },
     "t_mapping(t_bytes32,t_array(t_address)dyn_storage)": {
       "encoding": "mapping",
@@ -245,12 +245,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage))"
     },
-    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41391_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ReputationMiningCycleDataTypes.DisputedEntry[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(DisputedEntry)41391_storage)dyn_storage"
+      "value": "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage"
     },
     "t_mapping(t_uint256,t_bool)": {
       "encoding": "mapping",
@@ -273,12 +273,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(DisputedEntry)41391_storage": {
+    "t_struct(DisputedEntry)41202_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry",
       "members": [
         {
-          "astId": 41372,
+          "astId": 41183,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "firstSubmitter",
           "offset": 0,
@@ -286,7 +286,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41374,
+          "astId": 41185,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "lastResponseTimestamp",
           "offset": 0,
@@ -294,7 +294,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41376,
+          "astId": 41187,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "challengeStepCompleted",
           "offset": 0,
@@ -302,7 +302,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41378,
+          "astId": 41189,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "intermediateReputationHash",
           "offset": 0,
@@ -310,7 +310,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41380,
+          "astId": 41191,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "intermediateReputationNLeaves",
           "offset": 0,
@@ -318,7 +318,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41382,
+          "astId": 41193,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "lowerBound",
           "offset": 0,
@@ -326,7 +326,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41384,
+          "astId": 41195,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "upperBound",
           "offset": 0,
@@ -334,7 +334,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41386,
+          "astId": 41197,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "targetHashDuringSearch",
           "offset": 0,
@@ -342,7 +342,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41388,
+          "astId": 41199,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "hash1",
           "offset": 0,
@@ -350,7 +350,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41390,
+          "astId": 41201,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "hash2",
           "offset": 0,
@@ -360,12 +360,12 @@
       ],
       "numberOfBytes": "320"
     },
-    "t_struct(ReputationLogEntry)41361_storage": {
+    "t_struct(ReputationLogEntry)41172_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry",
       "members": [
         {
-          "astId": 41350,
+          "astId": 41161,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "user",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41352,
+          "astId": 41163,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "amount",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_int256"
         },
         {
-          "astId": 41354,
+          "astId": 41165,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "skillId",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41356,
+          "astId": 41167,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "colony",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41358,
+          "astId": 41169,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "nUpdates",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_uint128"
         },
         {
-          "astId": 41360,
+          "astId": 41171,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "nPreviousUpdates",
           "offset": 16,
@@ -415,12 +415,12 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(Submission)41370_storage": {
+    "t_struct(Submission)41181_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.Submission",
       "members": [
         {
-          "astId": 41363,
+          "astId": 41174,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "proposedNewRootHash",
           "offset": 0,
@@ -428,7 +428,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41365,
+          "astId": 41176,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "nLeaves",
           "offset": 0,
@@ -436,7 +436,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41367,
+          "astId": 41178,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "jrh",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41369,
+          "astId": 41180,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "jrhNLeaves",
           "offset": 0,

--- a/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon.json
+++ b/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43844,
+      "astId": 43655,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43846,
+      "astId": 43657,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "colonyNetworkAddress",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_address_payable"
     },
     {
-      "astId": 43848,
+      "astId": 43659,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "tokenLockingAddress",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43850,
+      "astId": 43661,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "clnyTokenAddress",
       "offset": 0,
@@ -49,15 +49,15 @@
       "type": "t_address"
     },
     {
-      "astId": 43854,
+      "astId": 43665,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "reputationUpdateLog",
       "offset": 0,
       "slot": "6",
-      "type": "t_array(t_struct(ReputationLogEntry)41361_storage)dyn_storage"
+      "type": "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage"
     },
     {
-      "astId": 43863,
+      "astId": 43674,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "submittedHashes",
       "offset": 0,
@@ -65,15 +65,15 @@
       "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage)))"
     },
     {
-      "astId": 43868,
+      "astId": 43679,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "reputationHashSubmissions",
       "offset": 0,
       "slot": "8",
-      "type": "t_mapping(t_address,t_struct(Submission)41370_storage)"
+      "type": "t_mapping(t_address,t_struct(Submission)41181_storage)"
     },
     {
-      "astId": 43870,
+      "astId": 43681,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "reputationMiningWindowOpenTimestamp",
       "offset": 0,
@@ -81,15 +81,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43876,
+      "astId": 43687,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "disputeRounds",
       "offset": 0,
       "slot": "10",
-      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41391_storage)dyn_storage)"
+      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)"
     },
     {
-      "astId": 43880,
+      "astId": 43691,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "nHashesCompletedChallengeRound",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 43883,
+      "astId": 43694,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "nUniqueSubmittedHashes",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43886,
+      "astId": 43697,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "nInvalidatedHashes",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43892,
+      "astId": 43703,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "submittedEntries",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 43911,
+      "astId": 43722,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "firstIncompleteRound",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43915,
+      "astId": 43726,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "respondedToChallenge",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 43917,
+      "astId": 43728,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "stakeLost",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43919,
+      "astId": 43730,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "rewardsPaidOut",
       "offset": 0,
@@ -153,7 +153,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43921,
+      "astId": 43732,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "cachedDisputeRewardSize",
       "offset": 0,
@@ -178,14 +178,14 @@
       "label": "address[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(DisputedEntry)41391_storage)dyn_storage": {
-      "base": "t_struct(DisputedEntry)41391_storage",
+    "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage": {
+      "base": "t_struct(DisputedEntry)41202_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ReputationLogEntry)41361_storage)dyn_storage": {
-      "base": "t_struct(ReputationLogEntry)41361_storage",
+    "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage": {
+      "base": "t_struct(ReputationLogEntry)41172_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry[]",
       "numberOfBytes": "32"
@@ -200,7 +200,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -224,12 +224,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_bool)"
     },
-    "t_mapping(t_address,t_struct(Submission)41370_storage)": {
+    "t_mapping(t_address,t_struct(Submission)41181_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ReputationMiningCycleDataTypes.Submission)",
       "numberOfBytes": "32",
-      "value": "t_struct(Submission)41370_storage"
+      "value": "t_struct(Submission)41181_storage"
     },
     "t_mapping(t_bytes32,t_array(t_address)dyn_storage)": {
       "encoding": "mapping",
@@ -245,12 +245,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage))"
     },
-    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41391_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ReputationMiningCycleDataTypes.DisputedEntry[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(DisputedEntry)41391_storage)dyn_storage"
+      "value": "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage"
     },
     "t_mapping(t_uint256,t_bool)": {
       "encoding": "mapping",
@@ -273,12 +273,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(DisputedEntry)41391_storage": {
+    "t_struct(DisputedEntry)41202_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry",
       "members": [
         {
-          "astId": 41372,
+          "astId": 41183,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "firstSubmitter",
           "offset": 0,
@@ -286,7 +286,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41374,
+          "astId": 41185,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "lastResponseTimestamp",
           "offset": 0,
@@ -294,7 +294,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41376,
+          "astId": 41187,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "challengeStepCompleted",
           "offset": 0,
@@ -302,7 +302,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41378,
+          "astId": 41189,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "intermediateReputationHash",
           "offset": 0,
@@ -310,7 +310,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41380,
+          "astId": 41191,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "intermediateReputationNLeaves",
           "offset": 0,
@@ -318,7 +318,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41382,
+          "astId": 41193,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "lowerBound",
           "offset": 0,
@@ -326,7 +326,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41384,
+          "astId": 41195,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "upperBound",
           "offset": 0,
@@ -334,7 +334,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41386,
+          "astId": 41197,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "targetHashDuringSearch",
           "offset": 0,
@@ -342,7 +342,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41388,
+          "astId": 41199,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "hash1",
           "offset": 0,
@@ -350,7 +350,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41390,
+          "astId": 41201,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "hash2",
           "offset": 0,
@@ -360,12 +360,12 @@
       ],
       "numberOfBytes": "320"
     },
-    "t_struct(ReputationLogEntry)41361_storage": {
+    "t_struct(ReputationLogEntry)41172_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry",
       "members": [
         {
-          "astId": 41350,
+          "astId": 41161,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "user",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41352,
+          "astId": 41163,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "amount",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_int256"
         },
         {
-          "astId": 41354,
+          "astId": 41165,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "skillId",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41356,
+          "astId": 41167,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "colony",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41358,
+          "astId": 41169,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "nUpdates",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_uint128"
         },
         {
-          "astId": 41360,
+          "astId": 41171,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "nPreviousUpdates",
           "offset": 16,
@@ -415,12 +415,12 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(Submission)41370_storage": {
+    "t_struct(Submission)41181_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.Submission",
       "members": [
         {
-          "astId": 41363,
+          "astId": 41174,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "proposedNewRootHash",
           "offset": 0,
@@ -428,7 +428,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41365,
+          "astId": 41176,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "nLeaves",
           "offset": 0,
@@ -436,7 +436,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41367,
+          "astId": 41178,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "jrh",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41369,
+          "astId": 41180,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "jrhNLeaves",
           "offset": 0,

--- a/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond.json
+++ b/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43844,
+      "astId": 43655,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43846,
+      "astId": 43657,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "colonyNetworkAddress",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_address_payable"
     },
     {
-      "astId": 43848,
+      "astId": 43659,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "tokenLockingAddress",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43850,
+      "astId": 43661,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "clnyTokenAddress",
       "offset": 0,
@@ -49,15 +49,15 @@
       "type": "t_address"
     },
     {
-      "astId": 43854,
+      "astId": 43665,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "reputationUpdateLog",
       "offset": 0,
       "slot": "6",
-      "type": "t_array(t_struct(ReputationLogEntry)41361_storage)dyn_storage"
+      "type": "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage"
     },
     {
-      "astId": 43863,
+      "astId": 43674,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "submittedHashes",
       "offset": 0,
@@ -65,15 +65,15 @@
       "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage)))"
     },
     {
-      "astId": 43868,
+      "astId": 43679,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "reputationHashSubmissions",
       "offset": 0,
       "slot": "8",
-      "type": "t_mapping(t_address,t_struct(Submission)41370_storage)"
+      "type": "t_mapping(t_address,t_struct(Submission)41181_storage)"
     },
     {
-      "astId": 43870,
+      "astId": 43681,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "reputationMiningWindowOpenTimestamp",
       "offset": 0,
@@ -81,15 +81,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43876,
+      "astId": 43687,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "disputeRounds",
       "offset": 0,
       "slot": "10",
-      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41391_storage)dyn_storage)"
+      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)"
     },
     {
-      "astId": 43880,
+      "astId": 43691,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "nHashesCompletedChallengeRound",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 43883,
+      "astId": 43694,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "nUniqueSubmittedHashes",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43886,
+      "astId": 43697,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "nInvalidatedHashes",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43892,
+      "astId": 43703,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "submittedEntries",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 43911,
+      "astId": 43722,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "firstIncompleteRound",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43915,
+      "astId": 43726,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "respondedToChallenge",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 43917,
+      "astId": 43728,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "stakeLost",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43919,
+      "astId": 43730,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "rewardsPaidOut",
       "offset": 0,
@@ -153,7 +153,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43921,
+      "astId": 43732,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "cachedDisputeRewardSize",
       "offset": 0,
@@ -178,14 +178,14 @@
       "label": "address[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(DisputedEntry)41391_storage)dyn_storage": {
-      "base": "t_struct(DisputedEntry)41391_storage",
+    "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage": {
+      "base": "t_struct(DisputedEntry)41202_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ReputationLogEntry)41361_storage)dyn_storage": {
-      "base": "t_struct(ReputationLogEntry)41361_storage",
+    "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage": {
+      "base": "t_struct(ReputationLogEntry)41172_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry[]",
       "numberOfBytes": "32"
@@ -200,7 +200,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -224,12 +224,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_bool)"
     },
-    "t_mapping(t_address,t_struct(Submission)41370_storage)": {
+    "t_mapping(t_address,t_struct(Submission)41181_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ReputationMiningCycleDataTypes.Submission)",
       "numberOfBytes": "32",
-      "value": "t_struct(Submission)41370_storage"
+      "value": "t_struct(Submission)41181_storage"
     },
     "t_mapping(t_bytes32,t_array(t_address)dyn_storage)": {
       "encoding": "mapping",
@@ -245,12 +245,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage))"
     },
-    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41391_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ReputationMiningCycleDataTypes.DisputedEntry[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(DisputedEntry)41391_storage)dyn_storage"
+      "value": "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage"
     },
     "t_mapping(t_uint256,t_bool)": {
       "encoding": "mapping",
@@ -273,12 +273,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(DisputedEntry)41391_storage": {
+    "t_struct(DisputedEntry)41202_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry",
       "members": [
         {
-          "astId": 41372,
+          "astId": 41183,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "firstSubmitter",
           "offset": 0,
@@ -286,7 +286,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41374,
+          "astId": 41185,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "lastResponseTimestamp",
           "offset": 0,
@@ -294,7 +294,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41376,
+          "astId": 41187,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "challengeStepCompleted",
           "offset": 0,
@@ -302,7 +302,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41378,
+          "astId": 41189,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "intermediateReputationHash",
           "offset": 0,
@@ -310,7 +310,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41380,
+          "astId": 41191,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "intermediateReputationNLeaves",
           "offset": 0,
@@ -318,7 +318,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41382,
+          "astId": 41193,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "lowerBound",
           "offset": 0,
@@ -326,7 +326,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41384,
+          "astId": 41195,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "upperBound",
           "offset": 0,
@@ -334,7 +334,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41386,
+          "astId": 41197,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "targetHashDuringSearch",
           "offset": 0,
@@ -342,7 +342,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41388,
+          "astId": 41199,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "hash1",
           "offset": 0,
@@ -350,7 +350,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41390,
+          "astId": 41201,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "hash2",
           "offset": 0,
@@ -360,12 +360,12 @@
       ],
       "numberOfBytes": "320"
     },
-    "t_struct(ReputationLogEntry)41361_storage": {
+    "t_struct(ReputationLogEntry)41172_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry",
       "members": [
         {
-          "astId": 41350,
+          "astId": 41161,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "user",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41352,
+          "astId": 41163,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "amount",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_int256"
         },
         {
-          "astId": 41354,
+          "astId": 41165,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "skillId",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41356,
+          "astId": 41167,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "colony",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41358,
+          "astId": 41169,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "nUpdates",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_uint128"
         },
         {
-          "astId": 41360,
+          "astId": 41171,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "nPreviousUpdates",
           "offset": 16,
@@ -415,12 +415,12 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(Submission)41370_storage": {
+    "t_struct(Submission)41181_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.Submission",
       "members": [
         {
-          "astId": 41363,
+          "astId": 41174,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "proposedNewRootHash",
           "offset": 0,
@@ -428,7 +428,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41365,
+          "astId": 41176,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "nLeaves",
           "offset": 0,
@@ -436,7 +436,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41367,
+          "astId": 41178,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "jrh",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41369,
+          "astId": 41180,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "jrhNLeaves",
           "offset": 0,

--- a/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage.json
+++ b/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43844,
+      "astId": 43655,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43846,
+      "astId": 43657,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "colonyNetworkAddress",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_address_payable"
     },
     {
-      "astId": 43848,
+      "astId": 43659,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "tokenLockingAddress",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43850,
+      "astId": 43661,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "clnyTokenAddress",
       "offset": 0,
@@ -49,15 +49,15 @@
       "type": "t_address"
     },
     {
-      "astId": 43854,
+      "astId": 43665,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "reputationUpdateLog",
       "offset": 0,
       "slot": "6",
-      "type": "t_array(t_struct(ReputationLogEntry)41361_storage)dyn_storage"
+      "type": "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage"
     },
     {
-      "astId": 43863,
+      "astId": 43674,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "submittedHashes",
       "offset": 0,
@@ -65,15 +65,15 @@
       "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage)))"
     },
     {
-      "astId": 43868,
+      "astId": 43679,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "reputationHashSubmissions",
       "offset": 0,
       "slot": "8",
-      "type": "t_mapping(t_address,t_struct(Submission)41370_storage)"
+      "type": "t_mapping(t_address,t_struct(Submission)41181_storage)"
     },
     {
-      "astId": 43870,
+      "astId": 43681,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "reputationMiningWindowOpenTimestamp",
       "offset": 0,
@@ -81,15 +81,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43876,
+      "astId": 43687,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "disputeRounds",
       "offset": 0,
       "slot": "10",
-      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41391_storage)dyn_storage)"
+      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)"
     },
     {
-      "astId": 43880,
+      "astId": 43691,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "nHashesCompletedChallengeRound",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 43883,
+      "astId": 43694,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "nUniqueSubmittedHashes",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43886,
+      "astId": 43697,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "nInvalidatedHashes",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43892,
+      "astId": 43703,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "submittedEntries",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 43911,
+      "astId": 43722,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "firstIncompleteRound",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43915,
+      "astId": 43726,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "respondedToChallenge",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 43917,
+      "astId": 43728,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "stakeLost",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43919,
+      "astId": 43730,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "rewardsPaidOut",
       "offset": 0,
@@ -153,7 +153,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43921,
+      "astId": 43732,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "cachedDisputeRewardSize",
       "offset": 0,
@@ -178,14 +178,14 @@
       "label": "address[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(DisputedEntry)41391_storage)dyn_storage": {
-      "base": "t_struct(DisputedEntry)41391_storage",
+    "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage": {
+      "base": "t_struct(DisputedEntry)41202_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ReputationLogEntry)41361_storage)dyn_storage": {
-      "base": "t_struct(ReputationLogEntry)41361_storage",
+    "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage": {
+      "base": "t_struct(ReputationLogEntry)41172_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry[]",
       "numberOfBytes": "32"
@@ -200,7 +200,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -224,12 +224,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_bool)"
     },
-    "t_mapping(t_address,t_struct(Submission)41370_storage)": {
+    "t_mapping(t_address,t_struct(Submission)41181_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ReputationMiningCycleDataTypes.Submission)",
       "numberOfBytes": "32",
-      "value": "t_struct(Submission)41370_storage"
+      "value": "t_struct(Submission)41181_storage"
     },
     "t_mapping(t_bytes32,t_array(t_address)dyn_storage)": {
       "encoding": "mapping",
@@ -245,12 +245,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage))"
     },
-    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41391_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ReputationMiningCycleDataTypes.DisputedEntry[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(DisputedEntry)41391_storage)dyn_storage"
+      "value": "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage"
     },
     "t_mapping(t_uint256,t_bool)": {
       "encoding": "mapping",
@@ -273,12 +273,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(DisputedEntry)41391_storage": {
+    "t_struct(DisputedEntry)41202_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry",
       "members": [
         {
-          "astId": 41372,
+          "astId": 41183,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "firstSubmitter",
           "offset": 0,
@@ -286,7 +286,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41374,
+          "astId": 41185,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "lastResponseTimestamp",
           "offset": 0,
@@ -294,7 +294,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41376,
+          "astId": 41187,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "challengeStepCompleted",
           "offset": 0,
@@ -302,7 +302,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41378,
+          "astId": 41189,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "intermediateReputationHash",
           "offset": 0,
@@ -310,7 +310,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41380,
+          "astId": 41191,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "intermediateReputationNLeaves",
           "offset": 0,
@@ -318,7 +318,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41382,
+          "astId": 41193,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "lowerBound",
           "offset": 0,
@@ -326,7 +326,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41384,
+          "astId": 41195,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "upperBound",
           "offset": 0,
@@ -334,7 +334,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41386,
+          "astId": 41197,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "targetHashDuringSearch",
           "offset": 0,
@@ -342,7 +342,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41388,
+          "astId": 41199,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "hash1",
           "offset": 0,
@@ -350,7 +350,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41390,
+          "astId": 41201,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "hash2",
           "offset": 0,
@@ -360,12 +360,12 @@
       ],
       "numberOfBytes": "320"
     },
-    "t_struct(ReputationLogEntry)41361_storage": {
+    "t_struct(ReputationLogEntry)41172_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry",
       "members": [
         {
-          "astId": 41350,
+          "astId": 41161,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "user",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41352,
+          "astId": 41163,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "amount",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_int256"
         },
         {
-          "astId": 41354,
+          "astId": 41165,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "skillId",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41356,
+          "astId": 41167,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "colony",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41358,
+          "astId": 41169,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "nUpdates",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_uint128"
         },
         {
-          "astId": 41360,
+          "astId": 41171,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "nPreviousUpdates",
           "offset": 16,
@@ -415,12 +415,12 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(Submission)41370_storage": {
+    "t_struct(Submission)41181_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.Submission",
       "members": [
         {
-          "astId": 41363,
+          "astId": 41174,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "proposedNewRootHash",
           "offset": 0,
@@ -428,7 +428,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41365,
+          "astId": 41176,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "nLeaves",
           "offset": 0,
@@ -436,7 +436,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41367,
+          "astId": 41178,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "jrh",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41369,
+          "astId": 41180,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "jrhNLeaves",
           "offset": 0,

--- a/.storage-layouts/contracts/testHelpers/FunctionsNotAvailableOnColony.sol:FunctionsNotAvailableOnColony.json
+++ b/.storage-layouts/contracts/testHelpers/FunctionsNotAvailableOnColony.sol:FunctionsNotAvailableOnColony.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/testHelpers/FunctionsNotAvailableOnColony.sol:FunctionsNotAvailableOnColony",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/testHelpers/FunctionsNotAvailableOnColony.sol:FunctionsNotAvailableOnColony",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/GasGuzzler.sol:GasGuzzler.json
+++ b/.storage-layouts/contracts/testHelpers/GasGuzzler.sol:GasGuzzler.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/testHelpers/GasGuzzler.sol:GasGuzzler",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/testHelpers/GasGuzzler.sol:GasGuzzler",
       "label": "owner",
       "offset": 0,
@@ -305,7 +305,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 44432,
+      "astId": 44243,
       "contract": "contracts/testHelpers/GasGuzzler.sol:GasGuzzler",
       "label": "storageVar",
       "offset": 0,
@@ -324,7 +324,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/NoLimitSubdomains.sol:NoLimitSubdomains.json
+++ b/.storage-layouts/contracts/testHelpers/NoLimitSubdomains.sol:NoLimitSubdomains.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/testHelpers/NoLimitSubdomains.sol:NoLimitSubdomains",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/testHelpers/NoLimitSubdomains.sol:NoLimitSubdomains",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned.json
+++ b/.storage-layouts/contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "owner",
       "offset": 0,
@@ -41,15 +41,15 @@
       "type": "t_bool"
     },
     {
-      "astId": 45147,
+      "astId": 44958,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "state",
       "offset": 21,
       "slot": "3",
-      "type": "t_enum(ExtensionState)45144"
+      "type": "t_enum(ExtensionState)44955"
     },
     {
-      "astId": 45150,
+      "astId": 44961,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "colonyNetwork",
       "offset": 0,
@@ -57,15 +57,15 @@
       "type": "t_contract(IColonyNetwork)20072"
     },
     {
-      "astId": 45153,
+      "astId": 44964,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "tokenLocking",
       "offset": 0,
       "slot": "5",
-      "type": "t_contract(ITokenLocking)49117"
+      "type": "t_contract(ITokenLocking)48928"
     },
     {
-      "astId": 45155,
+      "astId": 44966,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "token",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_address"
     },
     {
-      "astId": 45157,
+      "astId": 44968,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "totalStakeFraction",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 45159,
+      "astId": 44970,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "voterRewardFraction",
       "offset": 0,
@@ -89,7 +89,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 45161,
+      "astId": 44972,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "userMinStakeFraction",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 45163,
+      "astId": 44974,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "maxVoteFraction",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 45165,
+      "astId": 44976,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "stakePeriod",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 45167,
+      "astId": 44978,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "submitPeriod",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 45169,
+      "astId": 44980,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "revealPeriod",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 45171,
+      "astId": 44982,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "escalationPeriod",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 45175,
+      "astId": 44986,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 45507,
+      "astId": 45318,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "motionCount",
       "offset": 0,
@@ -153,15 +153,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 45512,
+      "astId": 45323,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "motions",
       "offset": 0,
       "slot": "17",
-      "type": "t_mapping(t_uint256,t_struct(Motion)45505_storage)"
+      "type": "t_mapping(t_uint256,t_struct(Motion)45316_storage)"
     },
     {
-      "astId": 45520,
+      "astId": 45331,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "stakes",
       "offset": 0,
@@ -169,7 +169,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))"
     },
     {
-      "astId": 45526,
+      "astId": 45337,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "voteSecrets",
       "offset": 0,
@@ -177,7 +177,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_bytes32))"
     },
     {
-      "astId": 45530,
+      "astId": 45341,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "expenditurePastVotes",
       "offset": 0,
@@ -185,7 +185,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 45534,
+      "astId": 45345,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "expenditureMotionCounts",
       "offset": 0,
@@ -226,7 +226,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -241,12 +241,12 @@
       "label": "contract IColonyNetwork",
       "numberOfBytes": "20"
     },
-    "t_contract(ITokenLocking)49117": {
+    "t_contract(ITokenLocking)48928": {
       "encoding": "inplace",
       "label": "contract ITokenLocking",
       "numberOfBytes": "20"
     },
-    "t_enum(ExtensionState)45144": {
+    "t_enum(ExtensionState)44955": {
       "encoding": "inplace",
       "label": "enum VotingReputationMisaligned.ExtensionState",
       "numberOfBytes": "1"
@@ -293,12 +293,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))"
     },
-    "t_mapping(t_uint256,t_struct(Motion)45505_storage)": {
+    "t_mapping(t_uint256,t_struct(Motion)45316_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct VotingReputationMisaligned.Motion)",
       "numberOfBytes": "32",
-      "value": "t_struct(Motion)45505_storage"
+      "value": "t_struct(Motion)45316_storage"
     },
     "t_mapping(t_uint256,t_uint256)": {
       "encoding": "mapping",
@@ -307,12 +307,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(Motion)45505_storage": {
+    "t_struct(Motion)45316_storage": {
       "encoding": "inplace",
       "label": "struct VotingReputationMisaligned.Motion",
       "members": [
         {
-          "astId": 45472,
+          "astId": 45283,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "events",
           "offset": 0,
@@ -320,7 +320,7 @@
           "type": "t_array(t_uint64)3_storage"
         },
         {
-          "astId": 45474,
+          "astId": 45285,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "rootHash",
           "offset": 0,
@@ -328,7 +328,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 45476,
+          "astId": 45287,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "domainId",
           "offset": 0,
@@ -336,7 +336,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 45478,
+          "astId": 45289,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "skillId",
           "offset": 0,
@@ -344,7 +344,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 45480,
+          "astId": 45291,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "skillRep",
           "offset": 0,
@@ -352,7 +352,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 45482,
+          "astId": 45293,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "repSubmitted",
           "offset": 0,
@@ -360,7 +360,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 45484,
+          "astId": 45295,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "paidVoterComp",
           "offset": 0,
@@ -368,7 +368,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 45488,
+          "astId": 45299,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "pastVoterComp",
           "offset": 0,
@@ -376,7 +376,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 45492,
+          "astId": 45303,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "stakes",
           "offset": 0,
@@ -384,7 +384,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 45496,
+          "astId": 45307,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "votes",
           "offset": 0,
@@ -392,7 +392,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 45498,
+          "astId": 45309,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "escalated",
           "offset": 0,
@@ -400,7 +400,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 45500,
+          "astId": 45311,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "finalized",
           "offset": 1,
@@ -408,7 +408,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 45502,
+          "astId": 45313,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "altTarget",
           "offset": 2,
@@ -416,7 +416,7 @@
           "type": "t_address"
         },
         {
-          "astId": 45504,
+          "astId": 45315,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "action",
           "offset": 0,

--- a/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension0.sol:TestExtension0.json
+++ b/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension0.sol:TestExtension0.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/testHelpers/testExtensions/TestExtension0.sol:TestExtension0",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/testHelpers/testExtensions/TestExtension0.sol:TestExtension0",
       "label": "owner",
       "offset": 0,
@@ -316,7 +316,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension1.sol:TestExtension1.json
+++ b/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension1.sol:TestExtension1.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/testHelpers/testExtensions/TestExtension1.sol:TestExtension1",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/testHelpers/testExtensions/TestExtension1.sol:TestExtension1",
       "label": "owner",
       "offset": 0,
@@ -316,7 +316,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension2.sol:TestExtension2.json
+++ b/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension2.sol:TestExtension2.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/testHelpers/testExtensions/TestExtension2.sol:TestExtension2",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/testHelpers/testExtensions/TestExtension2.sol:TestExtension2",
       "label": "owner",
       "offset": 0,
@@ -316,7 +316,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension3.sol:TestExtension3.json
+++ b/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension3.sol:TestExtension3.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/testHelpers/testExtensions/TestExtension3.sol:TestExtension3",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/testHelpers/testExtensions/TestExtension3.sol:TestExtension3",
       "label": "owner",
       "offset": 0,
@@ -316,7 +316,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/testExtensions/TestExtensionBase.sol:TestExtensionBase.json
+++ b/.storage-layouts/contracts/testHelpers/testExtensions/TestExtensionBase.sol:TestExtensionBase.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/testHelpers/testExtensions/TestExtensionBase.sol:TestExtensionBase",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/testHelpers/testExtensions/TestExtensionBase.sol:TestExtensionBase",
       "label": "owner",
       "offset": 0,
@@ -316,7 +316,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/testExtensions/TestVotingToken.sol:TestVotingToken.json
+++ b/.storage-layouts/contracts/testHelpers/testExtensions/TestVotingToken.sol:TestVotingToken.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/testHelpers/testExtensions/TestVotingToken.sol:TestVotingToken",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/testHelpers/testExtensions/TestVotingToken.sol:TestVotingToken",
       "label": "owner",
       "offset": 0,
@@ -316,7 +316,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/tokenLocking/TokenLocking.sol:TokenLocking.json
+++ b/.storage-layouts/contracts/tokenLocking/TokenLocking.sol:TokenLocking.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 50172,
+      "astId": 49983,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 50174,
+      "astId": 49985,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "colonyNetwork",
       "offset": 0,
@@ -33,15 +33,15 @@
       "type": "t_address"
     },
     {
-      "astId": 50181,
+      "astId": 49992,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "userLocks",
       "offset": 0,
       "slot": "4",
-      "type": "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)50158_storage))"
+      "type": "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)49969_storage))"
     },
     {
-      "astId": 50185,
+      "astId": 49996,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "totalLockCount",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 50193,
+      "astId": 50004,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "approvals",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_address,t_uint256)))"
     },
     {
-      "astId": 50201,
+      "astId": 50012,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "obligations",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_address,t_uint256)))"
     },
     {
-      "astId": 50207,
+      "astId": 50018,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "totalObligations",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
     },
     {
-      "astId": 50213,
+      "astId": 50024,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "lockers",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_address))"
     },
     {
-      "astId": 50217,
+      "astId": 50028,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -95,7 +95,7 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -107,12 +107,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
     },
-    "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)50158_storage))": {
+    "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)49969_storage))": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => mapping(address => struct TokenLockingDataTypes.Lock))",
       "numberOfBytes": "32",
-      "value": "t_mapping(t_address,t_struct(Lock)50158_storage)"
+      "value": "t_mapping(t_address,t_struct(Lock)49969_storage)"
     },
     "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
       "encoding": "mapping",
@@ -128,12 +128,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_address)"
     },
-    "t_mapping(t_address,t_struct(Lock)50158_storage)": {
+    "t_mapping(t_address,t_struct(Lock)49969_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct TokenLockingDataTypes.Lock)",
       "numberOfBytes": "32",
-      "value": "t_struct(Lock)50158_storage"
+      "value": "t_struct(Lock)49969_storage"
     },
     "t_mapping(t_address,t_uint256)": {
       "encoding": "mapping",
@@ -149,12 +149,12 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_struct(Lock)50158_storage": {
+    "t_struct(Lock)49969_storage": {
       "encoding": "inplace",
       "label": "struct TokenLockingDataTypes.Lock",
       "members": [
         {
-          "astId": 50151,
+          "astId": 49962,
           "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
           "label": "lockCount",
           "offset": 0,
@@ -162,7 +162,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 50153,
+          "astId": 49964,
           "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
           "label": "balance",
           "offset": 0,
@@ -170,7 +170,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 50155,
+          "astId": 49966,
           "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
           "label": "DEPRECATED_timestamp",
           "offset": 0,
@@ -178,7 +178,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 50157,
+          "astId": 49968,
           "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
           "label": "pendingBalance",
           "offset": 0,

--- a/.storage-layouts/contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage.json
+++ b/.storage-layouts/contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50553,
+      "astId": 50364,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50539"
+      "type": "t_contract(DSAuthority)50350"
     },
     {
-      "astId": 50555,
+      "astId": 50366,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 50172,
+      "astId": 49983,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 50174,
+      "astId": 49985,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "colonyNetwork",
       "offset": 0,
@@ -33,15 +33,15 @@
       "type": "t_address"
     },
     {
-      "astId": 50181,
+      "astId": 49992,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "userLocks",
       "offset": 0,
       "slot": "4",
-      "type": "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)50158_storage))"
+      "type": "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)49969_storage))"
     },
     {
-      "astId": 50185,
+      "astId": 49996,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "totalLockCount",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 50193,
+      "astId": 50004,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "approvals",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_address,t_uint256)))"
     },
     {
-      "astId": 50201,
+      "astId": 50012,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "obligations",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_address,t_uint256)))"
     },
     {
-      "astId": 50207,
+      "astId": 50018,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "totalObligations",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
     },
     {
-      "astId": 50213,
+      "astId": 50024,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "lockers",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_address))"
     },
     {
-      "astId": 50217,
+      "astId": 50028,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -95,7 +95,7 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_contract(DSAuthority)50539": {
+    "t_contract(DSAuthority)50350": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -107,12 +107,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
     },
-    "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)50158_storage))": {
+    "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)49969_storage))": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => mapping(address => struct TokenLockingDataTypes.Lock))",
       "numberOfBytes": "32",
-      "value": "t_mapping(t_address,t_struct(Lock)50158_storage)"
+      "value": "t_mapping(t_address,t_struct(Lock)49969_storage)"
     },
     "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
       "encoding": "mapping",
@@ -128,12 +128,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_address)"
     },
-    "t_mapping(t_address,t_struct(Lock)50158_storage)": {
+    "t_mapping(t_address,t_struct(Lock)49969_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct TokenLockingDataTypes.Lock)",
       "numberOfBytes": "32",
-      "value": "t_struct(Lock)50158_storage"
+      "value": "t_struct(Lock)49969_storage"
     },
     "t_mapping(t_address,t_uint256)": {
       "encoding": "mapping",
@@ -149,12 +149,12 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_struct(Lock)50158_storage": {
+    "t_struct(Lock)49969_storage": {
       "encoding": "inplace",
       "label": "struct TokenLockingDataTypes.Lock",
       "members": [
         {
-          "astId": 50151,
+          "astId": 49962,
           "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
           "label": "lockCount",
           "offset": 0,
@@ -162,7 +162,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 50153,
+          "astId": 49964,
           "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
           "label": "balance",
           "offset": 0,
@@ -170,7 +170,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 50155,
+          "astId": 49966,
           "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
           "label": "DEPRECATED_timestamp",
           "offset": 0,
@@ -178,7 +178,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 50157,
+          "astId": 49968,
           "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
           "label": "pendingBalance",
           "offset": 0,

--- a/contracts/extensions/StreamingPayments.sol
+++ b/contracts/extensions/StreamingPayments.sol
@@ -437,21 +437,19 @@ contract StreamingPayments is ColonyExtensionMeta {
     );
     uint256 expenditureFundingPotId = colony.getExpenditure(expenditureId).fundingPotId;
 
-    if (_amountToClaim > 0) {
-      colony.moveFundsBetweenPots(
-        _permissionDomainId,
-        _childSkillIndex,
-        streamingPayments[_id].domainId,
-        _fromChildSkillIndex,
-        _toChildSkillIndex,
-        _domainFundingPotId,
-        expenditureFundingPotId,
-        _amountToClaim,
-        _token
-      );
-      colony.setExpenditurePayout(expenditureId, SLOT, _token, _amountToClaim);
-    }
+    colony.moveFundsBetweenPots(
+      _permissionDomainId,
+      _childSkillIndex,
+      streamingPayments[_id].domainId,
+      _fromChildSkillIndex,
+      _toChildSkillIndex,
+      _domainFundingPotId,
+      expenditureFundingPotId,
+      _amountToClaim,
+      _token
+    );
 
+    colony.setExpenditurePayout(expenditureId, SLOT, _token, _amountToClaim);
     colony.setExpenditureRecipient(expenditureId, SLOT, streamingPayments[_id].recipient);
     colony.finalizeExpenditure(expenditureId);
     return expenditureId;

--- a/contracts/extensions/StreamingPayments.sol
+++ b/contracts/extensions/StreamingPayments.sol
@@ -228,8 +228,8 @@ contract StreamingPayments is ColonyExtensionMeta {
       _toChildSkillIndex,
       _id,
       domainFundingPotId,
-      toAddressArray(streamingPayment.token),
-      toUint256Array(amountToClaim)
+      streamingPayment.token,
+      amountToClaim
     );
 
     colony.claimExpenditurePayout(expenditureId, SLOT, streamingPayment.token);
@@ -427,8 +427,8 @@ contract StreamingPayments is ColonyExtensionMeta {
     uint256 _toChildSkillIndex,
     uint256 _id,
     uint256 _domainFundingPotId,
-    address[] memory _tokens,
-    uint256[] memory _amountsToClaim
+    address _token,
+    uint256 _amountToClaim
   ) internal returns (uint256) {
     uint256 expenditureId = colony.makeExpenditure(
       _permissionDomainId,
@@ -437,35 +437,23 @@ contract StreamingPayments is ColonyExtensionMeta {
     );
     uint256 expenditureFundingPotId = colony.getExpenditure(expenditureId).fundingPotId;
 
-    for (uint256 i; i < _tokens.length; i++) {
-      if (_amountsToClaim[i] > 0) {
-        colony.moveFundsBetweenPots(
-          _permissionDomainId,
-          _childSkillIndex,
-          streamingPayments[_id].domainId,
-          _fromChildSkillIndex,
-          _toChildSkillIndex,
-          _domainFundingPotId,
-          expenditureFundingPotId,
-          _amountsToClaim[i],
-          _tokens[i]
-        );
-        colony.setExpenditurePayout(expenditureId, SLOT, _tokens[i], _amountsToClaim[i]);
-      }
+    if (_amountToClaim > 0) {
+      colony.moveFundsBetweenPots(
+        _permissionDomainId,
+        _childSkillIndex,
+        streamingPayments[_id].domainId,
+        _fromChildSkillIndex,
+        _toChildSkillIndex,
+        _domainFundingPotId,
+        expenditureFundingPotId,
+        _amountToClaim,
+        _token
+      );
+      colony.setExpenditurePayout(expenditureId, SLOT, _token, _amountToClaim);
     }
 
     colony.setExpenditureRecipient(expenditureId, SLOT, streamingPayments[_id].recipient);
     colony.finalizeExpenditure(expenditureId);
     return expenditureId;
-  }
-
-  function toAddressArray(address _token) internal pure returns (address[] memory tokens) {
-    tokens = new address[](1);
-    tokens[0] = _token;
-  }
-
-  function toUint256Array(uint256 _value) internal pure returns (uint256[] memory values) {
-    values = new uint256[](1);
-    values[0] = _value;
   }
 }

--- a/docs/interfaces/extensions/streamingpayments.md
+++ b/docs/interfaces/extensions/streamingpayments.md
@@ -9,22 +9,6 @@ whatever frequency they choose.
   
 ## Interface Methods
 
-### ▸ `addToken(uint256 _fundingPermissionDomainId, uint256 _fundingChildSkillIndex, uint256 _id, address _token, uint256 _amount)`
-
-Add a new token/amount pair
-
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_fundingPermissionDomainId|uint256|The domain in which the caller holds the funding permission
-|_fundingChildSkillIndex|uint256|The index linking the fundingPermissionDomainId to the domainId
-|_id|uint256|The id of the streaming payment
-|_token|address|The address of the token
-|_amount|uint256|The amount to pay out
-
-
 ### ▸ `cancel(uint256 _adminPermissionDomainId, uint256 _adminChildSkillIndex, uint256 _id)`
 
 Cancel the streaming payment, specifically by setting endTime to block.timestamp
@@ -39,7 +23,7 @@ Cancel the streaming payment, specifically by setting endTime to block.timestamp
 |_id|uint256|The id of the streaming payment
 
 
-### ▸ `cancelAndWaive(uint256 _id, address[] memory _tokens)`
+### ▸ `cancelAndWaive(uint256 _id)`
 
 Cancel the streaming payment, specifically by setting endTime to block.timestamp, and waive claim to specified tokens already earned. Only callable by the recipient.
 
@@ -49,10 +33,9 @@ Cancel the streaming payment, specifically by setting endTime to block.timestamp
 |Name|Type|Description|
 |---|---|---|
 |_id|uint256|The id of the streaming payment
-|_tokens|address[]|The tokens to waive any claims to.
 
 
-### ▸ `claim(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _fromChildSkillIndex, uint256 _toChildSkillIndex, uint256 _id, address[] memory _tokens)`
+### ▸ `claim(uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _fromChildSkillIndex, uint256 _toChildSkillIndex, uint256 _id)`
 
 Claim a streaming payment
 
@@ -66,10 +49,9 @@ Claim a streaming payment
 |_fromChildSkillIndex|uint256|The linking the domainId to the fromPot domain
 |_toChildSkillIndex|uint256|The linking the domainId to the toPot domain
 |_id|uint256|The id of the streaming payment
-|_tokens|address[]|The tokens to be paid out
 
 
-### ▸ `create(uint256 _fundingPermissionDomainId, uint256 _fundingChildSkillIndex, uint256 _adminPermissionDomainId, uint256 _adminChildSkillIndex, uint256 _domainId, uint256 _startTime, uint256 _endTime, uint256 _interval, address _recipient, address[] memory _tokens, uint256[] memory _amounts)`
+### ▸ `create(uint256 _fundingPermissionDomainId, uint256 _fundingChildSkillIndex, uint256 _adminPermissionDomainId, uint256 _adminChildSkillIndex, uint256 _domainId, uint256 _startTime, uint256 _endTime, uint256 _interval, address _recipient, address _token, uint256 _amount)`
 
 Creates a new streaming payment
 
@@ -87,8 +69,8 @@ Creates a new streaming payment
 |_endTime|uint256|The time at which the payment ends paying out
 |_interval|uint256|The period of time over which _amounts are paid out
 |_recipient|address|The recipient of the streaming payment
-|_tokens|address[]|The tokens to be paid out
-|_amounts|uint256[]|The amounts to be paid out (per _interval of time)
+|_token|address|The token to be paid out
+|_amount|uint256|The amount to be paid out (per _interval of time)
 
 
 ### ▸ `deprecate(bool _deprecated)`
@@ -110,7 +92,7 @@ Called when upgrading the extension
 
 
 
-### ▸ `getAmountEntitledFromStart(uint256 _id, address _token):uint256 amount`
+### ▸ `getAmountEntitledFromStart(uint256 _id):uint256 amount`
 
 Get the amount entitled to claim from the start of the stream
 
@@ -120,7 +102,6 @@ Get the amount entitled to claim from the start of the stream
 |Name|Type|Description|
 |---|---|---|
 |_id|uint256|The id of the streaming payment
-|_token|address|The address of the token
 
 **Return Parameters**
 
@@ -139,24 +120,6 @@ Get the total number of streaming payments
 |Name|Type|Description|
 |---|---|---|
 |numPayments|uint256|The total number of streaming payments
-
-### ▸ `getPaymentToken(uint256 _id, address _token):PaymentToken paymentToken`
-
-Get the payment token struct by Id and token
-
-
-**Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|_id|uint256|The id of the streaming payment
-|_token|address|The address of the token
-
-**Return Parameters**
-
-|Name|Type|Description|
-|---|---|---|
-|paymentToken|PaymentToken|The payment token struct
 
 ### ▸ `getStreamingPayment(uint256 _id):StreamingPayment streamingPayment`
 
@@ -229,7 +192,7 @@ Update the startTime, only if the current startTime is in the future
 |_startTime|uint256|The new startTime to set
 
 
-### ▸ `setTokenAmount(uint256 _fundingPermissionDomainId, uint256 _fundingChildSkillIndex, uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _fromChildSkillIndex, uint256 _toChildSkillIndex, uint256 _id, address _token, uint256 _amount)`
+### ▸ `setTokenAmount(uint256 _fundingPermissionDomainId, uint256 _fundingChildSkillIndex, uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _fromChildSkillIndex, uint256 _toChildSkillIndex, uint256 _id, uint256 _amount)`
 
 Update the token amount to be paid out. Claims existing payout prior to the change
 
@@ -245,7 +208,6 @@ Update the token amount to be paid out. Claims existing payout prior to the chan
 |_fromChildSkillIndex|uint256|The linking the domainId to the fromPot domain
 |_toChildSkillIndex|uint256|The linking the domainId to the toPot domain
 |_id|uint256|The id of the streaming payment
-|_token|address|The address of the token
 |_amount|uint256|The new amount to pay out
 
 


### PR DESCRIPTION
NB Based on maint/pnpm.

Multiple streams in a single streaming payment are no longer desired on the frontend, so taking the opportunity to simplify the contracts. This will also allow accurate tracking of the number of pending payments, allowing the 'prevent uninstall if pending payments' feature.

I've taken advantage of `finishUpgrade` to make sure someone can't upgrade from v4 to v5, which we are declaring is impossible due to the storage layout changes.