### PR TITLE
Prevent StreamingPayment uninstallation if pending streams remain

### DIFF
--- a/.storage-layouts-normalized/contracts/extensions/StreamingPayments.sol:StreamingPayments.json
+++ b/.storage-layouts-normalized/contracts/extensions/StreamingPayments.sol:StreamingPayments.json
@@ -549,6 +549,17 @@
           "numberOfBytes": "256"
         }
       }
+    },
+    {
+      "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
+      "label": "nUnresolvedStreamingPayments",
+      "offset": 0,
+      "slot": "39",
+      "type": {
+        "encoding": "inplace",
+        "label": "uint256",
+        "numberOfBytes": "32"
+      }
     }
   ]
 }

--- a/.storage-layouts/contracts/bridging/WormholeBridgeForColony.sol:WormholeBridgeForColony.json
+++ b/.storage-layouts/contracts/bridging/WormholeBridgeForColony.sol:WormholeBridgeForColony.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/bridging/WormholeBridgeForColony.sol:WormholeBridgeForColony",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/bridging/WormholeBridgeForColony.sol:WormholeBridgeForColony",
       "label": "owner",
       "offset": 0,
@@ -30,7 +30,7 @@
       "label": "wormhole",
       "offset": 0,
       "slot": "3",
-      "type": "t_contract(IWormhole)54240"
+      "type": "t_contract(IWormhole)54533"
     },
     {
       "astId": 2588,
@@ -55,12 +55,12 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
     },
-    "t_contract(IWormhole)54240": {
+    "t_contract(IWormhole)54533": {
       "encoding": "inplace",
       "label": "contract IWormhole",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/Colony.sol:Colony.json
+++ b/.storage-layouts/contracts/colony/Colony.sol:Colony.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colony/Colony.sol:Colony",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colony/Colony.sol:Colony",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyArbitraryTransaction.sol:ColonyArbitraryTransaction.json
+++ b/.storage-layouts/contracts/colony/ColonyArbitraryTransaction.sol:ColonyArbitraryTransaction.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colony/ColonyArbitraryTransaction.sol:ColonyArbitraryTransaction",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colony/ColonyArbitraryTransaction.sol:ColonyArbitraryTransaction",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyAuthority.sol:ColonyAuthority.json
+++ b/.storage-layouts/contracts/colony/ColonyAuthority.sol:ColonyAuthority.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colony/ColonyAuthority.sol:ColonyAuthority",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colony/ColonyAuthority.sol:ColonyAuthority",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 50848,
+      "astId": 51141,
       "contract": "contracts/colony/ColonyAuthority.sol:ColonyAuthority",
       "label": "_root_users",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 50852,
+      "astId": 51145,
       "contract": "contracts/colony/ColonyAuthority.sol:ColonyAuthority",
       "label": "_user_roles",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_mapping(t_address,t_bytes32)"
     },
     {
-      "astId": 50858,
+      "astId": 51151,
       "contract": "contracts/colony/ColonyAuthority.sol:ColonyAuthority",
       "label": "_capability_roles",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_mapping(t_address,t_mapping(t_bytes4,t_bytes32))"
     },
     {
-      "astId": 50864,
+      "astId": 51157,
       "contract": "contracts/colony/ColonyAuthority.sol:ColonyAuthority",
       "label": "_public_capabilities",
       "offset": 0,
@@ -86,7 +86,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyDomains.sol:ColonyDomains.json
+++ b/.storage-layouts/contracts/colony/ColonyDomains.sol:ColonyDomains.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colony/ColonyDomains.sol:ColonyDomains",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colony/ColonyDomains.sol:ColonyDomains",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyExpenditure.sol:ColonyExpenditure.json
+++ b/.storage-layouts/contracts/colony/ColonyExpenditure.sol:ColonyExpenditure.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colony/ColonyExpenditure.sol:ColonyExpenditure",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colony/ColonyExpenditure.sol:ColonyExpenditure",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyFunding.sol:ColonyFunding.json
+++ b/.storage-layouts/contracts/colony/ColonyFunding.sol:ColonyFunding.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colony/ColonyFunding.sol:ColonyFunding",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colony/ColonyFunding.sol:ColonyFunding",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyRewards.sol:ColonyRewards.json
+++ b/.storage-layouts/contracts/colony/ColonyRewards.sol:ColonyRewards.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colony/ColonyRewards.sol:ColonyRewards",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colony/ColonyRewards.sol:ColonyRewards",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyRoles.sol:ColonyRoles.json
+++ b/.storage-layouts/contracts/colony/ColonyRoles.sol:ColonyRoles.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colony/ColonyRoles.sol:ColonyRoles",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colony/ColonyRoles.sol:ColonyRoles",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colony/ColonyStorage.sol:ColonyStorage.json
+++ b/.storage-layouts/contracts/colony/ColonyStorage.sol:ColonyStorage.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colony/ColonyStorage.sol:ColonyStorage",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colony/ColonyStorage.sol:ColonyStorage",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetwork.sol:ColonyNetwork.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetwork.sol:ColonyNetwork.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colonyNetwork/ColonyNetwork.sol:ColonyNetwork",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colonyNetwork/ColonyNetwork.sol:ColonyNetwork",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkAuction.sol:ColonyNetworkAuction.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkAuction.sol:ColonyNetworkAuction.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuction.sol:ColonyNetworkAuction",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuction.sol:ColonyNetworkAuction",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 50848,
+      "astId": 51141,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority",
       "label": "_root_users",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 50852,
+      "astId": 51145,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority",
       "label": "_user_roles",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_mapping(t_address,t_bytes32)"
     },
     {
-      "astId": 50858,
+      "astId": 51151,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority",
       "label": "_capability_roles",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_mapping(t_address,t_mapping(t_bytes4,t_bytes32))"
     },
     {
-      "astId": 50864,
+      "astId": 51157,
       "contract": "contracts/colonyNetwork/ColonyNetworkAuthority.sol:ColonyNetworkAuthority",
       "label": "_public_capabilities",
       "offset": 0,
@@ -78,7 +78,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkDeployer.sol:ColonyNetworkDeployer.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkDeployer.sol:ColonyNetworkDeployer.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colonyNetwork/ColonyNetworkDeployer.sol:ColonyNetworkDeployer",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colonyNetwork/ColonyNetworkDeployer.sol:ColonyNetworkDeployer",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkENS.sol:ColonyNetworkENS.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkENS.sol:ColonyNetworkENS.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colonyNetwork/ColonyNetworkENS.sol:ColonyNetworkENS",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colonyNetwork/ColonyNetworkENS.sol:ColonyNetworkENS",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkExtensions.sol:ColonyNetworkExtensions.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkExtensions.sol:ColonyNetworkExtensions.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colonyNetwork/ColonyNetworkExtensions.sol:ColonyNetworkExtensions",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colonyNetwork/ColonyNetworkExtensions.sol:ColonyNetworkExtensions",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkMining.sol:ColonyNetworkMining.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkMining.sol:ColonyNetworkMining.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colonyNetwork/ColonyNetworkMining.sol:ColonyNetworkMining",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colonyNetwork/ColonyNetworkMining.sol:ColonyNetworkMining",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkSkills.sol:ColonyNetworkSkills.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkSkills.sol:ColonyNetworkSkills.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colonyNetwork/ColonyNetworkSkills.sol:ColonyNetworkSkills",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colonyNetwork/ColonyNetworkSkills.sol:ColonyNetworkSkills",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/colonyNetwork/ColonyNetworkStorage.sol:ColonyNetworkStorage.json
+++ b/.storage-layouts/contracts/colonyNetwork/ColonyNetworkStorage.sol:ColonyNetworkStorage.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/colonyNetwork/ColonyNetworkStorage.sol:ColonyNetworkStorage",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/colonyNetwork/ColonyNetworkStorage.sol:ColonyNetworkStorage",
       "label": "owner",
       "offset": 0,
@@ -444,7 +444,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/common/CommonAuthority.sol:CommonAuthority.json
+++ b/.storage-layouts/contracts/common/CommonAuthority.sol:CommonAuthority.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/common/CommonAuthority.sol:CommonAuthority",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/common/CommonAuthority.sol:CommonAuthority",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 50848,
+      "astId": 51141,
       "contract": "contracts/common/CommonAuthority.sol:CommonAuthority",
       "label": "_root_users",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 50852,
+      "astId": 51145,
       "contract": "contracts/common/CommonAuthority.sol:CommonAuthority",
       "label": "_user_roles",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_mapping(t_address,t_bytes32)"
     },
     {
-      "astId": 50858,
+      "astId": 51151,
       "contract": "contracts/common/CommonAuthority.sol:CommonAuthority",
       "label": "_capability_roles",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_mapping(t_address,t_mapping(t_bytes4,t_bytes32))"
     },
     {
-      "astId": 50864,
+      "astId": 51157,
       "contract": "contracts/common/CommonAuthority.sol:CommonAuthority",
       "label": "_public_capabilities",
       "offset": 0,
@@ -78,7 +78,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/common/CommonStorage.sol:CommonStorage.json
+++ b/.storage-layouts/contracts/common/CommonStorage.sol:CommonStorage.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/common/CommonStorage.sol:CommonStorage",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/common/CommonStorage.sol:CommonStorage",
       "label": "owner",
       "offset": 0,
@@ -76,7 +76,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/common/ContractRecovery.sol:ContractRecovery.json
+++ b/.storage-layouts/contracts/common/ContractRecovery.sol:ContractRecovery.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/common/ContractRecovery.sol:ContractRecovery",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/common/ContractRecovery.sol:ContractRecovery",
       "label": "owner",
       "offset": 0,
@@ -76,7 +76,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/common/DomainRoles.sol:DomainRoles.json
+++ b/.storage-layouts/contracts/common/DomainRoles.sol:DomainRoles.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/common/DomainRoles.sol:DomainRoles",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/common/DomainRoles.sol:DomainRoles",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 50848,
+      "astId": 51141,
       "contract": "contracts/common/DomainRoles.sol:DomainRoles",
       "label": "_root_users",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 50852,
+      "astId": 51145,
       "contract": "contracts/common/DomainRoles.sol:DomainRoles",
       "label": "_user_roles",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_mapping(t_address,t_bytes32)"
     },
     {
-      "astId": 50858,
+      "astId": 51151,
       "contract": "contracts/common/DomainRoles.sol:DomainRoles",
       "label": "_capability_roles",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_mapping(t_address,t_mapping(t_bytes4,t_bytes32))"
     },
     {
-      "astId": 50864,
+      "astId": 51157,
       "contract": "contracts/common/DomainRoles.sol:DomainRoles",
       "label": "_public_capabilities",
       "offset": 0,
@@ -78,7 +78,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/common/EtherRouter.sol:EtherRouter.json
+++ b/.storage-layouts/contracts/common/EtherRouter.sol:EtherRouter.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/common/EtherRouter.sol:EtherRouter",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/common/EtherRouter.sol:EtherRouter",
       "label": "owner",
       "offset": 0,
@@ -31,7 +31,7 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/common/EtherRouterCreate3.sol:EtherRouterCreate3.json
+++ b/.storage-layouts/contracts/common/EtherRouterCreate3.sol:EtherRouterCreate3.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/common/EtherRouterCreate3.sol:EtherRouterCreate3",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/common/EtherRouterCreate3.sol:EtherRouterCreate3",
       "label": "owner",
       "offset": 0,
@@ -31,7 +31,7 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/common/Resolver.sol:Resolver.json
+++ b/.storage-layouts/contracts/common/Resolver.sol:Resolver.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/common/Resolver.sol:Resolver",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/common/Resolver.sol:Resolver",
       "label": "owner",
       "offset": 0,
@@ -36,7 +36,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/CoinMachine.sol:CoinMachine.json
+++ b/.storage-layouts/contracts/extensions/CoinMachine.sol:CoinMachine.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/CoinMachine.sol:CoinMachine",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/CoinMachine.sol:CoinMachine",
       "label": "owner",
       "offset": 0,
@@ -204,7 +204,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/ColonyExtension.sol:ColonyExtension.json
+++ b/.storage-layouts/contracts/extensions/ColonyExtension.sol:ColonyExtension.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/ColonyExtension.sol:ColonyExtension",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/ColonyExtension.sol:ColonyExtension",
       "label": "owner",
       "offset": 0,
@@ -52,7 +52,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/ColonyExtensionMeta.sol:ColonyExtensionMeta.json
+++ b/.storage-layouts/contracts/extensions/ColonyExtensionMeta.sol:ColonyExtensionMeta.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/ColonyExtensionMeta.sol:ColonyExtensionMeta",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/ColonyExtensionMeta.sol:ColonyExtensionMeta",
       "label": "owner",
       "offset": 0,
@@ -316,7 +316,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/EvaluatedExpenditure.sol:EvaluatedExpenditure.json
+++ b/.storage-layouts/contracts/extensions/EvaluatedExpenditure.sol:EvaluatedExpenditure.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/EvaluatedExpenditure.sol:EvaluatedExpenditure",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/EvaluatedExpenditure.sol:EvaluatedExpenditure",
       "label": "owner",
       "offset": 0,
@@ -60,7 +60,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/FundingQueue.sol:FundingQueue.json
+++ b/.storage-layouts/contracts/extensions/FundingQueue.sol:FundingQueue.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/FundingQueue.sol:FundingQueue",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/FundingQueue.sol:FundingQueue",
       "label": "owner",
       "offset": 0,
@@ -54,7 +54,7 @@
       "label": "tokenLocking",
       "offset": 0,
       "slot": "5",
-      "type": "t_contract(ITokenLocking)48928"
+      "type": "t_contract(ITokenLocking)49221"
     },
     {
       "astId": 24013,
@@ -116,7 +116,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -131,7 +131,7 @@
       "label": "contract IColonyNetwork",
       "numberOfBytes": "20"
     },
-    "t_contract(ITokenLocking)48928": {
+    "t_contract(ITokenLocking)49221": {
       "encoding": "inplace",
       "label": "contract ITokenLocking",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/OneTxPayment.sol:OneTxPayment.json
+++ b/.storage-layouts/contracts/extensions/OneTxPayment.sol:OneTxPayment.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/OneTxPayment.sol:OneTxPayment",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/OneTxPayment.sol:OneTxPayment",
       "label": "owner",
       "offset": 0,
@@ -60,7 +60,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/ReputationBootstrapper.sol:ReputationBootstrapper.json
+++ b/.storage-layouts/contracts/extensions/ReputationBootstrapper.sol:ReputationBootstrapper.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/ReputationBootstrapper.sol:ReputationBootstrapper",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/ReputationBootstrapper.sol:ReputationBootstrapper",
       "label": "owner",
       "offset": 0,
@@ -377,7 +377,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/StagedExpenditure.sol:StagedExpenditure.json
+++ b/.storage-layouts/contracts/extensions/StagedExpenditure.sol:StagedExpenditure.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/StagedExpenditure.sol:StagedExpenditure",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/StagedExpenditure.sol:StagedExpenditure",
       "label": "owner",
       "offset": 0,
@@ -324,7 +324,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/StakedExpenditure.sol:StakedExpenditure.json
+++ b/.storage-layouts/contracts/extensions/StakedExpenditure.sol:StakedExpenditure.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/StakedExpenditure.sol:StakedExpenditure",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/StakedExpenditure.sol:StakedExpenditure",
       "label": "owner",
       "offset": 0,
@@ -332,7 +332,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/StreamingPayments.sol:StreamingPayments.json
+++ b/.storage-layouts/contracts/extensions/StreamingPayments.sol:StreamingPayments.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
       "label": "owner",
       "offset": 0,
@@ -305,7 +305,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 28330,
+      "astId": 28332,
       "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
       "label": "numStreamingPayments",
       "offset": 0,
@@ -313,12 +313,20 @@
       "type": "t_uint256"
     },
     {
-      "astId": 28335,
+      "astId": 28337,
       "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
       "label": "streamingPayments",
       "offset": 0,
       "slot": "38",
-      "type": "t_mapping(t_uint256,t_struct(StreamingPayment)28328_storage)"
+      "type": "t_mapping(t_uint256,t_struct(StreamingPayment)28330_storage)"
+    },
+    {
+      "astId": 28339,
+      "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
+      "label": "nUnresolvedStreamingPayments",
+      "offset": 0,
+      "slot": "39",
+      "type": "t_uint256"
     }
   ],
   "types": {
@@ -337,7 +345,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -354,19 +362,19 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_mapping(t_uint256,t_struct(StreamingPayment)28328_storage)": {
+    "t_mapping(t_uint256,t_struct(StreamingPayment)28330_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct StreamingPayments.StreamingPayment)",
       "numberOfBytes": "32",
-      "value": "t_struct(StreamingPayment)28328_storage"
+      "value": "t_struct(StreamingPayment)28330_storage"
     },
-    "t_struct(StreamingPayment)28328_storage": {
+    "t_struct(StreamingPayment)28330_storage": {
       "encoding": "inplace",
       "label": "struct StreamingPayments.StreamingPayment",
       "members": [
         {
-          "astId": 28313,
+          "astId": 28315,
           "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
           "label": "recipient",
           "offset": 0,
@@ -374,7 +382,7 @@
           "type": "t_address_payable"
         },
         {
-          "astId": 28315,
+          "astId": 28317,
           "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
           "label": "domainId",
           "offset": 0,
@@ -382,7 +390,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 28317,
+          "astId": 28319,
           "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
           "label": "startTime",
           "offset": 0,
@@ -390,7 +398,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 28319,
+          "astId": 28321,
           "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
           "label": "endTime",
           "offset": 0,
@@ -398,7 +406,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 28321,
+          "astId": 28323,
           "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
           "label": "interval",
           "offset": 0,
@@ -406,7 +414,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 28323,
+          "astId": 28325,
           "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
           "label": "token",
           "offset": 0,
@@ -414,7 +422,7 @@
           "type": "t_address"
         },
         {
-          "astId": 28325,
+          "astId": 28327,
           "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
           "label": "amount",
           "offset": 0,
@@ -422,7 +430,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 28327,
+          "astId": 28329,
           "contract": "contracts/extensions/StreamingPayments.sol:StreamingPayments",
           "label": "pseudoAmountClaimedFromStart",
           "offset": 0,

--- a/.storage-layouts/contracts/extensions/TokenSupplier.sol:TokenSupplier.json
+++ b/.storage-layouts/contracts/extensions/TokenSupplier.sol:TokenSupplier.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "owner",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 29283,
+      "astId": 29576,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "token",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_address"
     },
     {
-      "astId": 29285,
+      "astId": 29578,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "tokenSupplyCeiling",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 29287,
+      "astId": 29580,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "tokenIssuanceRate",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 29289,
+      "astId": 29582,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "lastIssue",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 29291,
+      "astId": 29584,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "lastRateUpdate",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 29295,
+      "astId": 29588,
       "contract": "contracts/extensions/TokenSupplier.sol:TokenSupplier",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -100,7 +100,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/Whitelist.sol:Whitelist.json
+++ b/.storage-layouts/contracts/extensions/Whitelist.sol:Whitelist.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/Whitelist.sol:Whitelist",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/Whitelist.sol:Whitelist",
       "label": "owner",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 29747,
+      "astId": 30040,
       "contract": "contracts/extensions/Whitelist.sol:Whitelist",
       "label": "useApprovals",
       "offset": 21,
@@ -49,7 +49,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 29749,
+      "astId": 30042,
       "contract": "contracts/extensions/Whitelist.sol:Whitelist",
       "label": "agreementHash",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_string_storage"
     },
     {
-      "astId": 29753,
+      "astId": 30046,
       "contract": "contracts/extensions/Whitelist.sol:Whitelist",
       "label": "approvals",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 29757,
+      "astId": 30050,
       "contract": "contracts/extensions/Whitelist.sol:Whitelist",
       "label": "signatures",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 29761,
+      "astId": 30054,
       "contract": "contracts/extensions/Whitelist.sol:Whitelist",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -92,7 +92,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation.json
+++ b/.storage-layouts/contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "owner",
       "offset": 0,
@@ -41,15 +41,15 @@
       "type": "t_bool"
     },
     {
-      "astId": 34137,
+      "astId": 34430,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "state",
       "offset": 21,
       "slot": "3",
-      "type": "t_enum(ExtensionState)32385"
+      "type": "t_enum(ExtensionState)32678"
     },
     {
-      "astId": 34140,
+      "astId": 34433,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "colonyNetwork",
       "offset": 0,
@@ -57,15 +57,15 @@
       "type": "t_contract(IColonyNetwork)20072"
     },
     {
-      "astId": 34143,
+      "astId": 34436,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "tokenLocking",
       "offset": 0,
       "slot": "5",
-      "type": "t_contract(ITokenLocking)48928"
+      "type": "t_contract(ITokenLocking)49221"
     },
     {
-      "astId": 34145,
+      "astId": 34438,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "token",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_address"
     },
     {
-      "astId": 34147,
+      "astId": 34440,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "totalStakeFraction",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34149,
+      "astId": 34442,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "voterRewardFraction",
       "offset": 0,
@@ -89,7 +89,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34151,
+      "astId": 34444,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "userMinStakeFraction",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34153,
+      "astId": 34446,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "maxVoteFraction",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34155,
+      "astId": 34448,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "stakePeriod",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34157,
+      "astId": 34450,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "submitPeriod",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34159,
+      "astId": 34452,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "revealPeriod",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34161,
+      "astId": 34454,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "escalationPeriod",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34163,
+      "astId": 34456,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "motionCount",
       "offset": 0,
@@ -145,15 +145,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34168,
+      "astId": 34461,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "motions",
       "offset": 0,
       "slot": "16",
-      "type": "t_mapping(t_uint256,t_struct(Motion)32433_storage)"
+      "type": "t_mapping(t_uint256,t_struct(Motion)32726_storage)"
     },
     {
-      "astId": 34176,
+      "astId": 34469,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "stakes",
       "offset": 0,
@@ -161,7 +161,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))"
     },
     {
-      "astId": 34182,
+      "astId": 34475,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "voteSecrets",
       "offset": 0,
@@ -169,7 +169,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_bytes32))"
     },
     {
-      "astId": 34186,
+      "astId": 34479,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "expenditurePastVotes_DEPRECATED",
       "offset": 0,
@@ -177,7 +177,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 34190,
+      "astId": 34483,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "expenditureMotionCounts_DEPRECATED",
       "offset": 0,
@@ -185,7 +185,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 34194,
+      "astId": 34487,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -193,7 +193,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 34198,
+      "astId": 34491,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "expenditurePastVotes",
       "offset": 0,
@@ -201,7 +201,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 34202,
+      "astId": 34495,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "expenditureMotionLocks",
       "offset": 0,
@@ -209,7 +209,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 34204,
+      "astId": 34497,
       "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
       "label": "motionCountV10",
       "offset": 0,
@@ -255,7 +255,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -270,12 +270,12 @@
       "label": "contract IColonyNetwork",
       "numberOfBytes": "20"
     },
-    "t_contract(ITokenLocking)48928": {
+    "t_contract(ITokenLocking)49221": {
       "encoding": "inplace",
       "label": "contract ITokenLocking",
       "numberOfBytes": "20"
     },
-    "t_enum(ExtensionState)32385": {
+    "t_enum(ExtensionState)32678": {
       "encoding": "inplace",
       "label": "enum VotingReputationDataTypes.ExtensionState",
       "numberOfBytes": "1"
@@ -322,12 +322,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))"
     },
-    "t_mapping(t_uint256,t_struct(Motion)32433_storage)": {
+    "t_mapping(t_uint256,t_struct(Motion)32726_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct VotingReputationDataTypes.Motion)",
       "numberOfBytes": "32",
-      "value": "t_struct(Motion)32433_storage"
+      "value": "t_struct(Motion)32726_storage"
     },
     "t_mapping(t_uint256,t_uint256)": {
       "encoding": "mapping",
@@ -336,12 +336,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(Motion)32433_storage": {
+    "t_struct(Motion)32726_storage": {
       "encoding": "inplace",
       "label": "struct VotingReputationDataTypes.Motion",
       "members": [
         {
-          "astId": 32398,
+          "astId": 32691,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "events",
           "offset": 0,
@@ -349,7 +349,7 @@
           "type": "t_array(t_uint64)3_storage"
         },
         {
-          "astId": 32400,
+          "astId": 32693,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "rootHash",
           "offset": 0,
@@ -357,7 +357,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 32402,
+          "astId": 32695,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "domainId",
           "offset": 0,
@@ -365,7 +365,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32404,
+          "astId": 32697,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "skillId",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32406,
+          "astId": 32699,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "skillRep",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32408,
+          "astId": 32701,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "repSubmitted",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32410,
+          "astId": 32703,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "paidVoterComp",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32414,
+          "astId": 32707,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "pastVoterComp",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32418,
+          "astId": 32711,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "stakes",
           "offset": 0,
@@ -413,7 +413,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32422,
+          "astId": 32715,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "votes",
           "offset": 0,
@@ -421,7 +421,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32424,
+          "astId": 32717,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "escalated",
           "offset": 0,
@@ -429,7 +429,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32426,
+          "astId": 32719,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "finalized",
           "offset": 1,
@@ -437,7 +437,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32428,
+          "astId": 32721,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "altTarget",
           "offset": 2,
@@ -445,7 +445,7 @@
           "type": "t_address"
         },
         {
-          "astId": 32430,
+          "astId": 32723,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "sig",
           "offset": 22,
@@ -453,7 +453,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 32432,
+          "astId": 32725,
           "contract": "contracts/extensions/votingReputation/VotingReputation.sol:VotingReputation",
           "label": "action",
           "offset": 0,

--- a/.storage-layouts/contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery.json
+++ b/.storage-layouts/contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 32543,
+      "astId": 32836,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 32546,
+      "astId": 32839,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "colony",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_contract(IColony)12697"
     },
     {
-      "astId": 32548,
+      "astId": 32841,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_deprecated",
       "offset": 20,
@@ -41,15 +41,15 @@
       "type": "t_bool"
     },
     {
-      "astId": 32551,
+      "astId": 32844,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_state",
       "offset": 21,
       "slot": "3",
-      "type": "t_enum(ExtensionState)32385"
+      "type": "t_enum(ExtensionState)32678"
     },
     {
-      "astId": 32554,
+      "astId": 32847,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "colonyNetwork",
       "offset": 0,
@@ -57,15 +57,15 @@
       "type": "t_contract(IColonyNetwork)20072"
     },
     {
-      "astId": 32557,
+      "astId": 32850,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "tokenLocking",
       "offset": 0,
       "slot": "5",
-      "type": "t_contract(ITokenLocking)48928"
+      "type": "t_contract(ITokenLocking)49221"
     },
     {
-      "astId": 32559,
+      "astId": 32852,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "token",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_address"
     },
     {
-      "astId": 32561,
+      "astId": 32854,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "totalStakeFraction",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32563,
+      "astId": 32856,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_voterRewardFraction",
       "offset": 0,
@@ -89,7 +89,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32565,
+      "astId": 32858,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_userMinStakeFraction",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32567,
+      "astId": 32860,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_maxVoteFraction",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32569,
+      "astId": 32862,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_stakePeriod",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32571,
+      "astId": 32864,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_submitPeriod",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32573,
+      "astId": 32866,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_revealPeriod",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32575,
+      "astId": 32868,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_escalationPeriod",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32579,
+      "astId": 32872,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_metatransactionNonces",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 32581,
+      "astId": 32874,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_motionCount",
       "offset": 0,
@@ -153,15 +153,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 32586,
+      "astId": 32879,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "motions",
       "offset": 0,
       "slot": "17",
-      "type": "t_mapping(t_uint256,t_struct(Motion)32433_storage)"
+      "type": "t_mapping(t_uint256,t_struct(Motion)32726_storage)"
     },
     {
-      "astId": 32594,
+      "astId": 32887,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "stakes",
       "offset": 0,
@@ -169,7 +169,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))"
     },
     {
-      "astId": 32600,
+      "astId": 32893,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_voteSecrets",
       "offset": 0,
@@ -177,7 +177,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_bytes32))"
     },
     {
-      "astId": 32604,
+      "astId": 32897,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_expenditurePastVotes",
       "offset": 0,
@@ -185,7 +185,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 32608,
+      "astId": 32901,
       "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
       "label": "DO_NOT_USE_expenditureMotionCounts",
       "offset": 0,
@@ -231,7 +231,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -246,12 +246,12 @@
       "label": "contract IColonyNetwork",
       "numberOfBytes": "20"
     },
-    "t_contract(ITokenLocking)48928": {
+    "t_contract(ITokenLocking)49221": {
       "encoding": "inplace",
       "label": "contract ITokenLocking",
       "numberOfBytes": "20"
     },
-    "t_enum(ExtensionState)32385": {
+    "t_enum(ExtensionState)32678": {
       "encoding": "inplace",
       "label": "enum VotingReputationDataTypes.ExtensionState",
       "numberOfBytes": "1"
@@ -298,12 +298,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))"
     },
-    "t_mapping(t_uint256,t_struct(Motion)32433_storage)": {
+    "t_mapping(t_uint256,t_struct(Motion)32726_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct VotingReputationDataTypes.Motion)",
       "numberOfBytes": "32",
-      "value": "t_struct(Motion)32433_storage"
+      "value": "t_struct(Motion)32726_storage"
     },
     "t_mapping(t_uint256,t_uint256)": {
       "encoding": "mapping",
@@ -312,12 +312,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(Motion)32433_storage": {
+    "t_struct(Motion)32726_storage": {
       "encoding": "inplace",
       "label": "struct VotingReputationDataTypes.Motion",
       "members": [
         {
-          "astId": 32398,
+          "astId": 32691,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "events",
           "offset": 0,
@@ -325,7 +325,7 @@
           "type": "t_array(t_uint64)3_storage"
         },
         {
-          "astId": 32400,
+          "astId": 32693,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "rootHash",
           "offset": 0,
@@ -333,7 +333,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 32402,
+          "astId": 32695,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "domainId",
           "offset": 0,
@@ -341,7 +341,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32404,
+          "astId": 32697,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "skillId",
           "offset": 0,
@@ -349,7 +349,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32406,
+          "astId": 32699,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "skillRep",
           "offset": 0,
@@ -357,7 +357,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32408,
+          "astId": 32701,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "repSubmitted",
           "offset": 0,
@@ -365,7 +365,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32410,
+          "astId": 32703,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "paidVoterComp",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32414,
+          "astId": 32707,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "pastVoterComp",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32418,
+          "astId": 32711,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "stakes",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32422,
+          "astId": 32715,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "votes",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32424,
+          "astId": 32717,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "escalated",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32426,
+          "astId": 32719,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "finalized",
           "offset": 1,
@@ -413,7 +413,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32428,
+          "astId": 32721,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "altTarget",
           "offset": 2,
@@ -421,7 +421,7 @@
           "type": "t_address"
         },
         {
-          "astId": 32430,
+          "astId": 32723,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "sig",
           "offset": 22,
@@ -429,7 +429,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 32432,
+          "astId": 32725,
           "contract": "contracts/extensions/votingReputation/VotingReputationMisalignedRecovery.sol:VotingReputationMisalignedRecovery",
           "label": "action",
           "offset": 0,

--- a/.storage-layouts/contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking.json
+++ b/.storage-layouts/contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "owner",
       "offset": 0,
@@ -41,15 +41,15 @@
       "type": "t_bool"
     },
     {
-      "astId": 34137,
+      "astId": 34430,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "state",
       "offset": 21,
       "slot": "3",
-      "type": "t_enum(ExtensionState)32385"
+      "type": "t_enum(ExtensionState)32678"
     },
     {
-      "astId": 34140,
+      "astId": 34433,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "colonyNetwork",
       "offset": 0,
@@ -57,15 +57,15 @@
       "type": "t_contract(IColonyNetwork)20072"
     },
     {
-      "astId": 34143,
+      "astId": 34436,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "tokenLocking",
       "offset": 0,
       "slot": "5",
-      "type": "t_contract(ITokenLocking)48928"
+      "type": "t_contract(ITokenLocking)49221"
     },
     {
-      "astId": 34145,
+      "astId": 34438,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "token",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_address"
     },
     {
-      "astId": 34147,
+      "astId": 34440,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "totalStakeFraction",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34149,
+      "astId": 34442,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "voterRewardFraction",
       "offset": 0,
@@ -89,7 +89,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34151,
+      "astId": 34444,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "userMinStakeFraction",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34153,
+      "astId": 34446,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "maxVoteFraction",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34155,
+      "astId": 34448,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "stakePeriod",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34157,
+      "astId": 34450,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "submitPeriod",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34159,
+      "astId": 34452,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "revealPeriod",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34161,
+      "astId": 34454,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "escalationPeriod",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34163,
+      "astId": 34456,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "motionCount",
       "offset": 0,
@@ -145,15 +145,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34168,
+      "astId": 34461,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "motions",
       "offset": 0,
       "slot": "16",
-      "type": "t_mapping(t_uint256,t_struct(Motion)32433_storage)"
+      "type": "t_mapping(t_uint256,t_struct(Motion)32726_storage)"
     },
     {
-      "astId": 34176,
+      "astId": 34469,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "stakes",
       "offset": 0,
@@ -161,7 +161,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))"
     },
     {
-      "astId": 34182,
+      "astId": 34475,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "voteSecrets",
       "offset": 0,
@@ -169,7 +169,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_bytes32))"
     },
     {
-      "astId": 34186,
+      "astId": 34479,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "expenditurePastVotes_DEPRECATED",
       "offset": 0,
@@ -177,7 +177,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 34190,
+      "astId": 34483,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "expenditureMotionCounts_DEPRECATED",
       "offset": 0,
@@ -185,7 +185,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 34194,
+      "astId": 34487,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -193,7 +193,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 34198,
+      "astId": 34491,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "expenditurePastVotes",
       "offset": 0,
@@ -201,7 +201,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 34202,
+      "astId": 34495,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "expenditureMotionLocks",
       "offset": 0,
@@ -209,7 +209,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 34204,
+      "astId": 34497,
       "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
       "label": "motionCountV10",
       "offset": 0,
@@ -255,7 +255,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -270,12 +270,12 @@
       "label": "contract IColonyNetwork",
       "numberOfBytes": "20"
     },
-    "t_contract(ITokenLocking)48928": {
+    "t_contract(ITokenLocking)49221": {
       "encoding": "inplace",
       "label": "contract ITokenLocking",
       "numberOfBytes": "20"
     },
-    "t_enum(ExtensionState)32385": {
+    "t_enum(ExtensionState)32678": {
       "encoding": "inplace",
       "label": "enum VotingReputationDataTypes.ExtensionState",
       "numberOfBytes": "1"
@@ -322,12 +322,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))"
     },
-    "t_mapping(t_uint256,t_struct(Motion)32433_storage)": {
+    "t_mapping(t_uint256,t_struct(Motion)32726_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct VotingReputationDataTypes.Motion)",
       "numberOfBytes": "32",
-      "value": "t_struct(Motion)32433_storage"
+      "value": "t_struct(Motion)32726_storage"
     },
     "t_mapping(t_uint256,t_uint256)": {
       "encoding": "mapping",
@@ -336,12 +336,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(Motion)32433_storage": {
+    "t_struct(Motion)32726_storage": {
       "encoding": "inplace",
       "label": "struct VotingReputationDataTypes.Motion",
       "members": [
         {
-          "astId": 32398,
+          "astId": 32691,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "events",
           "offset": 0,
@@ -349,7 +349,7 @@
           "type": "t_array(t_uint64)3_storage"
         },
         {
-          "astId": 32400,
+          "astId": 32693,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "rootHash",
           "offset": 0,
@@ -357,7 +357,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 32402,
+          "astId": 32695,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "domainId",
           "offset": 0,
@@ -365,7 +365,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32404,
+          "astId": 32697,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "skillId",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32406,
+          "astId": 32699,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "skillRep",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32408,
+          "astId": 32701,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "repSubmitted",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32410,
+          "astId": 32703,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "paidVoterComp",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32414,
+          "astId": 32707,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "pastVoterComp",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32418,
+          "astId": 32711,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "stakes",
           "offset": 0,
@@ -413,7 +413,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32422,
+          "astId": 32715,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "votes",
           "offset": 0,
@@ -421,7 +421,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32424,
+          "astId": 32717,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "escalated",
           "offset": 0,
@@ -429,7 +429,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32426,
+          "astId": 32719,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "finalized",
           "offset": 1,
@@ -437,7 +437,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32428,
+          "astId": 32721,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "altTarget",
           "offset": 2,
@@ -445,7 +445,7 @@
           "type": "t_address"
         },
         {
-          "astId": 32430,
+          "astId": 32723,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "sig",
           "offset": 22,
@@ -453,7 +453,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 32432,
+          "astId": 32725,
           "contract": "contracts/extensions/votingReputation/VotingReputationStaking.sol:VotingReputationStaking",
           "label": "action",
           "offset": 0,

--- a/.storage-layouts/contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage.json
+++ b/.storage-layouts/contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "owner",
       "offset": 0,
@@ -41,15 +41,15 @@
       "type": "t_bool"
     },
     {
-      "astId": 34137,
+      "astId": 34430,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "state",
       "offset": 21,
       "slot": "3",
-      "type": "t_enum(ExtensionState)32385"
+      "type": "t_enum(ExtensionState)32678"
     },
     {
-      "astId": 34140,
+      "astId": 34433,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "colonyNetwork",
       "offset": 0,
@@ -57,15 +57,15 @@
       "type": "t_contract(IColonyNetwork)20072"
     },
     {
-      "astId": 34143,
+      "astId": 34436,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "tokenLocking",
       "offset": 0,
       "slot": "5",
-      "type": "t_contract(ITokenLocking)48928"
+      "type": "t_contract(ITokenLocking)49221"
     },
     {
-      "astId": 34145,
+      "astId": 34438,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "token",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_address"
     },
     {
-      "astId": 34147,
+      "astId": 34440,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "totalStakeFraction",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34149,
+      "astId": 34442,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "voterRewardFraction",
       "offset": 0,
@@ -89,7 +89,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34151,
+      "astId": 34444,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "userMinStakeFraction",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34153,
+      "astId": 34446,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "maxVoteFraction",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34155,
+      "astId": 34448,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "stakePeriod",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34157,
+      "astId": 34450,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "submitPeriod",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34159,
+      "astId": 34452,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "revealPeriod",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34161,
+      "astId": 34454,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "escalationPeriod",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34163,
+      "astId": 34456,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "motionCount",
       "offset": 0,
@@ -145,15 +145,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 34168,
+      "astId": 34461,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "motions",
       "offset": 0,
       "slot": "16",
-      "type": "t_mapping(t_uint256,t_struct(Motion)32433_storage)"
+      "type": "t_mapping(t_uint256,t_struct(Motion)32726_storage)"
     },
     {
-      "astId": 34176,
+      "astId": 34469,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "stakes",
       "offset": 0,
@@ -161,7 +161,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))"
     },
     {
-      "astId": 34182,
+      "astId": 34475,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "voteSecrets",
       "offset": 0,
@@ -169,7 +169,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_bytes32))"
     },
     {
-      "astId": 34186,
+      "astId": 34479,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "expenditurePastVotes_DEPRECATED",
       "offset": 0,
@@ -177,7 +177,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 34190,
+      "astId": 34483,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "expenditureMotionCounts_DEPRECATED",
       "offset": 0,
@@ -185,7 +185,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 34194,
+      "astId": 34487,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -193,7 +193,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 34198,
+      "astId": 34491,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "expenditurePastVotes",
       "offset": 0,
@@ -201,7 +201,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 34202,
+      "astId": 34495,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "expenditureMotionLocks",
       "offset": 0,
@@ -209,7 +209,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 34204,
+      "astId": 34497,
       "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
       "label": "motionCountV10",
       "offset": 0,
@@ -255,7 +255,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -270,12 +270,12 @@
       "label": "contract IColonyNetwork",
       "numberOfBytes": "20"
     },
-    "t_contract(ITokenLocking)48928": {
+    "t_contract(ITokenLocking)49221": {
       "encoding": "inplace",
       "label": "contract ITokenLocking",
       "numberOfBytes": "20"
     },
-    "t_enum(ExtensionState)32385": {
+    "t_enum(ExtensionState)32678": {
       "encoding": "inplace",
       "label": "enum VotingReputationDataTypes.ExtensionState",
       "numberOfBytes": "1"
@@ -322,12 +322,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))"
     },
-    "t_mapping(t_uint256,t_struct(Motion)32433_storage)": {
+    "t_mapping(t_uint256,t_struct(Motion)32726_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct VotingReputationDataTypes.Motion)",
       "numberOfBytes": "32",
-      "value": "t_struct(Motion)32433_storage"
+      "value": "t_struct(Motion)32726_storage"
     },
     "t_mapping(t_uint256,t_uint256)": {
       "encoding": "mapping",
@@ -336,12 +336,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(Motion)32433_storage": {
+    "t_struct(Motion)32726_storage": {
       "encoding": "inplace",
       "label": "struct VotingReputationDataTypes.Motion",
       "members": [
         {
-          "astId": 32398,
+          "astId": 32691,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "events",
           "offset": 0,
@@ -349,7 +349,7 @@
           "type": "t_array(t_uint64)3_storage"
         },
         {
-          "astId": 32400,
+          "astId": 32693,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "rootHash",
           "offset": 0,
@@ -357,7 +357,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 32402,
+          "astId": 32695,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "domainId",
           "offset": 0,
@@ -365,7 +365,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32404,
+          "astId": 32697,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "skillId",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32406,
+          "astId": 32699,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "skillRep",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32408,
+          "astId": 32701,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "repSubmitted",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32410,
+          "astId": 32703,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "paidVoterComp",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 32414,
+          "astId": 32707,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "pastVoterComp",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32418,
+          "astId": 32711,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "stakes",
           "offset": 0,
@@ -413,7 +413,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32422,
+          "astId": 32715,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "votes",
           "offset": 0,
@@ -421,7 +421,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 32424,
+          "astId": 32717,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "escalated",
           "offset": 0,
@@ -429,7 +429,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32426,
+          "astId": 32719,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "finalized",
           "offset": 1,
@@ -437,7 +437,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 32428,
+          "astId": 32721,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "altTarget",
           "offset": 2,
@@ -445,7 +445,7 @@
           "type": "t_address"
         },
         {
-          "astId": 32430,
+          "astId": 32723,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "sig",
           "offset": 22,
@@ -453,7 +453,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 32432,
+          "astId": 32725,
           "contract": "contracts/extensions/votingReputation/VotingReputationStorage.sol:VotingReputationStorage",
           "label": "action",
           "offset": 0,

--- a/.storage-layouts/contracts/metaTxToken/DSAuthMeta.sol:DSAuthMeta.json
+++ b/.storage-layouts/contracts/metaTxToken/DSAuthMeta.sol:DSAuthMeta.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 35279,
+      "astId": 35572,
       "contract": "contracts/metaTxToken/DSAuthMeta.sol:DSAuthMeta",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 35281,
+      "astId": 35574,
       "contract": "contracts/metaTxToken/DSAuthMeta.sol:DSAuthMeta",
       "label": "owner",
       "offset": 0,
@@ -23,7 +23,7 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/metaTxToken/MetaTxToken.sol:MetaTxToken.json
+++ b/.storage-layouts/contracts/metaTxToken/MetaTxToken.sol:MetaTxToken.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 35412,
+      "astId": 35705,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "_supply",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 35416,
+      "astId": 35709,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "_balances",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 35422,
+      "astId": 35715,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "_approvals",
       "offset": 0,
@@ -25,15 +25,15 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
     },
     {
-      "astId": 35279,
+      "astId": 35572,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "authority",
       "offset": 0,
       "slot": "3",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 35281,
+      "astId": 35574,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "owner",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_address"
     },
     {
-      "astId": 35610,
+      "astId": 35903,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "symbol",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_string_storage"
     },
     {
-      "astId": 35612,
+      "astId": 35905,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "name",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_string_storage"
     },
     {
-      "astId": 35614,
+      "astId": 35907,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "locked",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 35620,
+      "astId": 35913,
       "contract": "contracts/metaTxToken/MetaTxToken.sol:MetaTxToken",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -84,7 +84,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/patriciaTree/PatriciaTree.sol:PatriciaTree.json
+++ b/.storage-layouts/contracts/patriciaTree/PatriciaTree.sol:PatriciaTree.json
@@ -1,17 +1,17 @@
 {
   "storage": [
     {
-      "astId": 37037,
+      "astId": 37330,
       "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
       "label": "tree",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(Tree)36146_storage"
+      "type": "t_struct(Tree)36439_storage"
     }
   ],
   "types": {
-    "t_array(t_struct(Edge)36129_storage)2_storage": {
-      "base": "t_struct(Edge)36129_storage",
+    "t_array(t_struct(Edge)36422_storage)2_storage": {
+      "base": "t_struct(Edge)36422_storage",
       "encoding": "inplace",
       "label": "struct Data.Edge[2]",
       "numberOfBytes": "192"
@@ -21,19 +21,19 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_mapping(t_bytes32,t_struct(Node)36135_storage)": {
+    "t_mapping(t_bytes32,t_struct(Node)36428_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Data.Node)",
       "numberOfBytes": "32",
-      "value": "t_struct(Node)36135_storage"
+      "value": "t_struct(Node)36428_storage"
     },
-    "t_struct(Edge)36129_storage": {
+    "t_struct(Edge)36422_storage": {
       "encoding": "inplace",
       "label": "struct Data.Edge",
       "members": [
         {
-          "astId": 36125,
+          "astId": 36418,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "node",
           "offset": 0,
@@ -41,22 +41,22 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36128,
+          "astId": 36421,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "label",
           "offset": 0,
           "slot": "1",
-          "type": "t_struct(Label)36123_storage"
+          "type": "t_struct(Label)36416_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(Label)36123_storage": {
+    "t_struct(Label)36416_storage": {
       "encoding": "inplace",
       "label": "struct Data.Label",
       "members": [
         {
-          "astId": 36120,
+          "astId": 36413,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "data",
           "offset": 0,
@@ -64,7 +64,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36122,
+          "astId": 36415,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "length",
           "offset": 0,
@@ -74,27 +74,27 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Node)36135_storage": {
+    "t_struct(Node)36428_storage": {
       "encoding": "inplace",
       "label": "struct Data.Node",
       "members": [
         {
-          "astId": 36134,
+          "astId": 36427,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "children",
           "offset": 0,
           "slot": "0",
-          "type": "t_array(t_struct(Edge)36129_storage)2_storage"
+          "type": "t_array(t_struct(Edge)36422_storage)2_storage"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(Tree)36146_storage": {
+    "t_struct(Tree)36439_storage": {
       "encoding": "inplace",
       "label": "struct Data.Tree",
       "members": [
         {
-          "astId": 36137,
+          "astId": 36430,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "root",
           "offset": 0,
@@ -102,20 +102,20 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36140,
+          "astId": 36433,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "rootEdge",
           "offset": 0,
           "slot": "1",
-          "type": "t_struct(Edge)36129_storage"
+          "type": "t_struct(Edge)36422_storage"
         },
         {
-          "astId": 36145,
+          "astId": 36438,
           "contract": "contracts/patriciaTree/PatriciaTree.sol:PatriciaTree",
           "label": "nodes",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_bytes32,t_struct(Node)36135_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Node)36428_storage)"
         }
       ],
       "numberOfBytes": "160"

--- a/.storage-layouts/contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase.json
+++ b/.storage-layouts/contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase.json
@@ -1,17 +1,17 @@
 {
   "storage": [
     {
-      "astId": 37037,
+      "astId": 37330,
       "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
       "label": "tree",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(Tree)36146_storage"
+      "type": "t_struct(Tree)36439_storage"
     }
   ],
   "types": {
-    "t_array(t_struct(Edge)36129_storage)2_storage": {
-      "base": "t_struct(Edge)36129_storage",
+    "t_array(t_struct(Edge)36422_storage)2_storage": {
+      "base": "t_struct(Edge)36422_storage",
       "encoding": "inplace",
       "label": "struct Data.Edge[2]",
       "numberOfBytes": "192"
@@ -21,19 +21,19 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_mapping(t_bytes32,t_struct(Node)36135_storage)": {
+    "t_mapping(t_bytes32,t_struct(Node)36428_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Data.Node)",
       "numberOfBytes": "32",
-      "value": "t_struct(Node)36135_storage"
+      "value": "t_struct(Node)36428_storage"
     },
-    "t_struct(Edge)36129_storage": {
+    "t_struct(Edge)36422_storage": {
       "encoding": "inplace",
       "label": "struct Data.Edge",
       "members": [
         {
-          "astId": 36125,
+          "astId": 36418,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "node",
           "offset": 0,
@@ -41,22 +41,22 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36128,
+          "astId": 36421,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "label",
           "offset": 0,
           "slot": "1",
-          "type": "t_struct(Label)36123_storage"
+          "type": "t_struct(Label)36416_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(Label)36123_storage": {
+    "t_struct(Label)36416_storage": {
       "encoding": "inplace",
       "label": "struct Data.Label",
       "members": [
         {
-          "astId": 36120,
+          "astId": 36413,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "data",
           "offset": 0,
@@ -64,7 +64,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36122,
+          "astId": 36415,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "length",
           "offset": 0,
@@ -74,27 +74,27 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Node)36135_storage": {
+    "t_struct(Node)36428_storage": {
       "encoding": "inplace",
       "label": "struct Data.Node",
       "members": [
         {
-          "astId": 36134,
+          "astId": 36427,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "children",
           "offset": 0,
           "slot": "0",
-          "type": "t_array(t_struct(Edge)36129_storage)2_storage"
+          "type": "t_array(t_struct(Edge)36422_storage)2_storage"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(Tree)36146_storage": {
+    "t_struct(Tree)36439_storage": {
       "encoding": "inplace",
       "label": "struct Data.Tree",
       "members": [
         {
-          "astId": 36137,
+          "astId": 36430,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "root",
           "offset": 0,
@@ -102,20 +102,20 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36140,
+          "astId": 36433,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "rootEdge",
           "offset": 0,
           "slot": "1",
-          "type": "t_struct(Edge)36129_storage"
+          "type": "t_struct(Edge)36422_storage"
         },
         {
-          "astId": 36145,
+          "astId": 36438,
           "contract": "contracts/patriciaTree/PatriciaTreeBase.sol:PatriciaTreeBase",
           "label": "nodes",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_bytes32,t_struct(Node)36135_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Node)36428_storage)"
         }
       ],
       "numberOfBytes": "160"

--- a/.storage-layouts/contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash.json
+++ b/.storage-layouts/contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash.json
@@ -1,17 +1,17 @@
 {
   "storage": [
     {
-      "astId": 37037,
+      "astId": 37330,
       "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
       "label": "tree",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(Tree)36146_storage"
+      "type": "t_struct(Tree)36439_storage"
     }
   ],
   "types": {
-    "t_array(t_struct(Edge)36129_storage)2_storage": {
-      "base": "t_struct(Edge)36129_storage",
+    "t_array(t_struct(Edge)36422_storage)2_storage": {
+      "base": "t_struct(Edge)36422_storage",
       "encoding": "inplace",
       "label": "struct Data.Edge[2]",
       "numberOfBytes": "192"
@@ -21,19 +21,19 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_mapping(t_bytes32,t_struct(Node)36135_storage)": {
+    "t_mapping(t_bytes32,t_struct(Node)36428_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Data.Node)",
       "numberOfBytes": "32",
-      "value": "t_struct(Node)36135_storage"
+      "value": "t_struct(Node)36428_storage"
     },
-    "t_struct(Edge)36129_storage": {
+    "t_struct(Edge)36422_storage": {
       "encoding": "inplace",
       "label": "struct Data.Edge",
       "members": [
         {
-          "astId": 36125,
+          "astId": 36418,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "node",
           "offset": 0,
@@ -41,22 +41,22 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36128,
+          "astId": 36421,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "label",
           "offset": 0,
           "slot": "1",
-          "type": "t_struct(Label)36123_storage"
+          "type": "t_struct(Label)36416_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(Label)36123_storage": {
+    "t_struct(Label)36416_storage": {
       "encoding": "inplace",
       "label": "struct Data.Label",
       "members": [
         {
-          "astId": 36120,
+          "astId": 36413,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "data",
           "offset": 0,
@@ -64,7 +64,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36122,
+          "astId": 36415,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "length",
           "offset": 0,
@@ -74,27 +74,27 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Node)36135_storage": {
+    "t_struct(Node)36428_storage": {
       "encoding": "inplace",
       "label": "struct Data.Node",
       "members": [
         {
-          "astId": 36134,
+          "astId": 36427,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "children",
           "offset": 0,
           "slot": "0",
-          "type": "t_array(t_struct(Edge)36129_storage)2_storage"
+          "type": "t_array(t_struct(Edge)36422_storage)2_storage"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(Tree)36146_storage": {
+    "t_struct(Tree)36439_storage": {
       "encoding": "inplace",
       "label": "struct Data.Tree",
       "members": [
         {
-          "astId": 36137,
+          "astId": 36430,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "root",
           "offset": 0,
@@ -102,20 +102,20 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 36140,
+          "astId": 36433,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "rootEdge",
           "offset": 0,
           "slot": "1",
-          "type": "t_struct(Edge)36129_storage"
+          "type": "t_struct(Edge)36422_storage"
         },
         {
-          "astId": 36145,
+          "astId": 36438,
           "contract": "contracts/patriciaTree/PatriciaTreeNoHash.sol:PatriciaTreeNoHash",
           "label": "nodes",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_bytes32,t_struct(Node)36135_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Node)36428_storage)"
         }
       ],
       "numberOfBytes": "160"

--- a/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle.json
+++ b/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43655,
+      "astId": 43948,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43657,
+      "astId": 43950,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "colonyNetworkAddress",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_address_payable"
     },
     {
-      "astId": 43659,
+      "astId": 43952,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "tokenLockingAddress",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43661,
+      "astId": 43954,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "clnyTokenAddress",
       "offset": 0,
@@ -49,15 +49,15 @@
       "type": "t_address"
     },
     {
-      "astId": 43665,
+      "astId": 43958,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "reputationUpdateLog",
       "offset": 0,
       "slot": "6",
-      "type": "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage"
+      "type": "t_array(t_struct(ReputationLogEntry)41465_storage)dyn_storage"
     },
     {
-      "astId": 43674,
+      "astId": 43967,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "submittedHashes",
       "offset": 0,
@@ -65,15 +65,15 @@
       "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage)))"
     },
     {
-      "astId": 43679,
+      "astId": 43972,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "reputationHashSubmissions",
       "offset": 0,
       "slot": "8",
-      "type": "t_mapping(t_address,t_struct(Submission)41181_storage)"
+      "type": "t_mapping(t_address,t_struct(Submission)41474_storage)"
     },
     {
-      "astId": 43681,
+      "astId": 43974,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "reputationMiningWindowOpenTimestamp",
       "offset": 0,
@@ -81,15 +81,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43687,
+      "astId": 43980,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "disputeRounds",
       "offset": 0,
       "slot": "10",
-      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)"
+      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41495_storage)dyn_storage)"
     },
     {
-      "astId": 43691,
+      "astId": 43984,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "nHashesCompletedChallengeRound",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 43694,
+      "astId": 43987,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "nUniqueSubmittedHashes",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43697,
+      "astId": 43990,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "nInvalidatedHashes",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43703,
+      "astId": 43996,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "submittedEntries",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 43722,
+      "astId": 44015,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "firstIncompleteRound",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43726,
+      "astId": 44019,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "respondedToChallenge",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 43728,
+      "astId": 44021,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "stakeLost",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43730,
+      "astId": 44023,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "rewardsPaidOut",
       "offset": 0,
@@ -153,7 +153,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43732,
+      "astId": 44025,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
       "label": "cachedDisputeRewardSize",
       "offset": 0,
@@ -178,14 +178,14 @@
       "label": "address[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage": {
-      "base": "t_struct(DisputedEntry)41202_storage",
+    "t_array(t_struct(DisputedEntry)41495_storage)dyn_storage": {
+      "base": "t_struct(DisputedEntry)41495_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage": {
-      "base": "t_struct(ReputationLogEntry)41172_storage",
+    "t_array(t_struct(ReputationLogEntry)41465_storage)dyn_storage": {
+      "base": "t_struct(ReputationLogEntry)41465_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry[]",
       "numberOfBytes": "32"
@@ -200,7 +200,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -224,12 +224,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_bool)"
     },
-    "t_mapping(t_address,t_struct(Submission)41181_storage)": {
+    "t_mapping(t_address,t_struct(Submission)41474_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ReputationMiningCycleDataTypes.Submission)",
       "numberOfBytes": "32",
-      "value": "t_struct(Submission)41181_storage"
+      "value": "t_struct(Submission)41474_storage"
     },
     "t_mapping(t_bytes32,t_array(t_address)dyn_storage)": {
       "encoding": "mapping",
@@ -245,12 +245,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage))"
     },
-    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41495_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ReputationMiningCycleDataTypes.DisputedEntry[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage"
+      "value": "t_array(t_struct(DisputedEntry)41495_storage)dyn_storage"
     },
     "t_mapping(t_uint256,t_bool)": {
       "encoding": "mapping",
@@ -273,12 +273,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(DisputedEntry)41202_storage": {
+    "t_struct(DisputedEntry)41495_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry",
       "members": [
         {
-          "astId": 41183,
+          "astId": 41476,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "firstSubmitter",
           "offset": 0,
@@ -286,7 +286,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41185,
+          "astId": 41478,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "lastResponseTimestamp",
           "offset": 0,
@@ -294,7 +294,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41187,
+          "astId": 41480,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "challengeStepCompleted",
           "offset": 0,
@@ -302,7 +302,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41189,
+          "astId": 41482,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "intermediateReputationHash",
           "offset": 0,
@@ -310,7 +310,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41191,
+          "astId": 41484,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "intermediateReputationNLeaves",
           "offset": 0,
@@ -318,7 +318,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41193,
+          "astId": 41486,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "lowerBound",
           "offset": 0,
@@ -326,7 +326,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41195,
+          "astId": 41488,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "upperBound",
           "offset": 0,
@@ -334,7 +334,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41197,
+          "astId": 41490,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "targetHashDuringSearch",
           "offset": 0,
@@ -342,7 +342,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41199,
+          "astId": 41492,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "hash1",
           "offset": 0,
@@ -350,7 +350,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41201,
+          "astId": 41494,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "hash2",
           "offset": 0,
@@ -360,12 +360,12 @@
       ],
       "numberOfBytes": "320"
     },
-    "t_struct(ReputationLogEntry)41172_storage": {
+    "t_struct(ReputationLogEntry)41465_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry",
       "members": [
         {
-          "astId": 41161,
+          "astId": 41454,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "user",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41163,
+          "astId": 41456,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "amount",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_int256"
         },
         {
-          "astId": 41165,
+          "astId": 41458,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "skillId",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41167,
+          "astId": 41460,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "colony",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41169,
+          "astId": 41462,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "nUpdates",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_uint128"
         },
         {
-          "astId": 41171,
+          "astId": 41464,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "nPreviousUpdates",
           "offset": 16,
@@ -415,12 +415,12 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(Submission)41181_storage": {
+    "t_struct(Submission)41474_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.Submission",
       "members": [
         {
-          "astId": 41174,
+          "astId": 41467,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "proposedNewRootHash",
           "offset": 0,
@@ -428,7 +428,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41176,
+          "astId": 41469,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "nLeaves",
           "offset": 0,
@@ -436,7 +436,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41178,
+          "astId": 41471,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "jrh",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41180,
+          "astId": 41473,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycle.sol:ReputationMiningCycle",
           "label": "jrhNLeaves",
           "offset": 0,

--- a/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch.json
+++ b/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43655,
+      "astId": 43948,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43657,
+      "astId": 43950,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "colonyNetworkAddress",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_address_payable"
     },
     {
-      "astId": 43659,
+      "astId": 43952,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "tokenLockingAddress",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43661,
+      "astId": 43954,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "clnyTokenAddress",
       "offset": 0,
@@ -49,15 +49,15 @@
       "type": "t_address"
     },
     {
-      "astId": 43665,
+      "astId": 43958,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "reputationUpdateLog",
       "offset": 0,
       "slot": "6",
-      "type": "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage"
+      "type": "t_array(t_struct(ReputationLogEntry)41465_storage)dyn_storage"
     },
     {
-      "astId": 43674,
+      "astId": 43967,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "submittedHashes",
       "offset": 0,
@@ -65,15 +65,15 @@
       "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage)))"
     },
     {
-      "astId": 43679,
+      "astId": 43972,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "reputationHashSubmissions",
       "offset": 0,
       "slot": "8",
-      "type": "t_mapping(t_address,t_struct(Submission)41181_storage)"
+      "type": "t_mapping(t_address,t_struct(Submission)41474_storage)"
     },
     {
-      "astId": 43681,
+      "astId": 43974,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "reputationMiningWindowOpenTimestamp",
       "offset": 0,
@@ -81,15 +81,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43687,
+      "astId": 43980,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "disputeRounds",
       "offset": 0,
       "slot": "10",
-      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)"
+      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41495_storage)dyn_storage)"
     },
     {
-      "astId": 43691,
+      "astId": 43984,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "nHashesCompletedChallengeRound",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 43694,
+      "astId": 43987,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "nUniqueSubmittedHashes",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43697,
+      "astId": 43990,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "nInvalidatedHashes",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43703,
+      "astId": 43996,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "submittedEntries",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 43722,
+      "astId": 44015,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "firstIncompleteRound",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43726,
+      "astId": 44019,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "respondedToChallenge",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 43728,
+      "astId": 44021,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "stakeLost",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43730,
+      "astId": 44023,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "rewardsPaidOut",
       "offset": 0,
@@ -153,7 +153,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43732,
+      "astId": 44025,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
       "label": "cachedDisputeRewardSize",
       "offset": 0,
@@ -178,14 +178,14 @@
       "label": "address[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage": {
-      "base": "t_struct(DisputedEntry)41202_storage",
+    "t_array(t_struct(DisputedEntry)41495_storage)dyn_storage": {
+      "base": "t_struct(DisputedEntry)41495_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage": {
-      "base": "t_struct(ReputationLogEntry)41172_storage",
+    "t_array(t_struct(ReputationLogEntry)41465_storage)dyn_storage": {
+      "base": "t_struct(ReputationLogEntry)41465_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry[]",
       "numberOfBytes": "32"
@@ -200,7 +200,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -224,12 +224,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_bool)"
     },
-    "t_mapping(t_address,t_struct(Submission)41181_storage)": {
+    "t_mapping(t_address,t_struct(Submission)41474_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ReputationMiningCycleDataTypes.Submission)",
       "numberOfBytes": "32",
-      "value": "t_struct(Submission)41181_storage"
+      "value": "t_struct(Submission)41474_storage"
     },
     "t_mapping(t_bytes32,t_array(t_address)dyn_storage)": {
       "encoding": "mapping",
@@ -245,12 +245,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage))"
     },
-    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41495_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ReputationMiningCycleDataTypes.DisputedEntry[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage"
+      "value": "t_array(t_struct(DisputedEntry)41495_storage)dyn_storage"
     },
     "t_mapping(t_uint256,t_bool)": {
       "encoding": "mapping",
@@ -273,12 +273,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(DisputedEntry)41202_storage": {
+    "t_struct(DisputedEntry)41495_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry",
       "members": [
         {
-          "astId": 41183,
+          "astId": 41476,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "firstSubmitter",
           "offset": 0,
@@ -286,7 +286,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41185,
+          "astId": 41478,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "lastResponseTimestamp",
           "offset": 0,
@@ -294,7 +294,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41187,
+          "astId": 41480,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "challengeStepCompleted",
           "offset": 0,
@@ -302,7 +302,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41189,
+          "astId": 41482,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "intermediateReputationHash",
           "offset": 0,
@@ -310,7 +310,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41191,
+          "astId": 41484,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "intermediateReputationNLeaves",
           "offset": 0,
@@ -318,7 +318,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41193,
+          "astId": 41486,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "lowerBound",
           "offset": 0,
@@ -326,7 +326,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41195,
+          "astId": 41488,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "upperBound",
           "offset": 0,
@@ -334,7 +334,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41197,
+          "astId": 41490,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "targetHashDuringSearch",
           "offset": 0,
@@ -342,7 +342,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41199,
+          "astId": 41492,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "hash1",
           "offset": 0,
@@ -350,7 +350,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41201,
+          "astId": 41494,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "hash2",
           "offset": 0,
@@ -360,12 +360,12 @@
       ],
       "numberOfBytes": "320"
     },
-    "t_struct(ReputationLogEntry)41172_storage": {
+    "t_struct(ReputationLogEntry)41465_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry",
       "members": [
         {
-          "astId": 41161,
+          "astId": 41454,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "user",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41163,
+          "astId": 41456,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "amount",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_int256"
         },
         {
-          "astId": 41165,
+          "astId": 41458,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "skillId",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41167,
+          "astId": 41460,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "colony",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41169,
+          "astId": 41462,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "nUpdates",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_uint128"
         },
         {
-          "astId": 41171,
+          "astId": 41464,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "nPreviousUpdates",
           "offset": 16,
@@ -415,12 +415,12 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(Submission)41181_storage": {
+    "t_struct(Submission)41474_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.Submission",
       "members": [
         {
-          "astId": 41174,
+          "astId": 41467,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "proposedNewRootHash",
           "offset": 0,
@@ -428,7 +428,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41176,
+          "astId": 41469,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "nLeaves",
           "offset": 0,
@@ -436,7 +436,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41178,
+          "astId": 41471,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "jrh",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41180,
+          "astId": 41473,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol:ReputationMiningCycleBinarySearch",
           "label": "jrhNLeaves",
           "offset": 0,

--- a/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon.json
+++ b/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43655,
+      "astId": 43948,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43657,
+      "astId": 43950,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "colonyNetworkAddress",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_address_payable"
     },
     {
-      "astId": 43659,
+      "astId": 43952,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "tokenLockingAddress",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43661,
+      "astId": 43954,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "clnyTokenAddress",
       "offset": 0,
@@ -49,15 +49,15 @@
       "type": "t_address"
     },
     {
-      "astId": 43665,
+      "astId": 43958,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "reputationUpdateLog",
       "offset": 0,
       "slot": "6",
-      "type": "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage"
+      "type": "t_array(t_struct(ReputationLogEntry)41465_storage)dyn_storage"
     },
     {
-      "astId": 43674,
+      "astId": 43967,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "submittedHashes",
       "offset": 0,
@@ -65,15 +65,15 @@
       "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage)))"
     },
     {
-      "astId": 43679,
+      "astId": 43972,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "reputationHashSubmissions",
       "offset": 0,
       "slot": "8",
-      "type": "t_mapping(t_address,t_struct(Submission)41181_storage)"
+      "type": "t_mapping(t_address,t_struct(Submission)41474_storage)"
     },
     {
-      "astId": 43681,
+      "astId": 43974,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "reputationMiningWindowOpenTimestamp",
       "offset": 0,
@@ -81,15 +81,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43687,
+      "astId": 43980,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "disputeRounds",
       "offset": 0,
       "slot": "10",
-      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)"
+      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41495_storage)dyn_storage)"
     },
     {
-      "astId": 43691,
+      "astId": 43984,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "nHashesCompletedChallengeRound",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 43694,
+      "astId": 43987,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "nUniqueSubmittedHashes",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43697,
+      "astId": 43990,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "nInvalidatedHashes",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43703,
+      "astId": 43996,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "submittedEntries",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 43722,
+      "astId": 44015,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "firstIncompleteRound",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43726,
+      "astId": 44019,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "respondedToChallenge",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 43728,
+      "astId": 44021,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "stakeLost",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43730,
+      "astId": 44023,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "rewardsPaidOut",
       "offset": 0,
@@ -153,7 +153,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43732,
+      "astId": 44025,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
       "label": "cachedDisputeRewardSize",
       "offset": 0,
@@ -178,14 +178,14 @@
       "label": "address[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage": {
-      "base": "t_struct(DisputedEntry)41202_storage",
+    "t_array(t_struct(DisputedEntry)41495_storage)dyn_storage": {
+      "base": "t_struct(DisputedEntry)41495_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage": {
-      "base": "t_struct(ReputationLogEntry)41172_storage",
+    "t_array(t_struct(ReputationLogEntry)41465_storage)dyn_storage": {
+      "base": "t_struct(ReputationLogEntry)41465_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry[]",
       "numberOfBytes": "32"
@@ -200,7 +200,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -224,12 +224,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_bool)"
     },
-    "t_mapping(t_address,t_struct(Submission)41181_storage)": {
+    "t_mapping(t_address,t_struct(Submission)41474_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ReputationMiningCycleDataTypes.Submission)",
       "numberOfBytes": "32",
-      "value": "t_struct(Submission)41181_storage"
+      "value": "t_struct(Submission)41474_storage"
     },
     "t_mapping(t_bytes32,t_array(t_address)dyn_storage)": {
       "encoding": "mapping",
@@ -245,12 +245,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage))"
     },
-    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41495_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ReputationMiningCycleDataTypes.DisputedEntry[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage"
+      "value": "t_array(t_struct(DisputedEntry)41495_storage)dyn_storage"
     },
     "t_mapping(t_uint256,t_bool)": {
       "encoding": "mapping",
@@ -273,12 +273,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(DisputedEntry)41202_storage": {
+    "t_struct(DisputedEntry)41495_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry",
       "members": [
         {
-          "astId": 41183,
+          "astId": 41476,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "firstSubmitter",
           "offset": 0,
@@ -286,7 +286,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41185,
+          "astId": 41478,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "lastResponseTimestamp",
           "offset": 0,
@@ -294,7 +294,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41187,
+          "astId": 41480,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "challengeStepCompleted",
           "offset": 0,
@@ -302,7 +302,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41189,
+          "astId": 41482,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "intermediateReputationHash",
           "offset": 0,
@@ -310,7 +310,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41191,
+          "astId": 41484,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "intermediateReputationNLeaves",
           "offset": 0,
@@ -318,7 +318,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41193,
+          "astId": 41486,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "lowerBound",
           "offset": 0,
@@ -326,7 +326,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41195,
+          "astId": 41488,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "upperBound",
           "offset": 0,
@@ -334,7 +334,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41197,
+          "astId": 41490,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "targetHashDuringSearch",
           "offset": 0,
@@ -342,7 +342,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41199,
+          "astId": 41492,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "hash1",
           "offset": 0,
@@ -350,7 +350,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41201,
+          "astId": 41494,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "hash2",
           "offset": 0,
@@ -360,12 +360,12 @@
       ],
       "numberOfBytes": "320"
     },
-    "t_struct(ReputationLogEntry)41172_storage": {
+    "t_struct(ReputationLogEntry)41465_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry",
       "members": [
         {
-          "astId": 41161,
+          "astId": 41454,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "user",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41163,
+          "astId": 41456,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "amount",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_int256"
         },
         {
-          "astId": 41165,
+          "astId": 41458,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "skillId",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41167,
+          "astId": 41460,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "colony",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41169,
+          "astId": 41462,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "nUpdates",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_uint128"
         },
         {
-          "astId": 41171,
+          "astId": 41464,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "nPreviousUpdates",
           "offset": 16,
@@ -415,12 +415,12 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(Submission)41181_storage": {
+    "t_struct(Submission)41474_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.Submission",
       "members": [
         {
-          "astId": 41174,
+          "astId": 41467,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "proposedNewRootHash",
           "offset": 0,
@@ -428,7 +428,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41176,
+          "astId": 41469,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "nLeaves",
           "offset": 0,
@@ -436,7 +436,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41178,
+          "astId": 41471,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "jrh",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41180,
+          "astId": 41473,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleCommon.sol:ReputationMiningCycleCommon",
           "label": "jrhNLeaves",
           "offset": 0,

--- a/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond.json
+++ b/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43655,
+      "astId": 43948,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43657,
+      "astId": 43950,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "colonyNetworkAddress",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_address_payable"
     },
     {
-      "astId": 43659,
+      "astId": 43952,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "tokenLockingAddress",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43661,
+      "astId": 43954,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "clnyTokenAddress",
       "offset": 0,
@@ -49,15 +49,15 @@
       "type": "t_address"
     },
     {
-      "astId": 43665,
+      "astId": 43958,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "reputationUpdateLog",
       "offset": 0,
       "slot": "6",
-      "type": "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage"
+      "type": "t_array(t_struct(ReputationLogEntry)41465_storage)dyn_storage"
     },
     {
-      "astId": 43674,
+      "astId": 43967,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "submittedHashes",
       "offset": 0,
@@ -65,15 +65,15 @@
       "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage)))"
     },
     {
-      "astId": 43679,
+      "astId": 43972,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "reputationHashSubmissions",
       "offset": 0,
       "slot": "8",
-      "type": "t_mapping(t_address,t_struct(Submission)41181_storage)"
+      "type": "t_mapping(t_address,t_struct(Submission)41474_storage)"
     },
     {
-      "astId": 43681,
+      "astId": 43974,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "reputationMiningWindowOpenTimestamp",
       "offset": 0,
@@ -81,15 +81,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43687,
+      "astId": 43980,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "disputeRounds",
       "offset": 0,
       "slot": "10",
-      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)"
+      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41495_storage)dyn_storage)"
     },
     {
-      "astId": 43691,
+      "astId": 43984,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "nHashesCompletedChallengeRound",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 43694,
+      "astId": 43987,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "nUniqueSubmittedHashes",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43697,
+      "astId": 43990,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "nInvalidatedHashes",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43703,
+      "astId": 43996,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "submittedEntries",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 43722,
+      "astId": 44015,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "firstIncompleteRound",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43726,
+      "astId": 44019,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "respondedToChallenge",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 43728,
+      "astId": 44021,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "stakeLost",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43730,
+      "astId": 44023,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "rewardsPaidOut",
       "offset": 0,
@@ -153,7 +153,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43732,
+      "astId": 44025,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
       "label": "cachedDisputeRewardSize",
       "offset": 0,
@@ -178,14 +178,14 @@
       "label": "address[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage": {
-      "base": "t_struct(DisputedEntry)41202_storage",
+    "t_array(t_struct(DisputedEntry)41495_storage)dyn_storage": {
+      "base": "t_struct(DisputedEntry)41495_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage": {
-      "base": "t_struct(ReputationLogEntry)41172_storage",
+    "t_array(t_struct(ReputationLogEntry)41465_storage)dyn_storage": {
+      "base": "t_struct(ReputationLogEntry)41465_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry[]",
       "numberOfBytes": "32"
@@ -200,7 +200,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -224,12 +224,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_bool)"
     },
-    "t_mapping(t_address,t_struct(Submission)41181_storage)": {
+    "t_mapping(t_address,t_struct(Submission)41474_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ReputationMiningCycleDataTypes.Submission)",
       "numberOfBytes": "32",
-      "value": "t_struct(Submission)41181_storage"
+      "value": "t_struct(Submission)41474_storage"
     },
     "t_mapping(t_bytes32,t_array(t_address)dyn_storage)": {
       "encoding": "mapping",
@@ -245,12 +245,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage))"
     },
-    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41495_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ReputationMiningCycleDataTypes.DisputedEntry[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage"
+      "value": "t_array(t_struct(DisputedEntry)41495_storage)dyn_storage"
     },
     "t_mapping(t_uint256,t_bool)": {
       "encoding": "mapping",
@@ -273,12 +273,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(DisputedEntry)41202_storage": {
+    "t_struct(DisputedEntry)41495_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry",
       "members": [
         {
-          "astId": 41183,
+          "astId": 41476,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "firstSubmitter",
           "offset": 0,
@@ -286,7 +286,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41185,
+          "astId": 41478,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "lastResponseTimestamp",
           "offset": 0,
@@ -294,7 +294,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41187,
+          "astId": 41480,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "challengeStepCompleted",
           "offset": 0,
@@ -302,7 +302,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41189,
+          "astId": 41482,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "intermediateReputationHash",
           "offset": 0,
@@ -310,7 +310,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41191,
+          "astId": 41484,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "intermediateReputationNLeaves",
           "offset": 0,
@@ -318,7 +318,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41193,
+          "astId": 41486,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "lowerBound",
           "offset": 0,
@@ -326,7 +326,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41195,
+          "astId": 41488,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "upperBound",
           "offset": 0,
@@ -334,7 +334,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41197,
+          "astId": 41490,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "targetHashDuringSearch",
           "offset": 0,
@@ -342,7 +342,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41199,
+          "astId": 41492,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "hash1",
           "offset": 0,
@@ -350,7 +350,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41201,
+          "astId": 41494,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "hash2",
           "offset": 0,
@@ -360,12 +360,12 @@
       ],
       "numberOfBytes": "320"
     },
-    "t_struct(ReputationLogEntry)41172_storage": {
+    "t_struct(ReputationLogEntry)41465_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry",
       "members": [
         {
-          "astId": 41161,
+          "astId": 41454,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "user",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41163,
+          "astId": 41456,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "amount",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_int256"
         },
         {
-          "astId": 41165,
+          "astId": 41458,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "skillId",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41167,
+          "astId": 41460,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "colony",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41169,
+          "astId": 41462,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "nUpdates",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_uint128"
         },
         {
-          "astId": 41171,
+          "astId": 41464,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "nPreviousUpdates",
           "offset": 16,
@@ -415,12 +415,12 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(Submission)41181_storage": {
+    "t_struct(Submission)41474_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.Submission",
       "members": [
         {
-          "astId": 41174,
+          "astId": 41467,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "proposedNewRootHash",
           "offset": 0,
@@ -428,7 +428,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41176,
+          "astId": 41469,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "nLeaves",
           "offset": 0,
@@ -436,7 +436,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41178,
+          "astId": 41471,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "jrh",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41180,
+          "astId": 41473,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol:ReputationMiningCycleRespond",
           "label": "jrhNLeaves",
           "offset": 0,

--- a/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage.json
+++ b/.storage-layouts/contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43655,
+      "astId": 43948,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43657,
+      "astId": 43950,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "colonyNetworkAddress",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_address_payable"
     },
     {
-      "astId": 43659,
+      "astId": 43952,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "tokenLockingAddress",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_address"
     },
     {
-      "astId": 43661,
+      "astId": 43954,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "clnyTokenAddress",
       "offset": 0,
@@ -49,15 +49,15 @@
       "type": "t_address"
     },
     {
-      "astId": 43665,
+      "astId": 43958,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "reputationUpdateLog",
       "offset": 0,
       "slot": "6",
-      "type": "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage"
+      "type": "t_array(t_struct(ReputationLogEntry)41465_storage)dyn_storage"
     },
     {
-      "astId": 43674,
+      "astId": 43967,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "submittedHashes",
       "offset": 0,
@@ -65,15 +65,15 @@
       "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage)))"
     },
     {
-      "astId": 43679,
+      "astId": 43972,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "reputationHashSubmissions",
       "offset": 0,
       "slot": "8",
-      "type": "t_mapping(t_address,t_struct(Submission)41181_storage)"
+      "type": "t_mapping(t_address,t_struct(Submission)41474_storage)"
     },
     {
-      "astId": 43681,
+      "astId": 43974,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "reputationMiningWindowOpenTimestamp",
       "offset": 0,
@@ -81,15 +81,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43687,
+      "astId": 43980,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "disputeRounds",
       "offset": 0,
       "slot": "10",
-      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)"
+      "type": "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41495_storage)dyn_storage)"
     },
     {
-      "astId": 43691,
+      "astId": 43984,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "nHashesCompletedChallengeRound",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_mapping(t_uint256,t_uint256)"
     },
     {
-      "astId": 43694,
+      "astId": 43987,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "nUniqueSubmittedHashes",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43697,
+      "astId": 43990,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "nInvalidatedHashes",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43703,
+      "astId": 43996,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "submittedEntries",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_bool))"
     },
     {
-      "astId": 43722,
+      "astId": 44015,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "firstIncompleteRound",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43726,
+      "astId": 44019,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "respondedToChallenge",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 43728,
+      "astId": 44021,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "stakeLost",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43730,
+      "astId": 44023,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "rewardsPaidOut",
       "offset": 0,
@@ -153,7 +153,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43732,
+      "astId": 44025,
       "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
       "label": "cachedDisputeRewardSize",
       "offset": 0,
@@ -178,14 +178,14 @@
       "label": "address[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage": {
-      "base": "t_struct(DisputedEntry)41202_storage",
+    "t_array(t_struct(DisputedEntry)41495_storage)dyn_storage": {
+      "base": "t_struct(DisputedEntry)41495_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ReputationLogEntry)41172_storage)dyn_storage": {
-      "base": "t_struct(ReputationLogEntry)41172_storage",
+    "t_array(t_struct(ReputationLogEntry)41465_storage)dyn_storage": {
+      "base": "t_struct(ReputationLogEntry)41465_storage",
       "encoding": "dynamic_array",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry[]",
       "numberOfBytes": "32"
@@ -200,7 +200,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -224,12 +224,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_bool)"
     },
-    "t_mapping(t_address,t_struct(Submission)41181_storage)": {
+    "t_mapping(t_address,t_struct(Submission)41474_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ReputationMiningCycleDataTypes.Submission)",
       "numberOfBytes": "32",
-      "value": "t_struct(Submission)41181_storage"
+      "value": "t_struct(Submission)41474_storage"
     },
     "t_mapping(t_bytes32,t_array(t_address)dyn_storage)": {
       "encoding": "mapping",
@@ -245,12 +245,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_mapping(t_bytes32,t_array(t_address)dyn_storage))"
     },
-    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41202_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(DisputedEntry)41495_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ReputationMiningCycleDataTypes.DisputedEntry[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(DisputedEntry)41202_storage)dyn_storage"
+      "value": "t_array(t_struct(DisputedEntry)41495_storage)dyn_storage"
     },
     "t_mapping(t_uint256,t_bool)": {
       "encoding": "mapping",
@@ -273,12 +273,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(DisputedEntry)41202_storage": {
+    "t_struct(DisputedEntry)41495_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.DisputedEntry",
       "members": [
         {
-          "astId": 41183,
+          "astId": 41476,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "firstSubmitter",
           "offset": 0,
@@ -286,7 +286,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41185,
+          "astId": 41478,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "lastResponseTimestamp",
           "offset": 0,
@@ -294,7 +294,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41187,
+          "astId": 41480,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "challengeStepCompleted",
           "offset": 0,
@@ -302,7 +302,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41189,
+          "astId": 41482,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "intermediateReputationHash",
           "offset": 0,
@@ -310,7 +310,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41191,
+          "astId": 41484,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "intermediateReputationNLeaves",
           "offset": 0,
@@ -318,7 +318,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41193,
+          "astId": 41486,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "lowerBound",
           "offset": 0,
@@ -326,7 +326,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41195,
+          "astId": 41488,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "upperBound",
           "offset": 0,
@@ -334,7 +334,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41197,
+          "astId": 41490,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "targetHashDuringSearch",
           "offset": 0,
@@ -342,7 +342,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41199,
+          "astId": 41492,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "hash1",
           "offset": 0,
@@ -350,7 +350,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41201,
+          "astId": 41494,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "hash2",
           "offset": 0,
@@ -360,12 +360,12 @@
       ],
       "numberOfBytes": "320"
     },
-    "t_struct(ReputationLogEntry)41172_storage": {
+    "t_struct(ReputationLogEntry)41465_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.ReputationLogEntry",
       "members": [
         {
-          "astId": 41161,
+          "astId": 41454,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "user",
           "offset": 0,
@@ -373,7 +373,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41163,
+          "astId": 41456,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "amount",
           "offset": 0,
@@ -381,7 +381,7 @@
           "type": "t_int256"
         },
         {
-          "astId": 41165,
+          "astId": 41458,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "skillId",
           "offset": 0,
@@ -389,7 +389,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41167,
+          "astId": 41460,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "colony",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_address"
         },
         {
-          "astId": 41169,
+          "astId": 41462,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "nUpdates",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_uint128"
         },
         {
-          "astId": 41171,
+          "astId": 41464,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "nPreviousUpdates",
           "offset": 16,
@@ -415,12 +415,12 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(Submission)41181_storage": {
+    "t_struct(Submission)41474_storage": {
       "encoding": "inplace",
       "label": "struct ReputationMiningCycleDataTypes.Submission",
       "members": [
         {
-          "astId": 41174,
+          "astId": 41467,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "proposedNewRootHash",
           "offset": 0,
@@ -428,7 +428,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41176,
+          "astId": 41469,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "nLeaves",
           "offset": 0,
@@ -436,7 +436,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 41178,
+          "astId": 41471,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "jrh",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 41180,
+          "astId": 41473,
           "contract": "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol:ReputationMiningCycleStorage",
           "label": "jrhNLeaves",
           "offset": 0,

--- a/.storage-layouts/contracts/testHelpers/FunctionsNotAvailableOnColony.sol:FunctionsNotAvailableOnColony.json
+++ b/.storage-layouts/contracts/testHelpers/FunctionsNotAvailableOnColony.sol:FunctionsNotAvailableOnColony.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/testHelpers/FunctionsNotAvailableOnColony.sol:FunctionsNotAvailableOnColony",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/testHelpers/FunctionsNotAvailableOnColony.sol:FunctionsNotAvailableOnColony",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/GasGuzzler.sol:GasGuzzler.json
+++ b/.storage-layouts/contracts/testHelpers/GasGuzzler.sol:GasGuzzler.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/testHelpers/GasGuzzler.sol:GasGuzzler",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/testHelpers/GasGuzzler.sol:GasGuzzler",
       "label": "owner",
       "offset": 0,
@@ -305,7 +305,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 44243,
+      "astId": 44536,
       "contract": "contracts/testHelpers/GasGuzzler.sol:GasGuzzler",
       "label": "storageVar",
       "offset": 0,
@@ -324,7 +324,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/NoLimitSubdomains.sol:NoLimitSubdomains.json
+++ b/.storage-layouts/contracts/testHelpers/NoLimitSubdomains.sol:NoLimitSubdomains.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/testHelpers/NoLimitSubdomains.sol:NoLimitSubdomains",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/testHelpers/NoLimitSubdomains.sol:NoLimitSubdomains",
       "label": "owner",
       "offset": 0,
@@ -359,7 +359,7 @@
       "label": "bytes4",
       "numberOfBytes": "4"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned.json
+++ b/.storage-layouts/contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "owner",
       "offset": 0,
@@ -41,15 +41,15 @@
       "type": "t_bool"
     },
     {
-      "astId": 44958,
+      "astId": 45251,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "state",
       "offset": 21,
       "slot": "3",
-      "type": "t_enum(ExtensionState)44955"
+      "type": "t_enum(ExtensionState)45248"
     },
     {
-      "astId": 44961,
+      "astId": 45254,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "colonyNetwork",
       "offset": 0,
@@ -57,15 +57,15 @@
       "type": "t_contract(IColonyNetwork)20072"
     },
     {
-      "astId": 44964,
+      "astId": 45257,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "tokenLocking",
       "offset": 0,
       "slot": "5",
-      "type": "t_contract(ITokenLocking)48928"
+      "type": "t_contract(ITokenLocking)49221"
     },
     {
-      "astId": 44966,
+      "astId": 45259,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "token",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_address"
     },
     {
-      "astId": 44968,
+      "astId": 45261,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "totalStakeFraction",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 44970,
+      "astId": 45263,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "voterRewardFraction",
       "offset": 0,
@@ -89,7 +89,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 44972,
+      "astId": 45265,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "userMinStakeFraction",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 44974,
+      "astId": 45267,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "maxVoteFraction",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 44976,
+      "astId": 45269,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "stakePeriod",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 44978,
+      "astId": 45271,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "submitPeriod",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 44980,
+      "astId": 45273,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "revealPeriod",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 44982,
+      "astId": 45275,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "escalationPeriod",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 44986,
+      "astId": 45279,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 45318,
+      "astId": 45611,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "motionCount",
       "offset": 0,
@@ -153,15 +153,15 @@
       "type": "t_uint256"
     },
     {
-      "astId": 45323,
+      "astId": 45616,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "motions",
       "offset": 0,
       "slot": "17",
-      "type": "t_mapping(t_uint256,t_struct(Motion)45316_storage)"
+      "type": "t_mapping(t_uint256,t_struct(Motion)45609_storage)"
     },
     {
-      "astId": 45331,
+      "astId": 45624,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "stakes",
       "offset": 0,
@@ -169,7 +169,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))"
     },
     {
-      "astId": 45337,
+      "astId": 45630,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "voteSecrets",
       "offset": 0,
@@ -177,7 +177,7 @@
       "type": "t_mapping(t_uint256,t_mapping(t_address,t_bytes32))"
     },
     {
-      "astId": 45341,
+      "astId": 45634,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "expenditurePastVotes",
       "offset": 0,
@@ -185,7 +185,7 @@
       "type": "t_mapping(t_bytes32,t_uint256)"
     },
     {
-      "astId": 45345,
+      "astId": 45638,
       "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
       "label": "expenditureMotionCounts",
       "offset": 0,
@@ -226,7 +226,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -241,12 +241,12 @@
       "label": "contract IColonyNetwork",
       "numberOfBytes": "20"
     },
-    "t_contract(ITokenLocking)48928": {
+    "t_contract(ITokenLocking)49221": {
       "encoding": "inplace",
       "label": "contract ITokenLocking",
       "numberOfBytes": "20"
     },
-    "t_enum(ExtensionState)44955": {
+    "t_enum(ExtensionState)45248": {
       "encoding": "inplace",
       "label": "enum VotingReputationMisaligned.ExtensionState",
       "numberOfBytes": "1"
@@ -293,12 +293,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))"
     },
-    "t_mapping(t_uint256,t_struct(Motion)45316_storage)": {
+    "t_mapping(t_uint256,t_struct(Motion)45609_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct VotingReputationMisaligned.Motion)",
       "numberOfBytes": "32",
-      "value": "t_struct(Motion)45316_storage"
+      "value": "t_struct(Motion)45609_storage"
     },
     "t_mapping(t_uint256,t_uint256)": {
       "encoding": "mapping",
@@ -307,12 +307,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(Motion)45316_storage": {
+    "t_struct(Motion)45609_storage": {
       "encoding": "inplace",
       "label": "struct VotingReputationMisaligned.Motion",
       "members": [
         {
-          "astId": 45283,
+          "astId": 45576,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "events",
           "offset": 0,
@@ -320,7 +320,7 @@
           "type": "t_array(t_uint64)3_storage"
         },
         {
-          "astId": 45285,
+          "astId": 45578,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "rootHash",
           "offset": 0,
@@ -328,7 +328,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 45287,
+          "astId": 45580,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "domainId",
           "offset": 0,
@@ -336,7 +336,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 45289,
+          "astId": 45582,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "skillId",
           "offset": 0,
@@ -344,7 +344,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 45291,
+          "astId": 45584,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "skillRep",
           "offset": 0,
@@ -352,7 +352,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 45293,
+          "astId": 45586,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "repSubmitted",
           "offset": 0,
@@ -360,7 +360,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 45295,
+          "astId": 45588,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "paidVoterComp",
           "offset": 0,
@@ -368,7 +368,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 45299,
+          "astId": 45592,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "pastVoterComp",
           "offset": 0,
@@ -376,7 +376,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 45303,
+          "astId": 45596,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "stakes",
           "offset": 0,
@@ -384,7 +384,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 45307,
+          "astId": 45600,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "votes",
           "offset": 0,
@@ -392,7 +392,7 @@
           "type": "t_array(t_uint256)2_storage"
         },
         {
-          "astId": 45309,
+          "astId": 45602,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "escalated",
           "offset": 0,
@@ -400,7 +400,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 45311,
+          "astId": 45604,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "finalized",
           "offset": 1,
@@ -408,7 +408,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 45313,
+          "astId": 45606,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "altTarget",
           "offset": 2,
@@ -416,7 +416,7 @@
           "type": "t_address"
         },
         {
-          "astId": 45315,
+          "astId": 45608,
           "contract": "contracts/testHelpers/VotingReputationMisaligned.sol:VotingReputationMisaligned",
           "label": "action",
           "offset": 0,

--- a/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension0.sol:TestExtension0.json
+++ b/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension0.sol:TestExtension0.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/testHelpers/testExtensions/TestExtension0.sol:TestExtension0",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/testHelpers/testExtensions/TestExtension0.sol:TestExtension0",
       "label": "owner",
       "offset": 0,
@@ -316,7 +316,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension1.sol:TestExtension1.json
+++ b/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension1.sol:TestExtension1.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/testHelpers/testExtensions/TestExtension1.sol:TestExtension1",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/testHelpers/testExtensions/TestExtension1.sol:TestExtension1",
       "label": "owner",
       "offset": 0,
@@ -316,7 +316,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension2.sol:TestExtension2.json
+++ b/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension2.sol:TestExtension2.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/testHelpers/testExtensions/TestExtension2.sol:TestExtension2",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/testHelpers/testExtensions/TestExtension2.sol:TestExtension2",
       "label": "owner",
       "offset": 0,
@@ -316,7 +316,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension3.sol:TestExtension3.json
+++ b/.storage-layouts/contracts/testHelpers/testExtensions/TestExtension3.sol:TestExtension3.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/testHelpers/testExtensions/TestExtension3.sol:TestExtension3",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/testHelpers/testExtensions/TestExtension3.sol:TestExtension3",
       "label": "owner",
       "offset": 0,
@@ -316,7 +316,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/testExtensions/TestExtensionBase.sol:TestExtensionBase.json
+++ b/.storage-layouts/contracts/testHelpers/testExtensions/TestExtensionBase.sol:TestExtensionBase.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/testHelpers/testExtensions/TestExtensionBase.sol:TestExtensionBase",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/testHelpers/testExtensions/TestExtensionBase.sol:TestExtensionBase",
       "label": "owner",
       "offset": 0,
@@ -316,7 +316,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/testHelpers/testExtensions/TestVotingToken.sol:TestVotingToken.json
+++ b/.storage-layouts/contracts/testHelpers/testExtensions/TestVotingToken.sol:TestVotingToken.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/testHelpers/testExtensions/TestVotingToken.sol:TestVotingToken",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/testHelpers/testExtensions/TestVotingToken.sol:TestVotingToken",
       "label": "owner",
       "offset": 0,
@@ -316,7 +316,7 @@
       "label": "bool",
       "numberOfBytes": "1"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"

--- a/.storage-layouts/contracts/tokenLocking/TokenLocking.sol:TokenLocking.json
+++ b/.storage-layouts/contracts/tokenLocking/TokenLocking.sol:TokenLocking.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 49983,
+      "astId": 50276,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 49985,
+      "astId": 50278,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "colonyNetwork",
       "offset": 0,
@@ -33,15 +33,15 @@
       "type": "t_address"
     },
     {
-      "astId": 49992,
+      "astId": 50285,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "userLocks",
       "offset": 0,
       "slot": "4",
-      "type": "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)49969_storage))"
+      "type": "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)50262_storage))"
     },
     {
-      "astId": 49996,
+      "astId": 50289,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "totalLockCount",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 50004,
+      "astId": 50297,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "approvals",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_address,t_uint256)))"
     },
     {
-      "astId": 50012,
+      "astId": 50305,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "obligations",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_address,t_uint256)))"
     },
     {
-      "astId": 50018,
+      "astId": 50311,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "totalObligations",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
     },
     {
-      "astId": 50024,
+      "astId": 50317,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "lockers",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_address))"
     },
     {
-      "astId": 50028,
+      "astId": 50321,
       "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -95,7 +95,7 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -107,12 +107,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
     },
-    "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)49969_storage))": {
+    "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)50262_storage))": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => mapping(address => struct TokenLockingDataTypes.Lock))",
       "numberOfBytes": "32",
-      "value": "t_mapping(t_address,t_struct(Lock)49969_storage)"
+      "value": "t_mapping(t_address,t_struct(Lock)50262_storage)"
     },
     "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
       "encoding": "mapping",
@@ -128,12 +128,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_address)"
     },
-    "t_mapping(t_address,t_struct(Lock)49969_storage)": {
+    "t_mapping(t_address,t_struct(Lock)50262_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct TokenLockingDataTypes.Lock)",
       "numberOfBytes": "32",
-      "value": "t_struct(Lock)49969_storage"
+      "value": "t_struct(Lock)50262_storage"
     },
     "t_mapping(t_address,t_uint256)": {
       "encoding": "mapping",
@@ -149,12 +149,12 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_struct(Lock)49969_storage": {
+    "t_struct(Lock)50262_storage": {
       "encoding": "inplace",
       "label": "struct TokenLockingDataTypes.Lock",
       "members": [
         {
-          "astId": 49962,
+          "astId": 50255,
           "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
           "label": "lockCount",
           "offset": 0,
@@ -162,7 +162,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 49964,
+          "astId": 50257,
           "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
           "label": "balance",
           "offset": 0,
@@ -170,7 +170,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 49966,
+          "astId": 50259,
           "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
           "label": "DEPRECATED_timestamp",
           "offset": 0,
@@ -178,7 +178,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 49968,
+          "astId": 50261,
           "contract": "contracts/tokenLocking/TokenLocking.sol:TokenLocking",
           "label": "pendingBalance",
           "offset": 0,

--- a/.storage-layouts/contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage.json
+++ b/.storage-layouts/contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage.json
@@ -1,15 +1,15 @@
 {
   "storage": [
     {
-      "astId": 50364,
+      "astId": 50657,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "authority",
       "offset": 0,
       "slot": "0",
-      "type": "t_contract(DSAuthority)50350"
+      "type": "t_contract(DSAuthority)50643"
     },
     {
-      "astId": 50366,
+      "astId": 50659,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "owner",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 49983,
+      "astId": 50276,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "resolver",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 49985,
+      "astId": 50278,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "colonyNetwork",
       "offset": 0,
@@ -33,15 +33,15 @@
       "type": "t_address"
     },
     {
-      "astId": 49992,
+      "astId": 50285,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "userLocks",
       "offset": 0,
       "slot": "4",
-      "type": "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)49969_storage))"
+      "type": "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)50262_storage))"
     },
     {
-      "astId": 49996,
+      "astId": 50289,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "totalLockCount",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_mapping(t_address,t_uint256)"
     },
     {
-      "astId": 50004,
+      "astId": 50297,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "approvals",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_address,t_uint256)))"
     },
     {
-      "astId": 50012,
+      "astId": 50305,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "obligations",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_address,t_uint256)))"
     },
     {
-      "astId": 50018,
+      "astId": 50311,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "totalObligations",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
     },
     {
-      "astId": 50024,
+      "astId": 50317,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "lockers",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_mapping(t_address,t_mapping(t_uint256,t_address))"
     },
     {
-      "astId": 50028,
+      "astId": 50321,
       "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
       "label": "metatransactionNonces",
       "offset": 0,
@@ -95,7 +95,7 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_contract(DSAuthority)50350": {
+    "t_contract(DSAuthority)50643": {
       "encoding": "inplace",
       "label": "contract DSAuthority",
       "numberOfBytes": "20"
@@ -107,12 +107,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
     },
-    "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)49969_storage))": {
+    "t_mapping(t_address,t_mapping(t_address,t_struct(Lock)50262_storage))": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => mapping(address => struct TokenLockingDataTypes.Lock))",
       "numberOfBytes": "32",
-      "value": "t_mapping(t_address,t_struct(Lock)49969_storage)"
+      "value": "t_mapping(t_address,t_struct(Lock)50262_storage)"
     },
     "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
       "encoding": "mapping",
@@ -128,12 +128,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_uint256,t_address)"
     },
-    "t_mapping(t_address,t_struct(Lock)49969_storage)": {
+    "t_mapping(t_address,t_struct(Lock)50262_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct TokenLockingDataTypes.Lock)",
       "numberOfBytes": "32",
-      "value": "t_struct(Lock)49969_storage"
+      "value": "t_struct(Lock)50262_storage"
     },
     "t_mapping(t_address,t_uint256)": {
       "encoding": "mapping",
@@ -149,12 +149,12 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_struct(Lock)49969_storage": {
+    "t_struct(Lock)50262_storage": {
       "encoding": "inplace",
       "label": "struct TokenLockingDataTypes.Lock",
       "members": [
         {
-          "astId": 49962,
+          "astId": 50255,
           "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
           "label": "lockCount",
           "offset": 0,
@@ -162,7 +162,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 49964,
+          "astId": 50257,
           "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
           "label": "balance",
           "offset": 0,
@@ -170,7 +170,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 49966,
+          "astId": 50259,
           "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
           "label": "DEPRECATED_timestamp",
           "offset": 0,
@@ -178,7 +178,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 49968,
+          "astId": 50261,
           "contract": "contracts/tokenLocking/TokenLockingStorage.sol:TokenLockingStorage",
           "label": "pendingBalance",
           "offset": 0,

--- a/contracts/extensions/StreamingPayments.sol
+++ b/contracts/extensions/StreamingPayments.sol
@@ -389,7 +389,20 @@ contract StreamingPayments is ColonyExtensionMeta {
     if (durationToClaim == 0) {
       return 0;
     }
-    return wmul(streamingPayment.amount, wdiv(durationToClaim, streamingPayment.interval));
+
+    // Guard against overflow in wdiv
+    if (durationToClaim > type(uint256).max / WAD) {
+      durationToClaim = type(uint256).max / WAD;
+    }
+
+    uint256 intervalsToClaimAsWad = wdiv(durationToClaim, streamingPayment.interval);
+
+    // Guard against overflow in wmul
+    if (streamingPayment.amount > type(uint256).max / intervalsToClaimAsWad) {
+      return type(uint256).max;
+    }
+
+    return wmul(streamingPayment.amount, intervalsToClaimAsWad);
   }
 
   // Internal

--- a/contracts/extensions/StreamingPayments.sol
+++ b/contracts/extensions/StreamingPayments.sol
@@ -178,7 +178,7 @@ contract StreamingPayments is ColonyExtensionMeta {
     );
 
     if (getAmountClaimableLifetime(numStreamingPayments) > 0) {
-      nUnresolvedStreamingPayments++;
+      nUnresolvedStreamingPayments += 1;
     }
 
     emit StreamingPaymentCreated(msgSender(), numStreamingPayments);

--- a/docs/interfaces/extensions/streamingpayments.md
+++ b/docs/interfaces/extensions/streamingpayments.md
@@ -199,7 +199,7 @@ Update the startTime, only if the current startTime is in the future
 |_startTime|uint256|The new startTime to set
 
 
-### ▸ `setTokenAmount(uint256 _fundingPermissionDomainId, uint256 _fundingChildSkillIndex, uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _fromChildSkillIndex, uint256 _toChildSkillIndex, uint256 _id, uint256 _amount)`
+### ▸ `setTokenAmount(uint256 _fundingPermissionDomainId, uint256 _fundingChildSkillIndex, uint256 _permissionDomainId, uint256 _childSkillIndex, uint256 _fromChildSkillIndex, uint256 _toChildSkillIndex, uint256 _id, uint256 _amount, uint256 _interval)`
 
 Update the token amount to be paid out. Claims existing payout prior to the change
 
@@ -216,6 +216,7 @@ Update the token amount to be paid out. Claims existing payout prior to the chan
 |_toChildSkillIndex|uint256|The linking the domainId to the toPot domain
 |_id|uint256|The id of the streaming payment
 |_amount|uint256|The new amount to pay out
+|_interval|uint256|The new interval over which _amount is paid out
 
 
 ### ▸ `version():uint256 _version`

--- a/docs/interfaces/extensions/streamingpayments.md
+++ b/docs/interfaces/extensions/streamingpayments.md
@@ -219,6 +219,13 @@ Update the token amount to be paid out. Claims existing payout prior to the chan
 |_interval|uint256|The new interval over which _amount is paid out
 
 
+### ▸ `uninstall()`
+
+Called when uninstalling the extension
+
+
+
+
 ### ▸ `version():uint256 _version`
 
 Returns the version of the extension

--- a/docs/interfaces/extensions/streamingpayments.md
+++ b/docs/interfaces/extensions/streamingpayments.md
@@ -27,7 +27,7 @@ Cancel the streaming payment, specifically by setting endTime to block.timestamp
 
 ### ▸ `cancelAndWaive(uint256 _id)`
 
-Cancel the streaming payment, specifically by setting endTime to block.timestamp, and waive claim to specified tokens already earned. Only callable by the recipient.
+Cancel the streaming payment, specifically by setting endTime to block.timestamp, and waive claim to tokens already earned. Only callable by the recipient.
 
 
 **Parameters**
@@ -82,6 +82,23 @@ Called when upgrading the extension
 
 
 
+### ▸ `getAmountClaimableLifetime(uint256 _id):uint256 amount`
+
+Get the amount claimable in the lifetime of the stream
+
+
+**Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|_id|uint256|The id of the streaming payment
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|amount|uint256|The amount claimable
+
 ### ▸ `getAmountEntitledFromStart(uint256 _id):uint256 amount`
 
 Get the amount entitled to claim from the start of the stream
@@ -98,6 +115,18 @@ Get the amount entitled to claim from the start of the stream
 |Name|Type|Description|
 |---|---|---|
 |amount|uint256|The amount entitled
+
+### ▸ `getNUnresolvedStreamingPayments():uint256 nUnresolvedPayments`
+
+Get the number of unresolved streaming payments
+
+
+
+**Return Parameters**
+
+|Name|Type|Description|
+|---|---|---|
+|nUnresolvedPayments|uint256|The number of unresolved streaming payments
 
 ### ▸ `getNumStreamingPayments():uint256 numPayments`
 


### PR DESCRIPTION
The main feature here is to prevent uninstallation of the extension in the event that there are some streaming payments unclaimed. It also:

* Reworks some calculations to prevent over/underflows. This is somewhat opinionated in that the intention is to 'cap' the calculations
* Allows editing of the interval, which is a requirement. While in an ideal world, editing the interval shouldn't be necessary as you could edit the amount, rounding errors meant that this should be editable as well. This is possible as we have moved to single-stream payments.