### PR TITLE
Normalize coverage ports

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -22,7 +22,6 @@ module.exports = {
       'extensions/votingReputation/VotingReputationMisalignedRecovery.sol'
     ],
     providerOptions: {
-      port: 8555,
       network_id: 1999,
       account_keys_path: "./ganache-accounts.json",
       vmErrorsOnRPCResponse: false,

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -54,7 +54,7 @@ task("deploy", "Deploy Colony Network as per truffle-fixture.js").setAction(asyn
 
 task("coverage", "Run coverage with an open port").setAction(async () => {
   const app = express();
-  const port = 8555;
+  const port = 8545;
 
   app.use(bodyParser.json());
   app.post("/", async function (req, res) {

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -1,4 +1,5 @@
-/* globals artifacts, hre */
+/* globals artifacts */
+
 const fs = require("fs");
 const shortid = require("shortid");
 const chai = require("chai");
@@ -245,7 +246,7 @@ exports.checkErrorRevertEthers = async function checkErrorRevertEthers(promise, 
   } catch (err) {
     const txid = err.transactionHash;
 
-    const TRUFFLE_PORT = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+    const TRUFFLE_PORT = 8545;
     const OTHER_RPC_PORT = 8546;
 
     let provider = new ethers.providers.StaticJsonRpcProvider(`http://127.0.0.1:${TRUFFLE_PORT}`);

--- a/packages/reputation-miner/patricia-test.js
+++ b/packages/reputation-miner/patricia-test.js
@@ -1,4 +1,5 @@
-/* globals artifacts, hre */
+/* globals artifacts */
+
 
 const path = require("path");
 const { fromAscii } = require("web3-utils");
@@ -17,7 +18,7 @@ const contractLoader = new TruffleLoader({
 contract("Javascript Patricia Tree", accounts => {
   const MAIN_ACCOUNT = accounts[5];
   const OTHER_ACCOUNT = accounts[6];
-  const REAL_PROVIDER_PORT = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+  const REAL_PROVIDER_PORT = 8545;
 
   let colonyNetwork;
   let jsClient;

--- a/scripts/deployOldUpgradeableVersion.js
+++ b/scripts/deployOldUpgradeableVersion.js
@@ -275,6 +275,7 @@ module.exports.deployOldUpgradeableVersion = async (contractName, interfaceName,
 
   const res = await exec(
     `cd colonyNetwork-${versionTag} ` +
+      "&& sed -ie 's/8555/8545/g' ./truffle.js " +
       "&& npx truffle exec ./scripts/setupOldUpgradeableVersion.js " +
       `--network ${network} --interfaceName ${interfaceName} --implementationNames ${implementationNames.join(",")}`,
     { maxBuffer: 1024 * 5000 },

--- a/test-gas-costs/gasCosts.js
+++ b/test-gas-costs/gasCosts.js
@@ -1,4 +1,4 @@
-/* globals artifacts, hre */
+/* globals artifacts */
 
 const path = require("path");
 const { soliditySha3 } = require("web3-utils");
@@ -47,7 +47,7 @@ const ReputationBootstrapper = artifacts.require("ReputationBootstrapper");
 const VotingReputation = artifacts.require("VotingReputation");
 const IVotingReputation = artifacts.require("IVotingReputation");
 
-const REAL_PROVIDER_PORT = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+const REAL_PROVIDER_PORT = 8545;
 
 const contractLoader = new TruffleLoader({
   contractRoot: path.resolve(__dirname, "..", "artifacts", "contracts"),

--- a/test-system/end-to-end.js
+++ b/test-system/end-to-end.js
@@ -1,4 +1,4 @@
-/* globals artifacts, hre */
+/* globals artifacts */
 
 const path = require("path");
 const BN = require("bn.js");
@@ -55,7 +55,7 @@ contract("End to end Colony network and Reputation mining testing", function (ac
   let tokenLocking;
   let clnyToken;
   let goodClient;
-  const realProviderPort = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+  const realProviderPort = 8545;
   let colonies;
 
   before(async function () {

--- a/test/contracts-network/colony-network-recovery.js
+++ b/test/contracts-network/colony-network-recovery.js
@@ -49,7 +49,7 @@ const contractLoader = new TruffleLoader({
   contractRoot: path.resolve(__dirname, "..", "..", "artifacts", "contracts"),
 });
 
-const REAL_PROVIDER_PORT = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+const REAL_PROVIDER_PORT = 8545;
 
 contract("Colony Network Recovery", (accounts) => {
   let colonyNetwork;

--- a/test/contracts-network/colony-reward-payouts.js
+++ b/test/contracts-network/colony-reward-payouts.js
@@ -1,4 +1,4 @@
-/* globals artifacts, hre */
+/* globals artifacts */
 
 const { BN } = require("bn.js");
 const { ethers } = require("ethers");
@@ -40,7 +40,7 @@ const contractLoader = new TruffleLoader({
   contractRoot: path.resolve(__dirname, "..", "..", "artifacts", "contracts"),
 });
 
-const REAL_PROVIDER_PORT = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+const REAL_PROVIDER_PORT = 8545;
 
 contract("Colony Reward Payouts", (accounts) => {
   let colony;

--- a/test/contracts-network/token-locking.js
+++ b/test/contracts-network/token-locking.js
@@ -1,4 +1,4 @@
-/* globals artifacts, hre */
+/* globals artifacts */
 
 const path = require("path");
 const chai = require("chai");
@@ -38,7 +38,7 @@ const contractLoader = new TruffleLoader({
   contractRoot: path.resolve(__dirname, "..", "..", "artifacts", "contracts"),
 });
 
-const REAL_PROVIDER_PORT = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+const REAL_PROVIDER_PORT = 8545;
 
 contract("Token Locking", (addresses) => {
   const usersTokens = 10;

--- a/test/cross-chain/cross-chain.js
+++ b/test/cross-chain/cross-chain.js
@@ -1,4 +1,4 @@
-/* globals artifacts, hre */
+/* globals artifacts */
 
 const chai = require("chai");
 const bnChai = require("bn-chai");
@@ -74,7 +74,7 @@ contract("Cross-chain", (accounts) => {
 
   const ADDRESS_ZERO = ethers.constants.AddressZero;
 
-  const RPC_PORT_1 = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+  const RPC_PORT_1 = 8545;
   const RPC_PORT_2 = 8546;
 
   const MINER_ADDRESS = accounts[5];

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -2072,7 +2072,7 @@ contract("Voting Reputation", (accounts) => {
     let motionId;
 
     beforeEach(async () => {
-      const realProviderPort = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+      const realProviderPort = 8545;
       const provider = new ethers.providers.StaticJsonRpcProvider(`http://127.0.0.1:${realProviderPort}`);
 
       const loader = new TruffleLoader({

--- a/test/packages/metaTransactionBroadcaster.js
+++ b/test/packages/metaTransactionBroadcaster.js
@@ -27,7 +27,7 @@ const GasGuzzler = artifacts.require("GasGuzzler");
 
 chai.use(bnChai(web3.utils.BN));
 
-const realProviderPort = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+const realProviderPort = 8545;
 const provider = new ethers.providers.StaticJsonRpcProvider(`http://127.0.0.1:${realProviderPort}`);
 
 const loader = new TruffleLoader({

--- a/test/reputation-system/client-calculations.js
+++ b/test/reputation-system/client-calculations.js
@@ -38,7 +38,7 @@ let metaColony;
 let clnyToken;
 let goodClient;
 const domainSkills = {};
-const realProviderPort = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+const realProviderPort = 8545;
 
 const setupNewNetworkInstance = async (MINER1, MINER2) => {
   colonyNetwork = await setupColonyNetwork();

--- a/test/reputation-system/client-core-functionality.js
+++ b/test/reputation-system/client-core-functionality.js
@@ -28,7 +28,7 @@ const loader = new TruffleLoader({
   contractRoot: path.resolve(__dirname, "..", "..", "artifacts", "contracts"),
 });
 
-const realProviderPort = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+const realProviderPort = 8545;
 
 hre.__SOLIDITY_COVERAGE_RUNNING
   ? contract.skip

--- a/test/reputation-system/client-sync-functionality.js
+++ b/test/reputation-system/client-sync-functionality.js
@@ -26,7 +26,7 @@ const loader = new TruffleLoader({
   contractRoot: path.resolve(__dirname, "..", "..", "artifacts", "contracts"),
 });
 
-const realProviderPort = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+const realProviderPort = 8545;
 const useJsTree = true;
 
 hre.__SOLIDITY_COVERAGE_RUNNING

--- a/test/reputation-system/dispute-resolution-misbehaviour.js
+++ b/test/reputation-system/dispute-resolution-misbehaviour.js
@@ -1,4 +1,4 @@
-/* globals artifacts, hre */
+/* globals artifacts */
 
 const path = require("path");
 const BN = require("bn.js");
@@ -64,7 +64,7 @@ let clnyToken;
 let localSkillId;
 let goodClient;
 
-const realProviderPort = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+const realProviderPort = 8545;
 
 const setupNewNetworkInstance = async (MINER1, MINER2) => {
   colonyNetwork = await setupColonyNetwork();

--- a/test/reputation-system/disputes-over-child-reputation.js
+++ b/test/reputation-system/disputes-over-child-reputation.js
@@ -1,5 +1,3 @@
-/* globals hre */
-
 const path = require("path");
 const chai = require("chai");
 const bnChai = require("bn-chai");
@@ -52,7 +50,7 @@ let metaColony;
 let clnyToken;
 let localSkillId;
 let goodClient;
-const realProviderPort = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+const realProviderPort = 8545;
 
 const setupNewNetworkInstance = async (MINER1, MINER2) => {
   colonyNetwork = await setupColonyNetwork();

--- a/test/reputation-system/happy-paths.js
+++ b/test/reputation-system/happy-paths.js
@@ -1,4 +1,4 @@
-/* globals artifacts, hre */
+/* globals artifacts */
 
 const path = require("path");
 const BN = require("bn.js");
@@ -70,7 +70,7 @@ let miningSkillId;
 let metaRootSkillId;
 let chainId;
 let goodClient;
-const realProviderPort = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+const realProviderPort = 8545;
 
 const setupNewNetworkInstance = async (MINER1, MINER2) => {
   colonyNetwork = await setupColonyNetwork();

--- a/test/reputation-system/reputation-mining-client/client-auto-functionality.js
+++ b/test/reputation-system/reputation-mining-client/client-auto-functionality.js
@@ -48,7 +48,7 @@ const loader = new TruffleLoader({
   contractRoot: path.resolve(__dirname, "..", "..", "..", "artifacts", "contracts"),
 });
 
-const realProviderPort = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+const realProviderPort = 8545;
 
 hre.__SOLIDITY_COVERAGE_RUNNING
   ? contract.skip

--- a/test/reputation-system/root-hash-submissions.js
+++ b/test/reputation-system/root-hash-submissions.js
@@ -1,4 +1,4 @@
-/* globals artifacts, hre */
+/* globals artifacts */
 
 const BN = require("bn.js");
 const { ethers } = require("ethers");
@@ -55,7 +55,7 @@ const loader = new TruffleLoader({
   contractRoot: path.resolve(__dirname, "..", "..", "artifacts", "contracts"),
 });
 
-const realProviderPort = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+const realProviderPort = 8545;
 const useJsTree = true;
 
 let colonyNetwork;

--- a/test/reputation-system/types-of-disagreement.js
+++ b/test/reputation-system/types-of-disagreement.js
@@ -1,5 +1,3 @@
-/* globals hre */
-
 const path = require("path");
 const BN = require("bn.js");
 const { toBN } = require("web3-utils");
@@ -56,7 +54,7 @@ let metaColony;
 let clnyToken;
 let localSkillId;
 let goodClient;
-const realProviderPort = hre.__SOLIDITY_COVERAGE_RUNNING ? 8555 : 8545;
+const realProviderPort = 8545;
 
 const setupNewNetworkInstance = async (MINER1, MINER2) => {
   colonyNetwork = await setupColonyNetwork();

--- a/test/truffle-fixture.js
+++ b/test/truffle-fixture.js
@@ -1,4 +1,5 @@
 /* globals artifacts, hre */
+
 const EtherRouter = artifacts.require("EtherRouter");
 const EtherRouterCreate3 = artifacts.require("EtherRouterCreate3");
 const Resolver = artifacts.require("Resolver");


### PR DESCRIPTION
Coverage ports are under our control now, so there's absolutely no reason to use port 8555 for coverage and 8545 when we're not under coverage. This PR puts everything on 8545 for the primary provider, regardless of coverage status.

I believe some of our test suite, after the move to hardhat, is going to break once the next release is properly made on GitHub, however (which we should do, given the release has actually happened in a practical sense). However, that's not something for this PR.