### PR TITLE
Do not clobber goodClient in tests

### DIFF
--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -40,7 +40,7 @@ class ReputationMiner {
         network_id: 515,
         vmErrorsOnRPCResponse: false,
         locked: false,
-        logger: console,
+        logger: { log: x => console.log("Ganache:", x)},
         accounts: [
           {
             balance: "0x10000000000000000000000000",

--- a/test/reputation-system/happy-paths.js
+++ b/test/reputation-system/happy-paths.js
@@ -264,11 +264,11 @@ contract("Reputation Mining - happy paths", (accounts) => {
 
       // Complete two reputation cycles to process the log
       await advanceMiningCycleNoContest({ colonyNetwork, test: this });
-      goodClient = new ReputationMinerTestWrapper({ loader, realProviderPort, useJsTree: false, minerAddress: MINER1 });
-      await goodClient.initialise(colonyNetwork.address);
-      await goodClient.resetDB();
+      const goodClientSolidityTree = new ReputationMinerTestWrapper({ loader, realProviderPort, useJsTree: false, minerAddress: MINER1 });
+      await goodClientSolidityTree.initialise(colonyNetwork.address);
+      await goodClientSolidityTree.resetDB();
 
-      await advanceMiningCycleNoContest({ colonyNetwork, client: goodClient, test: this });
+      await advanceMiningCycleNoContest({ colonyNetwork, client: goodClientSolidityTree, test: this });
     });
 
     it("should allow submitted hashes to go through multiple responses to a challenge", async () => {


### PR DESCRIPTION
In this test, we replaced `goodClient` with a client that used the solidity patricia tree. All subsequent tests then used it, which I think has been causing intermittent issues in CI. Given I don't think this was a deliberate (tests affecting how each other run is bad, after all), I've stopped that from happening.

Of course, it _should_ work, but I think running that down should be separate. Indeed, arguably the priority should be to work out how to remove `ganache`, and then make whatever that replacement is sufficiently performant enough for the tests to work if the soldity trie is in use, but I don't think it's possible to drop-in `hardhat` as a replacement the way we've used `ganache` here.

The important piece of functionality around the solidity tree is to make sure it gives the same results as the javascript tree, and the tests still do that. In addition, we use the javascript tree in production (because it's faster), so I'm not too worried about this.