### PR TITLE
Introduce hardhat_setStorageAt

### DIFF
--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -1,4 +1,4 @@
-/* globals artifacts, hre */
+/* globals artifacts */
 
 const fs = require("fs");
 const shortid = require("shortid");
@@ -1296,8 +1296,7 @@ exports.upgradeColonyOnceThenToLatest = async function (colony) {
 
   const existingSlot = await exports.web3GetStorageAt(colony.address, 2);
   const newSlotValue = existingSlot.slice(0, 26) + newestResolver.slice(2);
-
-  await hre.network.provider.send("hardhat_setStorageAt", [colony.address, "0x2", newSlotValue]);
+  await exports.setStorageSlot(colony, "0x2", newSlotValue);
 };
 
 exports.isMainnet = async function isMainnet() {

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -1,4 +1,4 @@
-/* globals artifacts */
+/* globals artifacts, hre */
 
 const fs = require("fs");
 const shortid = require("shortid");
@@ -31,9 +31,7 @@ const Token = artifacts.require("Token");
 const IReputationMiningCycle = artifacts.require("IReputationMiningCycle");
 const NoLimitSubdomains = artifacts.require("NoLimitSubdomains");
 const Resolver = artifacts.require("Resolver");
-const ContractEditing = artifacts.require("ContractEditing");
 const ColonyDomains = artifacts.require("ColonyDomains");
-const EtherRouter = artifacts.require("EtherRouter");
 const ChainId = artifacts.require("ChainId");
 
 const { expect } = chai;
@@ -678,6 +676,26 @@ exports.startMining = async function startMining() {
   });
 };
 
+exports.setStorageSlot = async function (contract, slot, value) {
+  const slotString = `0x${new BN(slot).toString(16)}`;
+
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "hardhat_setStorageAt",
+        params: [contract.address, slotString, value],
+      },
+      (err) => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve();
+      },
+    );
+  });
+};
+
 exports.makeTxAtTimestamp = async function makeTxAtTimestamp(f, args, timestamp) {
   await helpers.time.setNextBlockTimestamp(timestamp);
   return f(...args);
@@ -1111,26 +1129,6 @@ exports.getChildSkillIndex = async function getChildSkillIndex(colonyNetwork, co
   throw Error("Supplied child domain is not a child of the supplied parent domain");
 };
 
-exports.getColonyEditable = async function getColonyEditable(colony, colonyNetwork) {
-  const colonyVersion = await colony.version();
-  const colonyResolverAddress = await colonyNetwork.getColonyVersionResolver(colonyVersion);
-  const colonyResolver = await Resolver.at(colonyResolverAddress);
-  const contractEditing = await ContractEditing.new();
-  await colonyResolver.register("setStorageSlot(uint256,bytes32)", contractEditing.address);
-  const colonyUnderRecovery = await ContractEditing.at(colony.address);
-  return colonyUnderRecovery;
-};
-
-exports.getColonyNetworkEditable = async function getColonyNetworkEditable(colonyNetwork) {
-  const networkAsEtherRouter = await EtherRouter.at(colonyNetwork.address);
-  const resolverAddress = await networkAsEtherRouter.resolver();
-  const colonyNetworkResolver = await Resolver.at(resolverAddress);
-  const contractEditing = await ContractEditing.new();
-  await colonyNetworkResolver.register("setStorageSlot(uint256,bytes32)", contractEditing.address);
-  const colonyNetworkEditable = await ContractEditing.at(colonyNetwork.address);
-  return colonyNetworkEditable;
-};
-
 exports.getWaitForNSubmissionsPromise = function getWaitForNSubmissionsPromise(repCycleEthers, fromBlock, rootHash, nLeaves, jrh, n) {
   if (!repCycleEthers || !fromBlock) {
     throw new Error("repCycleEthers and fromBlock must be defined when calling getWaitForNSubmissionsPromise");
@@ -1291,16 +1289,14 @@ exports.upgradeColonyOnceThenToLatest = async function (colony) {
   const networkAddress = await colony.getColonyNetwork();
   const colonyNetwork = await IColonyNetwork.at(networkAddress);
 
-  const editableColony = await exports.getColonyEditable(colony, colonyNetwork);
-  const existingSlot = await exports.web3GetStorageAt(colony.address, 2);
-
   // Doing it this way preserves the items that share this storage slot with the address,
   // which are recoverymode related.
   const newestResolver = await colonyNetwork.getColonyVersionResolver(CURR_VERSION);
 
+  const existingSlot = await exports.web3GetStorageAt(colony.address, 2);
   const newSlotValue = existingSlot.slice(0, 26) + newestResolver.slice(2);
 
-  await editableColony.setStorageSlot(2, newSlotValue);
+  await hre.network.provider.send("hardhat_setStorageAt", [colony.address, "0x2", newSlotValue]);
 };
 
 exports.isMainnet = async function isMainnet() {

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -676,16 +676,27 @@ exports.startMining = async function startMining() {
   });
 };
 
-exports.setStorageSlot = async function (contract, slot, value) {
-  const slotString = `0x${new BN(slot).toString(16)}`;
+exports.setStorageSlot = async function (_contract, _slot, _value) {
+  let slot = _slot;
+  if (typeof _slot === "string") {
+    if (!_slot.startsWith("0x")) {
+      slot = `0x${_slot}`;
+    } else {
+      slot = _slot;
+    }
+  } else if (isBN(_slot)) {
+    slot = `0x${_slot.toString(16)}`;
+  }
+
+  const slotString = `${ethers.BigNumber.from(slot).toHexString()}`;
   // Accommodate both ethers and truffle contract objects
-  const provider = contract.provider || contract.contract.currentProvider;
+  const provider = _contract.provider || _contract.contract.currentProvider;
   return new Promise((resolve, reject) => {
     provider.send(
       {
         jsonrpc: "2.0",
         method: "hardhat_setStorageAt",
-        params: [contract.address, slotString, value],
+        params: [_contract.address, slotString, _value],
       },
       (err) => {
         if (err) {

--- a/helpers/test-helper.js
+++ b/helpers/test-helper.js
@@ -678,9 +678,10 @@ exports.startMining = async function startMining() {
 
 exports.setStorageSlot = async function (contract, slot, value) {
   const slotString = `0x${new BN(slot).toString(16)}`;
-
+  // Accommodate both ethers and truffle contract objects
+  const provider = contract.provider || contract.contract.currentProvider;
   return new Promise((resolve, reject) => {
-    web3.currentProvider.send(
+    provider.send(
       {
         jsonrpc: "2.0",
         method: "hardhat_setStorageAt",

--- a/test/contracts-network/colony-network-auction.js
+++ b/test/contracts-network/colony-network-auction.js
@@ -12,6 +12,7 @@ const {
   getBlockTime,
   isMainnet,
   getChainId,
+  setStorageSlot,
 } = require("../../helpers/test-helper");
 
 const { WAD, SECONDS_PER_DAY } = require("../../helpers/constants");
@@ -79,7 +80,7 @@ contract("Colony Network Auction", (accounts) => {
     });
 
     it("should fail with a zero clny token", async () => {
-      await hre.network.provider.send("hardhat_setStorageAt", [metaColony.address, "0x7", ethers.constants.HashZero]);
+      await setStorageSlot(metaColony, "0x7", ethers.constants.HashZero);
 
       const args = getTokenArgs();
       token = await Token.new(...args);

--- a/test/contracts-network/colony-network-auction.js
+++ b/test/contracts-network/colony-network-auction.js
@@ -10,7 +10,6 @@ const {
   checkErrorRevert,
   forwardTime,
   getBlockTime,
-  getColonyEditable,
   isMainnet,
   getChainId,
 } = require("../../helpers/test-helper");
@@ -80,8 +79,7 @@ contract("Colony Network Auction", (accounts) => {
     });
 
     it("should fail with a zero clny token", async () => {
-      const metaColonyUnderRecovery = await getColonyEditable(metaColony, colonyNetwork);
-      await metaColonyUnderRecovery.setStorageSlot(7, ethers.constants.AddressZero);
+      await hre.network.provider.send("hardhat_setStorageAt", [metaColony.address, "0x7", ethers.constants.HashZero]);
 
       const args = getTokenArgs();
       token = await Token.new(...args);

--- a/test/contracts-network/colony-network.js
+++ b/test/contracts-network/colony-network.js
@@ -21,9 +21,9 @@ const {
   checkErrorRevert,
   expectEvent,
   expectNoEvent,
-  getColonyEditable,
   isXdai,
   getChainId,
+  setStorageSlot,
 } = require("../../helpers/test-helper");
 
 const { CURR_VERSION, MIN_STAKE, IPFS_HASH, ADDRESS_ZERO, WAD } = require("../../helpers/constants");
@@ -177,8 +177,7 @@ contract("Colony Network", (accounts) => {
     });
 
     it("should not allow initialisation of mining on this chain if the clny token is 0", async () => {
-      const metaColonyUnderRecovery = await getColonyEditable(metaColony, colonyNetwork);
-      await metaColonyUnderRecovery.setStorageSlot(7, ethers.constants.AddressZero);
+      await setStorageSlot(metaColony, 7, ethers.constants.HashZero);
       const chainId = await getChainId();
       await checkErrorRevert(
         metaColony.initialiseReputationMining(chainId, ethers.constants.HashZero, 0),
@@ -187,8 +186,7 @@ contract("Colony Network", (accounts) => {
     });
 
     it("should allow initialisation of mining on another chain if the clny token is 0", async () => {
-      const metaColonyUnderRecovery = await getColonyEditable(metaColony, colonyNetwork);
-      await metaColonyUnderRecovery.setStorageSlot(7, ethers.constants.AddressZero);
+      await setStorageSlot(metaColony, 7, ethers.constants.HashZero);
       let chainId = await getChainId();
       chainId += 1;
       await metaColony.initialiseReputationMining(chainId, ethers.constants.HashZero, 0);
@@ -201,8 +199,7 @@ contract("Colony Network", (accounts) => {
     it("should not allow another mining cycle to start if the clny token is 0", async () => {
       const chainId = await getChainId();
       await metaColony.initialiseReputationMining(chainId, ethers.constants.HashZero, 0);
-      const metaColonyUnderRecovery = await getColonyEditable(metaColony, colonyNetwork);
-      await metaColonyUnderRecovery.setStorageSlot(7, ethers.constants.AddressZero);
+      await setStorageSlot(metaColony, 7, ethers.constants.HashZero);
 
       await checkErrorRevert(colonyNetwork.startNextCycle(), "colony-reputation-mining-clny-token-invalid-address");
     });
@@ -472,8 +469,7 @@ contract("Colony Network", (accounts) => {
 
       // 8->9 upgrade, unlike other upgrades to date, not idempotent, so have to delete
       // the local root skill id
-      const editableColony = await getColonyEditable(colony, colonyNetwork);
-      await editableColony.setStorageSlot(36, "0x0000000000000000000000000000000000000000000000000000000000000000");
+      await setStorageSlot(colony, 36, ethers.constants.HashZero);
 
       const currentColonyVersion = await colonyNetwork.getCurrentColonyVersion();
       const newVersion = currentColonyVersion.addn(1);


### PR DESCRIPTION
Replace the custom storage editing via `ContractEditing` with calls to ` hardhat_setStorageAt`. We are still dependent on `ContractEditing` functionality in the Ganache-based tests, as the special opcode is not available.