### PR TITLE
Fix version check script

### DIFF
--- a/contracts/extensions/votingReputation/VotingReputationStorage.sol
+++ b/contracts/extensions/votingReputation/VotingReputationStorage.sol
@@ -137,7 +137,7 @@ contract VotingReputationStorage is
   /// @notice Returns the version of the extension
   /// @return _version The extension's version number
   function version() public pure override returns (uint256 _version) {
-    return 11;
+    return 12;
   }
 
   function install(address _colony) public override {

--- a/test/extensions/voting-rep.js
+++ b/test/extensions/voting-rep.js
@@ -34,6 +34,7 @@ const {
   expectEvent,
   getTokenArgs,
   getBlockTime,
+  upgradeExtensionOnceThenToLatest,
 } = require("../../helpers/test-helper");
 
 const { setupRandomColony, getMetaTransactionParameters, fundColonyWithTokens } = require("../../helpers/test-data-generator");
@@ -2833,8 +2834,9 @@ contract("Voting Reputation", (accounts) => {
     // This function as written would also need updating every version, but is infinitely more
     // upgradeable
     async function upgradeFromV9ToLatest(colonyInTest) {
-      await colonyInTest.upgradeExtension(VOTING_REPUTATION, 10);
-      await colonyInTest.upgradeExtension(VOTING_REPUTATION, 11);
+      const extensionAddress = await colonyNetwork.getExtensionInstallation(VOTING_REPUTATION, colonyInTest.address);
+      const extension = await IVotingReputation.at(extensionAddress);
+      await upgradeExtensionOnceThenToLatest(extension);
     }
 
     beforeEach(async () => {


### PR DESCRIPTION
@chmanie 's eagle-eyes noted that it was suspicious that `votingReputation` had not had its version bumped, but every other extension had. He was right, we should have done as part of #1248 (at least).

I've reworked a fair chunk of the version check script, simply because some of it didn't work. Bash if statements remain a real blind spot for me, but this [seems to work](https://app.circleci.com/pipelines/github/JoinColony/colonyNetwork/6926/workflows/8d73248f-8b45-4025-8675-066842bc98dc/jobs/53997?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary).

In summary:
* Fix iteration over `extensions` directory by including subdirectories
* Fix bash if statement
* Remove 'depends on' logic - I think maybe this was a leftover from when we weren't examining the bytecode directly; if you can come up with a scenario where not having this logic would cause us to miss something, please let me know!
* Removing that logic meant that some of the other things we're doing with passing variables around become much saner, which is good news.

The version bump means that some of the tests had to be updated, so I've written a `upgradeExtensionOnceThenToLatest` helper that mirrors the colony equivalent. ~~Not my finest work (an ideal solution would be to look for all relevant `ExtensionAddedToNetwork` events and take the biggest number), but thanks to my local setup those specific tests for v9 motions are now hard to test locally, and I wanted this out the door to unblock things downstream. If they work locally for you, I'd appreciate you switching out that logic for something event-based.~~ No longer required, managed to do it myself :smile: 