### PR TITLE
Add ERC20Like contract to helpers

### DIFF
--- a/contracts/testHelpers/ERC20Like.sol
+++ b/contracts/testHelpers/ERC20Like.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+contract ERC20Like {
+  event Transfer(address indexed from, address indexed to, uint256 value);
+  event Approval(address indexed owner, address indexed spender, uint256 value);
+
+  uint256 public totalSupply;
+  mapping(address => uint256) public balanceOf;
+  mapping(address => mapping(address => uint256)) allowance;
+  string public name;
+  string public symbol;
+  uint8 public decimals;
+
+  constructor(string memory _name, string memory _symbol, uint8 _decimals) {
+    name = _name;
+    symbol = _symbol;
+    decimals = _decimals;
+  }
+
+  function transfer(address recipient, uint256 amount) external returns (bool) {
+    balanceOf[msg.sender] -= amount;
+    balanceOf[recipient] += amount;
+    emit Transfer(msg.sender, recipient, amount);
+    return true;
+  }
+
+  function approve(address spender, uint256 amount) external returns (bool) {
+    allowance[msg.sender][spender] = amount;
+    emit Approval(msg.sender, spender, amount);
+    return true;
+  }
+
+  function transferFrom(address sender, address recipient, uint256 amount) external returns (bool) {
+    allowance[sender][msg.sender] -= amount;
+    balanceOf[sender] -= amount;
+    balanceOf[recipient] += amount;
+    emit Transfer(sender, recipient, amount);
+    return true;
+  }
+
+  function _mint(address to, uint256 amount) internal {
+    balanceOf[to] += amount;
+    totalSupply += amount;
+    emit Transfer(address(0), to, amount);
+  }
+
+  function _burn(address from, uint256 amount) internal {
+    balanceOf[from] -= amount;
+    totalSupply -= amount;
+    emit Transfer(from, address(0), amount);
+  }
+
+  function mint(address to, uint256 amount) external {
+    _mint(to, amount);
+  }
+
+  function burn(address from, uint256 amount) external {
+    _burn(from, amount);
+  }
+}

--- a/scripts/check-auth.js
+++ b/scripts/check-auth.js
@@ -105,6 +105,7 @@ walkSync("./contracts/").forEach((contractName) => {
       "contracts/testHelpers/ContractEditing.sol",
       "contracts/testHelpers/TasksPayments.sol",
       "contracts/testHelpers/ToggleableToken.sol",
+      "contracts/testHelpers/ERC20Like.sol",
       "contracts/tokenLocking/ITokenLocking.sol",
       "contracts/tokenLocking/TokenLocking.sol",
       "contracts/tokenLocking/TokenLockingStorage.sol",

--- a/scripts/check-recovery.js
+++ b/scripts/check-recovery.js
@@ -83,6 +83,7 @@ walkSync("./contracts/").forEach((contractName) => {
       "contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol",
       "contracts/testHelpers/BridgeMock.sol",
       "contracts/testHelpers/ContractEditing.sol",
+      "contracts/testHelpers/ERC20Like.sol",
       "contracts/testHelpers/ERC20PresetMinterPauser.sol",
       "contracts/testHelpers/ERC721Mock.sol",
       "contracts/testHelpers/NoLimitSubdomains.sol",

--- a/scripts/check-storage.js
+++ b/scripts/check-storage.js
@@ -46,6 +46,7 @@ walkSync("./contracts/").forEach((contractName) => {
       "contracts/patriciaTree/PatriciaTreeBase.sol", // Only used by mining clients
       "contracts/reputationMiningCycle/ReputationMiningCycleStorage.sol",
       "contracts/testHelpers/BridgeMock.sol",
+      "contracts/testHelpers/ERC20Like.sol",
       "contracts/testHelpers/ERC721Mock.sol",
       "contracts/testHelpers/ToggleableToken.sol",
       "contracts/testHelpers/testExtensions/TestExtensionBase.sol",


### PR DESCRIPTION
The CDApp team needed to test a case where a contract emitted an ERC 20 transfer event but wasn't a valid ERC20 token, so added a contract to let them do that. See [the block-ingestor PR](https://github.com/JoinColony/block-ingestor/pull/269) for the full gory details.