### PR TITLE
Update versioning check script

### DIFF
--- a/scripts/versioningCheck.sh
+++ b/scripts/versioningCheck.sh
@@ -26,7 +26,8 @@ fi
 # Compile release
 $NODE_MANAGER install
 $NODE_MANAGER use
-npm ci --force && npx hardhat compile
+pnpm install --frozen-lockfile
+npx hardhat compile
 rm -rf artifacts-$LATEST_RELEASE || true
 mv artifacts artifacts-$LATEST_RELEASE
 
@@ -36,7 +37,8 @@ git checkout $CURRENT_BRANCH
 $NODE_MANAGER install
 $NODE_MANAGER use
 find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +
-pnpm install --frozen-lockfile && npx hardhat compile
+pnpm install --frozen-lockfile
+npx hardhat compile
 
 version_from_commit() {
 	COMMIT=$1;


### PR DESCRIPTION
Prior to the release of `IMWSS2`, the last-but-one-release (`HMWSS`)  used `npm`. After `IMWSS2`, the last-but-one-release (`IMWSS`) uses `pnpm`. So the version check script needs to be updated. 

What confused me was that it was [silently failing](https://app.circleci.com/pipelines/github/JoinColony/colonyNetwork/7208/workflows/e3ff116b-dc6a-44a8-8e03-d77f9706415a/jobs/58961), when I added `set -e` [recently](#1278) to avoid exactly this scenario. 

It turns out, if you carefully inspect the documentation:

```
              -e    ...  The shell does not exit if the command that fails is part of the command list
                      immediately following a while or until keyword, part of the test following  the  if
                      or  elif reserved words, part of any command executed in a && or || list except the
                      command following the final && or ||, any command in a pipeline but the last, or if
                      the command's return value is being inverted with !. 

```

So I have removed the use of `&&` to avoid a situation like this cropping up in the future.