### PR TITLE
Let MTX broadcaster use not-checksummed network address

### DIFF
--- a/packages/metatransaction-broadcaster/MetatransactionBroadcaster.js
+++ b/packages/metatransaction-broadcaster/MetatransactionBroadcaster.js
@@ -76,9 +76,13 @@ class MetatransactionBroadcaster {
 
     const network = await this.provider.getNetwork();
     this.chainId = network.chainId;
+    if (colonyNetworkAddress !== ethers.utils.getAddress(colonyNetworkAddress)) {
+      console.warn("WARNING: Colony Network address is not checksummed");
+      console.warn("This should be fine, but ideally set to a checksummed address");
+    }
 
     const colonyNetworkDef = await this.loader.load({ contractDir: "colonyNetwork", contractName: "IColonyNetwork" });
-    this.colonyNetwork = new ethers.Contract(colonyNetworkAddress, colonyNetworkDef.abi, this.wallet);
+    this.colonyNetwork = new ethers.Contract(ethers.utils.getAddress(colonyNetworkAddress), colonyNetworkDef.abi, this.wallet);
 
     this.feeData = await getFeeData("safeLow", this.chainId, this.adapter, this.provider);
     this.tokenLockingAddress = await this.colonyNetwork.getTokenLocking();

--- a/packages/metatransaction-broadcaster/MetatransactionBroadcaster.js
+++ b/packages/metatransaction-broadcaster/MetatransactionBroadcaster.js
@@ -102,6 +102,13 @@ class MetatransactionBroadcaster {
     await db.close();
   }
 
+  async resetDB() {
+    const db = await sqlite.open({ filename: this.dbPath, driver: sqlite3.Database });
+    await db.run(`DROP TABLE IF EXISTS addresses`);
+    await db.close();
+    await this.createDB();
+  }
+
   async isAddressValid(address) {
     const checksummedAddress = ethers.utils.getAddress(address);
     const db = await sqlite.open({ filename: this.dbPath, driver: sqlite3.Database });

--- a/test/packages/metaTransactionBroadcaster.js
+++ b/test/packages/metaTransactionBroadcaster.js
@@ -64,11 +64,26 @@ contract("Metatransaction broadcaster", (accounts) => {
   });
 
   afterEach(async () => {
+    await broadcaster.resetDB();
     await broadcaster.close();
   });
 
   describe("should correctly identify transactions as valid or not", function () {
     it("transactions to network, token locking are accepted", async function () {
+      let valid = await broadcaster.isAddressValid(colonyNetwork.address);
+      expect(valid).to.be.equal(true);
+
+      const tokenLockingAddress = await colonyNetwork.getTokenLocking();
+      valid = await broadcaster.isAddressValid(tokenLockingAddress);
+      expect(valid).to.be.equal(true);
+    });
+
+    it("transactions to network, token locking are accepted even if initialised with lowercase address", async function () {
+      const networkAddress = colonyNetwork.address.toLowerCase();
+      await broadcaster.close();
+      broadcaster = new MetatransactionBroadcaster({ privateKey, loader, provider });
+      await broadcaster.initialise(networkAddress);
+
       let valid = await broadcaster.isAddressValid(colonyNetwork.address);
       expect(valid).to.be.equal(true);
 


### PR DESCRIPTION
Closes #1239. 

Nothing too clever here, I don't think? We (mostly implicitly, thanks to `ethers`) use checksummed addresses everywhere in the broadcaster (so that pulling them out of the database is reliable), it's just the network address that slipped through. 

This logs a warning if a not-checksummed address is used, because it's clearly better to use one, but I think this is the only place that it was an issue.