### PR TITLE
Fix minor grammatical issues in documentation

### DIFF
--- a/docs/guides/deploying-colony-locally.md
+++ b/docs/guides/deploying-colony-locally.md
@@ -132,4 +132,4 @@ Or just go down the easy path! We created [Colony SDK](https://app.gitbook.com/o
 
 ### Where to go from here?
 
-If you would like to access the reputation related functionality within your development work (mainly to get a user's reputation), please see the [this guide](reputation-oracle-setup).
+If you would like to access the reputation related functionality within your development work (mainly to get a user's reputation), please see [this guide](reputation-oracle-setup).

--- a/docs/guides/reputation-mining.md
+++ b/docs/guides/reputation-mining.md
@@ -15,7 +15,7 @@ To participate in the reputation mining process you need to have staked at least
 
 1\. Check out our contract repository, following [these instructions](../docs/quick-start.md#cloning-the-repository-and-preparing-the-dependencies). You should then be able to run `yarn run truffle console --network xdai` which will connect you to the right network. You will need to be able to sign messages from the address in control of your CLNY (which will also be the address earning reputation for mining), which in most cases means pasting your private key into `truffle.js` before launching the console. For Ledger support, you can use `yarn run truffle console --network xdaiLedger`. For other hardware wallets, you will need to find an appropriate provider compatible with Truffle, and add it into `truffle.js` in your local version of the repository.\
 \
-An appropriate gas price for the current level of network use can be found at [https://blockscout.com/xdai/mainnet/](https://blockscout.com/xdai/mainnet/). The default value in `truffle.js` represent 2Gwei.\
+An appropriate gas price for the current level of network use can be found at [https://blockscout.com/xdai/mainnet/](https://blockscout.com/xdai/mainnet/). The default value in `truffle.js` represents 2Gwei.\
 
 
 2\. Create references to the various contracts that we will need. Run each of these commands in turn:

--- a/docs/guides/reputation-oracle-setup.md
+++ b/docs/guides/reputation-oracle-setup.md
@@ -35,4 +35,4 @@ Wait for it to say
 ⭐️ Reputation oracle running on port 3000
 ```
 
-then you're all set up and ready to interact with the Reputation Oracle.
+Then you're all set up and ready to interact with the Reputation Oracle.


### PR DESCRIPTION
### Description

This pull request addresses the following grammatical errors in the documentation files:

1. **File:** `docs/guides/deploying-colony-locally.md`
   - **Issue:** The phrase "please see the this guide" was incorrect.
   - **Correction:** "the" is unnecessary before the word "this."
   - **Fixed sentence:** "Please see this guide."

2. **File:** `docs/guides/reputation-mining.md`
   - **Issue:** The word "represent" was used incorrectly in the sentence: "The default value in truffle.js represent 2Gwei."
   - **Correction:** The verb should be "represents" to agree with the singular subject "value."
   - **Fixed sentence:** "The default value in truffle.js represents 2Gwei."

3. **File:** `docs/guides/reputation-oracle-setup.md`
   - **Issue:** The word "then" in the sentence "then you're all set up and ready to interact with the Reputation Oracle." should be capitalized for consistency.
   - **Correction:** Capitalized "Then" to start the sentence correctly.
   - **Fixed sentence:** "Then you're all set up and ready to interact with the Reputation Oracle."

### Importance of this change
These changes improve the clarity and readability of the documentation, ensuring that the content is grammatically correct and consistent with professional writing standards. The fixes ensure users understand the instructions clearly without any confusion caused by minor errors.