### PR TITLE
Add rootHashes endpoint to oracle

### DIFF
--- a/packages/reputation-miner/ReputationMinerClient.js
+++ b/packages/reputation-miner/ReputationMinerClient.js
@@ -123,6 +123,12 @@ class ReputationMinerClient {
         return res.status(200).send({ active: activeAddr, inactive: inactiveAddr });
       });
 
+      this._app.get("/rootHashes", async (req, res) => {
+        const currentRootHash = await this._miner.previousReputationTree.getRootHash();
+        const nextRootHash = await this._miner.reputationTree.getRootHash();
+        return res.status(200).send({ currentRootHash, nextRootHash });
+      });
+
       // Query users who have given reputation in colony
       this._app.get("/:rootHash/:colonyAddress/:skillId/", cache('1 hour'), async (req, res) => {
         if (

--- a/test/reputation-system/client-core-functionality.js
+++ b/test/reputation-system/client-core-functionality.js
@@ -367,8 +367,22 @@ hre.__SOLIDITY_COVERAGE_RUNNING
           const url = `http://127.0.0.1:3000/0x0000/NotAValidAddress/1/all`;
           const res = await request(url);
           expect(res.statusCode).to.equal(400);
-          expect(res.statusCode).to.equal(400);
           expect(JSON.parse(res.body).message).to.equal("One of the parameters was incorrect");
+        });
+
+        it("should correctly respond to a request for the currently known states", async () => {
+          await client.initialise(colonyNetwork.address, 1);
+          await metaColony.setReputationMiningCycleReward(100);
+
+          const url = `http://127.0.0.1:3000/rootHashes`;
+          const res = await request(url);
+          expect(res.statusCode).to.equal(200);
+          const nextRootHash = await client._miner.reputationTree.getRootHash();
+          const currentRootHash = await client._miner.previousReputationTree.getRootHash();
+          const response = JSON.parse(res.body);
+
+          expect(response.currentRootHash).to.equal(currentRootHash);
+          expect(response.nextRootHash).to.equal(nextRootHash);
         });
       });
     });


### PR DESCRIPTION
Raul requested this to make his life easier. Naming is a little awkward because the miner/oracle works 'ahead'.