### PR TITLE
Rename _nonce return value to nonce for (historical) consistency

### DIFF
--- a/contracts/colonyNetwork/ColonyNetworkAuction.sol
+++ b/contracts/colonyNetwork/ColonyNetworkAuction.sol
@@ -141,7 +141,7 @@ contract DutchAuction is DSMath, MultiChain, BasicMetaTransaction {
     token = ERC20Extended(_token);
   }
 
-  function getMetatransactionNonce(address _user) public view override returns (uint256 _nonce) {
+  function getMetatransactionNonce(address _user) public view override returns (uint256 nonce) {
     return metatransactionNonces[_user];
   }
 

--- a/contracts/extensions/ColonyExtensionMeta.sol
+++ b/contracts/extensions/ColonyExtensionMeta.sol
@@ -27,7 +27,7 @@ abstract contract ColonyExtensionMeta is BasicMetaTransaction, ColonyExtension {
 
   function getMetatransactionNonce(
     address _user
-  ) public view override(BasicMetaTransaction, IBasicMetaTransaction) returns (uint256 _nonce) {
+  ) public view override(BasicMetaTransaction, IBasicMetaTransaction) returns (uint256 nonce) {
     return metatransactionNonces[_user];
   }
 

--- a/contracts/extensions/FundingQueue.sol
+++ b/contracts/extensions/FundingQueue.sol
@@ -91,10 +91,10 @@ contract FundingQueue is ColonyExtension, BasicMetaTransaction {
 
   /// @notice Gets the next nonce for a meta-transaction
   /// @param _user The user's address
-  /// @return _nonce The nonce
+  /// @return nonce The nonce
   function getMetatransactionNonce(
     address _user
-  ) public view override(IBasicMetaTransaction, BasicMetaTransaction) returns (uint256 _nonce) {
+  ) public view override(IBasicMetaTransaction, BasicMetaTransaction) returns (uint256 nonce) {
     return metatransactionNonces[_user];
   }
 

--- a/contracts/extensions/OneTxPayment.sol
+++ b/contracts/extensions/OneTxPayment.sol
@@ -38,10 +38,10 @@ contract OneTxPayment is ColonyExtension, BasicMetaTransaction {
 
   /// @notice Gets the next nonce for a meta-transaction
   /// @param _user The user's address
-  /// @return _nonce The nonce
+  /// @return nonce The nonce
   function getMetatransactionNonce(
     address _user
-  ) public view override(IBasicMetaTransaction, BasicMetaTransaction) returns (uint256 _nonce) {
+  ) public view override(IBasicMetaTransaction, BasicMetaTransaction) returns (uint256 nonce) {
     return metatransactionNonces[_user];
   }
 

--- a/contracts/extensions/TokenSupplier.sol
+++ b/contracts/extensions/TokenSupplier.sol
@@ -45,10 +45,10 @@ contract TokenSupplier is ColonyExtension, BasicMetaTransaction {
 
   /// @notice Gets the next nonce for a meta-transaction
   /// @param _user The user's address
-  /// @return _nonce The nonce
+  /// @return nonce The nonce
   function getMetatransactionNonce(
     address _user
-  ) public view override(IBasicMetaTransaction, BasicMetaTransaction) returns (uint256 _nonce) {
+  ) public view override(IBasicMetaTransaction, BasicMetaTransaction) returns (uint256 nonce) {
     return metatransactionNonces[_user];
   }
 

--- a/contracts/extensions/Whitelist.sol
+++ b/contracts/extensions/Whitelist.sol
@@ -43,10 +43,10 @@ contract Whitelist is ColonyExtension, BasicMetaTransaction {
 
   /// @notice Gets the next nonce for a meta-transaction
   /// @param _user The user's address
-  /// @return _nonce The nonce
+  /// @return nonce The nonce
   function getMetatransactionNonce(
     address _user
-  ) public view override(IBasicMetaTransaction, BasicMetaTransaction) returns (uint256 _nonce) {
+  ) public view override(IBasicMetaTransaction, BasicMetaTransaction) returns (uint256 nonce) {
     return metatransactionNonces[_user];
   }
 

--- a/contracts/extensions/votingReputation/VotingReputationStorage.sol
+++ b/contracts/extensions/votingReputation/VotingReputationStorage.sol
@@ -96,7 +96,7 @@ contract VotingReputationStorage is
 
   function getMetatransactionNonce(
     address _user
-  ) public view override(IBasicMetaTransaction, BasicMetaTransaction) returns (uint256 _nonce) {
+  ) public view override(IBasicMetaTransaction, BasicMetaTransaction) returns (uint256 nonce) {
     // This offset is a result of fixing the storage layout, and having to prevent metatransactions being able to be replayed as a result
     // of the nonce resetting. The broadcaster has made ~3000 transactions in total at time of commit, so we definitely won't have a single
     // account at 1 million nonce by then.


### PR DESCRIPTION
This messed up the typescript types for Chris, so renamed the return value (which shouldn't have a `_` in it anyway, by our convention, and doesn't elsewhere).

I wrote a script to check / enforce this naming convention but it's broken in a lot of places (some of which aren't under our control, at least), so not including that or fixing everything as this is sufficient for now, but a coordinated effort to make this consistent in the future is probably worthwhile.