### PR TITLE
Update Dockerfiles for pnpm (probably)

### DIFF
--- a/packages/metatransaction-broadcaster/Dockerfile
+++ b/packages/metatransaction-broadcaster/Dockerfile
@@ -2,6 +2,8 @@ FROM node:20.11.0-buster
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
+RUN mkdir /app
+WORKDIR /app
 COPY ./packages ./packages
 COPY ./package.json ./
 COPY ./pnpm-lock.yaml ./

--- a/packages/reputation-miner/Dockerfile
+++ b/packages/reputation-miner/Dockerfile
@@ -3,6 +3,8 @@ RUN apt-get update || : && apt-get install python -y
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
+RUN mkdir /app
+WORKDIR /app
 COPY ./packages ./packages
 COPY ./package.json ./
 COPY ./pnpm-lock.yaml ./


### PR DESCRIPTION
While trying to get #1312 deployed to QA for Raul, I discovered that (at least some of) our `Dockerfile`s were broken, and were seemingly refusing to install dependencies correctly for our packages. 

Couldn't really figure out what was going on, but putting everything in its own directory (following [the docs](https://pnpm.io/docker) more closely) seems to have solved it.