### PR TITLE
Add test for multiple releases of staged expenditure

### DIFF
--- a/test/extensions/staged-expenditure.js
+++ b/test/extensions/staged-expenditure.js
@@ -220,6 +220,48 @@ contract("Staged Expenditure", (accounts) => {
       await colony.claimExpenditurePayout(expenditureId, 0, token.address);
     });
 
+    it("releasing a staged payment repeatedly doesn't pay out repeatedly, even if funded multiple times", async () => {
+      await fundColonyWithTokens(colony, token, WAD.muln(10));
+
+      await colony.makeExpenditure(1, UINT256_MAX, 1, { from: USER0 });
+      const expenditureId = await colony.getExpenditureCount();
+      const expenditure = await colony.getExpenditure(expenditureId);
+      const domain1 = await colony.getDomain(1);
+
+      await stagedExpenditure.setExpenditureStaged(expenditureId, true, { from: USER0 });
+
+      await colony.setExpenditureRecipients(expenditureId, [0, 1], [USER1, USER1], { from: USER0 });
+      await colony.setExpenditureClaimDelays(expenditureId, [0, 1], [UINT128_MAX, UINT128_MAX], { from: USER0 });
+      await colony.setExpenditurePayouts(expenditureId, [0, 1], token.address, [WAD, WAD.muln(2)], { from: USER0 });
+
+      await colony.moveFundsBetweenPots(
+        1,
+        UINT256_MAX,
+        1,
+        UINT256_MAX,
+        UINT256_MAX,
+        domain1.fundingPotId,
+        expenditure.fundingPotId,
+        WAD.muln(10),
+        token.address,
+        { from: USER0 },
+      );
+
+      await colony.finalizeExpenditure(expenditureId);
+
+      await colony.setArbitrationRole(1, UINT256_MAX, USER1, 1, true);
+
+      await stagedExpenditure.releaseStagedPaymentViaArbitration(1, UINT256_MAX, 1, UINT256_MAX, expenditureId, 0, [token.address], { from: USER1 });
+      await colony.claimExpenditurePayout(expenditureId, 0, token.address);
+
+      const balanceBefore = await token.balanceOf(USER1);
+
+      await stagedExpenditure.releaseStagedPaymentViaArbitration(1, UINT256_MAX, 1, UINT256_MAX, expenditureId, 0, [token.address], { from: USER1 });
+      await colony.claimExpenditurePayout(expenditureId, 0, token.address);
+      const balanceAfter = await token.balanceOf(USER1);
+      expect(balanceBefore).to.eq.BN(balanceAfter);
+    });
+
     it("can't mark an expenditure as staged if extension is deprecated", async () => {
       await colony.makeExpenditure(1, UINT256_MAX, 1, { from: USER0 });
       const expenditureId = await colony.getExpenditureCount();


### PR DESCRIPTION
@mmioana stumbled across some behaviour that surprised her with staged payments; I ended up writing a test to check that nothing untoward could happen, and would seem like a shame to waste that effort!

You can release staged payments multiple times, and claim them multiple times. Indeed, you can claim the underlying expenditure multiple times and the transaction succeeds, it just pays nothing out (even if the associated funding pot still has funds).
