### PR TITLE
Fix typos in comments

### DIFF
--- a/contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleBinarySearch.sol
@@ -61,7 +61,7 @@ contract ReputationMiningCycleBinarySearch is ReputationMiningCycleCommon {
     uint256 expectedLength = expectedProofLength(
       submission.jrhNLeaves,
       disputeRounds[_round][_idx].lowerBound
-    ) - (disputeRounds[_round][_idx].challengeStepCompleted - 1); // We expect shorter proofs the more chanllenge rounds we've done so far
+    ) - (disputeRounds[_round][_idx].challengeStepCompleted - 1); // We expect shorter proofs the more challenge rounds we've done so far
     require(
       expectedLength == _siblings.length,
       "colony-reputation-mining-invalid-binary-search-proof-length"

--- a/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
+++ b/contracts/reputationMiningCycle/ReputationMiningCycleRespond.sol
@@ -389,7 +389,7 @@ contract ReputationMiningCycleRespond is ReputationMiningCycleCommon {
   }
 
   function confirmChallengeCompleted(uint256[26] memory _u) internal {
-    // If everthing checked out, note that we've responded to the challenge.
+    // If everything checked out, note that we've responded to the challenge.
     disputeRounds[_u[U_ROUND]][_u[U_IDX]].challengeStepCompleted += 1;
     disputeRounds[_u[U_ROUND]][_u[U_IDX]].lastResponseTimestamp = block.timestamp;
     Submission storage submission = reputationHashSubmissions[

--- a/packages/reputation-miner/ReputationMiner.js
+++ b/packages/reputation-miner/ReputationMiner.js
@@ -394,7 +394,7 @@ class ReputationMiner {
 
       // When reputation amount update is negative, adjust its value for child reputation updates and parent updates
       // We update colonywide sums first (children, parents, skill)
-      // Then the user-specifc sums in the order children, parents, skill.
+      // Then the user-specific sums in the order children, parents, skill.
       if (amount.lt(0)) {
         const nUpdates = ethers.BigNumber.from(logEntry.nUpdates);
         const [nParents] = await this.colonyNetwork.getSkill(logEntry.skillId, {blockTag: blockNumber});


### PR DESCRIPTION
This PR fixes minor typos in comments across several files:

- ReputationMiningCycleBinarySearch.sol: Fixed "challenge" spelling in comment
- ReputationMiningCycleRespond.sol: Fixed "everything" spelling in comment 
- ReputationMiner.js: Fixed hyphenation in "user-specific" comment

These changes only affect comments and have no functional impact on the code.